### PR TITLE
Persist pending confirms in SQLite

### DIFF
--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -431,17 +431,13 @@ async def handle_swap_confirm(
                     rate_str=commitment.rate_str,
                     reserved_until=reserved_until,
                 )
-                if validator.pending_confirms.enqueue(pending):
-                    synapse.accepted = True
-                    synapse.rejection_reason = (
-                        f'Queued — {tx_info.confirmations}/{chain_def.min_confirmations} confirmations. '
-                        f'Validator will auto-initiate when confirmed.'
-                    )
-                    bt.logging.info(
-                        f'{ctx} queued: {tx_info.confirmations}/{chain_def.min_confirmations} confirmations'
-                    )
-                else:
-                    _reject(synapse, 'Validator confirmation queue is full — retry later', ctx)
+                validator.pending_confirms.enqueue(pending)
+                synapse.accepted = True
+                synapse.rejection_reason = (
+                    f'Queued — {tx_info.confirmations}/{chain_def.min_confirmations} confirmations. '
+                    f'Validator will auto-initiate when confirmed.'
+                )
+                bt.logging.info(f'{ctx} queued: {tx_info.confirmations}/{chain_def.min_confirmations} confirmations')
                 return synapse
 
             miner_bytes = bytes.fromhex(Keypair(ss58_address=miner).public_key.hex())

--- a/allways/validator/pending_confirms.py
+++ b/allways/validator/pending_confirms.py
@@ -3,9 +3,8 @@
 Written by axon handler thread (handle_swap_confirm), read by forward loop thread
 (_process_pending_confirms). Keyed by miner_hotkey since reservations are 1:1 per miner.
 
-This module owns the queue abstraction and its storage backends. The validator
-uses a local SQLite-backed store in production so pending confirmations survive
-validator process restarts.
+The queue stores entries in a local SQLite database so pending confirmations
+survive validator process restarts.
 """
 
 import sqlite3
@@ -13,9 +12,7 @@ import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, List, Optional, Protocol
-
-MAX_QUEUE_SIZE = 50
+from typing import Callable, List, Optional
 
 
 @dataclass
@@ -47,78 +44,116 @@ class PendingConfirmQueue:
 
     def __init__(
         self,
-        store: Optional['PendingConfirmStore'] = None,
+        db_path: Path | str | None = None,
         current_block_fn: Optional[Callable[[], int]] = None,
     ):
-        self._store = store or SqlitePendingConfirmStore()
-        self._current_block_fn = current_block_fn
-
-    def enqueue(self, item: PendingConfirm) -> bool:
-        """Add or replace a pending confirm. Returns False if queue is full (and not an overwrite)."""
-        return self._store.upsert(item)
-
-    def get_all(self) -> List[PendingConfirm]:
-        """Return a snapshot of all pending items."""
-        self._purge_expired()
-        return self._store.list_all()
-
-    def remove(self, miner_hotkey: str) -> Optional[PendingConfirm]:
-        """Remove and return a specific entry."""
-        return self._store.remove(miner_hotkey)
-
-    def has(self, miner_hotkey: str) -> bool:
-        self._purge_expired()
-        return self._store.has(miner_hotkey)
-
-    def size(self) -> int:
-        self._purge_expired()
-        return self._store.size()
-
-    def _purge_expired(self) -> None:
-        if self._current_block_fn is None:
-            return
-        self._store.purge_expired(self._current_block_fn())
-
-
-class PendingConfirmStore(Protocol):
-    """Persistence interface for pending confirms."""
-
-    def upsert(self, item: PendingConfirm) -> bool:
-        """Add or replace a pending confirm. False means the queue is full."""
-
-    def list_all(self) -> List[PendingConfirm]:
-        """Return all pending confirms."""
-
-    def remove(self, miner_hotkey: str) -> Optional[PendingConfirm]:
-        """Remove and return a pending confirm."""
-
-    def has(self, miner_hotkey: str) -> bool:
-        """Return whether an entry exists for the miner."""
-
-    def size(self) -> int:
-        """Return the number of queued items."""
-
-    def purge_expired(self, current_block: int) -> None:
-        """Delete entries whose reservation has expired."""
-
-class SqlitePendingConfirmStore:
-    """Durable local SQLite store for pending confirms."""
-
-    def __init__(self, db_path: Path | str | None = None):
         self._db_path = Path(db_path or Path.home() / '.allways' / 'validator' / 'pending_confirms.db')
         self._db_path.parent.mkdir(parents=True, exist_ok=True)
         self._lock = threading.Lock()
+        self._conn = sqlite3.connect(self._db_path, check_same_thread=False)
+        self._conn.execute('PRAGMA journal_mode=WAL')
+        self._conn.execute('PRAGMA busy_timeout=5000')
+        self._conn.row_factory = sqlite3.Row
         self._init_db()
+        self._current_block_fn = current_block_fn
 
-    def _get_connection(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self._db_path)
-        conn.execute('PRAGMA journal_mode=WAL')
-        conn.execute('PRAGMA busy_timeout=5000')
-        conn.row_factory = sqlite3.Row
-        return conn
+    def enqueue(self, item: PendingConfirm) -> None:
+        """Add or replace a pending confirm."""
+        with self._lock:
+            conn = self._require_connection()
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO pending_confirms (
+                    miner_hotkey,
+                    source_tx_hash,
+                    source_chain,
+                    dest_chain,
+                    source_address,
+                    dest_address,
+                    tao_amount,
+                    source_amount,
+                    dest_amount,
+                    miner_deposit_address,
+                    miner_dest_address,
+                    rate_str,
+                    reserved_until,
+                    queued_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    item.miner_hotkey,
+                    item.source_tx_hash,
+                    item.source_chain,
+                    item.dest_chain,
+                    item.source_address,
+                    item.dest_address,
+                    item.tao_amount,
+                    item.source_amount,
+                    item.dest_amount,
+                    item.miner_deposit_address,
+                    item.miner_dest_address,
+                    item.rate_str,
+                    item.reserved_until,
+                    item.queued_at,
+                ),
+            )
+            conn.commit()
 
-    def _init_db(self):
-        with self._get_connection() as conn:
+    def get_all(self) -> List[PendingConfirm]:
+        """Return a snapshot of all pending items."""
+        with self._lock:
+            conn = self._require_connection()
+            self._purge_expired(conn)
+            rows = conn.execute('SELECT * FROM pending_confirms ORDER BY queued_at').fetchall()
+        return [self._row_to_item(row) for row in rows]
+
+    def remove(self, miner_hotkey: str) -> Optional[PendingConfirm]:
+        """Remove and return a specific entry."""
+        with self._lock:
+            conn = self._require_connection()
+            row = conn.execute(
+                'SELECT * FROM pending_confirms WHERE miner_hotkey = ?',
+                (miner_hotkey,),
+            ).fetchone()
+            if row is None:
+                return None
+            conn.execute('DELETE FROM pending_confirms WHERE miner_hotkey = ?', (miner_hotkey,))
+            conn.commit()
+        return self._row_to_item(row)
+
+    def has(self, miner_hotkey: str) -> bool:
+        with self._lock:
+            conn = self._require_connection()
+            self._purge_expired(conn)
+            row = conn.execute(
+                'SELECT 1 FROM pending_confirms WHERE miner_hotkey = ? LIMIT 1',
+                (miner_hotkey,),
+            ).fetchone()
+        return row is not None
+
+    def size(self) -> int:
+        with self._lock:
+            conn = self._require_connection()
+            self._purge_expired(conn)
+            count = conn.execute('SELECT COUNT(*) FROM pending_confirms').fetchone()[0]
+            return int(count)
+
+    def _purge_expired(self, conn: sqlite3.Connection) -> None:
+        if self._current_block_fn is None:
+            return
+        current_block = self._current_block_fn()
+        conn.execute('DELETE FROM pending_confirms WHERE reserved_until < ?', (current_block,))
+        conn.commit()
+
+    def close(self) -> None:
+        with self._lock:
+            if self._conn is not None:
+                self._conn.close()
+                self._conn = None
+
+    def _init_db(self) -> None:
+        with self._lock:
+            conn = self._require_connection()
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS pending_confirms (
                     miner_hotkey TEXT PRIMARY KEY,
@@ -158,90 +193,7 @@ class SqlitePendingConfirmStore:
             queued_at=row['queued_at'],
         )
 
-    def upsert(self, item: PendingConfirm) -> bool:
-        with self._lock:
-            with self._get_connection() as conn:
-                exists = conn.execute(
-                    'SELECT 1 FROM pending_confirms WHERE miner_hotkey = ?',
-                    (item.miner_hotkey,),
-                ).fetchone()
-                if exists is None:
-                    count = conn.execute('SELECT COUNT(*) FROM pending_confirms').fetchone()[0]
-                    if count >= MAX_QUEUE_SIZE:
-                        return False
-
-                fields = (
-                    'miner_hotkey',
-                    'source_tx_hash',
-                    'source_chain',
-                    'dest_chain',
-                    'source_address',
-                    'dest_address',
-                    'tao_amount',
-                    'source_amount',
-                    'dest_amount',
-                    'miner_deposit_address',
-                    'miner_dest_address',
-                    'rate_str',
-                    'reserved_until',
-                    'queued_at',
-                )
-                columns = ', '.join(fields)
-                placeholders = ', '.join('?' for _ in fields)
-                updates = ', '.join(
-                    f'{field} = excluded.{field}'
-                    for field in fields
-                    if field != 'miner_hotkey'
-                )
-                values = tuple(getattr(item, field) for field in fields)
-
-                conn.execute(
-                    f"""
-                    INSERT INTO pending_confirms ({columns})
-                    VALUES ({placeholders})
-                    ON CONFLICT (miner_hotkey)
-                    DO UPDATE SET {updates}
-                    """,
-                    values,
-                )
-                conn.commit()
-                return True
-
-    def list_all(self) -> List[PendingConfirm]:
-        with self._get_connection() as conn:
-            rows = conn.execute('SELECT * FROM pending_confirms ORDER BY queued_at').fetchall()
-        return [self._row_to_item(row) for row in rows]
-
-    def remove(self, miner_hotkey: str) -> Optional[PendingConfirm]:
-        with self._lock:
-            with self._get_connection() as conn:
-                row = conn.execute(
-                    'SELECT * FROM pending_confirms WHERE miner_hotkey = ?',
-                    (miner_hotkey,),
-                ).fetchone()
-                if row is None:
-                    return None
-                conn.execute('DELETE FROM pending_confirms WHERE miner_hotkey = ?', (miner_hotkey,))
-                conn.commit()
-        return self._row_to_item(row)
-
-    def has(self, miner_hotkey: str) -> bool:
-        with self._get_connection() as conn:
-            row = conn.execute(
-                'SELECT 1 FROM pending_confirms WHERE miner_hotkey = ?',
-                (miner_hotkey,),
-            ).fetchone()
-        return row is not None
-
-    def size(self) -> int:
-        with self._get_connection() as conn:
-            return int(conn.execute('SELECT COUNT(*) FROM pending_confirms').fetchone()[0])
-
-    def purge_expired(self, current_block: int) -> None:
-        with self._lock:
-            with self._get_connection() as conn:
-                conn.execute(
-                    'DELETE FROM pending_confirms WHERE reserved_until < ?',
-                    (current_block,),
-                )
-                conn.commit()
+    def _require_connection(self) -> sqlite3.Connection:
+        if self._conn is None:
+            raise RuntimeError('PendingConfirmQueue is closed')
+        return self._conn

--- a/allways/validator/pending_confirms.py
+++ b/allways/validator/pending_confirms.py
@@ -2,12 +2,18 @@
 
 Written by axon handler thread (handle_swap_confirm), read by forward loop thread
 (_process_pending_confirms). Keyed by miner_hotkey since reservations are 1:1 per miner.
+
+This module owns the queue abstraction and its storage backends. The validator
+uses a local SQLite-backed store in production so pending confirmations survive
+validator process restarts.
 """
 
+import sqlite3
 import threading
 import time
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from pathlib import Path
+from typing import Callable, List, Optional, Protocol
 
 MAX_QUEUE_SIZE = 50
 
@@ -39,32 +45,203 @@ class PendingConfirmQueue:
     so re-submissions for the same miner overwrite the previous entry.
     """
 
-    def __init__(self):
-        self._lock = threading.Lock()
-        self._pending: Dict[str, PendingConfirm] = {}
+    def __init__(
+        self,
+        store: Optional['PendingConfirmStore'] = None,
+        current_block_fn: Optional[Callable[[], int]] = None,
+    ):
+        self._store = store or SqlitePendingConfirmStore()
+        self._current_block_fn = current_block_fn
 
     def enqueue(self, item: PendingConfirm) -> bool:
         """Add or replace a pending confirm. Returns False if queue is full (and not an overwrite)."""
-        with self._lock:
-            if item.miner_hotkey not in self._pending and len(self._pending) >= MAX_QUEUE_SIZE:
-                return False
-            self._pending[item.miner_hotkey] = item
-            return True
+        return self._store.upsert(item)
 
     def get_all(self) -> List[PendingConfirm]:
         """Return a snapshot of all pending items."""
-        with self._lock:
-            return list(self._pending.values())
+        self._purge_expired()
+        return self._store.list_all()
 
     def remove(self, miner_hotkey: str) -> Optional[PendingConfirm]:
         """Remove and return a specific entry."""
-        with self._lock:
-            return self._pending.pop(miner_hotkey, None)
+        return self._store.remove(miner_hotkey)
 
     def has(self, miner_hotkey: str) -> bool:
-        with self._lock:
-            return miner_hotkey in self._pending
+        self._purge_expired()
+        return self._store.has(miner_hotkey)
 
     def size(self) -> int:
+        self._purge_expired()
+        return self._store.size()
+
+    def _purge_expired(self) -> None:
+        if self._current_block_fn is None:
+            return
+        self._store.purge_expired(self._current_block_fn())
+
+
+class PendingConfirmStore(Protocol):
+    """Persistence interface for pending confirms."""
+
+    def upsert(self, item: PendingConfirm) -> bool:
+        """Add or replace a pending confirm. False means the queue is full."""
+
+    def list_all(self) -> List[PendingConfirm]:
+        """Return all pending confirms."""
+
+    def remove(self, miner_hotkey: str) -> Optional[PendingConfirm]:
+        """Remove and return a pending confirm."""
+
+    def has(self, miner_hotkey: str) -> bool:
+        """Return whether an entry exists for the miner."""
+
+    def size(self) -> int:
+        """Return the number of queued items."""
+
+    def purge_expired(self, current_block: int) -> None:
+        """Delete entries whose reservation has expired."""
+
+class SqlitePendingConfirmStore:
+    """Durable local SQLite store for pending confirms."""
+
+    def __init__(self, db_path: Path | str | None = None):
+        self._db_path = Path(db_path or Path.home() / '.allways' / 'validator' / 'pending_confirms.db')
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._init_db()
+
+    def _get_connection(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._db_path)
+        conn.execute('PRAGMA journal_mode=WAL')
+        conn.execute('PRAGMA busy_timeout=5000')
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init_db(self):
+        with self._get_connection() as conn:
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS pending_confirms (
+                    miner_hotkey TEXT PRIMARY KEY,
+                    source_tx_hash TEXT NOT NULL,
+                    source_chain TEXT NOT NULL,
+                    dest_chain TEXT NOT NULL,
+                    source_address TEXT NOT NULL,
+                    dest_address TEXT NOT NULL,
+                    tao_amount INTEGER NOT NULL,
+                    source_amount INTEGER NOT NULL,
+                    dest_amount INTEGER NOT NULL,
+                    miner_deposit_address TEXT NOT NULL,
+                    miner_dest_address TEXT NOT NULL,
+                    rate_str TEXT NOT NULL,
+                    reserved_until INTEGER NOT NULL,
+                    queued_at REAL NOT NULL
+                )
+            """)
+            conn.commit()
+
+    @staticmethod
+    def _row_to_item(row: sqlite3.Row) -> PendingConfirm:
+        return PendingConfirm(
+            miner_hotkey=row['miner_hotkey'],
+            source_tx_hash=row['source_tx_hash'],
+            source_chain=row['source_chain'],
+            dest_chain=row['dest_chain'],
+            source_address=row['source_address'],
+            dest_address=row['dest_address'],
+            tao_amount=row['tao_amount'],
+            source_amount=row['source_amount'],
+            dest_amount=row['dest_amount'],
+            miner_deposit_address=row['miner_deposit_address'],
+            miner_dest_address=row['miner_dest_address'],
+            rate_str=row['rate_str'],
+            reserved_until=row['reserved_until'],
+            queued_at=row['queued_at'],
+        )
+
+    def upsert(self, item: PendingConfirm) -> bool:
         with self._lock:
-            return len(self._pending)
+            with self._get_connection() as conn:
+                exists = conn.execute(
+                    'SELECT 1 FROM pending_confirms WHERE miner_hotkey = ?',
+                    (item.miner_hotkey,),
+                ).fetchone()
+                if exists is None:
+                    count = conn.execute('SELECT COUNT(*) FROM pending_confirms').fetchone()[0]
+                    if count >= MAX_QUEUE_SIZE:
+                        return False
+
+                fields = (
+                    'miner_hotkey',
+                    'source_tx_hash',
+                    'source_chain',
+                    'dest_chain',
+                    'source_address',
+                    'dest_address',
+                    'tao_amount',
+                    'source_amount',
+                    'dest_amount',
+                    'miner_deposit_address',
+                    'miner_dest_address',
+                    'rate_str',
+                    'reserved_until',
+                    'queued_at',
+                )
+                columns = ', '.join(fields)
+                placeholders = ', '.join('?' for _ in fields)
+                updates = ', '.join(
+                    f'{field} = excluded.{field}'
+                    for field in fields
+                    if field != 'miner_hotkey'
+                )
+                values = tuple(getattr(item, field) for field in fields)
+
+                conn.execute(
+                    f"""
+                    INSERT INTO pending_confirms ({columns})
+                    VALUES ({placeholders})
+                    ON CONFLICT (miner_hotkey)
+                    DO UPDATE SET {updates}
+                    """,
+                    values,
+                )
+                conn.commit()
+                return True
+
+    def list_all(self) -> List[PendingConfirm]:
+        with self._get_connection() as conn:
+            rows = conn.execute('SELECT * FROM pending_confirms ORDER BY queued_at').fetchall()
+        return [self._row_to_item(row) for row in rows]
+
+    def remove(self, miner_hotkey: str) -> Optional[PendingConfirm]:
+        with self._lock:
+            with self._get_connection() as conn:
+                row = conn.execute(
+                    'SELECT * FROM pending_confirms WHERE miner_hotkey = ?',
+                    (miner_hotkey,),
+                ).fetchone()
+                if row is None:
+                    return None
+                conn.execute('DELETE FROM pending_confirms WHERE miner_hotkey = ?', (miner_hotkey,))
+                conn.commit()
+        return self._row_to_item(row)
+
+    def has(self, miner_hotkey: str) -> bool:
+        with self._get_connection() as conn:
+            row = conn.execute(
+                'SELECT 1 FROM pending_confirms WHERE miner_hotkey = ?',
+                (miner_hotkey,),
+            ).fetchone()
+        return row is not None
+
+    def size(self) -> int:
+        with self._get_connection() as conn:
+            return int(conn.execute('SELECT COUNT(*) FROM pending_confirms').fetchone()[0])
+
+    def purge_expired(self, current_block: int) -> None:
+        with self._lock:
+            with self._get_connection() as conn:
+                conn.execute(
+                    'DELETE FROM pending_confirms WHERE reserved_until < ?',
+                    (current_block,),
+                )
+                conn.commit()

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -82,7 +82,8 @@ class Validator(BaseValidatorNeuron):
         )
 
         # Pending confirmation queue (axon handler thread → forward loop thread)
-        self.pending_confirms = PendingConfirmQueue()
+        # Exposes current block so the queue can purge expired reservations on read.
+        self.pending_confirms = PendingConfirmQueue(current_block_fn=lambda: self.block)
 
         # Separate subtensor/contract/providers for axon handlers (thread safety).
         # axon_lock serialises substrate websocket calls across handler threads

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -119,6 +119,12 @@ class Validator(BaseValidatorNeuron):
         """Validator forward pass - delegates to allways.validator.forward."""
         return await forward(self)
 
+    def __exit__(self, exc_type, exc_value, traceback):
+        try:
+            super().__exit__(exc_type, exc_value, traceback)
+        finally:
+            self.pending_confirms.close()
+
 
 # Main entry point
 if __name__ == '__main__':

--- a/tests/test_pending_confirm_queue.py
+++ b/tests/test_pending_confirm_queue.py
@@ -1,14 +1,12 @@
-from dataclasses import replace
-from pathlib import Path
 import threading
 import time
+from dataclasses import replace
+from pathlib import Path
 
 from allways.validator.pending_confirms import (
     PendingConfirm,
     PendingConfirmQueue,
-    SqlitePendingConfirmStore,
 )
-
 
 PENDING_CONFIRM_SAMPLE1 = PendingConfirm(
     miner_hotkey='miner-1',
@@ -49,11 +47,12 @@ PENDING_CONFIRM_SAMPLE2 = PendingConfirm(
 class TestPendingConfirmQueue:
     def test_persists_across_queue_instances(self, tmp_path: Path):
         db_path = tmp_path / 'pending_confirms.db'
-        queue1 = PendingConfirmQueue(store=SqlitePendingConfirmStore(db_path))
-        assert queue1.enqueue(PENDING_CONFIRM_SAMPLE1)
-        assert queue1.enqueue(PENDING_CONFIRM_SAMPLE2)
+        queue1 = PendingConfirmQueue(db_path=db_path)
+        queue1.enqueue(PENDING_CONFIRM_SAMPLE1)
+        queue1.enqueue(PENDING_CONFIRM_SAMPLE2)
+        queue1.close()
 
-        queue2 = PendingConfirmQueue(store=SqlitePendingConfirmStore(db_path))
+        queue2 = PendingConfirmQueue(db_path=db_path)
         items = queue2.get_all()
 
         assert queue2.size() == 2
@@ -65,10 +64,10 @@ class TestPendingConfirmQueue:
 
     def test_overwrite_keeps_single_row(self, tmp_path: Path):
         db_path = tmp_path / 'pending_confirms.db'
-        queue = PendingConfirmQueue(store=SqlitePendingConfirmStore(db_path))
+        queue = PendingConfirmQueue(db_path=db_path)
 
-        assert queue.enqueue(PENDING_CONFIRM_SAMPLE1)
-        assert queue.enqueue(replace(PENDING_CONFIRM_SAMPLE1, source_tx_hash='tx-new'))
+        queue.enqueue(PENDING_CONFIRM_SAMPLE1)
+        queue.enqueue(replace(PENDING_CONFIRM_SAMPLE1, source_tx_hash='tx-new'))
 
         items = queue.get_all()
         assert queue.size() == 1
@@ -77,11 +76,11 @@ class TestPendingConfirmQueue:
 
     def test_has_reflects_enqueue_and_remove(self, tmp_path: Path):
         db_path = tmp_path / 'pending_confirms.db'
-        queue = PendingConfirmQueue(store=SqlitePendingConfirmStore(db_path))
+        queue = PendingConfirmQueue(db_path=db_path)
 
         assert not queue.has('miner-1')
 
-        assert queue.enqueue(PENDING_CONFIRM_SAMPLE1)
+        queue.enqueue(PENDING_CONFIRM_SAMPLE1)
         assert queue.has('miner-1')
 
         removed = queue.remove('miner-1')
@@ -92,12 +91,12 @@ class TestPendingConfirmQueue:
     def test_reads_purge_expired_entries(self, tmp_path: Path):
         db_path = tmp_path / 'pending_confirms.db'
         queue = PendingConfirmQueue(
-            store=SqlitePendingConfirmStore(db_path),
+            db_path=db_path,
             current_block_fn=lambda: 101,
         )
 
-        assert queue.enqueue(PENDING_CONFIRM_SAMPLE1)
-        assert queue.enqueue(replace(PENDING_CONFIRM_SAMPLE2, reserved_until=105))
+        queue.enqueue(PENDING_CONFIRM_SAMPLE1)
+        queue.enqueue(replace(PENDING_CONFIRM_SAMPLE2, reserved_until=105))
 
         items = queue.get_all()
 
@@ -108,13 +107,13 @@ class TestPendingConfirmQueue:
 
     def test_enqueue_and_remove_are_safe_across_threads(self, tmp_path: Path):
         db_path = tmp_path / 'pending_confirms.db'
-        queue = PendingConfirmQueue(store=SqlitePendingConfirmStore(db_path))
+        queue = PendingConfirmQueue(db_path=db_path)
         removed_hotkeys: list[str] = []
 
         def writer():
-            assert queue.enqueue(PENDING_CONFIRM_SAMPLE1)
+            queue.enqueue(PENDING_CONFIRM_SAMPLE1)
             time.sleep(0.01)
-            assert queue.enqueue(PENDING_CONFIRM_SAMPLE2)
+            queue.enqueue(PENDING_CONFIRM_SAMPLE2)
 
         def remover():
             deadline = time.monotonic() + 2.0
@@ -133,6 +132,6 @@ class TestPendingConfirmQueue:
         writer_thread.join()
         remover_thread.join()
 
-        assert removed_hotkeys == ['miner-1', 'miner-2']
+        assert set(removed_hotkeys) == {'miner-1', 'miner-2'}
         assert queue.size() == 0
         assert queue.get_all() == []

--- a/tests/test_pending_confirm_queue.py
+++ b/tests/test_pending_confirm_queue.py
@@ -1,0 +1,138 @@
+from dataclasses import replace
+from pathlib import Path
+import threading
+import time
+
+from allways.validator.pending_confirms import (
+    PendingConfirm,
+    PendingConfirmQueue,
+    SqlitePendingConfirmStore,
+)
+
+
+PENDING_CONFIRM_SAMPLE1 = PendingConfirm(
+    miner_hotkey='miner-1',
+    source_tx_hash='tx-1',
+    source_chain='btc',
+    dest_chain='tao',
+    source_address='bc1-user',
+    dest_address='5user',
+    tao_amount=123,
+    source_amount=456,
+    dest_amount=789,
+    miner_deposit_address='bc1-miner',
+    miner_dest_address='5miner',
+    rate_str='350',
+    reserved_until=100,
+    queued_at=1.0,
+)
+
+
+PENDING_CONFIRM_SAMPLE2 = PendingConfirm(
+    miner_hotkey='miner-2',
+    source_tx_hash='tx-2',
+    source_chain='btc',
+    dest_chain='tao',
+    source_address='bc1-user',
+    dest_address='5user',
+    tao_amount=123,
+    source_amount=456,
+    dest_amount=789,
+    miner_deposit_address='bc1-miner',
+    miner_dest_address='5miner',
+    rate_str='350',
+    reserved_until=100,
+    queued_at=2.0,
+)
+
+
+class TestPendingConfirmQueue:
+    def test_persists_across_queue_instances(self, tmp_path: Path):
+        db_path = tmp_path / 'pending_confirms.db'
+        queue1 = PendingConfirmQueue(store=SqlitePendingConfirmStore(db_path))
+        assert queue1.enqueue(PENDING_CONFIRM_SAMPLE1)
+        assert queue1.enqueue(PENDING_CONFIRM_SAMPLE2)
+
+        queue2 = PendingConfirmQueue(store=SqlitePendingConfirmStore(db_path))
+        items = queue2.get_all()
+
+        assert queue2.size() == 2
+        assert len(items) == 2
+        assert items[0].miner_hotkey == 'miner-1'
+        assert items[0].source_tx_hash == 'tx-1'
+        assert items[1].miner_hotkey == 'miner-2'
+        assert items[1].source_tx_hash == 'tx-2'
+
+    def test_overwrite_keeps_single_row(self, tmp_path: Path):
+        db_path = tmp_path / 'pending_confirms.db'
+        queue = PendingConfirmQueue(store=SqlitePendingConfirmStore(db_path))
+
+        assert queue.enqueue(PENDING_CONFIRM_SAMPLE1)
+        assert queue.enqueue(replace(PENDING_CONFIRM_SAMPLE1, source_tx_hash='tx-new'))
+
+        items = queue.get_all()
+        assert queue.size() == 1
+        assert len(items) == 1
+        assert items[0].source_tx_hash == 'tx-new'
+
+    def test_has_reflects_enqueue_and_remove(self, tmp_path: Path):
+        db_path = tmp_path / 'pending_confirms.db'
+        queue = PendingConfirmQueue(store=SqlitePendingConfirmStore(db_path))
+
+        assert not queue.has('miner-1')
+
+        assert queue.enqueue(PENDING_CONFIRM_SAMPLE1)
+        assert queue.has('miner-1')
+
+        removed = queue.remove('miner-1')
+        assert removed is not None
+        assert removed.miner_hotkey == 'miner-1'
+        assert not queue.has('miner-1')
+
+    def test_reads_purge_expired_entries(self, tmp_path: Path):
+        db_path = tmp_path / 'pending_confirms.db'
+        queue = PendingConfirmQueue(
+            store=SqlitePendingConfirmStore(db_path),
+            current_block_fn=lambda: 101,
+        )
+
+        assert queue.enqueue(PENDING_CONFIRM_SAMPLE1)
+        assert queue.enqueue(replace(PENDING_CONFIRM_SAMPLE2, reserved_until=105))
+
+        items = queue.get_all()
+
+        assert [item.miner_hotkey for item in items] == ['miner-2']
+        assert not queue.has('miner-1')
+        assert queue.has('miner-2')
+        assert queue.size() == 1
+
+    def test_enqueue_and_remove_are_safe_across_threads(self, tmp_path: Path):
+        db_path = tmp_path / 'pending_confirms.db'
+        queue = PendingConfirmQueue(store=SqlitePendingConfirmStore(db_path))
+        removed_hotkeys: list[str] = []
+
+        def writer():
+            assert queue.enqueue(PENDING_CONFIRM_SAMPLE1)
+            time.sleep(0.01)
+            assert queue.enqueue(PENDING_CONFIRM_SAMPLE2)
+
+        def remover():
+            deadline = time.monotonic() + 2.0
+            while len(removed_hotkeys) < 2 and time.monotonic() < deadline:
+                for item in queue.get_all():
+                    removed = queue.remove(item.miner_hotkey)
+                    if removed is not None:
+                        removed_hotkeys.append(removed.miner_hotkey)
+                time.sleep(0.001)
+
+        writer_thread = threading.Thread(target=writer)
+        remover_thread = threading.Thread(target=remover)
+
+        writer_thread.start()
+        remover_thread.start()
+        writer_thread.join()
+        remover_thread.join()
+
+        assert removed_hotkeys == ['miner-1', 'miner-2']
+        assert queue.size() == 0
+        assert queue.get_all() == []


### PR DESCRIPTION
## Summary

Persist `PendingConfirmQueue` to local SQLite so queued confirms survive validator restarts.

## Problem

`PendingConfirmQueue` is currently in-memory only. That works while a validator process stays alive, but queued confirms are lost on restart.

This matters when a source transaction has been accepted but is still waiting for confirmations. If several validators restart during that window, each restarted validator drops its local pending confirms and stops contributing toward the later `vote_initiate()` step for those items.

The most realistic case is a coordinated restart, such as a deploy or auto-update affecting multiple validators at once. In that case, pending confirms can be wiped across enough validators that progress toward initiation stalls until the user retries or validators re-accept the transaction.

## What Changed

- Folded SQLite persistence directly into `PendingConfirmQueue`.
- One persistent SQL connection created in queue init and reused under a single lock.
- Locked every public queue method so read and write paths follow the same thread-safety model.
- Removed `MAX_QUEUE_SIZE` and the queue-full rejection path since the queue is already naturally keyed by `miner_hotkey`.
- Updated validator teardown to close the queue connection when the queue is torn down.
- Updated queue tests to pass `db_path` directly and made the thread-safety assertion order-independent.

## Tests

Added targeted coverage for:

- persistence across queue instances
- overwrite behavior for the same miner
- enqueue/remove lifecycle
- purge-on-read for expired entries
- basic thread safety for enqueue/remove

Verification:

```bash
pytest -q tests/test_pending_confirm_queue.py
```