### PR TITLE
feat: add local swap history and receipt views

### DIFF
--- a/allways/cli/swap_commands/history_store.py
+++ b/allways/cli/swap_commands/history_store.py
@@ -1,0 +1,112 @@
+"""Local swap history persistence for CLI receipts and listing."""
+
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from allways.classes import SwapStatus
+
+HISTORY_FILE = Path.home() / '.allways' / 'swap_history.json'
+
+
+def _read_history() -> List[Dict[str, Any]]:
+    if not HISTORY_FILE.exists():
+        return []
+    try:
+        data = json.loads(HISTORY_FILE.read_text())
+        if isinstance(data, list):
+            return data
+    except Exception:
+        pass
+    return []
+
+
+def _write_history(records: List[Dict[str, Any]]) -> None:
+    HISTORY_FILE.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(records, indent=2)
+    fd, tmp_path = tempfile.mkstemp(dir=HISTORY_FILE.parent, suffix='.tmp')
+    try:
+        with os.fdopen(fd, 'w') as f:
+            f.write(payload)
+        os.replace(tmp_path, HISTORY_FILE)
+    except Exception:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise
+
+
+def _status_name(value: Any) -> str:
+    if isinstance(value, SwapStatus):
+        return value.name
+    if isinstance(value, str):
+        return value.upper()
+    return str(value)
+
+
+def make_pending_key(miner_hotkey: str, created_at: float) -> str:
+    return f'{miner_hotkey}:{int(created_at)}'
+
+
+def _find_index(
+    records: List[Dict[str, Any]], swap_id: Optional[int] = None, pending_key: Optional[str] = None
+) -> Optional[int]:
+    if swap_id is not None:
+        for idx, record in enumerate(records):
+            if record.get('swap_id') == swap_id:
+                return idx
+    if pending_key:
+        for idx, record in enumerate(records):
+            if record.get('pending_key') == pending_key:
+                return idx
+    return None
+
+
+def upsert_history(
+    *,
+    swap_id: Optional[int] = None,
+    pending_key: Optional[str] = None,
+    data: Dict[str, Any],
+) -> None:
+    records = _read_history()
+    idx = _find_index(records, swap_id=swap_id, pending_key=pending_key)
+    now = int(time.time())
+
+    if idx is None:
+        record = {'created_at': now, 'updated_at': now}
+        if swap_id is not None:
+            record['swap_id'] = swap_id
+        if pending_key:
+            record['pending_key'] = pending_key
+        record.update(data)
+        records.append(record)
+    else:
+        existing = records[idx]
+        if swap_id is not None:
+            existing['swap_id'] = swap_id
+        if pending_key:
+            existing['pending_key'] = pending_key
+        existing.update(data)
+        existing['updated_at'] = now
+        records[idx] = existing
+
+    _write_history(records)
+
+
+def get_history(limit: int = 50, status: Optional[str] = None) -> List[Dict[str, Any]]:
+    records = _read_history()
+    if status:
+        expected = status.upper()
+        records = [r for r in records if _status_name(r.get('status', '')) == expected]
+    records.sort(key=lambda r: r.get('updated_at', 0), reverse=True)
+    return records[:limit]
+
+
+def get_receipt(swap_id: int) -> Optional[Dict[str, Any]]:
+    records = _read_history()
+    for record in records:
+        if record.get('swap_id') == swap_id:
+            return record
+    return None

--- a/allways/cli/swap_commands/post_tx.py
+++ b/allways/cli/swap_commands/post_tx.py
@@ -13,6 +13,7 @@ from allways.cli.swap_commands.helpers import (
     load_pending_swap,
 )
 from allways.cli.swap_commands.swap import from_smallest_unit, poll_for_swap_creation, sign_and_broadcast_confirm
+from allways.cli.swap_commands.history_store import make_pending_key, upsert_history
 from allways.constants import NETUID_FINNEY
 from allways.contract_client import ContractError
 
@@ -74,6 +75,7 @@ def post_tx_command(tx_hash: str, netuid: int):
         return
 
     tx_hash = tx_hash.strip()
+    pending_key = make_pending_key(state.miner_hotkey, state.created_at)
 
     # Set up chain provider and signing key
     chain_providers = create_chain_providers(subtensor=subtensor)
@@ -105,6 +107,23 @@ def post_tx_command(tx_hash: str, netuid: int):
         from_chain=state.from_chain,
         to_chain=state.to_chain,
     )
+    upsert_history(
+        pending_key=pending_key,
+        data={
+            'status': 'CONFIRM_SUBMITTED',
+            'source_tx_hash': tx_hash,
+            'source_chain': state.from_chain,
+            'dest_chain': state.to_chain,
+            'source_amount': state.from_amount,
+            'dest_amount': state.to_amount,
+            'tao_amount': state.tao_amount,
+            'user_receives': state.user_receives,
+            'miner_uid': state.miner_uid,
+            'miner_hotkey': state.miner_hotkey,
+            'user_source_address': state.user_from_address,
+            'user_dest_address': state.receive_address,
+        },
+    )
 
     if accepted == 0:
         console.print('[yellow]No validators accepted. You can retry this command.[/yellow]')
@@ -122,6 +141,24 @@ def post_tx_command(tx_hash: str, netuid: int):
         clear_pending_swap()
         console.print(f'\n[green bold]Swap initiated! ID: {swap_id}[/green bold]')
         console.print(f'[dim]Track with: alw view swap {swap_id}[/dim]\n')
+        upsert_history(
+            swap_id=swap_id,
+            pending_key=pending_key,
+            data={
+                'status': 'ACTIVE',
+                'source_tx_hash': tx_hash,
+                'source_chain': state.from_chain,
+                'dest_chain': state.to_chain,
+                'source_amount': state.from_amount,
+                'dest_amount': state.to_amount,
+                'tao_amount': state.tao_amount,
+                'user_receives': state.user_receives,
+                'miner_uid': state.miner_uid,
+                'miner_hotkey': state.miner_hotkey,
+                'user_source_address': state.user_from_address,
+                'user_dest_address': state.receive_address,
+            },
+        )
     else:
         console.print('[yellow]Votes submitted but swap not yet on-chain. Check: alw view swaps[/yellow]')
         console.print('[dim]State file kept — you can retry this command.[/dim]\n')

--- a/allways/cli/swap_commands/resume.py
+++ b/allways/cli/swap_commands/resume.py
@@ -21,8 +21,10 @@ from allways.cli.swap_commands.helpers import (
 from allways.cli.swap_commands.swap import (
     from_smallest_unit,
     poll_for_swap_with_progress,
+    _record_swap_final_state,
     sign_and_broadcast_confirm,
 )
+from allways.cli.swap_commands.history_store import make_pending_key, upsert_history
 from allways.contract_client import ContractError
 
 
@@ -149,6 +151,7 @@ def resume_command(from_tx_hash_opt: Optional[str], skip_confirm: bool, netuid: 
             return
 
     from_tx_hash = from_tx_hash_opt.strip()
+    pending_key = make_pending_key(state.miner_hotkey, state.created_at)
 
     console.print('\n[dim]Confirming with validators...[/dim]')
     accepted, queued = sign_and_broadcast_confirm(
@@ -162,6 +165,23 @@ def resume_command(from_tx_hash_opt: Optional[str], skip_confirm: bool, netuid: 
         ephemeral_wallet,
         from_chain=state.from_chain,
         to_chain=state.to_chain,
+    )
+    upsert_history(
+        pending_key=pending_key,
+        data={
+            'status': 'CONFIRM_SUBMITTED',
+            'source_tx_hash': from_tx_hash,
+            'source_chain': state.from_chain,
+            'dest_chain': state.to_chain,
+            'source_amount': state.from_amount,
+            'dest_amount': state.to_amount,
+            'tao_amount': state.tao_amount,
+            'user_receives': state.user_receives,
+            'miner_uid': state.miner_uid,
+            'miner_hotkey': state.miner_hotkey,
+            'user_source_address': state.user_from_address,
+            'user_dest_address': state.receive_address,
+        },
     )
 
     if accepted == 0:
@@ -195,6 +215,24 @@ def resume_command(from_tx_hash_opt: Optional[str], skip_confirm: bool, netuid: 
 
     clear_pending_swap()
     console.print(f'\n[green bold]Swap initiated! ID: {swap_id}[/green bold]')
+    upsert_history(
+        swap_id=swap_id,
+        pending_key=pending_key,
+        data={
+            'status': 'ACTIVE',
+            'source_tx_hash': from_tx_hash,
+            'source_chain': state.from_chain,
+            'dest_chain': state.to_chain,
+            'source_amount': state.from_amount,
+            'dest_amount': state.to_amount,
+            'tao_amount': state.tao_amount,
+            'user_receives': state.user_receives,
+            'miner_uid': state.miner_uid,
+            'miner_hotkey': state.miner_hotkey,
+            'user_source_address': state.user_from_address,
+            'user_dest_address': state.receive_address,
+        },
+    )
 
     if skip_confirm:
         return
@@ -202,6 +240,8 @@ def resume_command(from_tx_hash_opt: Optional[str], skip_confirm: bool, netuid: 
     from allways.cli.swap_commands.view import watch_swap
 
     final_swap = watch_swap(client, swap_id)
+    if final_swap:
+        _record_swap_final_state(final_swap)
 
     if final_swap and final_swap.status == SwapStatus.COMPLETED:
         from allways.cli.swap_commands.swap import display_receipt

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -26,6 +26,7 @@ from allways.cli.swap_commands.helpers import (
     load_pending_swap,
     save_pending_swap,
 )
+from allways.cli.swap_commands.history_store import make_pending_key, upsert_history
 from allways.commitments import read_miner_commitments
 from allways.constants import FEE_DIVISOR, NETUID_FINNEY
 from allways.contract_client import ContractError
@@ -313,6 +314,21 @@ def display_receipt(swap):
     console.print()
     console.print(Panel(receipt, title='[bold green]Swap Complete[/bold green]', expand=False))
     console.print()
+
+
+def _record_swap_final_state(swap) -> None:
+    """Persist terminal swap state into local history."""
+    upsert_history(
+        swap_id=swap.id,
+        data={
+            'status': swap.status.name,
+            'source_tx_hash': swap.from_tx_hash,
+            'dest_tx_hash': swap.to_tx_hash,
+            'fulfilled_block': swap.fulfilled_block,
+            'completed_block': swap.completed_block,
+            'timeout_block': swap.timeout_block,
+        },
+    )
 
 
 def poll_for_swap_with_progress(client, miner_hotkey: str, from_chain: str, max_polls: int = 60):
@@ -739,6 +755,24 @@ def swap_now_command(
         created_at=time.time(),
     )
     save_pending_swap(state)
+    pending_key = make_pending_key(selected_pair.hotkey, state.created_at)
+    upsert_history(
+        pending_key=pending_key,
+        data={
+            'status': 'RESERVED',
+            'source_chain': from_chain,
+            'dest_chain': to_chain,
+            'source_amount': from_amount,
+            'dest_amount': to_amount,
+            'tao_amount': tao_amount,
+            'user_receives': user_receives,
+            'miner_uid': selected_pair.uid,
+            'miner_hotkey': selected_pair.hotkey,
+            'user_source_address': user_from_address,
+            'user_dest_address': receive_address,
+            'created_at': int(state.created_at),
+        },
+    )
 
     # Step 9: Send funds (or use pre-provided tx hash)
     if from_tx_hash_opt:
@@ -809,6 +843,13 @@ def swap_now_command(
         from_chain=from_chain,
         to_chain=to_chain,
     )
+    upsert_history(
+        pending_key=pending_key,
+        data={
+            'status': 'CONFIRM_SUBMITTED',
+            'source_tx_hash': from_tx_hash,
+        },
+    )
 
     if accepted == 0:
         console.print('[yellow]No validators accepted. Resume with: alw swap post-tx <tx_hash>[/yellow]')
@@ -850,6 +891,24 @@ def swap_now_command(
 
     clear_pending_swap()
     console.print(f'\n[green bold]Swap initiated! ID: {swap_id}[/green bold]')
+    upsert_history(
+        swap_id=swap_id,
+        pending_key=pending_key,
+        data={
+            'status': 'ACTIVE',
+            'source_chain': from_chain,
+            'dest_chain': to_chain,
+            'source_amount': from_amount,
+            'dest_amount': to_amount,
+            'tao_amount': tao_amount,
+            'user_receives': user_receives,
+            'miner_uid': selected_pair.uid,
+            'miner_hotkey': selected_pair.hotkey,
+            'user_source_address': user_from_address,
+            'user_dest_address': receive_address,
+            'source_tx_hash': from_tx_hash,
+        },
+    )
 
     # In non-interactive mode, just print the ID and exit (let caller handle watching)
     if skip_confirm:
@@ -859,6 +918,8 @@ def swap_now_command(
     from allways.cli.swap_commands.view import watch_swap
 
     final_swap = watch_swap(client, swap_id)
+    if final_swap:
+        _record_swap_final_state(final_swap)
 
     # Show completion receipt
     if final_swap and final_swap.status == SwapStatus.COMPLETED:

--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -2,6 +2,7 @@
 
 import time
 from dataclasses import replace
+from datetime import datetime, timezone
 
 import click
 from rich.live import Live
@@ -23,6 +24,7 @@ from allways.cli.swap_commands.helpers import (
     read_miner_commitments,
 )
 from allways.constants import FEE_DIVISOR
+from allways.cli.swap_commands.history_store import get_history, get_receipt, upsert_history
 from allways.contract_client import ContractError
 
 
@@ -314,6 +316,29 @@ def display_swap(swap, chain_info=True):
     console.print(build_swap_text(swap, chain_info=chain_info))
 
 
+def _persist_swap_state(swap) -> None:
+    upsert_history(
+        swap_id=swap.id,
+        data={
+            'status': swap.status.name,
+            'source_chain': swap.from_chain,
+            'dest_chain': swap.to_chain,
+            'source_amount': swap.from_amount,
+            'dest_amount': swap.to_amount,
+            'tao_amount': swap.tao_amount,
+            'user_source_address': swap.user_from_address,
+            'user_dest_address': swap.user_to_address,
+            'miner_hotkey': swap.miner_hotkey,
+            'source_tx_hash': swap.from_tx_hash,
+            'dest_tx_hash': swap.to_tx_hash,
+            'initiated_block': swap.initiated_block,
+            'fulfilled_block': swap.fulfilled_block,
+            'completed_block': swap.completed_block,
+            'timeout_block': swap.timeout_block,
+        },
+    )
+
+
 @view_group.command('swap')
 @click.argument('swap_id', type=int)
 @click.option('--watch', '-w', is_flag=True, help='Poll and refresh until swap completes or times out')
@@ -352,6 +377,7 @@ def view_swap(swap_id: int, watch: bool):
 
     if not watch:
         display_swap(swap)
+        _persist_swap_state(swap)
         return
 
     watch_swap(client, swap_id, swap)
@@ -376,6 +402,7 @@ def watch_swap(client, swap_id: int, swap=None):
     terminal = (SwapStatus.COMPLETED, SwapStatus.TIMED_OUT)
     if swap.status in terminal:
         display_swap(swap)
+        _persist_swap_state(swap)
         return swap
 
     def render(s, chain_info=True, watching=True):
@@ -409,15 +436,101 @@ def watch_swap(client, swap_id: int, swap=None):
                             completed_block=last_swap.fulfilled_block or last_swap.initiated_block,
                         )
                     live.update(render(final, chain_info=False, watching=False))
+                    live.update(render(final, chain_info=False, watching=False))
+                    _persist_swap_state(final)
                     return final
                 last_swap = swap
                 live.update(render(swap))
                 if swap.status in terminal:
                     live.update(render(swap, watching=False))
+                    _persist_swap_state(swap)
                     return swap
     except KeyboardInterrupt:
         console.print(f'\n[dim]Stopped watching. Resume with: alw view swap {swap_id} --watch[/dim]\n')
         return None
+
+
+def _fmt_ts(ts: int) -> str:
+    if not ts:
+        return '—'
+    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime('%Y-%m-%d %H:%M UTC')
+
+
+@view_group.command('history')
+@click.option('--limit', default=20, type=int, help='Max records to show')
+@click.option(
+    '--status',
+    default=None,
+    type=click.Choice(
+        ['reserved', 'confirm_submitted', 'active', 'fulfilled', 'completed', 'timed_out'],
+        case_sensitive=False,
+    ),
+    help='Filter by status',
+)
+def view_history(limit: int, status: str):
+    """View locally persisted swap history.
+
+    [dim]Examples:
+        $ alw view history
+        $ alw view history --status completed --limit 50[/dim]
+    """
+    records = get_history(limit=max(1, limit), status=status)
+    if not records:
+        console.print('[yellow]No local swap history found.[/yellow]')
+        console.print('[dim]History is recorded as you run swap commands in this CLI.[/dim]\n')
+        return
+
+    table = Table(show_header=True)
+    table.add_column('Swap ID', style='cyan')
+    table.add_column('Pair', style='green')
+    table.add_column('Amount', style='yellow')
+    table.add_column('Status', style='bold')
+    table.add_column('Updated', style='dim')
+
+    for rec in records:
+        swap_id = rec.get('swap_id')
+        pair = f'{rec.get("source_chain", "?").upper()}/{rec.get("dest_chain", "?").upper()}'
+        amount = rec.get('source_amount', 0)
+        amount_str = str(amount) if amount else '—'
+        table.add_row(
+            str(swap_id) if swap_id is not None else 'pending',
+            pair,
+            amount_str,
+            str(rec.get('status', 'UNKNOWN')).upper(),
+            _fmt_ts(int(rec.get('updated_at', 0))),
+        )
+
+    console.print()
+    console.print(table)
+    console.print(f'\n[dim]Showing {len(records)} record(s)[/dim]\n')
+
+
+@view_group.command('receipt')
+@click.argument('swap_id', type=int)
+def view_receipt(swap_id: int):
+    """View a local receipt for a swap ID.
+
+    [dim]Examples:
+        $ alw view receipt 42[/dim]
+    """
+    rec = get_receipt(swap_id)
+    if not rec:
+        console.print(f'[yellow]No local receipt found for swap {swap_id}.[/yellow]')
+        console.print('[dim]Try `alw view swap <id>` first to cache it locally.[/dim]\n')
+        return
+
+    status = str(rec.get('status', 'UNKNOWN')).upper()
+    console.print(f'\n[bold]Swap Receipt #{swap_id}[/bold] — {status}\n')
+    console.print(f'  Pair:       {rec.get("source_chain", "?").upper()} -> {rec.get("dest_chain", "?").upper()}')
+    console.print(f'  Sent:       {rec.get("source_amount", "—")}')
+    console.print(f'  Received:   {rec.get("dest_amount", "—")}')
+    console.print(f'  Source TX:  {rec.get("source_tx_hash") or "—"}')
+    console.print(f'  Dest TX:    {rec.get("dest_tx_hash") or "—"}')
+    console.print(f'  Initiated:  Block {rec.get("initiated_block", 0) or "—"}')
+    console.print(f'  Fulfilled:  Block {rec.get("fulfilled_block", 0) or "—"}')
+    console.print(f'  Completed:  Block {rec.get("completed_block", 0) or "—"}')
+    console.print(f'  Timeout:    Block {rec.get("timeout_block", 0) or "—"}')
+    console.print(f'  Updated:    {_fmt_ts(int(rec.get("updated_at", 0)))}\n')
 
 
 @view_group.command('contract')


### PR DESCRIPTION
## Summary

- Add a local swap history persistence layer at ~/.allways/swap_history.json via history_store.py.
- Track swap lifecycle transitions from existing CLI flows (swap now, swap resume, swap post-tx, and view swap/watch path).
- Add new CLI commands:
-- alw view history [--limit N] [--status ...]
-- alw view receipt <swap_id>

Closes #21 

## Why
Resolved swaps are removed from on-chain active storage, which makes it hard for users to review past swaps. This PR provides a practical local-first history/receipt UX without contract changes.

## User Impact
- Users can now inspect local swap history even after on-chain cleanup of resolved swaps.
- Users can retrieve a local receipt by swap_id for support/debugging/accounting.
