### PR TITLE
Rate-limit user-facing axon endpoints to block request floods before they hit chain queries

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -41,6 +41,11 @@ SCORING_SUCCESS_EXPONENT = 8  # Harsh failure penalty: 92% → 0.51x, 96% → 0.
 RECYCLE_UID = 53  # Subnet owner UID — emissions recycled on-chain
 DAILY_EMISSION_ALPHA = 7200 * 0.41  # 2952 alpha/day (7200 blocks/day * 0.41 miner share)
 
+# ─── Axon Rate Limiting ──────────────────────────────────
+RATE_LIMIT_MAX_REQUESTS = 10  # Max requests per IP within the sliding window
+RATE_LIMIT_WINDOW_SECONDS = 60  # Sliding window duration in seconds
+RATE_LIMIT_CLEANUP_SECONDS = 300  # Purge stale IP entries every 5 min
+
 # ─── Reservation ─────────────────────────────────────────
 RESERVATION_COOLDOWN_BLOCKS = 150  # ~30 min base cooldown on failed reservation (validator-enforced)
 RESERVATION_COOLDOWN_MULTIPLIER = 2  # Exponential backoff: 150 → 300 → 600 ...

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -96,6 +96,33 @@ def _reject(synapse, reason: str, context: str = '') -> None:
         bt.logging.debug(f'{context}: {reason}')
 
 
+def _get_caller_ip(synapse) -> str:
+    """Extract the caller's IP from the dendrite header, or empty string if unavailable."""
+    if synapse.dendrite is not None:
+        return getattr(synapse.dendrite, 'ip', None) or ''
+    return ''
+
+
+def _check_rate_limit(validator, synapse) -> Tuple[bool, str]:
+    """Apply rate limiting if the validator has a rate limiter configured.
+
+    Returns (blacklisted, reason) — same contract as blacklist_fn.
+    Fails open: if IP is unavailable or no limiter exists, the request passes.
+    """
+    if not hasattr(validator, 'rate_limiter'):
+        return False, 'No rate limiter'
+
+    caller_ip = _get_caller_ip(synapse)
+    if not caller_ip:
+        return False, 'No IP available'
+
+    allowed, reason = validator.rate_limiter.is_allowed(caller_ip)
+    if not allowed:
+        return True, reason
+
+    return False, 'Passed'
+
+
 # =============================================================================
 # MinerActivateSynapse handlers
 # =============================================================================
@@ -186,13 +213,13 @@ async def blacklist_swap_reserve(
     validator,
     synapse: SwapReserveSynapse,
 ) -> Tuple[bool, str]:
-    """Pass-through — custom field checks happen in forward handler.
+    """Rate-limit unauthenticated user requests before any chain work.
 
-    Bittensor's axon middleware constructs the synapse from HTTP headers (default values)
-    before calling blacklist. Custom fields (source_address, proof, etc.) are only available
-    in the JSON body, which is parsed later for the forward handler.
+    Custom synapse fields (source_address, proof, etc.) aren't available here —
+    they arrive in the JSON body parsed later for the forward handler. But the
+    dendrite IP header is available, so we can enforce per-IP rate limits.
     """
-    return False, 'Passed'
+    return _check_rate_limit(validator, synapse)
 
 
 async def priority_swap_reserve(
@@ -333,11 +360,12 @@ async def blacklist_swap_confirm(
     validator,
     synapse: SwapConfirmSynapse,
 ) -> Tuple[bool, str]:
-    """Pass-through — custom field checks happen in forward handler.
+    """Rate-limit unauthenticated user requests before any chain work.
 
-    See blacklist_swap_reserve docstring for rationale.
+    Same rationale as blacklist_swap_reserve — custom fields aren't parsed yet,
+    but the dendrite IP header is available for rate limiting.
     """
-    return False, 'Passed'
+    return _check_rate_limit(validator, synapse)
 
 
 async def priority_swap_confirm(

--- a/allways/validator/rate_limiter.py
+++ b/allways/validator/rate_limiter.py
@@ -1,0 +1,93 @@
+"""Per-IP sliding-window rate limiter for user-facing axon endpoints.
+
+Protects validators from request floods on unauthenticated endpoints (reserve, confirm)
+where callers use dendrite-lite and have no registered hotkey. Runs in the blacklist
+phase so rejected requests never reach chain queries or contract calls.
+"""
+
+import threading
+import time
+from collections import deque
+from typing import Deque, Dict, Tuple
+
+import bittensor as bt
+
+from allways.constants import (
+    RATE_LIMIT_CLEANUP_SECONDS,
+    RATE_LIMIT_MAX_REQUESTS,
+    RATE_LIMIT_WINDOW_SECONDS,
+)
+
+
+class AxonRateLimiter:
+    """Sliding-window rate limiter keyed by caller IP.
+
+    Tracks request timestamps per IP in a deque. On each check, timestamps
+    outside the window are pruned and the remaining count is compared against
+    the limit. Stale IP entries are garbage-collected periodically.
+    """
+
+    def __init__(
+        self,
+        max_requests: int = RATE_LIMIT_MAX_REQUESTS,
+        window_seconds: float = RATE_LIMIT_WINDOW_SECONDS,
+        cleanup_seconds: float = RATE_LIMIT_CLEANUP_SECONDS,
+    ):
+        self._lock = threading.Lock()
+        self._requests: Dict[str, Deque[float]] = {}
+        self._max_requests = max_requests
+        self._window_seconds = window_seconds
+        self._cleanup_seconds = cleanup_seconds
+        self._last_cleanup = time.monotonic()
+
+    def is_allowed(self, ip: str) -> Tuple[bool, str]:
+        """Check if a request from this IP is within the rate limit.
+
+        Returns (allowed, reason). Records the request timestamp atomically
+        if allowed, so check + record cannot race.
+        """
+        if not ip:
+            return True, 'No IP available'
+
+        now = time.monotonic()
+
+        with self._lock:
+            self._maybe_cleanup(now)
+            timestamps = self._requests.get(ip)
+
+            if timestamps is None:
+                timestamps = deque()
+                self._requests[ip] = timestamps
+
+            # Prune timestamps outside the current window
+            cutoff = now - self._window_seconds
+            while timestamps and timestamps[0] <= cutoff:
+                timestamps.popleft()
+
+            if len(timestamps) >= self._max_requests:
+                bt.logging.debug(
+                    f'Rate limited {ip}: {len(timestamps)}/{self._max_requests} in {int(self._window_seconds)}s window'
+                )
+                return False, f'Rate limited — max {self._max_requests} requests per {int(self._window_seconds)}s'
+
+            timestamps.append(now)
+            return True, 'Allowed'
+
+    def _maybe_cleanup(self, now: float) -> None:
+        """Remove IPs with no recent activity to prevent unbounded memory growth."""
+        if now - self._last_cleanup < self._cleanup_seconds:
+            return
+
+        self._last_cleanup = now
+        cutoff = now - self._window_seconds
+        stale = [ip for ip, ts in self._requests.items() if not ts or ts[-1] <= cutoff]
+        for ip in stale:
+            del self._requests[ip]
+
+        if stale:
+            bt.logging.debug(f'Rate limiter: purged {len(stale)} stale IP entries')
+
+    def active_count(self) -> int:
+        """Number of IPs currently tracked."""
+        with self._lock:
+            return len(self._requests)

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -32,6 +32,7 @@ from allways.validator.axon_handlers import (
 from allways.validator.chain_verification import SwapVerifier
 from allways.validator.forward import forward
 from allways.validator.pending_confirms import PendingConfirmQueue
+from allways.validator.rate_limiter import AxonRateLimiter
 from allways.validator.swap_tracker import SwapTracker
 from allways.validator.voting import SwapVoter
 from neurons.base.validator import BaseValidatorNeuron
@@ -83,6 +84,9 @@ class Validator(BaseValidatorNeuron):
 
         # Pending confirmation queue (axon handler thread → forward loop thread)
         self.pending_confirms = PendingConfirmQueue()
+
+        # Per-IP rate limiter for user-facing axon endpoints (reserve, confirm)
+        self.rate_limiter = AxonRateLimiter()
 
         # Separate subtensor/contract/providers for axon handlers (thread safety).
         # axon_lock serialises substrate websocket calls across handler threads


### PR DESCRIPTION
## Rate-limit swap reserve and confirm endpoints

Right now `blacklist_swap_reserve` and `blacklist_swap_confirm` are pass-throughs - they always return `(False, 'Passed')`. Every request goes straight to the forward handler, grabs `axon_lock`, and fires off chain RPC calls. Nothing stops a single IP from flooding these endpoints and blocking all other traffic.

This adds a simple per-IP rate limiter (10 req/min sliding window) that rejects floods in the blacklist phase, before any expensive work happens.

### Changes

- New `AxonRateLimiter` class in `allways/validator/rate_limiter.py` - thread-safe sliding window, auto-cleans stale entries
- Updated both blacklist handlers to check the rate limiter instead of passing everything through
- Added rate limit constants to `constants.py`
- Initialized the limiter on the validator in `neurons/validator.py`

### Notes

- Fails open - if IP is missing or limiter isn't set up, requests pass through as before
- MinerActivate already has hotkey auth in its blacklist, so it doesn't need this
- The dendrite IP comes from a client header so it can be spoofed, but it still raises the bar compared to zero protection
