### PR TITLE
Verify dest transaction sender matches miner's posted address

### DIFF
--- a/allways/classes.py
+++ b/allways/classes.py
@@ -62,6 +62,7 @@ class Swap:
     user_source_address: str
     user_dest_address: str
     miner_source_address: str = ''
+    miner_dest_address: str = ''
     rate: str = ''
     source_tx_hash: str = ''
     source_tx_block: int = 0

--- a/allways/contract_client.py
+++ b/allways/contract_client.py
@@ -113,6 +113,7 @@ CONTRACT_ARG_TYPES = {
         ('source_tx_block', 'u32'),
         ('dest_amount', 'u128'),
         ('miner_source_address', 'str'),
+        ('miner_dest_address', 'str'),
         ('rate', 'str'),
     ],
     'vote_activate': [('miner', 'AccountId')],
@@ -584,6 +585,7 @@ class AllwaysContractClient:
             user_source_address, o = self._decode_string(data, o)
             user_dest_address, o = self._decode_string(data, o)
             miner_source_address, o = self._decode_string(data, o)
+            miner_dest_address, o = self._decode_string(data, o)
             rate, o = self._decode_string(data, o)
             source_tx_hash, o = self._decode_string(data, o)
             source_tx_block = struct.unpack_from('<I', data, o)[0]
@@ -615,6 +617,7 @@ class AllwaysContractClient:
                 user_source_address=user_source_address,
                 user_dest_address=user_dest_address,
                 miner_source_address=miner_source_address,
+                miner_dest_address=miner_dest_address,
                 rate=rate,
                 source_tx_hash=source_tx_hash,
                 source_tx_block=source_tx_block,
@@ -997,6 +1000,7 @@ class AllwaysContractClient:
         source_tx_block: int = 0,
         dest_amount: int = 0,
         miner_source_address: str = '',
+        miner_dest_address: str = '',
         rate: str = '',
     ) -> str:
         """Vote to initiate a swap. On quorum, swap is created on contract."""
@@ -1017,6 +1021,7 @@ class AllwaysContractClient:
                 'source_tx_block': source_tx_block,
                 'dest_amount': dest_amount,
                 'miner_source_address': miner_source_address,
+                'miner_dest_address': miner_dest_address,
                 'rate': rate,
             },
             keypair=wallet.hotkey,

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -396,6 +396,9 @@ async def handle_swap_confirm(
             miner_deposit_address = (
                 commitment.source_address if swap_source_chain == commitment.source_chain else commitment.dest_address
             )
+            miner_fulfillment_address = (
+                commitment.dest_address if swap_source_chain == commitment.source_chain else commitment.source_address
+            )
 
             provider = validator.axon_chain_providers.get(swap_source_chain)
             if provider is None:
@@ -424,6 +427,7 @@ async def handle_swap_confirm(
                     source_amount=res_source_amount,
                     dest_amount=res_dest_amount,
                     miner_deposit_address=miner_deposit_address,
+                    miner_dest_address=miner_fulfillment_address,
                     rate_str=commitment.rate_str,
                     reserved_until=reserved_until,
                 )
@@ -468,6 +472,7 @@ async def handle_swap_confirm(
                 source_tx_block=tx_info.block_number or 0,
                 dest_amount=res_dest_amount,
                 miner_source_address=miner_deposit_address,
+                miner_dest_address=miner_fulfillment_address,
                 rate=commitment.rate_str,
             )
             synapse.accepted = True

--- a/allways/validator/chain_verification.py
+++ b/allways/validator/chain_verification.py
@@ -33,7 +33,14 @@ class SwapVerifier:
         self._last_logged_confs: Dict[str, int] = {}  # swap_id:chain -> confs
 
     def _verify_tx(
-        self, swap: Swap, chain: str, tx_hash: str, expected_recipient: str, expected_amount: int, block_hint: int = 0
+        self,
+        swap: Swap,
+        chain: str,
+        tx_hash: str,
+        expected_recipient: str,
+        expected_amount: int,
+        block_hint: int = 0,
+        expected_sender: str = '',
     ) -> bool:
         """Verify a confirmed transaction on a specific chain."""
         provider = self.providers.get(chain)
@@ -67,7 +74,14 @@ class SwapVerifier:
                         f'(confs={tx_info.confirmations} tx={tx_hash[:16]}... '
                         f'addr={expected_recipient[:16]}... expected={expected_amount})'
                     )
-            return tx_info is not None and tx_info.confirmed
+            if tx_info is None or not tx_info.confirmed:
+                return False
+            if expected_sender and tx_info.sender != expected_sender:
+                bt.logging.warning(
+                    f'Swap {swap.id}: sender mismatch on {chain} — expected {expected_sender}, got {tx_info.sender}'
+                )
+                return False
+            return True
         except Exception as e:
             bt.logging.error(f'Swap {swap.id}: verification error on {chain}: {e}')
             return False
@@ -113,6 +127,7 @@ class SwapVerifier:
             swap.user_dest_address,
             expected_user_receives,
             swap.dest_tx_block,
+            swap.miner_dest_address,
         )
 
         return source_ok and dest_ok

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -188,6 +188,7 @@ def _process_pending_confirms(self: Validator) -> None:
                 source_tx_block=tx_info.block_number or 0,
                 dest_amount=item.dest_amount,
                 miner_source_address=item.miner_deposit_address,
+                miner_dest_address=item.miner_dest_address,
                 rate=item.rate_str,
             )
             bt.logging.success(

--- a/allways/validator/pending_confirms.py
+++ b/allways/validator/pending_confirms.py
@@ -26,6 +26,7 @@ class PendingConfirm:
     source_amount: int
     dest_amount: int
     miner_deposit_address: str
+    miner_dest_address: str
     rate_str: str
     reserved_until: int
     queued_at: float = field(default_factory=time.time)

--- a/smart-contracts/ink/lib.rs
+++ b/smart-contracts/ink/lib.rs
@@ -546,6 +546,7 @@ mod allways_swap_manager {
             source_tx_block: u32,
             dest_amount: Balance,
             miner_source_address: String,
+            miner_dest_address: String,
             rate: String,
         ) -> Result<(), Error> {
             self.ensure_validator()?;
@@ -567,7 +568,7 @@ mod allways_swap_manager {
             if source_amount == 0 || tao_amount == 0 {
                 return Err(Error::InvalidAmount);
             }
-            if source_tx_hash.is_empty() || miner_source_address.is_empty() || rate.is_empty() {
+            if source_tx_hash.is_empty() || miner_source_address.is_empty() || miner_dest_address.is_empty() || rate.is_empty() {
                 return Err(Error::InputEmpty);
             }
             if source_tx_hash.len() > 128 {
@@ -625,6 +626,7 @@ mod allways_swap_manager {
                     user_source_address,
                     user_dest_address,
                     miner_source_address,
+                    miner_dest_address,
                     rate,
                     source_tx_hash: source_tx_hash.clone(),
                     source_tx_block,

--- a/smart-contracts/ink/types.rs
+++ b/smart-contracts/ink/types.rs
@@ -42,6 +42,7 @@ pub struct SwapData {
     pub user_source_address: String,
     pub user_dest_address: String,
     pub miner_source_address: String,
+    pub miner_dest_address: String,
     pub rate: String,
     pub source_tx_hash: String,
     pub source_tx_block: u32,


### PR DESCRIPTION
**Verify dest transaction sender matches miner's posted address**

## Summary
- **Security fix**: The dest-side swap verification only checked that the correct amount reached the user's address by tx hash — it did not verify the transaction came FROM the miner's posted address. A miner could watch for any third-party tx to the user's dest address of the correct amount and claim that tx hash as their fulfillment without actually sending funds.
- **Contract**: Added `miner_dest_address` field to `SwapData`
- **Validator**: `chain_verification.py` now validates `tx_info.sender` against `swap.miner_dest_address` on the dest leg, rejecting mismatches

## Test plan
- [x] `cargo contract build` compiles with new field
- [x] `ruff check allways/ neurons/` passes
- [x] Restart dev environment and run E2E suite 02 (swap lifecycle)
- [x] Verify validator logs show sender validation on dest-side confirmation