### PR TITLE
feat: add timeout margin gate, terminal error handling, and recovery log to miner fulfillment

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -55,6 +55,7 @@ SWAP_FEE_PERCENT = 0.01  # display only — derived from DEFAULT_FEE_DIVISOR
 MAX_FEE_PERCENT = 0.05  # contract enforces divisor >= 20 (max 5% fee)
 MIN_COLLATERAL_TAO = 0.1  # Must be > max swap amount
 DEFAULT_FULFILLMENT_TIMEOUT_BLOCKS = 30  # ~5 min — `alw admin set-timeout`
+FULFILLMENT_TIMEOUT_MARGIN_BLOCKS = 3  # ~36s — reject new sends when fewer blocks remain before swap timeout
 DEFAULT_MIN_SWAP_AMOUNT_RAO = 100_000_000  # 0.1 TAO — `alw admin set-min-swap`
 DEFAULT_MAX_SWAP_AMOUNT_RAO = 500_000_000  # 0.5 TAO   — `alw admin set-max-swap`
 RESERVATION_TTL_BLOCKS = 30  # ~5 min — `alw admin set-reservation-ttl`

--- a/allways/miner/fulfillment.py
+++ b/allways/miner/fulfillment.py
@@ -1,15 +1,20 @@
 """Swap fulfillment engine - verifies receipt and sends funds."""
 
 import json
+import os
 from pathlib import Path
 from typing import Dict, Optional, Set, Tuple
 
 import bittensor as bt
 
 from allways.chain_providers.base import ChainProvider
-from allways.classes import Swap
-from allways.contract_client import AllwaysContractClient, ContractError
+from allways.classes import Swap, SwapStatus
+from allways.constants import FULFILLMENT_TIMEOUT_MARGIN_BLOCKS
+from allways.contract_client import AllwaysContractClient, ContractError, ContractErrorKind
 from allways.utils.rate import expected_swap_amounts
+
+# Contract error substrings that indicate mark_fulfilled will never succeed.
+_TERMINAL_CONTRACT_ERRORS = ('SwapNotFound', 'InvalidStatus', 'NotAssignedMiner', 'MinerNotActive')
 
 
 class SwapFulfiller:
@@ -31,6 +36,8 @@ class SwapFulfiller:
         metagraph: Optional['bt.Metagraph'] = None,
         fee_divisor: int = 100,
         sent_cache_path: Optional[Path] = None,
+        timeout_margin_blocks: int = FULFILLMENT_TIMEOUT_MARGIN_BLOCKS,
+        recovery_log_path: Optional[Path] = None,
     ):
         self.client = contract_client
         self.providers = chain_providers
@@ -41,7 +48,14 @@ class SwapFulfiller:
         self.fee_divisor = fee_divisor
         self._sent: Dict[int, Tuple[str, int]] = {}
         self._sent_cache_path = sent_cache_path
+        self._timeout_margin_blocks = timeout_margin_blocks
+        self._recovery_log_path = recovery_log_path
+        self._terminal_failures: Set[int] = set()
         self._load_sent_cache()
+
+    # ------------------------------------------------------------------
+    # Sent cache persistence
+    # ------------------------------------------------------------------
 
     def _load_sent_cache(self):
         """Load persisted send results from disk to prevent double-sends after restart."""
@@ -65,26 +79,130 @@ class SwapFulfiller:
             data = {str(k): [v[0], v[1]] for k, v in self._sent.items()}
             tmp = self._sent_cache_path.with_suffix('.tmp')
             tmp.write_text(json.dumps(data))
-            tmp.rename(self._sent_cache_path)
+            os.replace(tmp, self._sent_cache_path)
         except Exception as e:
             bt.logging.error(f'CRITICAL: Failed to persist sent cache: {e}')
+
+    # ------------------------------------------------------------------
+    # Recovery log
+    # ------------------------------------------------------------------
+
+    def _write_recovery_entry(self, entry: Dict) -> None:
+        """Append a JSONL line for stuck-funds scenarios needing manual action."""
+        if not self._recovery_log_path:
+            return
+        try:
+            self._recovery_log_path.parent.mkdir(parents=True, exist_ok=True)
+            with self._recovery_log_path.open('a', encoding='utf-8') as f:
+                f.write(json.dumps(entry) + '\n')
+        except Exception as e:
+            bt.logging.error(f"Swap {entry.get('swap_id', '?')}: failed to write recovery log: {e}")
+
+    def _log_stuck_funds(
+        self,
+        swap: Swap,
+        dest_tx_hash: str,
+        dest_tx_block: int,
+        dest_amount: int,
+        reason: str,
+        event: str,
+    ) -> None:
+        """Log a stuck-funds event to both bittensor logger and recovery JSONL."""
+        bt.logging.error(
+            f'Swap {swap.id}: RECOVERY REQUIRED ({event}) — '
+            f'dest_tx={dest_tx_hash}, block={dest_tx_block}, amount={dest_amount}, reason={reason}'
+        )
+        self._write_recovery_entry({
+            'event': event,
+            'swap_id': swap.id,
+            'miner_hotkey': swap.miner_hotkey,
+            'source_chain': swap.source_chain,
+            'dest_chain': swap.dest_chain,
+            'source_tx_hash': swap.source_tx_hash,
+            'dest_tx_hash': dest_tx_hash,
+            'dest_tx_block': dest_tx_block,
+            'dest_amount': dest_amount,
+            'timeout_block': swap.timeout_block,
+            'reason': reason,
+        })
+
+    # ------------------------------------------------------------------
+    # Terminal error detection
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _is_terminal_contract_error(error: ContractError) -> bool:
+        """Return True if mark_fulfilled will never succeed for this error."""
+        if error.kind in (
+            ContractErrorKind.NOT_INITIALIZED,
+            ContractErrorKind.RPC_FAILURE,
+            ContractErrorKind.INSUFFICIENT_BALANCE,
+        ):
+            return False
+        msg = str(error)
+        return any(variant in msg for variant in _TERMINAL_CONTRACT_ERRORS)
+
+    # ------------------------------------------------------------------
+    # Stale send cleanup
+    # ------------------------------------------------------------------
 
     def cleanup_stale_sends(self, active_swap_ids: Set[int]):
         """Remove cached send results for swaps no longer active."""
         stale = [sid for sid in self._sent if sid not in active_swap_ids]
         for sid in stale:
+            tx_hash, tx_block = self._sent[sid]
+
+            # Check on-chain status to detect timed-out swaps where funds were already sent.
+            resolved = None
+            try:
+                resolved = self.client.get_swap(sid)
+            except Exception as e:
+                bt.logging.debug(f'Swap {sid}: could not read status during cleanup: {e}')
+
+            if resolved is not None and resolved.status == SwapStatus.TIMED_OUT:
+                bt.logging.error(
+                    f'Swap {sid}: timed out after funds were sent '
+                    f'(tx={tx_hash}, block={tx_block}) — manual recovery may be required'
+                )
+                self._write_recovery_entry({
+                    'event': 'timeout_after_send',
+                    'swap_id': sid,
+                    'dest_tx_hash': tx_hash,
+                    'dest_tx_block': tx_block,
+                    'status': resolved.status.name,
+                    'reason': 'swap timed out after destination funds were sent',
+                })
+            elif resolved is not None and resolved.status == SwapStatus.COMPLETED:
+                bt.logging.info(f'Swap {sid}: completed — clearing send cache (tx={tx_hash})')
+            else:
+                status_name = resolved.status.name if resolved else 'UNKNOWN'
+                bt.logging.warning(f'Swap {sid}: clearing stale send cache, status={status_name}')
+
             self._sent.pop(sid)
-            bt.logging.debug(f'Cleaned up stale send cache for swap {sid}')
+            self._terminal_failures.discard(sid)
+
         if stale:
             self._save_sent_cache()
 
-    def _verify_swap_safety(self, swap: Swap) -> Optional[Tuple[int, str]]:
+    # ------------------------------------------------------------------
+    # Safety checks
+    # ------------------------------------------------------------------
+
+    def _verify_swap_safety(self, swap: Swap, enforce_timeout_margin: bool = True) -> Optional[Tuple[int, str]]:
         """Verify the swap is safe to fulfill. Returns (dest_amount, miner_source_address) or None."""
-        # Timeout check
         current_block = self.subtensor.get_current_block()
-        if current_block >= swap.timeout_block:
-            bt.logging.warning(f'Swap {swap.id}: already timed out (block {current_block} >= {swap.timeout_block})')
-            return None
+
+        if swap.timeout_block > 0:
+            blocks_left = swap.timeout_block - current_block
+            if blocks_left <= 0:
+                bt.logging.warning(f'Swap {swap.id}: already timed out (block {current_block} >= {swap.timeout_block})')
+                return None
+            if enforce_timeout_margin and blocks_left <= self._timeout_margin_blocks:
+                bt.logging.warning(
+                    f'Swap {swap.id}: too close to timeout '
+                    f'(blocks_left={blocks_left}, margin={self._timeout_margin_blocks})'
+                )
+                return None
 
         # Rate and address from swap struct (snapshotted at initiation)
         if not swap.rate or not swap.miner_source_address:
@@ -177,28 +295,42 @@ class SwapFulfiller:
             )
         return result
 
+    # ------------------------------------------------------------------
+    # Main processing flow
+    # ------------------------------------------------------------------
+
     def process_swap(self, swap: Swap) -> bool:
         """Full swap processing flow: verify safety -> verify funds -> send -> mark fulfilled.
 
-        Returns True if swap was successfully fulfilled.
+        Returns True if swap was successfully fulfilled (or terminally failed).
         """
         bt.logging.info(f'Processing swap {swap.id}: {swap.source_chain} -> {swap.dest_chain}')
 
+        # Skip swaps that already hit a terminal mark_fulfilled error this session.
+        if swap.id in self._terminal_failures:
+            bt.logging.warning(f'Swap {swap.id}: skipped — terminal mark_fulfilled failure (recovery required)')
+            return True
+
+        has_cached_send = swap.id in self._sent
+
         # Step 1: Verify swap safety (timeout, rate, collateral)
-        safety_result = self._verify_swap_safety(swap)
+        # Bypass timeout margin for cached sends — we already sent funds and must
+        # still attempt mark_fulfilled even close to timeout.
+        safety_result = self._verify_swap_safety(swap, enforce_timeout_margin=not has_cached_send)
         if safety_result is None:
             bt.logging.warning(f'Swap {swap.id}: failed safety checks, skipping')
             return False
 
         dest_amount, my_source_address = safety_result
 
-        # Step 2: Verify user sent source funds
-        if not self.verify_user_sent_funds(swap, my_source_address):
-            bt.logging.debug(f'Swap {swap.id}: waiting for source funds confirmation')
-            return False
+        # Step 2: Verify user sent source funds (skip if we already sent ours)
+        if not has_cached_send:
+            if not self.verify_user_sent_funds(swap, my_source_address):
+                bt.logging.debug(f'Swap {swap.id}: waiting for source funds confirmation')
+                return False
 
         # Step 3: Send destination funds (with double-send prevention)
-        if swap.id in self._sent:
+        if has_cached_send:
             dest_tx_hash, dest_tx_block = self._sent[swap.id]
             bt.logging.info(f'Swap {swap.id}: using cached send result (tx: {dest_tx_hash}, block: {dest_tx_block})')
         else:
@@ -221,8 +353,20 @@ class SwapFulfiller:
             )
             bt.logging.success(f'Swap {swap.id}: marked as fulfilled')
             self._sent.pop(swap.id, None)
+            self._terminal_failures.discard(swap.id)
             self._save_sent_cache()
             return True
         except ContractError as e:
+            if self._is_terminal_contract_error(e):
+                self._terminal_failures.add(swap.id)
+                self._log_stuck_funds(
+                    swap=swap,
+                    dest_tx_hash=dest_tx_hash,
+                    dest_tx_block=dest_tx_block,
+                    dest_amount=dest_amount,
+                    reason=str(e),
+                    event='terminal_mark_fulfilled_failure',
+                )
+                return True
             bt.logging.error(f'Swap {swap.id}: failed to mark fulfilled on contract: {e}')
             return False

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -15,7 +15,12 @@ from dotenv import load_dotenv
 
 from allways.chain_providers import create_chain_providers
 from allways.commitments import read_miner_commitment
-from allways.constants import DEFAULT_FEE_DIVISOR, MINER_STATUS_LOG_INTERVAL_STEPS, TAO_TO_RAO
+from allways.constants import (
+    DEFAULT_FEE_DIVISOR,
+    FULFILLMENT_TIMEOUT_MARGIN_BLOCKS,
+    MINER_STATUS_LOG_INTERVAL_STEPS,
+    TAO_TO_RAO,
+)
 from allways.contract_client import AllwaysContractClient, ContractError
 from allways.miner.fulfillment import SwapFulfiller
 from allways.miner.swap_poller import SwapPoller
@@ -50,6 +55,7 @@ class Miner(BaseMinerNeuron):
 
         hotkey = self.wallet.hotkey.ss58_address
         sent_cache_path = Path.home() / '.allways' / 'miner' / f'sent_cache_{hotkey[:12]}.json'
+        recovery_log_path = Path.home() / '.allways' / 'miner' / f'fulfillment_recovery_{hotkey[:12]}.jsonl'
 
         self.swap_fulfiller = SwapFulfiller(
             contract_client=self.contract_client,
@@ -60,6 +66,8 @@ class Miner(BaseMinerNeuron):
             metagraph=self.metagraph,
             fee_divisor=fee_divisor,
             sent_cache_path=sent_cache_path,
+            timeout_margin_blocks=FULFILLMENT_TIMEOUT_MARGIN_BLOCKS,
+            recovery_log_path=recovery_log_path,
         )
 
         self._last_status_step = 0


### PR DESCRIPTION
Gate new destination sends behind a configurable block margin before swap timeout to prevent near-deadline fund loss. 
Cached sends bypass the margin so mark_fulfilled retries remain open. 
Classify SwapNotFound, InvalidStatus, NotAssignedMiner, and MinerNotActive as terminal to halt futile retries. 
Write stuck-funds events to an append-only JSONL recovery log for operator action. 
Detect timed-out swaps during stale cache cleanup and surface them in the recovery log. 
Use os.replace for cross-platform atomic file writes.