### PR TITLE
Strengthen halt lockdown to block collateral deposits and activations

### DIFF
--- a/allways/metadata/allways_swap_manager.json
+++ b/allways/metadata/allways_swap_manager.json
@@ -1,6 +1,6 @@
 {
   "source": {
-    "hash": "0x30b3f2dc49bdb3ba3843f7c0851a8036e6b4f89e76132515d88653301a41ff15",
+    "hash": "0xd107a94d3c007dbe3fb4dc7767535b674cea6eaa098611a98906f248322f73a2",
     "language": "ink! 5.1.1",
     "compiler": "rustc 1.91.1",
     "build_info": {
@@ -1237,6 +1237,15 @@
           },
           {
             "label": "miner_source_address",
+            "type": {
+              "displayName": [
+                "String"
+              ],
+              "type": 13
+            }
+          },
+          {
+            "label": "miner_dest_address",
             "type": {
               "displayName": [
                 "String"
@@ -2736,6 +2745,15 @@
                               "ty": 13
                             }
                           },
+                          "name": "miner_dest_address"
+                        },
+                        {
+                          "layout": {
+                            "leaf": {
+                              "key": "0x2b1d1362",
+                              "ty": 13
+                            }
+                          },
                           "name": "rate"
                         },
                         {
@@ -3526,6 +3544,11 @@
               },
               {
                 "name": "miner_source_address",
+                "type": 13,
+                "typeName": "String"
+              },
+              {
+                "name": "miner_dest_address",
                 "type": 13,
                 "typeName": "String"
               },

--- a/smart-contracts/ink/errors.rs
+++ b/smart-contracts/ink/errors.rs
@@ -58,6 +58,6 @@ pub enum Error {
     PendingConflict,
     /// Source and destination chains must be different
     SameChain,
-    /// System is halted — no new reservations allowed
+    /// System is halted — no new activity allowed
     SystemHalted,
 }

--- a/smart-contracts/ink/lib.rs
+++ b/smart-contracts/ink/lib.rs
@@ -108,6 +108,13 @@ mod allways_swap_manager {
             Ok(())
         }
 
+        fn ensure_not_halted(&self) -> Result<(), Error> {
+            if self.halted {
+                return Err(Error::SystemHalted);
+            }
+            Ok(())
+        }
+
         fn get_required_votes(&self) -> u32 {
             if self.validator_count == 0 {
                 return 1;
@@ -293,6 +300,7 @@ mod allways_swap_manager {
 
         #[ink(message, payable)]
         pub fn post_collateral(&mut self) -> Result<(), Error> {
+            self.ensure_not_halted()?;
             let caller = self.env().caller();
             let amount = self.env().transferred_value();
             if amount == 0 {
@@ -373,9 +381,7 @@ mod allways_swap_manager {
             dest_amount: Balance,
         ) -> Result<(), Error> {
             self.ensure_validator()?;
-            if self.halted {
-                return Err(Error::SystemHalted);
-            }
+            self.ensure_not_halted()?;
             let caller = self.env().caller();
             let current_block = self.env().block_number();
 
@@ -939,6 +945,7 @@ mod allways_swap_manager {
         #[ink(message)]
         pub fn vote_activate(&mut self, miner: AccountId) -> Result<(), Error> {
             self.ensure_validator()?;
+            self.ensure_not_halted()?;
             let caller = self.env().caller();
 
             if self.miner_active.get(miner).unwrap_or(false) {


### PR DESCRIPTION
### Strengthen halt (emergency stop) lockdown

## Summary

- Add `ensure_not_halted()` helper following the existing `ensure_owner()`/`ensure_validator()` pattern. Refactored `vote_reserve()` to use this.
- Block `post_collateral()`, `vote_activate()` when halted

## Design

The halt gates at the earliest commitment points only. Everything downstream of an existing reservation is allowed to resolve naturally:

## Test plan

- [x] Contract builds successfully (`cargo contract build`)
- [x] Verify `post_collateral` returns `SystemHalted` when halted
- [x] Verify `vote_activate` returns `SystemHalted` when halted
- [x] Verify `withdraw_collateral` still works when halted
- [x] Verify in-flight swap lifecycle completes normally when halted
- [x] E2E: `./tests/run.sh --chains btc --suite 02`

