### PR TITLE
Synapse broadcasting to only interact with whitelisted validators

### DIFF
--- a/allways/cli/dendrite_lite.py
+++ b/allways/cli/dendrite_lite.py
@@ -34,10 +34,11 @@ def get_ephemeral_wallet() -> bt.Wallet:
     return wallet
 
 
-def discover_validators(subtensor: bt.Subtensor, netuid: int) -> list:
+def discover_validators(subtensor: bt.Subtensor, netuid: int, contract_client=None) -> list:
     """Discover validator axon endpoints from metagraph.
 
     Filters for UIDs with validator_permit=True and is_serving=True.
+    When contract_client is provided, also filters to only whitelisted validators.
     Returns list of axon endpoints.
     """
     metagraph = subtensor.metagraph(netuid=netuid)
@@ -49,6 +50,12 @@ def discover_validators(subtensor: bt.Subtensor, netuid: int) -> list:
         axon = metagraph.axons[uid]
         if not axon.is_serving:
             continue
+        if contract_client:
+            try:
+                if not contract_client.is_validator(metagraph.hotkeys[uid]):
+                    continue
+            except Exception:
+                pass
         axons.append(axon)
 
     return axons

--- a/allways/cli/swap_commands/miner_commands.py
+++ b/allways/cli/swap_commands/miner_commands.py
@@ -6,6 +6,7 @@ import time
 import rich_click as click
 from rich.table import Table
 
+from allways.cli.dendrite_lite import discover_validators
 from allways.cli.swap_commands.helpers import (
     SWAP_STATUS_COLORS,
     console,
@@ -14,7 +15,6 @@ from allways.cli.swap_commands.helpers import (
     loading,
     read_miner_commitment,
 )
-from allways.cli.dendrite_lite import discover_validators
 from allways.contract_client import ContractError
 
 

--- a/allways/cli/swap_commands/miner_commands.py
+++ b/allways/cli/swap_commands/miner_commands.py
@@ -14,6 +14,7 @@ from allways.cli.swap_commands.helpers import (
     loading,
     read_miner_commitment,
 )
+from allways.cli.dendrite_lite import discover_validators
 from allways.contract_client import ContractError
 
 
@@ -176,13 +177,9 @@ def miner_activate():
 
     synapse = MinerActivateSynapse(hotkey=hotkey, signature=signature, message=message)
 
-    # Discover validators from metagraph
-    metagraph = subtensor.metagraph(netuid=netuid)
+    # Discover whitelisted validators from metagraph
     dendrite = bt.Dendrite(wallet=wallet)
-
-    validator_axons = [
-        axon for uid, axon in enumerate(metagraph.axons) if metagraph.validator_permit[uid] and axon.is_serving
-    ]
+    validator_axons = discover_validators(subtensor, netuid, contract_client=client)
 
     if not validator_axons:
         console.print('[red]No validators found on metagraph[/red]\n')

--- a/allways/cli/swap_commands/post_tx.py
+++ b/allways/cli/swap_commands/post_tx.py
@@ -86,7 +86,7 @@ def post_tx_command(tx_hash: str, netuid: int):
     source_key = wallet.coldkey if state.source_chain == 'tao' else None
 
     # Discover validators
-    validator_axons = discover_validators(subtensor, netuid)
+    validator_axons = discover_validators(subtensor, netuid, contract_client=client)
     if not validator_axons:
         console.print('[red]No validators found on metagraph[/red]')
         return

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -187,7 +187,7 @@ def broadcast_reserve_with_retry(
     )
 
     ephemeral_wallet = get_ephemeral_wallet()
-    validator_axons = discover_validators(subtensor, netuid)
+    validator_axons = discover_validators(subtensor, netuid, contract_client=client)
     if not validator_axons:
         console.print('[red]No validators found on metagraph[/red]')
         return None


### PR DESCRIPTION
This betters the user and miner experience when taking CLI actions that include broadcasting to validators.
Rather than broadcasting to inactive valis and appearing to be rejected, we can smooth the UX by only broadcasting to whitelisted valis