### PR TITLE
Improve CLI help to a production-grade renderer

### DIFF
--- a/allways/cli/help.py
+++ b/allways/cli/help.py
@@ -1,0 +1,260 @@
+"""Shared Click classes for Rich-rendered CLI help."""
+
+from __future__ import annotations
+
+from inspect import cleandoc
+
+import click
+from rich import box
+from rich.console import Console
+from rich.markup import escape
+from rich.padding import Padding
+from rich.panel import Panel
+from rich.table import Table
+
+DISCLAIMER = (
+    'Allways is permissionless, open-source, beta software. The protocol facilitates trustless'
+    ' peer-to-peer transactions -- the creators and contributors do not custody, control, or'
+    ' intermediate any funds. Use at your own risk. No warranty. Not financial advice.'
+)
+
+
+def _single_paragraph(text: str) -> str:
+    """Collapse multiline help text into a single paragraph."""
+    return ' '.join(text.split())
+
+
+def _has_rich_markup(text: str) -> bool:
+    """Return whether the help text includes explicit Rich markup tags."""
+    return '[' in text and ']' in text
+
+
+def _collect_help_rows(params: list[click.Parameter], ctx: click.Context) -> list[tuple[str, str]]:
+    """Collect Click help records for parameters."""
+    rows: list[tuple[str, str]] = []
+    for param in params:
+        record = param.get_help_record(ctx)
+        if record is None:
+            continue
+        rows.append((record[0], record[1] or ''))
+    return rows
+
+
+def _render_usage(console: Console, usage: str) -> None:
+    """Render the usage line with styling."""
+    usage = usage.strip()
+    if usage.startswith('Usage:'):
+        usage_template = usage[len('Usage:') :].strip()
+        console.print(
+            Padding(
+                f'[bold yellow]Usage:[/bold yellow] [bold white]{escape(usage_template)}[/bold white]',
+                (0, 0, 0, 1),
+            )
+        )
+        console.print()
+        return
+
+    console.print(Padding(f'[bold white]{escape(usage)}[/bold white]', (0, 0, 0, 1)))
+    console.print()
+
+
+def _section_panel(
+    title: str,
+    rows: list[tuple[str, str]],
+    left_style: str = 'bold cyan',
+    right_style: str = 'bright_white',
+) -> Panel:
+    """Render a titled help section."""
+    table = Table.grid(expand=True)
+    table.add_column(style=left_style, no_wrap=True, ratio=1, justify='left')
+    table.add_column(style=right_style, ratio=4, justify='left')
+
+    if rows:
+        for left, right in rows:
+            table.add_row(left, right)
+    else:
+        table.add_row('-', 'No entries')
+
+    return Panel(
+        table,
+        title=f' {title} ',
+        title_align='left',
+        border_style='grey66',
+        box=box.ROUNDED,
+        padding=(0, 1),
+    )
+
+
+def _parse_option_decl(option_decl: str) -> tuple[str, str, str]:
+    """Split Click option declaration into long names, short alias, and type."""
+    names_part = option_decl.strip()
+    option_type = ''
+
+    if ' ' in names_part:
+        maybe_names, maybe_type = names_part.rsplit(' ', 1)
+        if maybe_type.isupper() or (maybe_type.startswith('[') and maybe_type.endswith(']')):
+            names_part = maybe_names
+            option_type = maybe_type
+
+    tokens = [token.strip() for token in names_part.split(',') if token.strip()]
+    short_tokens = [token for token in tokens if token.startswith('-') and not token.startswith('--')]
+    long_tokens = [token for token in tokens if token.startswith('--')]
+
+    long_names = ','.join(long_tokens) if long_tokens else ','.join(tokens)
+    short_alias = ','.join(short_tokens)
+    return long_names, short_alias, option_type
+
+
+def _options_panel(rows: list[tuple[str, str]]) -> Panel:
+    """Render options with separate long, short, and type columns."""
+    table = Table.grid(expand=True)
+    table.add_column(style='bold cyan', no_wrap=True, ratio=4, justify='left')
+    table.add_column(style='bold green', no_wrap=True, ratio=1, justify='left')
+    table.add_column(style='bold yellow', no_wrap=True, ratio=1, justify='left')
+    table.add_column(style='bright_white', ratio=7, justify='left')
+
+    if rows:
+        for decl, description in rows:
+            long_names, short_alias, option_type = _parse_option_decl(decl)
+            table.add_row(long_names, short_alias, option_type, description or '')
+    else:
+        table.add_row('-', '-', '-', 'No entries')
+
+    return Panel(
+        table,
+        title=' Options ',
+        title_align='left',
+        border_style='grey66',
+        box=box.ROUNDED,
+        padding=(0, 1),
+    )
+
+
+def _render_footer(console: Console, command: click.Command) -> None:
+    """Render shared disclaimer and footer if present."""
+    show_disclaimer = getattr(command, 'show_disclaimer', False)
+    footer = getattr(command, 'help_footer', None)
+
+    if show_disclaimer:
+        console.print(f'\n[dim]{DISCLAIMER}[/dim]')
+
+    if footer:
+        console.print(f'\n{footer}')
+
+
+class StyledCommand(click.Command):
+    """Click command with styled Rich help output."""
+
+    help_footer = '[red]\u2764[/red] Ventura Labs'
+
+    def __init__(self, *args, show_disclaimer: bool = False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.show_disclaimer = show_disclaimer
+
+    def _help_options_rows(self, ctx: click.Context) -> list[tuple[str, str]]:
+        return _collect_help_rows(self.get_params(ctx), ctx)
+
+    def get_help(self, ctx: click.Context) -> str:
+        console = Console(width=ctx.terminal_width or 120)
+
+        with console.capture() as capture:
+            _render_usage(console, self.get_usage(ctx))
+
+            help_text = cleandoc(self.help or '').replace('\x08', '')
+            if help_text:
+                console.print(Padding(help_text, (0, 0, 0, 1)))
+                console.print()
+
+            console.print(_options_panel(self._help_options_rows(ctx)))
+            _render_footer(console, self)
+
+        return capture.get()
+
+
+class StyledGroup(click.Group):
+    """Click group with Rich help rendering."""
+
+    command_class = StyledCommand
+    help_footer = StyledCommand.help_footer
+
+    def __init__(self, *args, show_disclaimer: bool = False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.show_disclaimer = show_disclaimer
+
+    def _alias_map(self) -> dict[str, list[str]]:
+        """Return canonical-command -> aliases mapping."""
+        return {}
+
+    def _help_options_rows(self, ctx: click.Context) -> list[tuple[str, str]]:
+        return _collect_help_rows(self.get_params(ctx), ctx)
+
+    def _help_commands_rows(self, ctx: click.Context) -> list[tuple[str, str]]:
+        rows: list[tuple[str, str]] = []
+        alias_map = self._alias_map()
+
+        for name in self.list_commands(ctx):
+            cmd = self.get_command(ctx, name)
+            if cmd is None or cmd.hidden:
+                continue
+
+            desc = cmd.get_short_help_str(limit=150)
+            aliases = alias_map.get(name, [])
+            if aliases:
+                quoted = ', '.join(f'`{alias}`' for alias in sorted(aliases))
+                alias_label = 'alias' if len(aliases) == 1 else 'aliases'
+                alias_text = f'{alias_label}: {quoted}'
+                if desc:
+                    desc = f'{desc.rstrip(".")}, {alias_text}'
+                else:
+                    desc = alias_text
+
+            rows.append((name, desc))
+        return rows
+
+    def get_help(self, ctx: click.Context) -> str:
+        console = Console(width=ctx.terminal_width or 120)
+
+        with console.capture() as capture:
+            _render_usage(console, self.get_usage(ctx))
+
+            help_text = cleandoc(self.help or '').replace('\x08', '')
+            if help_text:
+                if _has_rich_markup(help_text):
+                    console.print(Padding(help_text, (0, 0, 0, 1)))
+                else:
+                    console.print(
+                        Padding(
+                            f'[bright_white]{escape(_single_paragraph(help_text))}[/bright_white]',
+                            (0, 0, 0, 1),
+                        )
+                    )
+                console.print()
+
+            console.print(_options_panel(self._help_options_rows(ctx)))
+            console.print()
+            console.print(_section_panel('Commands', self._help_commands_rows(ctx)))
+            _render_footer(console, self)
+
+        return capture.get()
+
+
+class StyledAliasGroup(StyledGroup):
+    """Styled group with command alias support."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._aliases: dict[str, str] = {}
+
+    def add_alias(self, name: str, alias: str) -> None:
+        """Register an alias for an existing command."""
+        self._aliases[alias] = name
+
+    def get_command(self, ctx: click.Context, cmd_name: str):
+        canonical = self._aliases.get(cmd_name, cmd_name)
+        return super().get_command(ctx, canonical)
+
+    def _alias_map(self) -> dict[str, list[str]]:
+        reverse: dict[str, list[str]] = {}
+        for alias, canonical in self._aliases.items():
+            reverse.setdefault(canonical, []).append(alias)
+        return reverse

--- a/allways/cli/main.py
+++ b/allways/cli/main.py
@@ -19,18 +19,13 @@ _sys.argv = [_sys.argv[0]]
 
 import json  # noqa: E402
 
-import rich_click as click  # noqa: E402
+import click  # noqa: E402
 from dotenv import load_dotenv  # noqa: E402
 from rich.table import Table  # noqa: E402
 
-click.rich_click.USE_RICH_MARKUP = True
-click.rich_click.SHOW_ARGUMENTS = True
-click.rich_click.GROUP_ARGUMENTS_OPTIONS = True
-click.rich_click.STYLE_EPILOG = 'dim'
-click.rich_click.FOOTER_TEXT = '\u2764 Ventura Labs'
-
 load_dotenv()
 
+from allways.cli.help import StyledAliasGroup, StyledGroup  # noqa: E402
 from allways.cli.swap_commands.helpers import ALLWAYS_DIR, CONFIG_FILE, console, parse_global_flags  # noqa: E402
 
 # Restore original argv now that bittensor has been imported
@@ -41,30 +36,19 @@ _sys.argv = _saved_argv
 parse_global_flags()
 
 
-DISCLAIMER = (
-    'Allways is permissionless, open-source, beta software. The protocol facilitates trustless'
-    ' peer-to-peer transactions — the creators and contributors do not custody, control, or'
-    ' intermediate any funds. Use at your own risk. No warranty. Not financial advice.'
-)
-
-
-@click.group(epilog=DISCLAIMER)
+@click.group(cls=StyledAliasGroup, show_disclaimer=True)
 @click.version_option(version=__import__('allways').__version__, prog_name='allways')
 def cli():
     """Universal Transaction Layer"""
     pass
 
 
-@click.group(name='config', invoke_without_command=True)
+@click.group(name='config', invoke_without_command=True, cls=StyledGroup)
 @click.pass_context
 def config_group(ctx):
     """CLI configuration management.
 
-    Show current configuration (default) or set config values.
-
-    \b
-    Subcommands:
-        set <key> <value>    Set a config value
+    [dim]Show current configuration (default) or set config values.[/dim]
     """
     if ctx.invoked_subcommand is None:
         show_config()
@@ -114,27 +98,24 @@ KNOWN_NETWORKS = {
 def config_set(key: str, value: str):
     """Set a configuration value.
 
-    \b
-    Common keys:
+    [dim]Common keys:
         wallet              Wallet name
         hotkey              Hotkey name
         contract-address    Contract address
         network             Network name or endpoint URL
-        netuid              Subnet UID
+        netuid              Subnet UID[/dim]
 
-    \b
-    Networks:
+    [dim]Networks:
         finney              Production  (wss://entrypoint-finney.opentensor.ai:443)
         test                Test        (wss://test.finney.opentensor.ai:443)
         local               Local dev   (ws://127.0.0.1:9944)
-        ws://...            Custom endpoint
+        ws://...            Custom endpoint[/dim]
 
-    \b
-    Examples:
-        alw config set wallet alice
-        alw config set contract-address 5Cxxx...
-        alw config set network finney
-        alw config set network local
+    [dim]Examples:
+        $ alw config set wallet alice
+        $ alw config set contract-address 5Cxxx...
+        $ alw config set network finney
+        $ alw config set network local[/dim]
     """
     ALLWAYS_DIR.mkdir(parents=True, exist_ok=True)
 

--- a/allways/cli/swap_commands/admin.py
+++ b/allways/cli/swap_commands/admin.py
@@ -1,43 +1,25 @@
 """alw admin - Contract administration commands (owner-only)."""
 
-import rich_click as click
+import click
 
+from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import SECONDS_PER_BLOCK, console, from_rao, get_cli_context, loading, to_rao
 from allways.contract_client import ContractError
 
 
-@click.group('admin')
+@click.group('admin', cls=StyledGroup, show_disclaimer=True)
 def admin_group():
-    """Contract administration commands (owner-only).
-
-    \b
-    Subcommands:
-        set-timeout <blocks>            Set fulfillment timeout
-        set-reservation-ttl <blocks>    Set reservation TTL
-        set-fee-divisor <divisor>       Set fee divisor (100 = 1%, 50 = 2%)
-        set-min-collateral <amount_tao> Set minimum collateral
-        set-max-collateral <amount_tao> Set maximum collateral (0 = unlimited)
-        set-min-swap <amount_tao>       Set minimum swap amount (0 = no minimum)
-        set-max-swap <amount_tao>       Set maximum swap amount (0 = no maximum)
-        set-votes <count>               Set required validator votes
-        set-recycle-address <account_id> Set address for fee recycling transfers
-        add-vali <hotkey>               Add a validator
-        remove-vali <hotkey>            Remove a validator
-        recycle-fees                    Recycle accumulated fees (stake + burn alpha)
-        transfer-ownership <account_id> Transfer contract ownership
-        danger halt                     Halt the system (block new reservations)
-        danger resume                   Resume the system (allow new reservations)
-    """
+    """Contract administration commands (owner-only)."""
     pass
 
 
-@admin_group.command('set-timeout')
+@admin_group.command('set-timeout', show_disclaimer=True)
 @click.argument('blocks', type=int)
 def set_timeout(blocks: int):
     """Set the fulfillment timeout in blocks (minimum 10).
 
-    Example:
-        alw admin set-timeout 300
+    [dim]Examples:
+        $ alw admin set-timeout 300[/dim]
     """
     if blocks < 10:
         console.print('[red]Blocks must be >= 10 (contract minimum)[/red]')
@@ -70,13 +52,13 @@ def set_timeout(blocks: int):
         console.print(f'[red]Failed to set fulfillment timeout: {e}[/red]\n')
 
 
-@admin_group.command('set-reservation-ttl')
+@admin_group.command('set-reservation-ttl', show_disclaimer=True)
 @click.argument('blocks', type=int)
 def set_reservation_ttl(blocks: int):
     """Set the reservation TTL in blocks (how long a user has to send funds).
 
-    Example:
-        alw admin set-reservation-ttl 50
+    [dim]Examples:
+        $ alw admin set-reservation-ttl 50[/dim]
     """
     if blocks <= 0:
         console.print('[red]Blocks must be positive[/red]')
@@ -109,13 +91,13 @@ def set_reservation_ttl(blocks: int):
         console.print(f'[red]Failed to set reservation TTL: {e}[/red]\n')
 
 
-@admin_group.command('set-fee-divisor')
+@admin_group.command('set-fee-divisor', show_disclaimer=True)
 @click.argument('divisor', type=int)
 def set_fee_divisor(divisor: int):
     """Set the fee divisor (100 = 1% fee, 50 = 2% fee, 20 = 5% fee max).
 
-    Example:
-        alw admin set-fee-divisor 100
+    [dim]Examples:
+        $ alw admin set-fee-divisor 100[/dim]
     """
     if divisor < 20:
         console.print('[red]Divisor must be at least 20 (max 5% fee)[/red]')
@@ -148,13 +130,13 @@ def set_fee_divisor(divisor: int):
         console.print(f'[red]Failed to set fee divisor: {e}[/red]\n')
 
 
-@admin_group.command('set-min-collateral')
+@admin_group.command('set-min-collateral', show_disclaimer=True)
 @click.argument('amount_tao', type=float)
 def set_min_collateral(amount_tao: float):
     """Set the minimum collateral amount (in TAO).
 
-    Example:
-        alw admin set-min-collateral 2.0
+    [dim]Examples:
+        $ alw admin set-min-collateral 2.0[/dim]
     """
     if amount_tao <= 0:
         console.print('[red]Amount must be positive[/red]')
@@ -186,14 +168,14 @@ def set_min_collateral(amount_tao: float):
         console.print(f'[red]Failed to set minimum collateral: {e}[/red]\n')
 
 
-@admin_group.command('set-max-collateral')
+@admin_group.command('set-max-collateral', show_disclaimer=True)
 @click.argument('amount_tao', type=float)
 def set_max_collateral(amount_tao: float):
     """Set the maximum collateral amount (in TAO). Use 0 to remove the cap.
 
-    Example:
-        alw admin set-max-collateral 100.0
-        alw admin set-max-collateral 0
+    [dim]Examples:
+        $ alw admin set-max-collateral 100.0
+        $ alw admin set-max-collateral 0[/dim]
     """
     if amount_tao < 0:
         console.print('[red]Amount must be non-negative[/red]')
@@ -225,14 +207,14 @@ def set_max_collateral(amount_tao: float):
         console.print(f'[red]Failed to set maximum collateral: {e}[/red]\n')
 
 
-@admin_group.command('set-min-swap')
+@admin_group.command('set-min-swap', show_disclaimer=True)
 @click.argument('amount_tao', type=float)
 def set_min_swap(amount_tao: float):
     """Set the minimum swap amount in TAO. Use 0 to remove the minimum.
 
-    Example:
-        alw admin set-min-swap 1.0
-        alw admin set-min-swap 0
+    [dim]Examples:
+        $ alw admin set-min-swap 1.0
+        $ alw admin set-min-swap 0[/dim]
     """
     if amount_tao < 0:
         console.print('[red]Amount must be non-negative[/red]')
@@ -264,14 +246,14 @@ def set_min_swap(amount_tao: float):
         console.print(f'[red]Failed to set minimum swap amount: {e}[/red]\n')
 
 
-@admin_group.command('set-max-swap')
+@admin_group.command('set-max-swap', show_disclaimer=True)
 @click.argument('amount_tao', type=float)
 def set_max_swap(amount_tao: float):
     """Set the maximum swap amount in TAO. Use 0 to remove the maximum.
 
-    Example:
-        alw admin set-max-swap 50.0
-        alw admin set-max-swap 0
+    [dim]Examples:
+        $ alw admin set-max-swap 50.0
+        $ alw admin set-max-swap 0[/dim]
     """
     if amount_tao < 0:
         console.print('[red]Amount must be non-negative[/red]')
@@ -303,13 +285,13 @@ def set_max_swap(amount_tao: float):
         console.print(f'[red]Failed to set maximum swap amount: {e}[/red]\n')
 
 
-@admin_group.command('set-threshold')
+@admin_group.command('set-threshold', show_disclaimer=True)
 @click.argument('percent', type=int)
 def set_threshold(percent: int):
     """Set the consensus threshold percentage (1-100).
 
-    Example:
-        alw admin set-threshold 67
+    [dim]Examples:
+        $ alw admin set-threshold 67[/dim]
     """
     if percent <= 0 or percent > 100:
         console.print('[red]Threshold must be 1-100[/red]')
@@ -339,13 +321,13 @@ def set_threshold(percent: int):
         console.print(f'[red]Failed to set consensus threshold: {e}[/red]\n')
 
 
-@admin_group.command('add-vali')
+@admin_group.command('add-vali', show_disclaimer=True)
 @click.argument('hotkey', type=str)
 def add_vali(hotkey: str):
     """Add a validator to the contract.
 
-    Example:
-        alw admin add-vali 5Cxyz...
+    [dim]Examples:
+        $ alw admin add-vali 5Cxyz...[/dim]
     """
     _, wallet, _, client = get_cli_context()
 
@@ -375,13 +357,13 @@ def add_vali(hotkey: str):
         console.print(f'[red]Failed to add validator: {e}[/red]\n')
 
 
-@admin_group.command('remove-vali')
+@admin_group.command('remove-vali', show_disclaimer=True)
 @click.argument('hotkey', type=str)
 def remove_vali(hotkey: str):
     """Remove a validator from the contract.
 
-    Example:
-        alw admin remove-vali 5Cxyz...
+    [dim]Examples:
+        $ alw admin remove-vali 5Cxyz...[/dim]
     """
     _, wallet, _, client = get_cli_context()
 
@@ -411,13 +393,13 @@ def remove_vali(hotkey: str):
         console.print(f'[red]Failed to remove validator: {e}[/red]\n')
 
 
-@admin_group.command('set-recycle-address')
+@admin_group.command('set-recycle-address', show_disclaimer=True)
 @click.argument('account_id', type=str)
 def set_recycle_address(account_id: str):
     """Set the address where recycled fees are transferred.
 
-    Example:
-        alw admin set-recycle-address 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+    [dim]Examples:
+        $ alw admin set-recycle-address 5Cxyz...[/dim]
     """
     _, wallet, _, client = get_cli_context()
 
@@ -436,12 +418,12 @@ def set_recycle_address(account_id: str):
         console.print(f'[red]Failed to set recycle address: {e}[/red]\n')
 
 
-@admin_group.command('recycle-fees')
+@admin_group.command('recycle-fees', show_disclaimer=True)
 def recycle_fees():
     """Transfer accumulated fees to the designated recycle address.
 
-    Example:
-        alw admin recycle-fees
+    [dim]Examples:
+        $ alw admin recycle-fees[/dim]
     """
     _, wallet, _, client = get_cli_context()
 
@@ -460,13 +442,13 @@ def recycle_fees():
         console.print(f'[red]Failed to recycle fees: {e}[/red]\n')
 
 
-@admin_group.command('transfer-ownership')
+@admin_group.command('transfer-ownership', show_disclaimer=True)
 @click.argument('account_id', type=str)
 def transfer_ownership(account_id: str):
     """Transfer contract ownership to a new account. This is irreversible.
 
-    Example:
-        alw admin transfer-ownership 5Cxyz...
+    [dim]Examples:
+        $ alw admin transfer-ownership 5Cxyz...[/dim]
     """
     _, wallet, _, client = get_cli_context()
 
@@ -494,26 +476,20 @@ def transfer_ownership(account_id: str):
         console.print(f'[red]Failed to transfer ownership: {e}[/red]\n')
 
 
-@click.group('danger')
+@click.group('danger', cls=StyledGroup, show_disclaimer=True)
 def danger_group():
-    """Dangerous operations that affect system availability.
-
-    \b
-    Subcommands:
-        halt      Halt the system (block new reservations)
-        resume    Resume the system (allow new reservations)
-    """
+    """Dangerous operations that affect system availability."""
     pass
 
 
-@danger_group.command('halt')
+@danger_group.command('halt', show_disclaimer=True)
 def halt_system():
     """Halt the system — blocks all new swap reservations.
 
-    Existing in-flight swaps will continue through their lifecycle.
+    [dim]Existing in-flight swaps will continue through their lifecycle.[/dim]
 
-    Example:
-        alw admin danger halt
+    [dim]Examples:
+        $ alw admin danger halt[/dim]
     """
     _, wallet, _, client = get_cli_context()
 
@@ -543,12 +519,12 @@ def halt_system():
         console.print(f'[red]Failed to halt system: {e}[/red]\n')
 
 
-@danger_group.command('resume')
+@danger_group.command('resume', show_disclaimer=True)
 def resume_system():
     """Resume the system — allows new swap reservations again.
 
-    Example:
-        alw admin danger resume
+    [dim]Examples:
+        $ alw admin danger resume[/dim]
     """
     _, wallet, _, client = get_cli_context()
 

--- a/allways/cli/swap_commands/claim.py
+++ b/allways/cli/swap_commands/claim.py
@@ -1,23 +1,23 @@
 """alw claim - Claim a pending slash payout for a timed-out swap."""
 
-import rich_click as click
+import click
 
+from allways.cli.help import StyledCommand
 from allways.cli.swap_commands.helpers import console, from_rao, get_cli_context, loading
 from allways.contract_client import ContractError
 
 
-@click.command('claim')
+@click.command('claim', cls=StyledCommand, show_disclaimer=True)
 @click.argument('swap_id', type=int)
 @click.option('--yes', '-y', is_flag=True, help='Skip confirmation prompt')
 def claim_command(swap_id: int, yes: bool):
     """Claim a pending slash payout for a timed-out swap.
 
-    \b
-    If a miner failed to fulfill your swap before the timeout,
-    you can claim a slash payout from their collateral.
+    [dim]If a miner failed to fulfill your swap before the timeout,
+    you can claim a slash payout from their collateral.[/dim]
 
-    Example:
-        alw claim 42
+    [dim]Examples:
+        $ alw claim 42[/dim]
     """
     _, wallet, _, client = get_cli_context()
 

--- a/allways/cli/swap_commands/collateral.py
+++ b/allways/cli/swap_commands/collateral.py
@@ -1,38 +1,31 @@
 """alw collateral - Manage miner collateral on the smart contract."""
 
-import rich_click as click
+import click
 from rich.table import Table
 
+from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import SECONDS_PER_BLOCK, console, from_rao, get_cli_context, loading, to_rao
 from allways.constants import MIN_BALANCE_FOR_TX_RAO, MIN_COLLATERAL_TAO
 from allways.contract_client import ContractError
 
 
-@click.group('collateral')
+@click.group('collateral', cls=StyledGroup, show_disclaimer=True)
 def collateral_group():
-    """Manage miner collateral.
-
-    \b
-    Subcommands:
-        deposit             Deposit collateral (in TAO)
-        withdraw            Withdraw collateral (in TAO)
-        view                View current collateral
-    """
+    """Manage miner collateral."""
     pass
 
 
-@collateral_group.command('deposit')
+@collateral_group.command('deposit', show_disclaimer=True)
 @click.option('--amount', default=None, type=float, help='Amount in TAO')
 @click.option('--yes', '-y', is_flag=True, help='Skip confirmation prompt')
 def collateral_deposit(amount: float | None, yes: bool):
     """Deposit collateral to the swap contract.
 
-    \b
-    Amount is in TAO. Minimum collateral to be active: see MIN_COLLATERAL_TAO.
+    [dim]Amount is in TAO. Minimum collateral to be active: see MIN_COLLATERAL_TAO.[/dim]
 
-    Examples:
-        alw collateral deposit --amount 5.0
-        alw collateral deposit                  (prompts interactively)
+    [dim]Examples:
+        $ alw collateral deposit --amount 5.0
+        $ alw collateral deposit  (prompts interactively)[/dim]
     """
     if amount is None:
         amount = click.prompt('Amount to deposit (TAO)', type=float)
@@ -89,18 +82,17 @@ def collateral_deposit(amount: float | None, yes: bool):
         console.print(f'[red]Failed to deposit collateral: {e}[/red]')
 
 
-@collateral_group.command('withdraw')
+@collateral_group.command('withdraw', show_disclaimer=True)
 @click.option('--amount', default=None, type=float, help='Amount in TAO')
 @click.option('--yes', '-y', is_flag=True, help='Skip confirmation prompt')
 def collateral_withdraw(amount: float | None, yes: bool):
     """Withdraw collateral from the swap contract.
 
-    \b
-    Amount is in TAO. Cannot withdraw if you have active swaps.
+    [dim]Amount is in TAO. Cannot withdraw if you have active swaps.[/dim]
 
-    Examples:
-        alw collateral withdraw --amount 2.0
-        alw collateral withdraw                 (prompts interactively)
+    [dim]Examples:
+        $ alw collateral withdraw --amount 2.0
+        $ alw collateral withdraw  (prompts interactively)[/dim]
     """
     if amount is None:
         amount = click.prompt('Amount to withdraw (TAO)', type=float)
@@ -178,9 +170,9 @@ def collateral_withdraw(amount: float | None, yes: bool):
 def collateral_view(hotkey: str):
     """View collateral balance.
 
-    Example:
-        alw collateral view
-        alw collateral view --hotkey 5Cxyz...
+    [dim]Examples:
+        $ alw collateral view
+        $ alw collateral view --hotkey 5Cxyz...[/dim]
     """
     _, wallet, _, client = get_cli_context()
 

--- a/allways/cli/swap_commands/miner_commands.py
+++ b/allways/cli/swap_commands/miner_commands.py
@@ -3,10 +3,11 @@
 import asyncio
 import time
 
-import rich_click as click
+import click
 from rich.table import Table
 
 from allways.cli.dendrite_lite import discover_validators
+from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
     SWAP_STATUS_COLORS,
     console,
@@ -18,18 +19,9 @@ from allways.cli.swap_commands.helpers import (
 from allways.contract_client import ContractError
 
 
-@click.group('miner')
+@click.group('miner', cls=StyledGroup)
 def miner_group():
-    """Miner dashboard commands.
-
-    \b
-    Subcommands:
-        post            Post a trading pair commitment
-        status          View miner collateral, pair, and active swaps
-        activate        Activate miner via validator API
-        deactivate      Deactivate miner via validator API
-        mark-fulfilled  Manually mark a swap as fulfilled
-    """
+    """Miner dashboard commands."""
     pass
 
 
@@ -38,9 +30,9 @@ def miner_group():
 def miner_status(hotkey: str):
     """View miner status: collateral, committed pair, and active swaps.
 
-    Example:
-        alw miner status
-        alw miner status --hotkey 5Cxyz...
+    [dim]Examples:
+        $ alw miner status
+        $ alw miner status --hotkey 5Cxyz...[/dim]
     """
     config, wallet, subtensor, client = get_cli_context()
     netuid = config['netuid']
@@ -161,12 +153,12 @@ def _friendly_rejection(reason: str) -> str:
 def miner_activate():
     """Activate miner via dendrite broadcast to all validators.
 
-    Broadcasts a MinerActivateSynapse to all validators. Each validator
+    [dim]Broadcasts a MinerActivateSynapse to all validators. Each validator
     independently verifies commitment and collateral, then votes on contract.
-    Activation requires quorum.
+    Activation requires quorum.[/dim]
 
-    Example:
-        alw miner activate
+    [dim]Examples:
+        $ alw miner activate[/dim]
     """
     import bittensor as bt
 
@@ -248,11 +240,11 @@ def miner_activate():
 def miner_deactivate():
     """Deactivate miner directly on contract (permissionless).
 
-    Calls deactivate() on the contract directly. No validator needed.
-    After deactivation, must wait 2 * timeout_blocks before withdrawing collateral.
+    [dim]Calls deactivate() on the contract directly. No validator needed.
+    After deactivation, must wait 2 * timeout_blocks before withdrawing collateral.[/dim]
 
-    Example:
-        alw miner deactivate
+    [dim]Examples:
+        $ alw miner deactivate[/dim]
     """
     _, wallet, _, client = get_cli_context()
     hotkey = wallet.hotkey.ss58_address
@@ -280,12 +272,11 @@ def miner_deactivate():
 def miner_mark_fulfilled(swap_id: int, tx_hash: str, amount: int, block: int, yes: bool):
     """Manually mark a swap as fulfilled on the contract.
 
-    \b
-    Use this when you've sent destination funds manually (e.g. via external
-    wallet) and need to notify the contract.
+    [dim]Use this when you've sent destination funds manually (e.g. via external wallet)
+    and need to notify the contract.[/dim]
 
-    Examples:
-        alw miner mark-fulfilled --swap-id 5 --tx-hash abc123... --amount 500000000
+    [dim]Examples:
+        $ alw miner mark-fulfilled --swap-id 5 --tx-hash abc123... --amount 500000000[/dim]
     """
     _, wallet, _, client = get_cli_context()
     hotkey = wallet.hotkey.ss58_address

--- a/allways/cli/swap_commands/pair.py
+++ b/allways/cli/swap_commands/pair.py
@@ -1,8 +1,9 @@
 """alw post - Post a trading pair commitment to chain."""
 
-import rich_click as click
+import click
 
 from allways.chains import SUPPORTED_CHAINS, canonical_pair
+from allways.cli.help import StyledCommand
 from allways.cli.swap_commands.helpers import console, get_cli_context, loading
 from allways.constants import COMMITMENT_VERSION
 
@@ -39,7 +40,7 @@ def _prompt_rates(canon_src: str, canon_dest: str) -> tuple:
     return fwd, rev
 
 
-@click.command('pair')
+@click.command('pair', cls=StyledCommand)
 @click.argument('src_chain', required=False, default=None, type=str)
 @click.argument('src_addr', required=False, default=None, type=str)
 @click.argument('dst_chain', required=False, default=None, type=str)
@@ -58,23 +59,20 @@ def post_pair(
 ):
     """Post a trading pair to chain via commitment.
 
-    \b
-    All arguments are optional — if omitted, you'll be prompted interactively.
+    [dim]All arguments are optional — if omitted, you'll be prompted interactively.[/dim]
 
-    \b
-    Arguments:
-        SRC_CHAIN      Source chain ID (e.g. btc, tao)
-        SRC_ADDR       Your receiving address on source chain
-        DST_CHAIN      Destination chain ID (e.g. tao, btc)
-        DST_ADDR       Your sending address on destination chain
-        RATE           source→dest rate (e.g. TAO per 1 BTC for btc-tao pair)
-        COUNTER_RATE   dest→source rate (optional, defaults to RATE)
+    [dim]Arguments:
+        SRC_CHAIN       Source chain ID (e.g. btc, tao)
+        SRC_ADDR        Your receiving address on source chain
+        DST_CHAIN       Destination chain ID (e.g. tao, btc)
+        DST_ADDR        Your sending address on destination chain
+        RATE            source→dest rate (e.g. TAO per 1 BTC for btc-tao pair)
+        COUNTER_RATE    dest→source rate (optional, defaults to RATE)[/dim]
 
-    \b
-    Examples:
-        alw miner post                                              (interactive wizard)
-        alw miner post btc bc1q...abc tao 5Cxyz...def 340 350      (direction-specific rates)
-        alw miner post btc bc1q...abc tao 5Cxyz...def 345          (same rate both ways)
+    [dim]Examples:
+        $ alw miner post                                            (interactive wizard)
+        $ alw miner post btc bc1q...abc tao 5Cxyz...def 340 350     (direction-specific rates)
+        $ alw miner post btc bc1q...abc tao 5Cxyz...def 345         (same rate both ways)[/dim]
     """
     # --- Prompt for any missing arguments ---
     if src_chain is None:

--- a/allways/cli/swap_commands/post_tx.py
+++ b/allways/cli/swap_commands/post_tx.py
@@ -1,9 +1,10 @@
 """alw swap post-tx - Submit source transaction hash for a pending swap reservation."""
 
-import rich_click as click
+import click
 
 from allways.chain_providers import create_chain_providers
 from allways.cli.dendrite_lite import discover_validators, get_ephemeral_wallet
+from allways.cli.help import StyledCommand
 from allways.cli.swap_commands.helpers import (
     SECONDS_PER_BLOCK,
     clear_pending_swap,
@@ -16,19 +17,17 @@ from allways.constants import NETUID_FINNEY
 from allways.contract_client import ContractError
 
 
-@click.command('post-tx')
+@click.command('post-tx', cls=StyledCommand, show_disclaimer=True)
 @click.argument('tx_hash', required=False, default=None, type=str)
 @click.option('--netuid', default=None, type=int, help='Subnet UID')
 def post_tx_command(tx_hash: str, netuid: int):
     """Submit your source transaction hash for a pending swap reservation.
 
-    \b
-    Reads reservation context from ~/.allways/pending_swap.json (saved by `alw swap now`).
+    [dim]Reads reservation context from ~/.allways/pending_swap.json (saved by `alw swap now`).[/dim]
 
-    \b
-    Examples:
-        alw swap post-tx abc123def...
-        alw swap post-tx            (prompts for tx hash)
+    [dim]Examples:
+        $ alw swap post-tx abc123def...
+        $ alw swap post-tx  (prompts for tx hash)[/dim]
     """
     config, wallet, subtensor, client = get_cli_context()
     if netuid is None:

--- a/allways/cli/swap_commands/status.py
+++ b/allways/cli/swap_commands/status.py
@@ -1,8 +1,9 @@
 """alw status - Quick dashboard showing network, wallet, and swap state."""
 
-import rich_click as click
+import click
 from rich.table import Table
 
+from allways.cli.help import StyledCommand
 from allways.cli.swap_commands.helpers import (
     SECONDS_PER_BLOCK,
     console,
@@ -16,17 +17,16 @@ from allways.constants import NETUID_FINNEY
 from allways.contract_client import ContractError
 
 
-@click.command('status')
+@click.command('status', cls=StyledCommand)
 @click.option('--netuid', default=None, type=int, help='Subnet UID')
 def status_command(netuid: int):
     """Show a quick dashboard of your current state.
 
-    \b
-    Displays network info, wallet balance, active swaps,
-    pending reservations, and miner status (if applicable).
+    [dim]Displays network info, wallet balance, active swaps,
+    pending reservations, and miner status (if applicable).[/dim]
 
-    Example:
-        alw status
+    [dim]Examples:
+        $ alw status[/dim]
     """
     config, wallet, subtensor, client = get_cli_context()
     if netuid is None:

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -5,7 +5,7 @@ import time
 from typing import Optional
 
 import bittensor as bt
-import rich_click as click
+import click
 from rich.panel import Panel
 from rich.table import Table
 
@@ -13,6 +13,7 @@ from allways.chain_providers import create_chain_providers
 from allways.chains import SUPPORTED_CHAINS, canonical_pair, get_chain
 from allways.classes import MinerPair, SwapStatus
 from allways.cli.dendrite_lite import broadcast_synapse, discover_validators, get_ephemeral_wallet
+from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
     SECONDS_PER_BLOCK,
     PendingSwapState,
@@ -391,18 +392,12 @@ def _send_btc(chain_providers, config, to_address: str, amount_sat: int, from_ad
 # =========================================================================
 
 
-@click.group('swap')
+@click.group('swap', cls=StyledGroup, show_disclaimer=True)
 def swap_group():
-    """Execute and manage cross-chain swaps.
-
-    \b
-    Subcommands:
-        now       Execute a swap (guided interactive)
-        post-tx   Submit source transaction hash for a pending swap
-    """
+    """Execute and manage cross-chain swaps."""
 
 
-@swap_group.command('now')
+@swap_group.command('now', show_disclaimer=True)
 @click.option('--netuid', default=None, type=int, help='Subnet UID')
 @click.option('--src', 'source_chain_opt', default=None, help='Source chain (e.g. btc, tao)')
 @click.option('--dest', 'dest_chain_opt', default=None, help='Destination chain (e.g. btc, tao)')
@@ -425,22 +420,19 @@ def swap_now_command(
 ):
     """Guided interactive swap - step by step.
 
-    \b
-    Walks through a complete swap from start to finish:
+    [dim]Walks through a complete swap from start to finish:
     - Select swap direction and miner
     - Enter amount and addresses
     - Funds are sent automatically when possible
-    - Transaction hash is posted to validators automatically
+    - Transaction hash is posted to validators automatically[/dim]
 
-    \b
-    Non-interactive mode (for scripting/testing):
-        alw swap now --src btc --dest tao --amount 0.001 \\
+    [dim]Non-interactive mode (for scripting/testing):
+        $ alw swap now --src btc --dest tao --amount 0.001 \\
             --receive-address 5C... --source-address bc1q... \\
-            --source-tx-hash abc123... --auto --yes
+            --source-tx-hash abc123... --auto --yes[/dim]
 
-    \b
-    Interactive mode:
-        alw swap now
+    [dim]Interactive mode:
+        $ alw swap now[/dim]
     """
     config, wallet, subtensor, client = get_cli_context()
     if netuid is None:

--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -3,13 +3,14 @@
 import time
 from dataclasses import replace
 
-import rich_click as click
+import click
 from rich.live import Live
 from rich.table import Table
 from rich.text import Text
 
 from allways.chains import SUPPORTED_CHAINS, get_chain
 from allways.classes import SwapStatus
+from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
     SECONDS_PER_BLOCK,
     SWAP_STATUS_COLORS,
@@ -24,17 +25,9 @@ from allways.cli.swap_commands.helpers import (
 from allways.contract_client import ContractError
 
 
-@click.group('view')
+@click.group('view', cls=StyledGroup)
 def view_group():
-    """View swaps, miners, and rates.
-
-    \b
-    Subcommands:
-        miners      View active miners and their pairs
-        rates       View exchange rates
-        swaps       View active swaps
-        swap <id>   View a specific swap
-    """
+    """View swaps, miners, and rates."""
     pass
 
 
@@ -42,8 +35,8 @@ def view_group():
 def view_miners():
     """View active miners and their trading pairs.
 
-    Example:
-        alw view miners
+    [dim]Examples:
+        $ alw view miners[/dim]
     """
     config, _, subtensor, client = get_cli_context(need_wallet=False)
     netuid = config['netuid']
@@ -104,10 +97,9 @@ def view_miners():
 def view_rates(pair: str):
     """View current exchange rates.
 
-    \b
-    Examples:
-        alw view rates
-        alw view rates --pair btc-tao
+    [dim]Examples:
+        $ alw view rates
+        $ alw view rates --pair btc-tao[/dim]
     """
     config, _, subtensor, client = get_cli_context(need_wallet=False)
     netuid = config['netuid']
@@ -187,13 +179,18 @@ def view_rates(pair: str):
 
 
 @view_group.command('swaps')
-@click.option('--status', default=None, type=str, help='Filter by status (active, fulfilled, completed, timed_out)')
+@click.option(
+    '--status',
+    default=None,
+    type=click.Choice(['active', 'fulfilled', 'completed', 'timed_out'], case_sensitive=False),
+    help='Filter by status (active, fulfilled, completed, timed_out)',
+)
 def view_swaps(status: str):
     """View active swaps on the contract.
 
-    Example:
-        alw view swaps
-        alw view swaps --status pending
+    [dim]Examples:
+        $ alw view swaps
+        $ alw view swaps --status active[/dim]
     """
     _, _, _, client = get_cli_context(need_wallet=False)
 
@@ -309,10 +306,9 @@ def _display_swap(swap, chain_info=True):
 def view_swap(swap_id: int, watch: bool):
     """View details of a specific swap.
 
-    \b
-    Examples:
-        alw view swap 42
-        alw view swap 42 --watch
+    [dim]Examples:
+        $ alw view swap 42
+        $ alw view swap 42 --watch[/dim]
     """
     _, _, subtensor, client = get_cli_context(need_wallet=False)
 
@@ -414,8 +410,8 @@ def watch_swap(client, swap_id: int, swap=None):
 def view_contract():
     """View contract parameters.
 
-    Example:
-        alw view contract
+    [dim]Examples:
+        $ alw view contract[/dim]
     """
     config, wallet, _, client = get_cli_context(need_wallet=False)
 
@@ -485,11 +481,10 @@ def view_contract():
 def view_reservation():
     """View your active swap reservation.
 
-    \b
-    Reads local state file and validates against on-chain data.
+    [dim]Reads local state file and validates against on-chain data.[/dim]
 
-    Example:
-        alw view reservation
+    [dim]Examples:
+        $ alw view reservation[/dim]
     """
     _, _, subtensor, client = get_cli_context(need_wallet=False)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     "bitcoin-message-tool",
     "click",
     "rich",
-    "rich-click",
     "embit",
     "base58",
     "bech32",


### PR DESCRIPTION
## Summary
Align `Allways` CLI help with a richer, production-grade presentation so command discovery is easier and examples are more readable.

## What Changed
- Added a shared Rich-based help renderer for commands, groups, and aliases.
- Switched the CLI from `rich-click` to native `click` plus the new shared renderer.
- Standardized help text across swap, admin, config, miner, collateral, claim, status, and view commands with cleaner descriptions and example blocks.
- Kept the protocol disclaimer and footer consistent across high-risk command surfaces.
- Tightened `alw view swaps --status` to accept only supported status values.
- Removed the `rich-click` dependency.

## Why It Matters
This makes `--help` output more consistent, easier to scan, and closer to a production-grade CLI experience, without changing the underlying swap flows.

The Gittensor CLI help is much more polished and feels production-ready. It’s great to see it aligning with the UI/UX of other Ventura Labs products.
https://github.com/entrius/gittensor/pull/341

## Screenshots
#### Before:
<img width="1492" height="992" alt="image" src="https://github.com/user-attachments/assets/5b85bc7c-ce54-4686-ba96-08a5d2cae753" />

#### After:
<img width="1252" height="592" alt="image" src="https://github.com/user-attachments/assets/b4551915-db36-4dd0-800e-779db2a4eb14" />
<img width="1237" height="361" alt="image" src="https://github.com/user-attachments/assets/24554c4b-0a63-453a-ad43-d45544a6c303" />
<img width="1208" height="650" alt="image" src="https://github.com/user-attachments/assets/74afb3e9-75af-4ba6-bc60-55b42bc6eeea" />
<img width="1239" height="691" alt="image" src="https://github.com/user-attachments/assets/3f8658f7-afa1-4093-b29d-28603babc56e" />
<img width="1250" height="385" alt="image" src="https://github.com/user-attachments/assets/ec571e05-5b37-4741-87db-d98ca0f986ea" />
<img width="1237" height="425" alt="image" src="https://github.com/user-attachments/assets/c469e2c0-e713-474b-940e-c58ea1bbe6f3" />
<img width="1230" height="469" alt="image" src="https://github.com/user-attachments/assets/2e174a3d-64a2-41a4-b9ed-9918bedc641d" />
<img width="1238" height="448" alt="image" src="https://github.com/user-attachments/assets/2a8d583a-e36e-453c-9b37-9b95ab617d74" />
<img width="1218" height="492" alt="image" src="https://github.com/user-attachments/assets/f0f0c6a2-a94b-44b9-aa52-e3ff81c0ae0b" />
<img width="1217" height="410" alt="image" src="https://github.com/user-attachments/assets/f0360be4-254f-4a7a-9451-fbff8390ba8a" />
<img width="1209" height="474" alt="image" src="https://github.com/user-attachments/assets/92b81502-d24c-482a-8552-870854ce59c2" />
<img width="1225" height="431" alt="image" src="https://github.com/user-attachments/assets/3ea88ea9-f226-49f1-b5c0-12f8d103a469" />
<img width="1272" height="432" alt="image" src="https://github.com/user-attachments/assets/d01300a8-944e-48ac-9dc2-1758413bfd70" />

...