### PR TITLE
Link resolved swaps to dashboard URL in view.py

### DIFF
--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -1,5 +1,6 @@
 """alw view - View swaps, miners, and rates."""
 
+import os
 import time
 from dataclasses import replace
 
@@ -24,6 +25,8 @@ from allways.cli.swap_commands.helpers import (
 )
 from allways.constants import FEE_DIVISOR
 from allways.contract_client import ContractError
+
+DEFAULT_DASHBOARD_URL = 'https://test.all-ways.io'
 
 
 @click.group('view', cls=StyledGroup)
@@ -370,6 +373,9 @@ def display_swap(swap, chain_info=True):
 def view_swap(swap_id: int, watch: bool):
     """View details of a specific swap.
 
+    If the swap is no longer in contract storage (completed or timed out), a
+    dashboard URL is shown where resolved swap history is available.
+
     [dim]Examples:
         $ alw view swap 42
         $ alw view swap 42 --watch[/dim]
@@ -390,9 +396,11 @@ def view_swap(swap_id: int, watch: bool):
             next_id = None
 
         if next_id is not None and swap_id < next_id:
+            dashboard_url = os.environ.get('ALLWAYS_DASHBOARD_URL', DEFAULT_DASHBOARD_URL).rstrip('/')
             console.print(
                 f'[green]Swap {swap_id} has been resolved (completed or timed out).[/green]\n'
-                f'[dim]Resolved swaps are removed from on-chain storage.[/dim]'
+                f'[dim]Resolved swaps are removed from on-chain storage. '
+                f'View history at:[/dim] {dashboard_url}/swap/{swap_id}'
             )
         elif next_id is not None:
             console.print(f'[red]Swap {swap_id} does not exist. Next swap ID: {next_id}.[/red]')


### PR DESCRIPTION
Closes #66

## Summary

When a swap completes or times out, the contract removes it from on-chain storage. `alw view swap <id>` previously dead-ended on a generic "Swap resolved" message.

Per [your feedback](https://github.com/entrius/allways/pull/31#issuecomment-4271204429) — keeping `allways/` as the chain-state-direct layer with no HTTP calls to deployed services — this PR drops the earlier API-client approach and replaces it with a minimal dashboard URL hint that routes users to the module (`allways-ui`) that owns resolved swap history.

## Changes

- `allways/cli/swap_commands/view.py` — when `get_swap()` returns None and the swap ID is below `next_swap_id`, append the dashboard URL (`/swap/{id}`) to the existing message
- `DEFAULT_DASHBOARD_URL` module constant (`https://test.all-ways.io`) overridable via `ALLWAYS_DASHBOARD_URL` env var
- No new modules, no new dependencies, no HTTP calls from the CLI

Reverted from previous revision: `das_api.py`, `test_das_api.py`, and all indexer-fetch logic.

## Example

Before:
```
$ alw view swap 1
Swap 1 has been resolved (completed or timed out).
Resolved swaps are removed from on-chain storage.
```

After:
```
$ alw view swap 1
Swap 1 has been resolved (completed or timed out).
Resolved swaps are removed from on-chain storage. View history at: https://test.all-ways.io/swap/1
```

## Test plan
- [ ] Manual: `alw view swap <resolved_id>` prints the dashboard URL
- [ ] Manual: `alw view swap <active_id>` still shows full on-chain details
- [ ] Manual: `ALLWAYS_DASHBOARD_URL=https://my.host alw view swap <resolved_id>` uses the override