### PR TITLE
QA foundation polish

### DIFF
--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -11,7 +11,7 @@ from rich.table import Table
 
 from allways.chain_providers import create_chain_providers
 from allways.chains import SUPPORTED_CHAINS, canonical_pair, get_chain
-from allways.classes import MinerPair, SwapStatus
+from allways.classes import SwapStatus
 from allways.cli.dendrite_lite import broadcast_synapse, discover_validators, get_ephemeral_wallet
 from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
@@ -19,6 +19,7 @@ from allways.cli.swap_commands.helpers import (
     PendingSwapState,
     clear_pending_swap,
     console,
+    find_matching_miners,
     from_rao,
     get_cli_context,
     is_local_network,
@@ -527,28 +528,7 @@ def swap_now_command(
     console.print('\n[dim]Reading miner commitments...[/dim]')
     all_pairs = read_miner_commitments(subtensor, netuid)
 
-    matching_pairs = []
-    for p in all_pairs:
-        if p.source_chain == source_chain and p.dest_chain == dest_chain:
-            if p.rate > 0:
-                matching_pairs.append(p)
-        elif p.source_chain == dest_chain and p.dest_chain == source_chain:
-            rev_rate, rev_rate_str = p.get_rate_for_direction(source_chain)
-            if rev_rate > 0:
-                matching_pairs.append(
-                    MinerPair(
-                        uid=p.uid,
-                        hotkey=p.hotkey,
-                        source_chain=p.dest_chain,
-                        source_address=p.dest_address,
-                        dest_chain=p.source_chain,
-                        dest_address=p.source_address,
-                        rate=rev_rate,
-                        rate_str=rev_rate_str,
-                        counter_rate=p.rate,
-                        counter_rate_str=p.rate_str,
-                    )
-                )
+    matching_pairs = find_matching_miners(all_pairs, source_chain, dest_chain)
 
     if not matching_pairs:
         console.print('[yellow]No miners found for this pair[/yellow]\n')

--- a/allways/commitments.py
+++ b/allways/commitments.py
@@ -14,7 +14,7 @@ def parse_commitment_data(raw: str, uid: int = 0, hotkey: str = '') -> Optional[
 
     Format: v{VERSION}:{src_chain}:{src_addr}:{dst_chain}:{dst_addr}:{rate}:{counter_rate}
     Both rates are 'canonical_dest per 1 canonical_source'. rate is for source→dest, counter_rate for dest→source.
-    Example: v3:btc:bc1q...:tao:5C...:340:350
+    Example: v1:btc:bc1q...:tao:5C...:340:350
     """
     try:
         parts = raw.split(':')

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -14,7 +14,7 @@ MINER_POLL_INTERVAL_SECONDS = 12  # Match Bittensor block time for lowest latenc
 VALIDATOR_POLL_INTERVAL_SECONDS = 12  # Match Bittensor block time for lowest latency
 
 # ─── Commitment Format ────────────────────────────────────
-COMMITMENT_VERSION = 3
+COMMITMENT_VERSION = 1
 COMMITMENT_REVEAL_BLOCKS = 360  # ~72 min at 12s/block
 
 # ─── Unit Conversions ────────────────────────────────────

--- a/allways/contract_client.py
+++ b/allways/contract_client.py
@@ -93,7 +93,7 @@ CONTRACT_ARG_TYPES = {
     'vote_reserve': [
         ('request_hash', 'hash'),
         ('miner', 'AccountId'),
-        ('user_source_address', 'bytes'),
+        ('user_source_address', 'str'),
         ('source_chain', 'str'),
         ('dest_chain', 'str'),
         ('tao_amount', 'u128'),
@@ -161,7 +161,7 @@ CONTRACT_ARG_TYPES = {
     ],
     'get_extend_vote_count': [('miner', 'AccountId')],
     'vote_extend_timeout': [('swap_id', 'u64')],
-    'get_cooldown': [('source_address', 'bytes')],
+    'get_cooldown': [('source_address', 'str')],
     'set_halted': [('halted', 'bool')],
     'get_halted': [],
     'get_accumulated_fees': [],
@@ -820,7 +820,7 @@ class AllwaysContractClient:
     def get_extend_vote_count(self, miner_hotkey: str) -> int:
         return self._read_u32('get_extend_vote_count', {'miner': miner_hotkey})
 
-    def get_cooldown(self, source_address: bytes) -> Tuple[int, int]:
+    def get_cooldown(self, source_address: str) -> Tuple[int, int]:
         """Returns (strike_count, last_expired_block) for a source address."""
         self._ensure_initialized()
         data = self._raw_contract_read('get_cooldown', {'source_address': source_address})
@@ -863,7 +863,7 @@ class AllwaysContractClient:
     def get_fee_divisor(self) -> int:
         return self._read_u128('get_fee_divisor')
 
-    def get_reservation_data(self, miner_hotkey: str) -> Optional[Tuple[bytes, int, int, int, int]]:
+    def get_reservation_data(self, miner_hotkey: str) -> Optional[Tuple[str, int, int, int, int]]:
         """Get reservation data for a miner.
 
         Returns (source_addr, tao_amount, source_amount, dest_amount, reserved_until) or None.
@@ -878,7 +878,7 @@ class AllwaysContractClient:
         if data[0] != 0x01:
             return None
         o = 1
-        # Vec<u8> source_addr: compact length + bytes
+        # String source_addr: compact length + UTF-8 bytes
         first = data[o]
         mode = first & 0x03
         if mode == 0:
@@ -889,7 +889,7 @@ class AllwaysContractClient:
             o += 2
         else:
             return None
-        source_addr = data[o : o + addr_len]
+        source_addr = data[o : o + addr_len].decode('utf-8')
         o += addr_len
         # 3 x u128 + 1 x u32
         tao_lo = struct.unpack_from('<Q', data, o)[0]
@@ -929,7 +929,7 @@ class AllwaysContractClient:
         wallet: bt.Wallet,
         request_hash: bytes,
         miner_hotkey: str,
-        user_source_address: bytes,
+        user_source_address: str,
         source_chain: str,
         dest_chain: str,
         tao_amount: int,

--- a/allways/metadata/allways_swap_manager.json
+++ b/allways/metadata/allways_swap_manager.json
@@ -1,6 +1,6 @@
 {
   "source": {
-    "hash": "0x351b1d86ee73248c336fd6a2b233b8e9485fc698513464c3160222632fb64495",
+    "hash": "0xa02fffcf387e8c5062f763674de78a068f33aedc5e1e762bd088fe6291ec3734",
     "language": "ink! 5.1.1",
     "compiler": "rustc 1.91.1",
     "build_info": {
@@ -109,7 +109,7 @@
             "ink_primitives",
             "ConstructorResult"
           ],
-          "type": 96
+          "type": 95
         },
         "selector": "0x9bae9d5e"
       }
@@ -138,7 +138,7 @@
         "displayName": [
           "ChainExtension"
         ],
-        "type": 115
+        "type": 114
       },
       "hash": {
         "displayName": [
@@ -893,7 +893,7 @@
                 "types",
                 "VoteType"
               ],
-              "type": 114
+              "type": 113
             }
           },
           {
@@ -921,7 +921,7 @@
         "ink",
         "LangError"
       ],
-      "type": 97
+      "type": 96
     },
     "messages": [
       {
@@ -936,7 +936,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0x31b3f423"
       },
@@ -962,7 +962,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0xe098e62d"
       },
@@ -990,9 +990,9 @@
             "label": "user_source_address",
             "type": {
               "displayName": [
-                "Vec"
+                "String"
               ],
-              "type": 72
+              "type": 12
             }
           },
           {
@@ -1051,7 +1051,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0xff3b86a0"
       },
@@ -1077,7 +1077,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0xc4cb59cb"
       },
@@ -1121,7 +1121,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0xf668d950"
       },
@@ -1273,7 +1273,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0x90c444d8"
       },
@@ -1328,7 +1328,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0x2dbeeb8d"
       },
@@ -1356,7 +1356,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0xd0065335"
       },
@@ -1384,7 +1384,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0x5325f39c"
       },
@@ -1414,7 +1414,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0x0fb2d2e5"
       },
@@ -1442,7 +1442,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0xcf3c3dd9"
       },
@@ -1470,7 +1470,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0x339db2a5"
       },
@@ -1498,7 +1498,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0x00088a2d"
       },
@@ -1524,7 +1524,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0x107e33ea"
       },
@@ -1550,7 +1550,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0x82f48fa6"
       },
@@ -1576,7 +1576,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0x62135acd"
       },
@@ -1602,7 +1602,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0xe9cb777b"
       },
@@ -1628,7 +1628,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0xb3f48b5e"
       },
@@ -1654,7 +1654,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0xb7fae7fd"
       },
@@ -1680,7 +1680,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0xc0d8ec47"
       },
@@ -1706,7 +1706,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0x800e1573"
       },
@@ -1732,7 +1732,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0x3e868f32"
       },
@@ -1758,7 +1758,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0x50dfe685"
       },
@@ -1784,7 +1784,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0x3143d9e3"
       },
@@ -1810,7 +1810,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0x8832de41"
       },
@@ -1836,7 +1836,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0x8fe1c210"
       },
@@ -1852,7 +1852,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 98
+          "type": 97
         },
         "selector": "0x97756ea1"
       },
@@ -1878,7 +1878,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 101
+          "type": 100
         },
         "selector": "0xa35f1bbf"
       },
@@ -1904,7 +1904,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 103
+          "type": 102
         },
         "selector": "0xf48343ad"
       },
@@ -1930,7 +1930,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 104
+          "type": 103
         },
         "selector": "0x25652be8"
       },
@@ -1956,7 +1956,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 104
+          "type": 103
         },
         "selector": "0x1d07dec1"
       },
@@ -1982,7 +1982,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 105
+          "type": 104
         },
         "selector": "0xa4b68d1f"
       },
@@ -2008,7 +2008,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 104
+          "type": 103
         },
         "selector": "0xf844fc5f"
       },
@@ -2024,7 +2024,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 106
+          "type": 105
         },
         "selector": "0xd80244d2"
       },
@@ -2040,7 +2040,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 105
+          "type": 104
         },
         "selector": "0xe820174a"
       },
@@ -2056,7 +2056,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 103
+          "type": 102
         },
         "selector": "0x233a7832"
       },
@@ -2072,7 +2072,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 103
+          "type": 102
         },
         "selector": "0x54945717"
       },
@@ -2088,7 +2088,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 105
+          "type": 104
         },
         "selector": "0xfe07130d"
       },
@@ -2104,7 +2104,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 103
+          "type": 102
         },
         "selector": "0xbf3b5d4e"
       },
@@ -2120,7 +2120,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 103
+          "type": 102
         },
         "selector": "0x9910e939"
       },
@@ -2136,7 +2136,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 107
+          "type": 106
         },
         "selector": "0x07fcd0b1"
       },
@@ -2152,7 +2152,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 104
+          "type": 103
         },
         "selector": "0xec540804"
       },
@@ -2168,7 +2168,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 107
+          "type": 106
         },
         "selector": "0x3847e06c"
       },
@@ -2194,7 +2194,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 103
+          "type": 102
         },
         "selector": "0x48c78c4a"
       },
@@ -2210,7 +2210,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 103
+          "type": 102
         },
         "selector": "0xfca7daa4"
       },
@@ -2226,7 +2226,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 103
+          "type": 102
         },
         "selector": "0x97826e04"
       },
@@ -2252,7 +2252,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 105
+          "type": 104
         },
         "selector": "0xd5ed7150"
       },
@@ -2268,7 +2268,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 105
+          "type": 104
         },
         "selector": "0xf7e24a31"
       },
@@ -2284,7 +2284,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 103
+          "type": 102
         },
         "selector": "0x41afd8bc"
       },
@@ -2310,7 +2310,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 105
+          "type": 104
         },
         "selector": "0x361acc31"
       },
@@ -2326,7 +2326,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 108
+          "type": 107
         },
         "selector": "0x2c283460"
       },
@@ -2342,7 +2342,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 105
+          "type": 104
         },
         "selector": "0xa30ab5c4"
       },
@@ -2368,7 +2368,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 105
+          "type": 104
         },
         "selector": "0x154595d0"
       },
@@ -2394,7 +2394,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 109
+          "type": 108
         },
         "selector": "0x79fe2717"
       },
@@ -2420,7 +2420,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 105
+          "type": 104
         },
         "selector": "0x3781315a"
       },
@@ -2446,7 +2446,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 105
+          "type": 104
         },
         "selector": "0x24fa0aae"
       },
@@ -2456,9 +2456,9 @@
             "label": "source_address",
             "type": {
               "displayName": [
-                "Vec"
+                "String"
               ],
-              "type": 72
+              "type": 12
             }
           }
         ],
@@ -2472,7 +2472,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 112
+          "type": 111
         },
         "selector": "0x19a837c6"
       }
@@ -3117,11 +3117,11 @@
                   "layout": {
                     "leaf": {
                       "key": "0x903da210",
-                      "ty": 72
+                      "ty": 12
                     }
                   },
                   "root_key": "0x903da210",
-                  "ty": 73
+                  "ty": 72
                 }
               },
               "name": "reservation_source_addr"
@@ -3136,7 +3136,7 @@
                     }
                   },
                   "root_key": "0x696675ed",
-                  "ty": 76
+                  "ty": 75
                 }
               },
               "name": "reservation_tao_amount"
@@ -3151,7 +3151,7 @@
                     }
                   },
                   "root_key": "0xda515005",
-                  "ty": 79
+                  "ty": 78
                 }
               },
               "name": "reservation_source_amount"
@@ -3166,7 +3166,7 @@
                     }
                   },
                   "root_key": "0xef4d66a0",
-                  "ty": 82
+                  "ty": 81
                 }
               },
               "name": "reservation_dest_amount"
@@ -3181,7 +3181,7 @@
                     }
                   },
                   "root_key": "0xebebacef",
-                  "ty": 85
+                  "ty": 84
                 }
               },
               "name": "address_strike_count"
@@ -3196,7 +3196,7 @@
                     }
                   },
                   "root_key": "0x936b90dc",
-                  "ty": 88
+                  "ty": 87
                 }
               },
               "name": "address_last_expired"
@@ -3248,7 +3248,7 @@
                     }
                   },
                   "root_key": "0x0a1285bc",
-                  "ty": 91
+                  "ty": 90
                 }
               },
               "name": "pending_slashes"
@@ -3258,7 +3258,7 @@
         }
       },
       "root_key": "0x00000000",
-      "ty": 95
+      "ty": 94
     }
   },
   "types": [
@@ -4896,10 +4896,28 @@
       "id": 72,
       "type": {
         "def": {
-          "sequence": {
-            "type": 2
+          "composite": {}
+        },
+        "params": [
+          {
+            "name": "K",
+            "type": 0
+          },
+          {
+            "name": "V",
+            "type": 12
+          },
+          {
+            "name": "KeyType",
+            "type": 73
           }
-        }
+        ],
+        "path": [
+          "ink_storage",
+          "lazy",
+          "mapping",
+          "Mapping"
+        ]
       }
     },
     {
@@ -4910,23 +4928,18 @@
         },
         "params": [
           {
-            "name": "K",
-            "type": 0
+            "name": "L",
+            "type": 8
           },
           {
-            "name": "V",
-            "type": 72
-          },
-          {
-            "name": "KeyType",
+            "name": "R",
             "type": 74
           }
         ],
         "path": [
-          "ink_storage",
-          "lazy",
-          "mapping",
-          "Mapping"
+          "ink_storage_traits",
+          "impls",
+          "ResolverKey"
         ]
       }
     },
@@ -4938,18 +4951,14 @@
         },
         "params": [
           {
-            "name": "L",
-            "type": 8
-          },
-          {
-            "name": "R",
-            "type": 75
+            "name": "ParentKey",
+            "type": 10
           }
         ],
         "path": [
           "ink_storage_traits",
           "impls",
-          "ResolverKey"
+          "ManualKey"
         ]
       }
     },
@@ -4961,14 +4970,23 @@
         },
         "params": [
           {
-            "name": "ParentKey",
-            "type": 10
+            "name": "K",
+            "type": 0
+          },
+          {
+            "name": "V",
+            "type": 4
+          },
+          {
+            "name": "KeyType",
+            "type": 76
           }
         ],
         "path": [
-          "ink_storage_traits",
-          "impls",
-          "ManualKey"
+          "ink_storage",
+          "lazy",
+          "mapping",
+          "Mapping"
         ]
       }
     },
@@ -4980,23 +4998,18 @@
         },
         "params": [
           {
-            "name": "K",
-            "type": 0
+            "name": "L",
+            "type": 8
           },
           {
-            "name": "V",
-            "type": 4
-          },
-          {
-            "name": "KeyType",
+            "name": "R",
             "type": 77
           }
         ],
         "path": [
-          "ink_storage",
-          "lazy",
-          "mapping",
-          "Mapping"
+          "ink_storage_traits",
+          "impls",
+          "ResolverKey"
         ]
       }
     },
@@ -5008,18 +5021,14 @@
         },
         "params": [
           {
-            "name": "L",
-            "type": 8
-          },
-          {
-            "name": "R",
-            "type": 78
+            "name": "ParentKey",
+            "type": 10
           }
         ],
         "path": [
           "ink_storage_traits",
           "impls",
-          "ResolverKey"
+          "ManualKey"
         ]
       }
     },
@@ -5031,14 +5040,23 @@
         },
         "params": [
           {
-            "name": "ParentKey",
-            "type": 10
+            "name": "K",
+            "type": 0
+          },
+          {
+            "name": "V",
+            "type": 4
+          },
+          {
+            "name": "KeyType",
+            "type": 79
           }
         ],
         "path": [
-          "ink_storage_traits",
-          "impls",
-          "ManualKey"
+          "ink_storage",
+          "lazy",
+          "mapping",
+          "Mapping"
         ]
       }
     },
@@ -5050,23 +5068,18 @@
         },
         "params": [
           {
-            "name": "K",
-            "type": 0
+            "name": "L",
+            "type": 8
           },
           {
-            "name": "V",
-            "type": 4
-          },
-          {
-            "name": "KeyType",
+            "name": "R",
             "type": 80
           }
         ],
         "path": [
-          "ink_storage",
-          "lazy",
-          "mapping",
-          "Mapping"
+          "ink_storage_traits",
+          "impls",
+          "ResolverKey"
         ]
       }
     },
@@ -5078,29 +5091,6 @@
         },
         "params": [
           {
-            "name": "L",
-            "type": 8
-          },
-          {
-            "name": "R",
-            "type": 81
-          }
-        ],
-        "path": [
-          "ink_storage_traits",
-          "impls",
-          "ResolverKey"
-        ]
-      }
-    },
-    {
-      "id": 81,
-      "type": {
-        "def": {
-          "composite": {}
-        },
-        "params": [
-          {
             "name": "ParentKey",
             "type": 10
           }
@@ -5113,7 +5103,7 @@
       }
     },
     {
-      "id": 82,
+      "id": 81,
       "type": {
         "def": {
           "composite": {}
@@ -5129,7 +5119,7 @@
           },
           {
             "name": "KeyType",
-            "type": 83
+            "type": 82
           }
         ],
         "path": [
@@ -5137,6 +5127,29 @@
           "lazy",
           "mapping",
           "Mapping"
+        ]
+      }
+    },
+    {
+      "id": 82,
+      "type": {
+        "def": {
+          "composite": {}
+        },
+        "params": [
+          {
+            "name": "L",
+            "type": 8
+          },
+          {
+            "name": "R",
+            "type": 83
+          }
+        ],
+        "path": [
+          "ink_storage_traits",
+          "impls",
+          "ResolverKey"
         ]
       }
     },
@@ -5148,18 +5161,14 @@
         },
         "params": [
           {
-            "name": "L",
-            "type": 8
-          },
-          {
-            "name": "R",
-            "type": 84
+            "name": "ParentKey",
+            "type": 10
           }
         ],
         "path": [
           "ink_storage_traits",
           "impls",
-          "ResolverKey"
+          "ManualKey"
         ]
       }
     },
@@ -5171,14 +5180,23 @@
         },
         "params": [
           {
-            "name": "ParentKey",
-            "type": 10
+            "name": "K",
+            "type": 12
+          },
+          {
+            "name": "V",
+            "type": 2
+          },
+          {
+            "name": "KeyType",
+            "type": 85
           }
         ],
         "path": [
-          "ink_storage_traits",
-          "impls",
-          "ManualKey"
+          "ink_storage",
+          "lazy",
+          "mapping",
+          "Mapping"
         ]
       }
     },
@@ -5190,23 +5208,18 @@
         },
         "params": [
           {
-            "name": "K",
-            "type": 72
+            "name": "L",
+            "type": 8
           },
           {
-            "name": "V",
-            "type": 2
-          },
-          {
-            "name": "KeyType",
+            "name": "R",
             "type": 86
           }
         ],
         "path": [
-          "ink_storage",
-          "lazy",
-          "mapping",
-          "Mapping"
+          "ink_storage_traits",
+          "impls",
+          "ResolverKey"
         ]
       }
     },
@@ -5218,18 +5231,14 @@
         },
         "params": [
           {
-            "name": "L",
-            "type": 8
-          },
-          {
-            "name": "R",
-            "type": 87
+            "name": "ParentKey",
+            "type": 10
           }
         ],
         "path": [
           "ink_storage_traits",
           "impls",
-          "ResolverKey"
+          "ManualKey"
         ]
       }
     },
@@ -5241,14 +5250,23 @@
         },
         "params": [
           {
-            "name": "ParentKey",
-            "type": 10
+            "name": "K",
+            "type": 12
+          },
+          {
+            "name": "V",
+            "type": 3
+          },
+          {
+            "name": "KeyType",
+            "type": 88
           }
         ],
         "path": [
-          "ink_storage_traits",
-          "impls",
-          "ManualKey"
+          "ink_storage",
+          "lazy",
+          "mapping",
+          "Mapping"
         ]
       }
     },
@@ -5260,23 +5278,18 @@
         },
         "params": [
           {
-            "name": "K",
-            "type": 72
+            "name": "L",
+            "type": 8
           },
           {
-            "name": "V",
-            "type": 3
-          },
-          {
-            "name": "KeyType",
+            "name": "R",
             "type": 89
           }
         ],
         "path": [
-          "ink_storage",
-          "lazy",
-          "mapping",
-          "Mapping"
+          "ink_storage_traits",
+          "impls",
+          "ResolverKey"
         ]
       }
     },
@@ -5288,18 +5301,14 @@
         },
         "params": [
           {
-            "name": "L",
-            "type": 8
-          },
-          {
-            "name": "R",
-            "type": 90
+            "name": "ParentKey",
+            "type": 10
           }
         ],
         "path": [
           "ink_storage_traits",
           "impls",
-          "ResolverKey"
+          "ManualKey"
         ]
       }
     },
@@ -5311,35 +5320,16 @@
         },
         "params": [
           {
-            "name": "ParentKey",
-            "type": 10
-          }
-        ],
-        "path": [
-          "ink_storage_traits",
-          "impls",
-          "ManualKey"
-        ]
-      }
-    },
-    {
-      "id": 91,
-      "type": {
-        "def": {
-          "composite": {}
-        },
-        "params": [
-          {
             "name": "K",
             "type": 11
           },
           {
             "name": "V",
-            "type": 92
+            "type": 91
           },
           {
             "name": "KeyType",
-            "type": 93
+            "type": 92
           }
         ],
         "path": [
@@ -5351,7 +5341,7 @@
       }
     },
     {
-      "id": 92,
+      "id": 91,
       "type": {
         "def": {
           "tuple": [
@@ -5362,7 +5352,7 @@
       }
     },
     {
-      "id": 93,
+      "id": 92,
       "type": {
         "def": {
           "composite": {}
@@ -5374,7 +5364,7 @@
           },
           {
             "name": "R",
-            "type": 94
+            "type": 93
           }
         ],
         "path": [
@@ -5385,7 +5375,7 @@
       }
     },
     {
-      "id": 94,
+      "id": 93,
       "type": {
         "def": {
           "composite": {}
@@ -5404,7 +5394,7 @@
       }
     },
     {
-      "id": 95,
+      "id": 94,
       "type": {
         "def": {
           "composite": {
@@ -5576,33 +5566,33 @@
               },
               {
                 "name": "reservation_source_addr",
-                "type": 73,
-                "typeName": "<Mapping<AccountId, Vec<u8>> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<279068048u32, ()\n>,>>::Type"
+                "type": 72,
+                "typeName": "<Mapping<AccountId, String> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<279068048u32, ()\n>,>>::Type"
               },
               {
                 "name": "reservation_tao_amount",
-                "type": 76,
+                "type": 75,
                 "typeName": "<Mapping<AccountId, Balance> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<3983894121u32,\n()>,>>::Type"
               },
               {
                 "name": "reservation_source_amount",
-                "type": 79,
+                "type": 78,
                 "typeName": "<Mapping<AccountId, Balance> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<89149914u32, ()\n>,>>::Type"
               },
               {
                 "name": "reservation_dest_amount",
-                "type": 82,
+                "type": 81,
                 "typeName": "<Mapping<AccountId, Balance> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<2691059183u32,\n()>,>>::Type"
               },
               {
                 "name": "address_strike_count",
-                "type": 85,
-                "typeName": "<Mapping<Vec<u8>, u8> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<4021087211u32,\n()>,>>::Type"
+                "type": 84,
+                "typeName": "<Mapping<String, u8> as::ink::storage::traits::AutoStorableHint<\n::ink::storage::traits::ManualKey<4021087211u32, ()>,>>::Type"
               },
               {
                 "name": "address_last_expired",
-                "type": 88,
-                "typeName": "<Mapping<Vec<u8>, u32> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<3700452243u32,\n()>,>>::Type"
+                "type": 87,
+                "typeName": "<Mapping<String, u32> as::ink::storage::traits::AutoStorableHint<\n::ink::storage::traits::ManualKey<3700452243u32, ()>,>>::Type"
               },
               {
                 "name": "accumulated_fees",
@@ -5616,7 +5606,7 @@
               },
               {
                 "name": "pending_slashes",
-                "type": 91,
+                "type": 90,
                 "typeName": "<Mapping<u64, (AccountId, Balance)> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<3162837514u32,\n()>,>>::Type"
               }
             ]
@@ -5630,7 +5620,7 @@
       }
     },
     {
-      "id": 96,
+      "id": 95,
       "type": {
         "def": {
           "variant": {
@@ -5647,7 +5637,7 @@
               {
                 "fields": [
                   {
-                    "type": 97
+                    "type": 96
                   }
                 ],
                 "index": 1,
@@ -5663,7 +5653,7 @@
           },
           {
             "name": "E",
-            "type": 97
+            "type": 96
           }
         ],
         "path": [
@@ -5672,7 +5662,7 @@
       }
     },
     {
-      "id": 97,
+      "id": 96,
       "type": {
         "def": {
           "variant": {
@@ -5691,7 +5681,7 @@
       }
     },
     {
-      "id": 98,
+      "id": 97,
       "type": {
         "def": {
           "variant": {
@@ -5699,7 +5689,7 @@
               {
                 "fields": [
                   {
-                    "type": 99
+                    "type": 98
                   }
                 ],
                 "index": 0,
@@ -5708,7 +5698,7 @@
               {
                 "fields": [
                   {
-                    "type": 97
+                    "type": 96
                   }
                 ],
                 "index": 1,
@@ -5720,11 +5710,11 @@
         "params": [
           {
             "name": "T",
-            "type": 99
+            "type": 98
           },
           {
             "name": "E",
-            "type": 97
+            "type": 96
           }
         ],
         "path": [
@@ -5733,7 +5723,7 @@
       }
     },
     {
-      "id": 99,
+      "id": 98,
       "type": {
         "def": {
           "variant": {
@@ -5750,7 +5740,7 @@
               {
                 "fields": [
                   {
-                    "type": 100
+                    "type": 99
                   }
                 ],
                 "index": 1,
@@ -5766,7 +5756,7 @@
           },
           {
             "name": "E",
-            "type": 100
+            "type": 99
           }
         ],
         "path": [
@@ -5775,7 +5765,7 @@
       }
     },
     {
-      "id": 100,
+      "id": 99,
       "type": {
         "def": {
           "variant": {
@@ -5903,7 +5893,7 @@
       }
     },
     {
-      "id": 101,
+      "id": 100,
       "type": {
         "def": {
           "variant": {
@@ -5911,7 +5901,7 @@
               {
                 "fields": [
                   {
-                    "type": 102
+                    "type": 101
                   }
                 ],
                 "index": 0,
@@ -5920,7 +5910,7 @@
               {
                 "fields": [
                   {
-                    "type": 97
+                    "type": 96
                   }
                 ],
                 "index": 1,
@@ -5932,11 +5922,11 @@
         "params": [
           {
             "name": "T",
-            "type": 102
+            "type": 101
           },
           {
             "name": "E",
-            "type": 97
+            "type": 96
           }
         ],
         "path": [
@@ -5945,7 +5935,7 @@
       }
     },
     {
-      "id": 102,
+      "id": 101,
       "type": {
         "def": {
           "variant": {
@@ -5978,7 +5968,7 @@
       }
     },
     {
-      "id": 103,
+      "id": 102,
       "type": {
         "def": {
           "variant": {
@@ -5995,7 +5985,7 @@
               {
                 "fields": [
                   {
-                    "type": 97
+                    "type": 96
                   }
                 ],
                 "index": 1,
@@ -6011,7 +6001,7 @@
           },
           {
             "name": "E",
-            "type": 97
+            "type": 96
           }
         ],
         "path": [
@@ -6020,7 +6010,7 @@
       }
     },
     {
-      "id": 104,
+      "id": 103,
       "type": {
         "def": {
           "variant": {
@@ -6037,7 +6027,7 @@
               {
                 "fields": [
                   {
-                    "type": 97
+                    "type": 96
                   }
                 ],
                 "index": 1,
@@ -6053,7 +6043,7 @@
           },
           {
             "name": "E",
-            "type": 97
+            "type": 96
           }
         ],
         "path": [
@@ -6062,7 +6052,7 @@
       }
     },
     {
-      "id": 105,
+      "id": 104,
       "type": {
         "def": {
           "variant": {
@@ -6079,7 +6069,7 @@
               {
                 "fields": [
                   {
-                    "type": 97
+                    "type": 96
                   }
                 ],
                 "index": 1,
@@ -6095,7 +6085,7 @@
           },
           {
             "name": "E",
-            "type": 97
+            "type": 96
           }
         ],
         "path": [
@@ -6104,7 +6094,7 @@
       }
     },
     {
-      "id": 106,
+      "id": 105,
       "type": {
         "def": {
           "variant": {
@@ -6121,7 +6111,7 @@
               {
                 "fields": [
                   {
-                    "type": 97
+                    "type": 96
                   }
                 ],
                 "index": 1,
@@ -6137,7 +6127,7 @@
           },
           {
             "name": "E",
-            "type": 97
+            "type": 96
           }
         ],
         "path": [
@@ -6146,7 +6136,7 @@
       }
     },
     {
-      "id": 107,
+      "id": 106,
       "type": {
         "def": {
           "variant": {
@@ -6163,7 +6153,7 @@
               {
                 "fields": [
                   {
-                    "type": 97
+                    "type": 96
                   }
                 ],
                 "index": 1,
@@ -6179,7 +6169,7 @@
           },
           {
             "name": "E",
-            "type": 97
+            "type": 96
           }
         ],
         "path": [
@@ -6188,7 +6178,7 @@
       }
     },
     {
-      "id": 108,
+      "id": 107,
       "type": {
         "def": {
           "variant": {
@@ -6205,7 +6195,7 @@
               {
                 "fields": [
                   {
-                    "type": 97
+                    "type": 96
                   }
                 ],
                 "index": 1,
@@ -6221,7 +6211,49 @@
           },
           {
             "name": "E",
-            "type": 97
+            "type": 96
+          }
+        ],
+        "path": [
+          "Result"
+        ]
+      }
+    },
+    {
+      "id": 108,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "fields": [
+                  {
+                    "type": 109
+                  }
+                ],
+                "index": 0,
+                "name": "Ok"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 96
+                  }
+                ],
+                "index": 1,
+                "name": "Err"
+              }
+            ]
+          }
+        },
+        "params": [
+          {
+            "name": "T",
+            "type": 109
+          },
+          {
+            "name": "E",
+            "type": 96
           }
         ],
         "path": [
@@ -6236,55 +6268,13 @@
           "variant": {
             "variants": [
               {
-                "fields": [
-                  {
-                    "type": 110
-                  }
-                ],
-                "index": 0,
-                "name": "Ok"
-              },
-              {
-                "fields": [
-                  {
-                    "type": 97
-                  }
-                ],
-                "index": 1,
-                "name": "Err"
-              }
-            ]
-          }
-        },
-        "params": [
-          {
-            "name": "T",
-            "type": 110
-          },
-          {
-            "name": "E",
-            "type": 97
-          }
-        ],
-        "path": [
-          "Result"
-        ]
-      }
-    },
-    {
-      "id": 110,
-      "type": {
-        "def": {
-          "variant": {
-            "variants": [
-              {
                 "index": 0,
                 "name": "None"
               },
               {
                 "fields": [
                   {
-                    "type": 111
+                    "type": 110
                   }
                 ],
                 "index": 1,
@@ -6296,7 +6286,7 @@
         "params": [
           {
             "name": "T",
-            "type": 111
+            "type": 110
           }
         ],
         "path": [
@@ -6305,11 +6295,11 @@
       }
     },
     {
-      "id": 111,
+      "id": 110,
       "type": {
         "def": {
           "tuple": [
-            72,
+            12,
             4,
             4,
             4,
@@ -6319,7 +6309,7 @@
       }
     },
     {
-      "id": 112,
+      "id": 111,
       "type": {
         "def": {
           "variant": {
@@ -6327,7 +6317,7 @@
               {
                 "fields": [
                   {
-                    "type": 113
+                    "type": 112
                   }
                 ],
                 "index": 0,
@@ -6336,7 +6326,7 @@
               {
                 "fields": [
                   {
-                    "type": 97
+                    "type": 96
                   }
                 ],
                 "index": 1,
@@ -6348,11 +6338,11 @@
         "params": [
           {
             "name": "T",
-            "type": 113
+            "type": 112
           },
           {
             "name": "E",
-            "type": 97
+            "type": 96
           }
         ],
         "path": [
@@ -6361,7 +6351,7 @@
       }
     },
     {
-      "id": 113,
+      "id": 112,
       "type": {
         "def": {
           "tuple": [
@@ -6372,7 +6362,7 @@
       }
     },
     {
-      "id": 114,
+      "id": 113,
       "type": {
         "def": {
           "variant": {
@@ -6400,7 +6390,7 @@
       }
     },
     {
-      "id": 115,
+      "id": 114,
       "type": {
         "def": {
           "variant": {}

--- a/allways/metadata/allways_swap_manager.json
+++ b/allways/metadata/allways_swap_manager.json
@@ -1,10 +1,10 @@
 {
   "source": {
-    "hash": "0xa9366ce46778c703549e625adf39d154f87dce58dded686937c0e2630cb1052e",
+    "hash": "0x351b1d86ee73248c336fd6a2b233b8e9485fc698513464c3160222632fb64495",
     "language": "ink! 5.1.1",
     "compiler": "rustc 1.91.1",
     "build_info": {
-      "build_mode": "Release",
+      "build_mode": "Debug",
       "cargo_contract_version": "5.0.3",
       "rust_toolchain": "stable-x86_64-unknown-linux-gnu",
       "wasm_opt_settings": {
@@ -26,15 +26,6 @@
       {
         "args": [
           {
-            "label": "treasury_hotkey",
-            "type": {
-              "displayName": [
-                "AccountId"
-              ],
-              "type": 0
-            }
-          },
-          {
             "label": "recycle_address",
             "type": {
               "displayName": [
@@ -44,21 +35,12 @@
             }
           },
           {
-            "label": "netuid",
-            "type": {
-              "displayName": [
-                "u16"
-              ],
-              "type": 3
-            }
-          },
-          {
             "label": "fulfillment_timeout_blocks",
             "type": {
               "displayName": [
                 "u32"
               ],
-              "type": 4
+              "type": 3
             }
           },
           {
@@ -67,7 +49,7 @@
               "displayName": [
                 "u32"
               ],
-              "type": 4
+              "type": 3
             }
           },
           {
@@ -76,7 +58,7 @@
               "displayName": [
                 "Balance"
               ],
-              "type": 5
+              "type": 4
             }
           },
           {
@@ -85,7 +67,7 @@
               "displayName": [
                 "Balance"
               ],
-              "type": 5
+              "type": 4
             }
           },
           {
@@ -94,7 +76,7 @@
               "displayName": [
                 "Balance"
               ],
-              "type": 5
+              "type": 4
             }
           },
           {
@@ -103,7 +85,7 @@
               "displayName": [
                 "Balance"
               ],
-              "type": 5
+              "type": 4
             }
           },
           {
@@ -127,7 +109,7 @@
             "ink_primitives",
             "ConstructorResult"
           ],
-          "type": 97
+          "type": 96
         },
         "selector": "0x9bae9d5e"
       }
@@ -144,25 +126,25 @@
         "displayName": [
           "Balance"
         ],
-        "type": 5
+        "type": 4
       },
       "blockNumber": {
         "displayName": [
           "BlockNumber"
         ],
-        "type": 4
+        "type": 3
       },
       "chainExtension": {
         "displayName": [
           "ChainExtension"
         ],
-        "type": 116
+        "type": 115
       },
       "hash": {
         "displayName": [
           "Hash"
         ],
-        "type": 62
+        "type": 61
       },
       "maxEventTopics": 4,
       "staticBufferSize": 16384,
@@ -170,7 +152,7 @@
         "displayName": [
           "Timestamp"
         ],
-        "type": 12
+        "type": 11
       }
     },
     "events": [
@@ -184,7 +166,7 @@
               "displayName": [
                 "u128"
               ],
-              "type": 5
+              "type": 4
             }
           }
         ],
@@ -205,7 +187,7 @@
               "displayName": [
                 "u64"
               ],
-              "type": 12
+              "type": 11
             }
           },
           {
@@ -227,7 +209,7 @@
               "displayName": [
                 "u128"
               ],
-              "type": 5
+              "type": 4
             }
           }
         ],
@@ -248,7 +230,7 @@
               "displayName": [
                 "u64"
               ],
-              "type": 12
+              "type": 11
             }
           },
           {
@@ -270,7 +252,7 @@
               "displayName": [
                 "u128"
               ],
-              "type": 5
+              "type": 4
             }
           }
         ],
@@ -291,7 +273,7 @@
               "displayName": [
                 "u64"
               ],
-              "type": 12
+              "type": 11
             }
           },
           {
@@ -313,7 +295,7 @@
               "displayName": [
                 "u128"
               ],
-              "type": 5
+              "type": 4
             }
           },
           {
@@ -324,7 +306,7 @@
               "displayName": [
                 "u128"
               ],
-              "type": 5
+              "type": 4
             }
           }
         ],
@@ -348,7 +330,7 @@
                 "string",
                 "String"
               ],
-              "type": 13
+              "type": 12
             }
           },
           {
@@ -359,7 +341,7 @@
               "displayName": [
                 "u128"
               ],
-              "type": 5
+              "type": 4
             }
           }
         ],
@@ -391,7 +373,7 @@
               "displayName": [
                 "u32"
               ],
-              "type": 4
+              "type": 3
             }
           }
         ],
@@ -412,7 +394,7 @@
               "displayName": [
                 "u64"
               ],
-              "type": 12
+              "type": 11
             }
           },
           {
@@ -434,7 +416,7 @@
               "displayName": [
                 "u128"
               ],
-              "type": 5
+              "type": 4
             }
           },
           {
@@ -445,7 +427,7 @@
               "displayName": [
                 "u128"
               ],
-              "type": 5
+              "type": 4
             }
           }
         ],
@@ -466,7 +448,7 @@
               "displayName": [
                 "u64"
               ],
-              "type": 12
+              "type": 11
             }
           },
           {
@@ -491,7 +473,7 @@
                 "string",
                 "String"
               ],
-              "type": 13
+              "type": 12
             }
           }
         ],
@@ -512,7 +494,7 @@
               "displayName": [
                 "u64"
               ],
-              "type": 12
+              "type": 11
             }
           },
           {
@@ -545,7 +527,7 @@
               "displayName": [
                 "u128"
               ],
-              "type": 5
+              "type": 4
             }
           },
           {
@@ -556,7 +538,7 @@
               "displayName": [
                 "u32"
               ],
-              "type": 4
+              "type": 3
             }
           }
         ],
@@ -588,7 +570,7 @@
               "displayName": [
                 "bool"
               ],
-              "type": 6
+              "type": 5
             }
           }
         ],
@@ -620,7 +602,7 @@
               "displayName": [
                 "u128"
               ],
-              "type": 5
+              "type": 4
             }
           },
           {
@@ -631,7 +613,7 @@
               "displayName": [
                 "u128"
               ],
-              "type": 5
+              "type": 4
             }
           }
         ],
@@ -663,7 +645,7 @@
               "displayName": [
                 "bool"
               ],
-              "type": 6
+              "type": 5
             }
           }
         ],
@@ -695,7 +677,7 @@
               "displayName": [
                 "u128"
               ],
-              "type": 5
+              "type": 4
             }
           },
           {
@@ -738,7 +720,7 @@
               "displayName": [
                 "u128"
               ],
-              "type": 5
+              "type": 4
             }
           },
           {
@@ -749,7 +731,7 @@
               "displayName": [
                 "u128"
               ],
-              "type": 5
+              "type": 4
             }
           }
         ],
@@ -781,7 +763,7 @@
               "displayName": [
                 "u32"
               ],
-              "type": 4
+              "type": 3
             }
           }
         ],
@@ -802,7 +784,7 @@
               "displayName": [
                 "u64"
               ],
-              "type": 12
+              "type": 11
             }
           },
           {
@@ -813,7 +795,7 @@
               "displayName": [
                 "u32"
               ],
-              "type": 4
+              "type": 3
             }
           }
         ],
@@ -887,7 +869,7 @@
               "displayName": [
                 "u64"
               ],
-              "type": 12
+              "type": 11
             }
           },
           {
@@ -911,7 +893,7 @@
                 "types",
                 "VoteType"
               ],
-              "type": 115
+              "type": 114
             }
           },
           {
@@ -922,7 +904,7 @@
               "displayName": [
                 "u32"
               ],
-              "type": 4
+              "type": 3
             }
           }
         ],
@@ -939,7 +921,7 @@
         "ink",
         "LangError"
       ],
-      "type": 98
+      "type": 97
     },
     "messages": [
       {
@@ -954,7 +936,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0x31b3f423"
       },
@@ -966,7 +948,7 @@
               "displayName": [
                 "Balance"
               ],
-              "type": 5
+              "type": 4
             }
           }
         ],
@@ -980,7 +962,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0xe098e62d"
       },
@@ -992,7 +974,7 @@
               "displayName": [
                 "Hash"
               ],
-              "type": 62
+              "type": 61
             }
           },
           {
@@ -1010,7 +992,7 @@
               "displayName": [
                 "Vec"
               ],
-              "type": 73
+              "type": 72
             }
           },
           {
@@ -1019,7 +1001,7 @@
               "displayName": [
                 "String"
               ],
-              "type": 13
+              "type": 12
             }
           },
           {
@@ -1028,7 +1010,7 @@
               "displayName": [
                 "String"
               ],
-              "type": 13
+              "type": 12
             }
           },
           {
@@ -1037,7 +1019,7 @@
               "displayName": [
                 "Balance"
               ],
-              "type": 5
+              "type": 4
             }
           },
           {
@@ -1046,7 +1028,7 @@
               "displayName": [
                 "Balance"
               ],
-              "type": 5
+              "type": 4
             }
           },
           {
@@ -1055,7 +1037,7 @@
               "displayName": [
                 "Balance"
               ],
-              "type": 5
+              "type": 4
             }
           }
         ],
@@ -1069,7 +1051,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0xff3b86a0"
       },
@@ -1095,7 +1077,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0xc4cb59cb"
       },
@@ -1107,7 +1089,7 @@
               "displayName": [
                 "Hash"
               ],
-              "type": 62
+              "type": 61
             }
           },
           {
@@ -1125,7 +1107,7 @@
               "displayName": [
                 "String"
               ],
-              "type": 13
+              "type": 12
             }
           }
         ],
@@ -1139,7 +1121,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0xf668d950"
       },
@@ -1151,7 +1133,7 @@
               "displayName": [
                 "Hash"
               ],
-              "type": 62
+              "type": 61
             }
           },
           {
@@ -1178,7 +1160,7 @@
               "displayName": [
                 "String"
               ],
-              "type": 13
+              "type": 12
             }
           },
           {
@@ -1187,7 +1169,7 @@
               "displayName": [
                 "String"
               ],
-              "type": 13
+              "type": 12
             }
           },
           {
@@ -1196,7 +1178,7 @@
               "displayName": [
                 "Balance"
               ],
-              "type": 5
+              "type": 4
             }
           },
           {
@@ -1205,7 +1187,7 @@
               "displayName": [
                 "Balance"
               ],
-              "type": 5
+              "type": 4
             }
           },
           {
@@ -1214,7 +1196,7 @@
               "displayName": [
                 "String"
               ],
-              "type": 13
+              "type": 12
             }
           },
           {
@@ -1223,7 +1205,7 @@
               "displayName": [
                 "String"
               ],
-              "type": 13
+              "type": 12
             }
           },
           {
@@ -1232,7 +1214,7 @@
               "displayName": [
                 "String"
               ],
-              "type": 13
+              "type": 12
             }
           },
           {
@@ -1241,7 +1223,7 @@
               "displayName": [
                 "u32"
               ],
-              "type": 4
+              "type": 3
             }
           },
           {
@@ -1250,7 +1232,7 @@
               "displayName": [
                 "Balance"
               ],
-              "type": 5
+              "type": 4
             }
           },
           {
@@ -1259,7 +1241,7 @@
               "displayName": [
                 "String"
               ],
-              "type": 13
+              "type": 12
             }
           },
           {
@@ -1268,7 +1250,7 @@
               "displayName": [
                 "String"
               ],
-              "type": 13
+              "type": 12
             }
           },
           {
@@ -1277,7 +1259,7 @@
               "displayName": [
                 "String"
               ],
-              "type": 13
+              "type": 12
             }
           }
         ],
@@ -1291,7 +1273,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0x90c444d8"
       },
@@ -1303,7 +1285,7 @@
               "displayName": [
                 "u64"
               ],
-              "type": 12
+              "type": 11
             }
           },
           {
@@ -1312,7 +1294,7 @@
               "displayName": [
                 "String"
               ],
-              "type": 13
+              "type": 12
             }
           },
           {
@@ -1321,7 +1303,7 @@
               "displayName": [
                 "u32"
               ],
-              "type": 4
+              "type": 3
             }
           },
           {
@@ -1330,7 +1312,7 @@
               "displayName": [
                 "Balance"
               ],
-              "type": 5
+              "type": 4
             }
           }
         ],
@@ -1346,7 +1328,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0x2dbeeb8d"
       },
@@ -1358,7 +1340,7 @@
               "displayName": [
                 "u64"
               ],
-              "type": 12
+              "type": 11
             }
           }
         ],
@@ -1374,7 +1356,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0xd0065335"
       },
@@ -1386,7 +1368,7 @@
               "displayName": [
                 "u64"
               ],
-              "type": 12
+              "type": 11
             }
           }
         ],
@@ -1402,7 +1384,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0x5325f39c"
       },
@@ -1414,7 +1396,7 @@
               "displayName": [
                 "u64"
               ],
-              "type": 12
+              "type": 11
             }
           }
         ],
@@ -1432,7 +1414,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0x0fb2d2e5"
       },
@@ -1444,7 +1426,7 @@
               "displayName": [
                 "u64"
               ],
-              "type": 12
+              "type": 11
             }
           }
         ],
@@ -1460,7 +1442,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0xcf3c3dd9"
       },
@@ -1488,7 +1470,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0x339db2a5"
       },
@@ -1516,7 +1498,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0x00088a2d"
       },
@@ -1542,7 +1524,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0x107e33ea"
       },
@@ -1568,7 +1550,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0x82f48fa6"
       },
@@ -1594,7 +1576,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0x62135acd"
       },
@@ -1606,7 +1588,7 @@
               "displayName": [
                 "u32"
               ],
-              "type": 4
+              "type": 3
             }
           }
         ],
@@ -1620,7 +1602,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0xe9cb777b"
       },
@@ -1632,7 +1614,7 @@
               "displayName": [
                 "Balance"
               ],
-              "type": 5
+              "type": 4
             }
           }
         ],
@@ -1646,7 +1628,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0xb3f48b5e"
       },
@@ -1658,7 +1640,7 @@
               "displayName": [
                 "Balance"
               ],
-              "type": 5
+              "type": 4
             }
           }
         ],
@@ -1672,7 +1654,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0xb7fae7fd"
       },
@@ -1698,7 +1680,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0xc0d8ec47"
       },
@@ -1710,7 +1692,7 @@
               "displayName": [
                 "Balance"
               ],
-              "type": 5
+              "type": 4
             }
           }
         ],
@@ -1724,7 +1706,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0x800e1573"
       },
@@ -1736,7 +1718,7 @@
               "displayName": [
                 "Balance"
               ],
-              "type": 5
+              "type": 4
             }
           }
         ],
@@ -1750,7 +1732,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0x3e868f32"
       },
@@ -1776,7 +1758,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0x50dfe685"
       },
@@ -1788,7 +1770,7 @@
               "displayName": [
                 "u32"
               ],
-              "type": 4
+              "type": 3
             }
           }
         ],
@@ -1802,7 +1784,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0x3143d9e3"
       },
@@ -1814,7 +1796,7 @@
               "displayName": [
                 "u128"
               ],
-              "type": 5
+              "type": 4
             }
           }
         ],
@@ -1828,7 +1810,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0x8832de41"
       },
@@ -1840,7 +1822,7 @@
               "displayName": [
                 "bool"
               ],
-              "type": 6
+              "type": 5
             }
           }
         ],
@@ -1854,7 +1836,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0x8fe1c210"
       },
@@ -1870,7 +1852,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 99
+          "type": 98
         },
         "selector": "0x97756ea1"
       },
@@ -1882,7 +1864,7 @@
               "displayName": [
                 "u64"
               ],
-              "type": 12
+              "type": 11
             }
           }
         ],
@@ -1896,7 +1878,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 102
+          "type": 101
         },
         "selector": "0xa35f1bbf"
       },
@@ -1922,7 +1904,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 104
+          "type": 103
         },
         "selector": "0xf48343ad"
       },
@@ -1948,7 +1930,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 105
+          "type": 104
         },
         "selector": "0x25652be8"
       },
@@ -1974,7 +1956,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 105
+          "type": 104
         },
         "selector": "0x1d07dec1"
       },
@@ -2000,7 +1982,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 106
+          "type": 105
         },
         "selector": "0xa4b68d1f"
       },
@@ -2026,7 +2008,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 105
+          "type": 104
         },
         "selector": "0xf844fc5f"
       },
@@ -2042,7 +2024,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 107
+          "type": 106
         },
         "selector": "0xd80244d2"
       },
@@ -2058,7 +2040,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 106
+          "type": 105
         },
         "selector": "0xe820174a"
       },
@@ -2074,7 +2056,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 104
+          "type": 103
         },
         "selector": "0x233a7832"
       },
@@ -2090,7 +2072,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 104
+          "type": 103
         },
         "selector": "0x54945717"
       },
@@ -2106,7 +2088,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 106
+          "type": 105
         },
         "selector": "0xfe07130d"
       },
@@ -2122,7 +2104,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 104
+          "type": 103
         },
         "selector": "0xbf3b5d4e"
       },
@@ -2138,7 +2120,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 104
+          "type": 103
         },
         "selector": "0x9910e939"
       },
@@ -2154,7 +2136,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 108
+          "type": 107
         },
         "selector": "0x07fcd0b1"
       },
@@ -2170,7 +2152,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 105
+          "type": 104
         },
         "selector": "0xec540804"
       },
@@ -2186,7 +2168,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 108
+          "type": 107
         },
         "selector": "0x3847e06c"
       },
@@ -2198,7 +2180,7 @@
               "displayName": [
                 "u64"
               ],
-              "type": 12
+              "type": 11
             }
           }
         ],
@@ -2212,7 +2194,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 104
+          "type": 103
         },
         "selector": "0x48c78c4a"
       },
@@ -2228,7 +2210,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 104
+          "type": 103
         },
         "selector": "0xfca7daa4"
       },
@@ -2244,7 +2226,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 104
+          "type": 103
         },
         "selector": "0x97826e04"
       },
@@ -2270,7 +2252,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 106
+          "type": 105
         },
         "selector": "0xd5ed7150"
       },
@@ -2286,7 +2268,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 106
+          "type": 105
         },
         "selector": "0xf7e24a31"
       },
@@ -2302,7 +2284,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 104
+          "type": 103
         },
         "selector": "0x41afd8bc"
       },
@@ -2328,7 +2310,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 106
+          "type": 105
         },
         "selector": "0x361acc31"
       },
@@ -2344,7 +2326,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 109
+          "type": 108
         },
         "selector": "0x2c283460"
       },
@@ -2360,7 +2342,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 106
+          "type": 105
         },
         "selector": "0xa30ab5c4"
       },
@@ -2386,7 +2368,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 106
+          "type": 105
         },
         "selector": "0x154595d0"
       },
@@ -2412,7 +2394,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 110
+          "type": 109
         },
         "selector": "0x79fe2717"
       },
@@ -2438,7 +2420,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 106
+          "type": 105
         },
         "selector": "0x3781315a"
       },
@@ -2464,7 +2446,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 106
+          "type": 105
         },
         "selector": "0x24fa0aae"
       },
@@ -2476,7 +2458,7 @@
               "displayName": [
                 "Vec"
               ],
-              "type": 73
+              "type": 72
             }
           }
         ],
@@ -2490,7 +2472,7 @@
             "ink",
             "MessageResult"
           ],
-          "type": 113
+          "type": 112
         },
         "selector": "0x19a837c6"
       }
@@ -2517,15 +2499,6 @@
                   "ty": 0
                 }
               },
-              "name": "treasury_hotkey"
-            },
-            {
-              "layout": {
-                "leaf": {
-                  "key": "0x00000000",
-                  "ty": 0
-                }
-              },
               "name": "recycle_address"
             },
             {
@@ -2535,22 +2508,13 @@
                   "ty": 3
                 }
               },
-              "name": "netuid"
-            },
-            {
-              "layout": {
-                "leaf": {
-                  "key": "0x00000000",
-                  "ty": 4
-                }
-              },
               "name": "fulfillment_timeout_blocks"
             },
             {
               "layout": {
                 "leaf": {
                   "key": "0x00000000",
-                  "ty": 4
+                  "ty": 3
                 }
               },
               "name": "reservation_ttl"
@@ -2559,7 +2523,7 @@
               "layout": {
                 "leaf": {
                   "key": "0x00000000",
-                  "ty": 5
+                  "ty": 4
                 }
               },
               "name": "min_collateral"
@@ -2568,7 +2532,7 @@
               "layout": {
                 "leaf": {
                   "key": "0x00000000",
-                  "ty": 5
+                  "ty": 4
                 }
               },
               "name": "max_collateral"
@@ -2577,7 +2541,7 @@
               "layout": {
                 "leaf": {
                   "key": "0x00000000",
-                  "ty": 5
+                  "ty": 4
                 }
               },
               "name": "min_swap_amount"
@@ -2586,7 +2550,7 @@
               "layout": {
                 "leaf": {
                   "key": "0x00000000",
-                  "ty": 5
+                  "ty": 4
                 }
               },
               "name": "max_swap_amount"
@@ -2604,7 +2568,7 @@
               "layout": {
                 "leaf": {
                   "key": "0x00000000",
-                  "ty": 4
+                  "ty": 3
                 }
               },
               "name": "validator_count"
@@ -2613,7 +2577,7 @@
               "layout": {
                 "leaf": {
                   "key": "0x00000000",
-                  "ty": 5
+                  "ty": 4
                 }
               },
               "name": "fee_divisor"
@@ -2622,7 +2586,7 @@
               "layout": {
                 "leaf": {
                   "key": "0x00000000",
-                  "ty": 6
+                  "ty": 5
                 }
               },
               "name": "halted"
@@ -2633,11 +2597,11 @@
                   "layout": {
                     "leaf": {
                       "key": "0x8fb2fd51",
-                      "ty": 6
+                      "ty": 5
                     }
                   },
                   "root_key": "0x8fb2fd51",
-                  "ty": 7
+                  "ty": 6
                 }
               },
               "name": "validators"
@@ -2646,7 +2610,7 @@
               "layout": {
                 "leaf": {
                   "key": "0x00000000",
-                  "ty": 12
+                  "ty": 11
                 }
               },
               "name": "next_swap_id"
@@ -2661,7 +2625,7 @@
                           "layout": {
                             "leaf": {
                               "key": "0x2b1d1362",
-                              "ty": 12
+                              "ty": 11
                             }
                           },
                           "name": "id"
@@ -2688,7 +2652,7 @@
                           "layout": {
                             "leaf": {
                               "key": "0x2b1d1362",
-                              "ty": 13
+                              "ty": 12
                             }
                           },
                           "name": "source_chain"
@@ -2697,7 +2661,7 @@
                           "layout": {
                             "leaf": {
                               "key": "0x2b1d1362",
-                              "ty": 13
+                              "ty": 12
                             }
                           },
                           "name": "dest_chain"
@@ -2706,7 +2670,7 @@
                           "layout": {
                             "leaf": {
                               "key": "0x2b1d1362",
-                              "ty": 5
+                              "ty": 4
                             }
                           },
                           "name": "source_amount"
@@ -2715,7 +2679,7 @@
                           "layout": {
                             "leaf": {
                               "key": "0x2b1d1362",
-                              "ty": 5
+                              "ty": 4
                             }
                           },
                           "name": "dest_amount"
@@ -2724,7 +2688,7 @@
                           "layout": {
                             "leaf": {
                               "key": "0x2b1d1362",
-                              "ty": 5
+                              "ty": 4
                             }
                           },
                           "name": "tao_amount"
@@ -2733,7 +2697,7 @@
                           "layout": {
                             "leaf": {
                               "key": "0x2b1d1362",
-                              "ty": 13
+                              "ty": 12
                             }
                           },
                           "name": "user_source_address"
@@ -2742,7 +2706,7 @@
                           "layout": {
                             "leaf": {
                               "key": "0x2b1d1362",
-                              "ty": 13
+                              "ty": 12
                             }
                           },
                           "name": "user_dest_address"
@@ -2751,7 +2715,7 @@
                           "layout": {
                             "leaf": {
                               "key": "0x2b1d1362",
-                              "ty": 13
+                              "ty": 12
                             }
                           },
                           "name": "miner_source_address"
@@ -2760,7 +2724,7 @@
                           "layout": {
                             "leaf": {
                               "key": "0x2b1d1362",
-                              "ty": 13
+                              "ty": 12
                             }
                           },
                           "name": "miner_dest_address"
@@ -2769,7 +2733,7 @@
                           "layout": {
                             "leaf": {
                               "key": "0x2b1d1362",
-                              "ty": 13
+                              "ty": 12
                             }
                           },
                           "name": "rate"
@@ -2778,7 +2742,7 @@
                           "layout": {
                             "leaf": {
                               "key": "0x2b1d1362",
-                              "ty": 13
+                              "ty": 12
                             }
                           },
                           "name": "source_tx_hash"
@@ -2787,7 +2751,7 @@
                           "layout": {
                             "leaf": {
                               "key": "0x2b1d1362",
-                              "ty": 4
+                              "ty": 3
                             }
                           },
                           "name": "source_tx_block"
@@ -2796,7 +2760,7 @@
                           "layout": {
                             "leaf": {
                               "key": "0x2b1d1362",
-                              "ty": 13
+                              "ty": 12
                             }
                           },
                           "name": "dest_tx_hash"
@@ -2805,7 +2769,7 @@
                           "layout": {
                             "leaf": {
                               "key": "0x2b1d1362",
-                              "ty": 4
+                              "ty": 3
                             }
                           },
                           "name": "dest_tx_block"
@@ -2841,7 +2805,7 @@
                           "layout": {
                             "leaf": {
                               "key": "0x2b1d1362",
-                              "ty": 4
+                              "ty": 3
                             }
                           },
                           "name": "initiated_block"
@@ -2850,7 +2814,7 @@
                           "layout": {
                             "leaf": {
                               "key": "0x2b1d1362",
-                              "ty": 4
+                              "ty": 3
                             }
                           },
                           "name": "timeout_block"
@@ -2859,7 +2823,7 @@
                           "layout": {
                             "leaf": {
                               "key": "0x2b1d1362",
-                              "ty": 4
+                              "ty": 3
                             }
                           },
                           "name": "fulfilled_block"
@@ -2868,7 +2832,7 @@
                           "layout": {
                             "leaf": {
                               "key": "0x2b1d1362",
-                              "ty": 4
+                              "ty": 3
                             }
                           },
                           "name": "completed_block"
@@ -2878,7 +2842,7 @@
                     }
                   },
                   "root_key": "0x2b1d1362",
-                  "ty": 14
+                  "ty": 13
                 }
               },
               "name": "swaps"
@@ -2889,11 +2853,11 @@
                   "layout": {
                     "leaf": {
                       "key": "0xe9ec6cd5",
-                      "ty": 6
+                      "ty": 5
                     }
                   },
                   "root_key": "0xe9ec6cd5",
-                  "ty": 19
+                  "ty": 18
                 }
               },
               "name": "swap_confirm_votes"
@@ -2904,11 +2868,11 @@
                   "layout": {
                     "leaf": {
                       "key": "0xaf897260",
-                      "ty": 4
+                      "ty": 3
                     }
                   },
                   "root_key": "0xaf897260",
-                  "ty": 23
+                  "ty": 22
                 }
               },
               "name": "swap_confirm_vote_count"
@@ -2919,11 +2883,11 @@
                   "layout": {
                     "leaf": {
                       "key": "0xc6e30f20",
-                      "ty": 6
+                      "ty": 5
                     }
                   },
                   "root_key": "0xc6e30f20",
-                  "ty": 26
+                  "ty": 25
                 }
               },
               "name": "swap_timeout_votes"
@@ -2934,11 +2898,11 @@
                   "layout": {
                     "leaf": {
                       "key": "0xbde6b9bf",
-                      "ty": 4
+                      "ty": 3
                     }
                   },
                   "root_key": "0xbde6b9bf",
-                  "ty": 29
+                  "ty": 28
                 }
               },
               "name": "swap_timeout_vote_count"
@@ -2949,11 +2913,11 @@
                   "layout": {
                     "leaf": {
                       "key": "0x7a197e1a",
-                      "ty": 6
+                      "ty": 5
                     }
                   },
                   "root_key": "0x7a197e1a",
-                  "ty": 32
+                  "ty": 31
                 }
               },
               "name": "used_source_tx"
@@ -2964,11 +2928,11 @@
                   "layout": {
                     "leaf": {
                       "key": "0xf62525e8",
-                      "ty": 5
+                      "ty": 4
                     }
                   },
                   "root_key": "0xf62525e8",
-                  "ty": 35
+                  "ty": 34
                 }
               },
               "name": "collateral"
@@ -2979,11 +2943,11 @@
                   "layout": {
                     "leaf": {
                       "key": "0x67d295fa",
-                      "ty": 6
+                      "ty": 5
                     }
                   },
                   "root_key": "0x67d295fa",
-                  "ty": 38
+                  "ty": 37
                 }
               },
               "name": "miner_active"
@@ -2994,11 +2958,11 @@
                   "layout": {
                     "leaf": {
                       "key": "0x236f4565",
-                      "ty": 6
+                      "ty": 5
                     }
                   },
                   "root_key": "0x236f4565",
-                  "ty": 41
+                  "ty": 40
                 }
               },
               "name": "miner_has_active_swap"
@@ -3009,11 +2973,11 @@
                   "layout": {
                     "leaf": {
                       "key": "0x6ff1c750",
-                      "ty": 4
+                      "ty": 3
                     }
                   },
                   "root_key": "0x6ff1c750",
-                  "ty": 44
+                  "ty": 43
                 }
               },
               "name": "miner_reserved_until"
@@ -3024,11 +2988,11 @@
                   "layout": {
                     "leaf": {
                       "key": "0x80e900bc",
-                      "ty": 4
+                      "ty": 3
                     }
                   },
                   "root_key": "0x80e900bc",
-                  "ty": 47
+                  "ty": 46
                 }
               },
               "name": "miner_last_resolved_block"
@@ -3039,11 +3003,11 @@
                   "layout": {
                     "leaf": {
                       "key": "0x8e2b6134",
-                      "ty": 4
+                      "ty": 3
                     }
                   },
                   "root_key": "0x8e2b6134",
-                  "ty": 50
+                  "ty": 49
                 }
               },
               "name": "miner_deactivation_block"
@@ -3052,7 +3016,7 @@
               "layout": {
                 "leaf": {
                   "key": "0x00000000",
-                  "ty": 12
+                  "ty": 11
                 }
               },
               "name": "next_request_id"
@@ -3063,11 +3027,11 @@
                   "layout": {
                     "leaf": {
                       "key": "0x26e30584",
-                      "ty": 6
+                      "ty": 5
                     }
                   },
                   "root_key": "0x26e30584",
-                  "ty": 53
+                  "ty": 52
                 }
               },
               "name": "request_votes"
@@ -3078,11 +3042,11 @@
                   "layout": {
                     "leaf": {
                       "key": "0xd6c62dcd",
-                      "ty": 4
+                      "ty": 3
                     }
                   },
                   "root_key": "0xd6c62dcd",
-                  "ty": 56
+                  "ty": 55
                 }
               },
               "name": "request_vote_count"
@@ -3093,11 +3057,11 @@
                   "layout": {
                     "leaf": {
                       "key": "0x681b05e3",
-                      "ty": 4
+                      "ty": 3
                     }
                   },
                   "root_key": "0x681b05e3",
-                  "ty": 59
+                  "ty": 58
                 }
               },
               "name": "request_created"
@@ -3108,11 +3072,11 @@
                   "layout": {
                     "leaf": {
                       "key": "0x57f4431e",
-                      "ty": 62
+                      "ty": 61
                     }
                   },
                   "root_key": "0x57f4431e",
-                  "ty": 63
+                  "ty": 62
                 }
               },
               "name": "request_hash"
@@ -3123,11 +3087,11 @@
                   "layout": {
                     "leaf": {
                       "key": "0x7467cc7b",
-                      "ty": 12
+                      "ty": 11
                     }
                   },
                   "root_key": "0x7467cc7b",
-                  "ty": 66
+                  "ty": 65
                 }
               },
               "name": "miner_active_request"
@@ -3138,11 +3102,11 @@
                   "layout": {
                     "leaf": {
                       "key": "0x278e3f4b",
-                      "ty": 62
+                      "ty": 61
                     }
                   },
                   "root_key": "0x278e3f4b",
-                  "ty": 70
+                  "ty": 69
                 }
               },
               "name": "reservation_hash"
@@ -3153,11 +3117,11 @@
                   "layout": {
                     "leaf": {
                       "key": "0x903da210",
-                      "ty": 73
+                      "ty": 72
                     }
                   },
                   "root_key": "0x903da210",
-                  "ty": 74
+                  "ty": 73
                 }
               },
               "name": "reservation_source_addr"
@@ -3168,11 +3132,11 @@
                   "layout": {
                     "leaf": {
                       "key": "0x696675ed",
-                      "ty": 5
+                      "ty": 4
                     }
                   },
                   "root_key": "0x696675ed",
-                  "ty": 77
+                  "ty": 76
                 }
               },
               "name": "reservation_tao_amount"
@@ -3183,11 +3147,11 @@
                   "layout": {
                     "leaf": {
                       "key": "0xda515005",
-                      "ty": 5
+                      "ty": 4
                     }
                   },
                   "root_key": "0xda515005",
-                  "ty": 80
+                  "ty": 79
                 }
               },
               "name": "reservation_source_amount"
@@ -3198,11 +3162,11 @@
                   "layout": {
                     "leaf": {
                       "key": "0xef4d66a0",
-                      "ty": 5
+                      "ty": 4
                     }
                   },
                   "root_key": "0xef4d66a0",
-                  "ty": 83
+                  "ty": 82
                 }
               },
               "name": "reservation_dest_amount"
@@ -3217,7 +3181,7 @@
                     }
                   },
                   "root_key": "0xebebacef",
-                  "ty": 86
+                  "ty": 85
                 }
               },
               "name": "address_strike_count"
@@ -3228,11 +3192,11 @@
                   "layout": {
                     "leaf": {
                       "key": "0x936b90dc",
-                      "ty": 4
+                      "ty": 3
                     }
                   },
                   "root_key": "0x936b90dc",
-                  "ty": 89
+                  "ty": 88
                 }
               },
               "name": "address_last_expired"
@@ -3241,7 +3205,7 @@
               "layout": {
                 "leaf": {
                   "key": "0x00000000",
-                  "ty": 5
+                  "ty": 4
                 }
               },
               "name": "accumulated_fees"
@@ -3250,7 +3214,7 @@
               "layout": {
                 "leaf": {
                   "key": "0x00000000",
-                  "ty": 5
+                  "ty": 4
                 }
               },
               "name": "total_recycled_fees"
@@ -3274,7 +3238,7 @@
                           "layout": {
                             "leaf": {
                               "key": "0x0a1285bc",
-                              "ty": 5
+                              "ty": 4
                             }
                           },
                           "name": "1"
@@ -3284,7 +3248,7 @@
                     }
                   },
                   "root_key": "0x0a1285bc",
-                  "ty": 92
+                  "ty": 91
                 }
               },
               "name": "pending_slashes"
@@ -3294,7 +3258,7 @@
         }
       },
       "root_key": "0x00000000",
-      "ty": 96
+      "ty": 95
     }
   },
   "types": [
@@ -3341,7 +3305,7 @@
       "id": 3,
       "type": {
         "def": {
-          "primitive": "u16"
+          "primitive": "u32"
         }
       }
     },
@@ -3349,7 +3313,7 @@
       "id": 4,
       "type": {
         "def": {
-          "primitive": "u32"
+          "primitive": "u128"
         }
       }
     },
@@ -3357,20 +3321,12 @@
       "id": 5,
       "type": {
         "def": {
-          "primitive": "u128"
-        }
-      }
-    },
-    {
-      "id": 6,
-      "type": {
-        "def": {
           "primitive": "bool"
         }
       }
     },
     {
-      "id": 7,
+      "id": 6,
       "type": {
         "def": {
           "composite": {}
@@ -3382,11 +3338,11 @@
           },
           {
             "name": "V",
-            "type": 6
+            "type": 5
           },
           {
             "name": "KeyType",
-            "type": 8
+            "type": 7
           }
         ],
         "path": [
@@ -3398,7 +3354,7 @@
       }
     },
     {
-      "id": 8,
+      "id": 7,
       "type": {
         "def": {
           "composite": {}
@@ -3406,11 +3362,11 @@
         "params": [
           {
             "name": "L",
-            "type": 9
+            "type": 8
           },
           {
             "name": "R",
-            "type": 10
+            "type": 9
           }
         ],
         "path": [
@@ -3421,7 +3377,7 @@
       }
     },
     {
-      "id": 9,
+      "id": 8,
       "type": {
         "def": {
           "composite": {}
@@ -3434,7 +3390,7 @@
       }
     },
     {
-      "id": 10,
+      "id": 9,
       "type": {
         "def": {
           "composite": {}
@@ -3442,7 +3398,7 @@
         "params": [
           {
             "name": "ParentKey",
-            "type": 11
+            "type": 10
           }
         ],
         "path": [
@@ -3453,7 +3409,7 @@
       }
     },
     {
-      "id": 11,
+      "id": 10,
       "type": {
         "def": {
           "tuple": []
@@ -3461,7 +3417,7 @@
       }
     },
     {
-      "id": 12,
+      "id": 11,
       "type": {
         "def": {
           "primitive": "u64"
@@ -3469,7 +3425,7 @@
       }
     },
     {
-      "id": 13,
+      "id": 12,
       "type": {
         "def": {
           "primitive": "str"
@@ -3477,7 +3433,7 @@
       }
     },
     {
-      "id": 14,
+      "id": 13,
       "type": {
         "def": {
           "composite": {}
@@ -3485,15 +3441,15 @@
         "params": [
           {
             "name": "K",
-            "type": 12
+            "type": 11
           },
           {
             "name": "V",
-            "type": 15
+            "type": 14
           },
           {
             "name": "KeyType",
-            "type": 17
+            "type": 16
           }
         ],
         "path": [
@@ -3505,14 +3461,14 @@
       }
     },
     {
-      "id": 15,
+      "id": 14,
       "type": {
         "def": {
           "composite": {
             "fields": [
               {
                 "name": "id",
-                "type": 12,
+                "type": 11,
                 "typeName": "u64"
               },
               {
@@ -3527,97 +3483,97 @@
               },
               {
                 "name": "source_chain",
-                "type": 13,
+                "type": 12,
                 "typeName": "String"
               },
               {
                 "name": "dest_chain",
-                "type": 13,
+                "type": 12,
                 "typeName": "String"
               },
               {
                 "name": "source_amount",
-                "type": 5,
+                "type": 4,
                 "typeName": "Balance"
               },
               {
                 "name": "dest_amount",
-                "type": 5,
+                "type": 4,
                 "typeName": "Balance"
               },
               {
                 "name": "tao_amount",
-                "type": 5,
+                "type": 4,
                 "typeName": "Balance"
               },
               {
                 "name": "user_source_address",
-                "type": 13,
+                "type": 12,
                 "typeName": "String"
               },
               {
                 "name": "user_dest_address",
-                "type": 13,
+                "type": 12,
                 "typeName": "String"
               },
               {
                 "name": "miner_source_address",
-                "type": 13,
+                "type": 12,
                 "typeName": "String"
               },
               {
                 "name": "miner_dest_address",
-                "type": 13,
+                "type": 12,
                 "typeName": "String"
               },
               {
                 "name": "rate",
-                "type": 13,
+                "type": 12,
                 "typeName": "String"
               },
               {
                 "name": "source_tx_hash",
-                "type": 13,
+                "type": 12,
                 "typeName": "String"
               },
               {
                 "name": "source_tx_block",
-                "type": 4,
+                "type": 3,
                 "typeName": "u32"
               },
               {
                 "name": "dest_tx_hash",
-                "type": 13,
+                "type": 12,
                 "typeName": "String"
               },
               {
                 "name": "dest_tx_block",
-                "type": 4,
+                "type": 3,
                 "typeName": "u32"
               },
               {
                 "name": "status",
-                "type": 16,
+                "type": 15,
                 "typeName": "SwapStatus"
               },
               {
                 "name": "initiated_block",
-                "type": 4,
+                "type": 3,
                 "typeName": "u32"
               },
               {
                 "name": "timeout_block",
-                "type": 4,
+                "type": 3,
                 "typeName": "u32"
               },
               {
                 "name": "fulfilled_block",
-                "type": 4,
+                "type": 3,
                 "typeName": "u32"
               },
               {
                 "name": "completed_block",
-                "type": 4,
+                "type": 3,
                 "typeName": "u32"
               }
             ]
@@ -3631,7 +3587,7 @@
       }
     },
     {
-      "id": 16,
+      "id": 15,
       "type": {
         "def": {
           "variant": {
@@ -3663,7 +3619,7 @@
       }
     },
     {
-      "id": 17,
+      "id": 16,
       "type": {
         "def": {
           "composite": {}
@@ -3671,17 +3627,36 @@
         "params": [
           {
             "name": "L",
-            "type": 9
+            "type": 8
           },
           {
             "name": "R",
-            "type": 18
+            "type": 17
           }
         ],
         "path": [
           "ink_storage_traits",
           "impls",
           "ResolverKey"
+        ]
+      }
+    },
+    {
+      "id": 17,
+      "type": {
+        "def": {
+          "composite": {}
+        },
+        "params": [
+          {
+            "name": "ParentKey",
+            "type": 10
+          }
+        ],
+        "path": [
+          "ink_storage_traits",
+          "impls",
+          "ManualKey"
         ]
       }
     },
@@ -3693,35 +3668,16 @@
         },
         "params": [
           {
-            "name": "ParentKey",
-            "type": 11
-          }
-        ],
-        "path": [
-          "ink_storage_traits",
-          "impls",
-          "ManualKey"
-        ]
-      }
-    },
-    {
-      "id": 19,
-      "type": {
-        "def": {
-          "composite": {}
-        },
-        "params": [
-          {
             "name": "K",
-            "type": 20
+            "type": 19
           },
           {
             "name": "V",
-            "type": 6
+            "type": 5
           },
           {
             "name": "KeyType",
-            "type": 21
+            "type": 20
           }
         ],
         "path": [
@@ -3733,14 +3689,37 @@
       }
     },
     {
-      "id": 20,
+      "id": 19,
       "type": {
         "def": {
           "tuple": [
-            12,
+            11,
             0
           ]
         }
+      }
+    },
+    {
+      "id": 20,
+      "type": {
+        "def": {
+          "composite": {}
+        },
+        "params": [
+          {
+            "name": "L",
+            "type": 8
+          },
+          {
+            "name": "R",
+            "type": 21
+          }
+        ],
+        "path": [
+          "ink_storage_traits",
+          "impls",
+          "ResolverKey"
+        ]
       }
     },
     {
@@ -3751,18 +3730,14 @@
         },
         "params": [
           {
-            "name": "L",
-            "type": 9
-          },
-          {
-            "name": "R",
-            "type": 22
+            "name": "ParentKey",
+            "type": 10
           }
         ],
         "path": [
           "ink_storage_traits",
           "impls",
-          "ResolverKey"
+          "ManualKey"
         ]
       }
     },
@@ -3774,14 +3749,23 @@
         },
         "params": [
           {
-            "name": "ParentKey",
+            "name": "K",
             "type": 11
+          },
+          {
+            "name": "V",
+            "type": 3
+          },
+          {
+            "name": "KeyType",
+            "type": 23
           }
         ],
         "path": [
-          "ink_storage_traits",
-          "impls",
-          "ManualKey"
+          "ink_storage",
+          "lazy",
+          "mapping",
+          "Mapping"
         ]
       }
     },
@@ -3793,23 +3777,18 @@
         },
         "params": [
           {
-            "name": "K",
-            "type": 12
+            "name": "L",
+            "type": 8
           },
           {
-            "name": "V",
-            "type": 4
-          },
-          {
-            "name": "KeyType",
+            "name": "R",
             "type": 24
           }
         ],
         "path": [
-          "ink_storage",
-          "lazy",
-          "mapping",
-          "Mapping"
+          "ink_storage_traits",
+          "impls",
+          "ResolverKey"
         ]
       }
     },
@@ -3821,18 +3800,14 @@
         },
         "params": [
           {
-            "name": "L",
-            "type": 9
-          },
-          {
-            "name": "R",
-            "type": 25
+            "name": "ParentKey",
+            "type": 10
           }
         ],
         "path": [
           "ink_storage_traits",
           "impls",
-          "ResolverKey"
+          "ManualKey"
         ]
       }
     },
@@ -3844,14 +3819,23 @@
         },
         "params": [
           {
-            "name": "ParentKey",
-            "type": 11
+            "name": "K",
+            "type": 19
+          },
+          {
+            "name": "V",
+            "type": 5
+          },
+          {
+            "name": "KeyType",
+            "type": 26
           }
         ],
         "path": [
-          "ink_storage_traits",
-          "impls",
-          "ManualKey"
+          "ink_storage",
+          "lazy",
+          "mapping",
+          "Mapping"
         ]
       }
     },
@@ -3863,23 +3847,18 @@
         },
         "params": [
           {
-            "name": "K",
-            "type": 20
+            "name": "L",
+            "type": 8
           },
           {
-            "name": "V",
-            "type": 6
-          },
-          {
-            "name": "KeyType",
+            "name": "R",
             "type": 27
           }
         ],
         "path": [
-          "ink_storage",
-          "lazy",
-          "mapping",
-          "Mapping"
+          "ink_storage_traits",
+          "impls",
+          "ResolverKey"
         ]
       }
     },
@@ -3891,18 +3870,14 @@
         },
         "params": [
           {
-            "name": "L",
-            "type": 9
-          },
-          {
-            "name": "R",
-            "type": 28
+            "name": "ParentKey",
+            "type": 10
           }
         ],
         "path": [
           "ink_storage_traits",
           "impls",
-          "ResolverKey"
+          "ManualKey"
         ]
       }
     },
@@ -3914,14 +3889,23 @@
         },
         "params": [
           {
-            "name": "ParentKey",
+            "name": "K",
             "type": 11
+          },
+          {
+            "name": "V",
+            "type": 3
+          },
+          {
+            "name": "KeyType",
+            "type": 29
           }
         ],
         "path": [
-          "ink_storage_traits",
-          "impls",
-          "ManualKey"
+          "ink_storage",
+          "lazy",
+          "mapping",
+          "Mapping"
         ]
       }
     },
@@ -3933,23 +3917,18 @@
         },
         "params": [
           {
-            "name": "K",
-            "type": 12
+            "name": "L",
+            "type": 8
           },
           {
-            "name": "V",
-            "type": 4
-          },
-          {
-            "name": "KeyType",
+            "name": "R",
             "type": 30
           }
         ],
         "path": [
-          "ink_storage",
-          "lazy",
-          "mapping",
-          "Mapping"
+          "ink_storage_traits",
+          "impls",
+          "ResolverKey"
         ]
       }
     },
@@ -3961,18 +3940,14 @@
         },
         "params": [
           {
-            "name": "L",
-            "type": 9
-          },
-          {
-            "name": "R",
-            "type": 31
+            "name": "ParentKey",
+            "type": 10
           }
         ],
         "path": [
           "ink_storage_traits",
           "impls",
-          "ResolverKey"
+          "ManualKey"
         ]
       }
     },
@@ -3984,35 +3959,16 @@
         },
         "params": [
           {
-            "name": "ParentKey",
-            "type": 11
-          }
-        ],
-        "path": [
-          "ink_storage_traits",
-          "impls",
-          "ManualKey"
-        ]
-      }
-    },
-    {
-      "id": 32,
-      "type": {
-        "def": {
-          "composite": {}
-        },
-        "params": [
-          {
             "name": "K",
-            "type": 13
+            "type": 12
           },
           {
             "name": "V",
-            "type": 6
+            "type": 5
           },
           {
             "name": "KeyType",
-            "type": 33
+            "type": 32
           }
         ],
         "path": [
@@ -4024,7 +3980,7 @@
       }
     },
     {
-      "id": 33,
+      "id": 32,
       "type": {
         "def": {
           "composite": {}
@@ -4032,17 +3988,36 @@
         "params": [
           {
             "name": "L",
-            "type": 9
+            "type": 8
           },
           {
             "name": "R",
-            "type": 34
+            "type": 33
           }
         ],
         "path": [
           "ink_storage_traits",
           "impls",
           "ResolverKey"
+        ]
+      }
+    },
+    {
+      "id": 33,
+      "type": {
+        "def": {
+          "composite": {}
+        },
+        "params": [
+          {
+            "name": "ParentKey",
+            "type": 10
+          }
+        ],
+        "path": [
+          "ink_storage_traits",
+          "impls",
+          "ManualKey"
         ]
       }
     },
@@ -4054,8 +4029,59 @@
         },
         "params": [
           {
+            "name": "K",
+            "type": 0
+          },
+          {
+            "name": "V",
+            "type": 4
+          },
+          {
+            "name": "KeyType",
+            "type": 35
+          }
+        ],
+        "path": [
+          "ink_storage",
+          "lazy",
+          "mapping",
+          "Mapping"
+        ]
+      }
+    },
+    {
+      "id": 35,
+      "type": {
+        "def": {
+          "composite": {}
+        },
+        "params": [
+          {
+            "name": "L",
+            "type": 8
+          },
+          {
+            "name": "R",
+            "type": 36
+          }
+        ],
+        "path": [
+          "ink_storage_traits",
+          "impls",
+          "ResolverKey"
+        ]
+      }
+    },
+    {
+      "id": 36,
+      "type": {
+        "def": {
+          "composite": {}
+        },
+        "params": [
+          {
             "name": "ParentKey",
-            "type": 11
+            "type": 10
           }
         ],
         "path": [
@@ -4066,7 +4092,7 @@
       }
     },
     {
-      "id": 35,
+      "id": 37,
       "type": {
         "def": {
           "composite": {}
@@ -4082,7 +4108,7 @@
           },
           {
             "name": "KeyType",
-            "type": 36
+            "type": 38
           }
         ],
         "path": [
@@ -4090,48 +4116,6 @@
           "lazy",
           "mapping",
           "Mapping"
-        ]
-      }
-    },
-    {
-      "id": 36,
-      "type": {
-        "def": {
-          "composite": {}
-        },
-        "params": [
-          {
-            "name": "L",
-            "type": 9
-          },
-          {
-            "name": "R",
-            "type": 37
-          }
-        ],
-        "path": [
-          "ink_storage_traits",
-          "impls",
-          "ResolverKey"
-        ]
-      }
-    },
-    {
-      "id": 37,
-      "type": {
-        "def": {
-          "composite": {}
-        },
-        "params": [
-          {
-            "name": "ParentKey",
-            "type": 11
-          }
-        ],
-        "path": [
-          "ink_storage_traits",
-          "impls",
-          "ManualKey"
         ]
       }
     },
@@ -4143,23 +4127,18 @@
         },
         "params": [
           {
-            "name": "K",
-            "type": 0
+            "name": "L",
+            "type": 8
           },
           {
-            "name": "V",
-            "type": 6
-          },
-          {
-            "name": "KeyType",
+            "name": "R",
             "type": 39
           }
         ],
         "path": [
-          "ink_storage",
-          "lazy",
-          "mapping",
-          "Mapping"
+          "ink_storage_traits",
+          "impls",
+          "ResolverKey"
         ]
       }
     },
@@ -4171,18 +4150,14 @@
         },
         "params": [
           {
-            "name": "L",
-            "type": 9
-          },
-          {
-            "name": "R",
-            "type": 40
+            "name": "ParentKey",
+            "type": 10
           }
         ],
         "path": [
           "ink_storage_traits",
           "impls",
-          "ResolverKey"
+          "ManualKey"
         ]
       }
     },
@@ -4194,14 +4169,23 @@
         },
         "params": [
           {
-            "name": "ParentKey",
-            "type": 11
+            "name": "K",
+            "type": 0
+          },
+          {
+            "name": "V",
+            "type": 5
+          },
+          {
+            "name": "KeyType",
+            "type": 41
           }
         ],
         "path": [
-          "ink_storage_traits",
-          "impls",
-          "ManualKey"
+          "ink_storage",
+          "lazy",
+          "mapping",
+          "Mapping"
         ]
       }
     },
@@ -4213,23 +4197,18 @@
         },
         "params": [
           {
-            "name": "K",
-            "type": 0
+            "name": "L",
+            "type": 8
           },
           {
-            "name": "V",
-            "type": 6
-          },
-          {
-            "name": "KeyType",
+            "name": "R",
             "type": 42
           }
         ],
         "path": [
-          "ink_storage",
-          "lazy",
-          "mapping",
-          "Mapping"
+          "ink_storage_traits",
+          "impls",
+          "ResolverKey"
         ]
       }
     },
@@ -4241,18 +4220,14 @@
         },
         "params": [
           {
-            "name": "L",
-            "type": 9
-          },
-          {
-            "name": "R",
-            "type": 43
+            "name": "ParentKey",
+            "type": 10
           }
         ],
         "path": [
           "ink_storage_traits",
           "impls",
-          "ResolverKey"
+          "ManualKey"
         ]
       }
     },
@@ -4264,14 +4239,23 @@
         },
         "params": [
           {
-            "name": "ParentKey",
-            "type": 11
+            "name": "K",
+            "type": 0
+          },
+          {
+            "name": "V",
+            "type": 3
+          },
+          {
+            "name": "KeyType",
+            "type": 44
           }
         ],
         "path": [
-          "ink_storage_traits",
-          "impls",
-          "ManualKey"
+          "ink_storage",
+          "lazy",
+          "mapping",
+          "Mapping"
         ]
       }
     },
@@ -4283,23 +4267,18 @@
         },
         "params": [
           {
-            "name": "K",
-            "type": 0
+            "name": "L",
+            "type": 8
           },
           {
-            "name": "V",
-            "type": 4
-          },
-          {
-            "name": "KeyType",
+            "name": "R",
             "type": 45
           }
         ],
         "path": [
-          "ink_storage",
-          "lazy",
-          "mapping",
-          "Mapping"
+          "ink_storage_traits",
+          "impls",
+          "ResolverKey"
         ]
       }
     },
@@ -4311,18 +4290,14 @@
         },
         "params": [
           {
-            "name": "L",
-            "type": 9
-          },
-          {
-            "name": "R",
-            "type": 46
+            "name": "ParentKey",
+            "type": 10
           }
         ],
         "path": [
           "ink_storage_traits",
           "impls",
-          "ResolverKey"
+          "ManualKey"
         ]
       }
     },
@@ -4334,14 +4309,23 @@
         },
         "params": [
           {
-            "name": "ParentKey",
-            "type": 11
+            "name": "K",
+            "type": 0
+          },
+          {
+            "name": "V",
+            "type": 3
+          },
+          {
+            "name": "KeyType",
+            "type": 47
           }
         ],
         "path": [
-          "ink_storage_traits",
-          "impls",
-          "ManualKey"
+          "ink_storage",
+          "lazy",
+          "mapping",
+          "Mapping"
         ]
       }
     },
@@ -4353,23 +4337,18 @@
         },
         "params": [
           {
-            "name": "K",
-            "type": 0
+            "name": "L",
+            "type": 8
           },
           {
-            "name": "V",
-            "type": 4
-          },
-          {
-            "name": "KeyType",
+            "name": "R",
             "type": 48
           }
         ],
         "path": [
-          "ink_storage",
-          "lazy",
-          "mapping",
-          "Mapping"
+          "ink_storage_traits",
+          "impls",
+          "ResolverKey"
         ]
       }
     },
@@ -4381,18 +4360,14 @@
         },
         "params": [
           {
-            "name": "L",
-            "type": 9
-          },
-          {
-            "name": "R",
-            "type": 49
+            "name": "ParentKey",
+            "type": 10
           }
         ],
         "path": [
           "ink_storage_traits",
           "impls",
-          "ResolverKey"
+          "ManualKey"
         ]
       }
     },
@@ -4404,14 +4379,23 @@
         },
         "params": [
           {
-            "name": "ParentKey",
-            "type": 11
+            "name": "K",
+            "type": 0
+          },
+          {
+            "name": "V",
+            "type": 3
+          },
+          {
+            "name": "KeyType",
+            "type": 50
           }
         ],
         "path": [
-          "ink_storage_traits",
-          "impls",
-          "ManualKey"
+          "ink_storage",
+          "lazy",
+          "mapping",
+          "Mapping"
         ]
       }
     },
@@ -4423,23 +4407,18 @@
         },
         "params": [
           {
-            "name": "K",
-            "type": 0
+            "name": "L",
+            "type": 8
           },
           {
-            "name": "V",
-            "type": 4
-          },
-          {
-            "name": "KeyType",
+            "name": "R",
             "type": 51
           }
         ],
         "path": [
-          "ink_storage",
-          "lazy",
-          "mapping",
-          "Mapping"
+          "ink_storage_traits",
+          "impls",
+          "ResolverKey"
         ]
       }
     },
@@ -4451,18 +4430,14 @@
         },
         "params": [
           {
-            "name": "L",
-            "type": 9
-          },
-          {
-            "name": "R",
-            "type": 52
+            "name": "ParentKey",
+            "type": 10
           }
         ],
         "path": [
           "ink_storage_traits",
           "impls",
-          "ResolverKey"
+          "ManualKey"
         ]
       }
     },
@@ -4474,14 +4449,23 @@
         },
         "params": [
           {
-            "name": "ParentKey",
-            "type": 11
+            "name": "K",
+            "type": 19
+          },
+          {
+            "name": "V",
+            "type": 5
+          },
+          {
+            "name": "KeyType",
+            "type": 53
           }
         ],
         "path": [
-          "ink_storage_traits",
-          "impls",
-          "ManualKey"
+          "ink_storage",
+          "lazy",
+          "mapping",
+          "Mapping"
         ]
       }
     },
@@ -4493,23 +4477,18 @@
         },
         "params": [
           {
-            "name": "K",
-            "type": 20
+            "name": "L",
+            "type": 8
           },
           {
-            "name": "V",
-            "type": 6
-          },
-          {
-            "name": "KeyType",
+            "name": "R",
             "type": 54
           }
         ],
         "path": [
-          "ink_storage",
-          "lazy",
-          "mapping",
-          "Mapping"
+          "ink_storage_traits",
+          "impls",
+          "ResolverKey"
         ]
       }
     },
@@ -4521,18 +4500,14 @@
         },
         "params": [
           {
-            "name": "L",
-            "type": 9
-          },
-          {
-            "name": "R",
-            "type": 55
+            "name": "ParentKey",
+            "type": 10
           }
         ],
         "path": [
           "ink_storage_traits",
           "impls",
-          "ResolverKey"
+          "ManualKey"
         ]
       }
     },
@@ -4544,14 +4519,23 @@
         },
         "params": [
           {
-            "name": "ParentKey",
+            "name": "K",
             "type": 11
+          },
+          {
+            "name": "V",
+            "type": 3
+          },
+          {
+            "name": "KeyType",
+            "type": 56
           }
         ],
         "path": [
-          "ink_storage_traits",
-          "impls",
-          "ManualKey"
+          "ink_storage",
+          "lazy",
+          "mapping",
+          "Mapping"
         ]
       }
     },
@@ -4563,23 +4547,18 @@
         },
         "params": [
           {
-            "name": "K",
-            "type": 12
+            "name": "L",
+            "type": 8
           },
           {
-            "name": "V",
-            "type": 4
-          },
-          {
-            "name": "KeyType",
+            "name": "R",
             "type": 57
           }
         ],
         "path": [
-          "ink_storage",
-          "lazy",
-          "mapping",
-          "Mapping"
+          "ink_storage_traits",
+          "impls",
+          "ResolverKey"
         ]
       }
     },
@@ -4591,18 +4570,14 @@
         },
         "params": [
           {
-            "name": "L",
-            "type": 9
-          },
-          {
-            "name": "R",
-            "type": 58
+            "name": "ParentKey",
+            "type": 10
           }
         ],
         "path": [
           "ink_storage_traits",
           "impls",
-          "ResolverKey"
+          "ManualKey"
         ]
       }
     },
@@ -4614,35 +4589,16 @@
         },
         "params": [
           {
-            "name": "ParentKey",
-            "type": 11
-          }
-        ],
-        "path": [
-          "ink_storage_traits",
-          "impls",
-          "ManualKey"
-        ]
-      }
-    },
-    {
-      "id": 59,
-      "type": {
-        "def": {
-          "composite": {}
-        },
-        "params": [
-          {
             "name": "K",
-            "type": 12
+            "type": 11
           },
           {
             "name": "V",
-            "type": 4
+            "type": 3
           },
           {
             "name": "KeyType",
-            "type": 60
+            "type": 59
           }
         ],
         "path": [
@@ -4654,7 +4610,7 @@
       }
     },
     {
-      "id": 60,
+      "id": 59,
       "type": {
         "def": {
           "composite": {}
@@ -4662,11 +4618,11 @@
         "params": [
           {
             "name": "L",
-            "type": 9
+            "type": 8
           },
           {
             "name": "R",
-            "type": 61
+            "type": 60
           }
         ],
         "path": [
@@ -4677,7 +4633,7 @@
       }
     },
     {
-      "id": 61,
+      "id": 60,
       "type": {
         "def": {
           "composite": {}
@@ -4685,7 +4641,7 @@
         "params": [
           {
             "name": "ParentKey",
-            "type": 11
+            "type": 10
           }
         ],
         "path": [
@@ -4696,7 +4652,7 @@
       }
     },
     {
-      "id": 62,
+      "id": 61,
       "type": {
         "def": {
           "composite": {
@@ -4716,7 +4672,7 @@
       }
     },
     {
-      "id": 63,
+      "id": 62,
       "type": {
         "def": {
           "composite": {}
@@ -4724,15 +4680,15 @@
         "params": [
           {
             "name": "K",
-            "type": 12
+            "type": 11
           },
           {
             "name": "V",
-            "type": 62
+            "type": 61
           },
           {
             "name": "KeyType",
-            "type": 64
+            "type": 63
           }
         ],
         "path": [
@@ -4740,6 +4696,29 @@
           "lazy",
           "mapping",
           "Mapping"
+        ]
+      }
+    },
+    {
+      "id": 63,
+      "type": {
+        "def": {
+          "composite": {}
+        },
+        "params": [
+          {
+            "name": "L",
+            "type": 8
+          },
+          {
+            "name": "R",
+            "type": 64
+          }
+        ],
+        "path": [
+          "ink_storage_traits",
+          "impls",
+          "ResolverKey"
         ]
       }
     },
@@ -4751,18 +4730,14 @@
         },
         "params": [
           {
-            "name": "L",
-            "type": 9
-          },
-          {
-            "name": "R",
-            "type": 65
+            "name": "ParentKey",
+            "type": 10
           }
         ],
         "path": [
           "ink_storage_traits",
           "impls",
-          "ResolverKey"
+          "ManualKey"
         ]
       }
     },
@@ -4774,35 +4749,16 @@
         },
         "params": [
           {
-            "name": "ParentKey",
-            "type": 11
-          }
-        ],
-        "path": [
-          "ink_storage_traits",
-          "impls",
-          "ManualKey"
-        ]
-      }
-    },
-    {
-      "id": 66,
-      "type": {
-        "def": {
-          "composite": {}
-        },
-        "params": [
-          {
             "name": "K",
-            "type": 67
+            "type": 66
           },
           {
             "name": "V",
-            "type": 12
+            "type": 11
           },
           {
             "name": "KeyType",
-            "type": 68
+            "type": 67
           }
         ],
         "path": [
@@ -4814,7 +4770,7 @@
       }
     },
     {
-      "id": 67,
+      "id": 66,
       "type": {
         "def": {
           "tuple": [
@@ -4825,7 +4781,7 @@
       }
     },
     {
-      "id": 68,
+      "id": 67,
       "type": {
         "def": {
           "composite": {}
@@ -4833,17 +4789,36 @@
         "params": [
           {
             "name": "L",
-            "type": 9
+            "type": 8
           },
           {
             "name": "R",
-            "type": 69
+            "type": 68
           }
         ],
         "path": [
           "ink_storage_traits",
           "impls",
           "ResolverKey"
+        ]
+      }
+    },
+    {
+      "id": 68,
+      "type": {
+        "def": {
+          "composite": {}
+        },
+        "params": [
+          {
+            "name": "ParentKey",
+            "type": 10
+          }
+        ],
+        "path": [
+          "ink_storage_traits",
+          "impls",
+          "ManualKey"
         ]
       }
     },
@@ -4855,14 +4830,23 @@
         },
         "params": [
           {
-            "name": "ParentKey",
-            "type": 11
+            "name": "K",
+            "type": 0
+          },
+          {
+            "name": "V",
+            "type": 61
+          },
+          {
+            "name": "KeyType",
+            "type": 70
           }
         ],
         "path": [
-          "ink_storage_traits",
-          "impls",
-          "ManualKey"
+          "ink_storage",
+          "lazy",
+          "mapping",
+          "Mapping"
         ]
       }
     },
@@ -4874,23 +4858,18 @@
         },
         "params": [
           {
-            "name": "K",
-            "type": 0
+            "name": "L",
+            "type": 8
           },
           {
-            "name": "V",
-            "type": 62
-          },
-          {
-            "name": "KeyType",
+            "name": "R",
             "type": 71
           }
         ],
         "path": [
-          "ink_storage",
-          "lazy",
-          "mapping",
-          "Mapping"
+          "ink_storage_traits",
+          "impls",
+          "ResolverKey"
         ]
       }
     },
@@ -4902,31 +4881,8 @@
         },
         "params": [
           {
-            "name": "L",
-            "type": 9
-          },
-          {
-            "name": "R",
-            "type": 72
-          }
-        ],
-        "path": [
-          "ink_storage_traits",
-          "impls",
-          "ResolverKey"
-        ]
-      }
-    },
-    {
-      "id": 72,
-      "type": {
-        "def": {
-          "composite": {}
-        },
-        "params": [
-          {
             "name": "ParentKey",
-            "type": 11
+            "type": 10
           }
         ],
         "path": [
@@ -4937,7 +4893,7 @@
       }
     },
     {
-      "id": 73,
+      "id": 72,
       "type": {
         "def": {
           "sequence": {
@@ -4947,7 +4903,7 @@
       }
     },
     {
-      "id": 74,
+      "id": 73,
       "type": {
         "def": {
           "composite": {}
@@ -4959,11 +4915,11 @@
           },
           {
             "name": "V",
-            "type": 73
+            "type": 72
           },
           {
             "name": "KeyType",
-            "type": 75
+            "type": 74
           }
         ],
         "path": [
@@ -4971,6 +4927,29 @@
           "lazy",
           "mapping",
           "Mapping"
+        ]
+      }
+    },
+    {
+      "id": 74,
+      "type": {
+        "def": {
+          "composite": {}
+        },
+        "params": [
+          {
+            "name": "L",
+            "type": 8
+          },
+          {
+            "name": "R",
+            "type": 75
+          }
+        ],
+        "path": [
+          "ink_storage_traits",
+          "impls",
+          "ResolverKey"
         ]
       }
     },
@@ -4982,18 +4961,14 @@
         },
         "params": [
           {
-            "name": "L",
-            "type": 9
-          },
-          {
-            "name": "R",
-            "type": 76
+            "name": "ParentKey",
+            "type": 10
           }
         ],
         "path": [
           "ink_storage_traits",
           "impls",
-          "ResolverKey"
+          "ManualKey"
         ]
       }
     },
@@ -5005,14 +4980,23 @@
         },
         "params": [
           {
-            "name": "ParentKey",
-            "type": 11
+            "name": "K",
+            "type": 0
+          },
+          {
+            "name": "V",
+            "type": 4
+          },
+          {
+            "name": "KeyType",
+            "type": 77
           }
         ],
         "path": [
-          "ink_storage_traits",
-          "impls",
-          "ManualKey"
+          "ink_storage",
+          "lazy",
+          "mapping",
+          "Mapping"
         ]
       }
     },
@@ -5024,23 +5008,18 @@
         },
         "params": [
           {
-            "name": "K",
-            "type": 0
+            "name": "L",
+            "type": 8
           },
           {
-            "name": "V",
-            "type": 5
-          },
-          {
-            "name": "KeyType",
+            "name": "R",
             "type": 78
           }
         ],
         "path": [
-          "ink_storage",
-          "lazy",
-          "mapping",
-          "Mapping"
+          "ink_storage_traits",
+          "impls",
+          "ResolverKey"
         ]
       }
     },
@@ -5052,18 +5031,14 @@
         },
         "params": [
           {
-            "name": "L",
-            "type": 9
-          },
-          {
-            "name": "R",
-            "type": 79
+            "name": "ParentKey",
+            "type": 10
           }
         ],
         "path": [
           "ink_storage_traits",
           "impls",
-          "ResolverKey"
+          "ManualKey"
         ]
       }
     },
@@ -5075,14 +5050,23 @@
         },
         "params": [
           {
-            "name": "ParentKey",
-            "type": 11
+            "name": "K",
+            "type": 0
+          },
+          {
+            "name": "V",
+            "type": 4
+          },
+          {
+            "name": "KeyType",
+            "type": 80
           }
         ],
         "path": [
-          "ink_storage_traits",
-          "impls",
-          "ManualKey"
+          "ink_storage",
+          "lazy",
+          "mapping",
+          "Mapping"
         ]
       }
     },
@@ -5094,23 +5078,18 @@
         },
         "params": [
           {
-            "name": "K",
-            "type": 0
+            "name": "L",
+            "type": 8
           },
           {
-            "name": "V",
-            "type": 5
-          },
-          {
-            "name": "KeyType",
+            "name": "R",
             "type": 81
           }
         ],
         "path": [
-          "ink_storage",
-          "lazy",
-          "mapping",
-          "Mapping"
+          "ink_storage_traits",
+          "impls",
+          "ResolverKey"
         ]
       }
     },
@@ -5122,18 +5101,14 @@
         },
         "params": [
           {
-            "name": "L",
-            "type": 9
-          },
-          {
-            "name": "R",
-            "type": 82
+            "name": "ParentKey",
+            "type": 10
           }
         ],
         "path": [
           "ink_storage_traits",
           "impls",
-          "ResolverKey"
+          "ManualKey"
         ]
       }
     },
@@ -5145,14 +5120,23 @@
         },
         "params": [
           {
-            "name": "ParentKey",
-            "type": 11
+            "name": "K",
+            "type": 0
+          },
+          {
+            "name": "V",
+            "type": 4
+          },
+          {
+            "name": "KeyType",
+            "type": 83
           }
         ],
         "path": [
-          "ink_storage_traits",
-          "impls",
-          "ManualKey"
+          "ink_storage",
+          "lazy",
+          "mapping",
+          "Mapping"
         ]
       }
     },
@@ -5164,23 +5148,18 @@
         },
         "params": [
           {
-            "name": "K",
-            "type": 0
+            "name": "L",
+            "type": 8
           },
           {
-            "name": "V",
-            "type": 5
-          },
-          {
-            "name": "KeyType",
+            "name": "R",
             "type": 84
           }
         ],
         "path": [
-          "ink_storage",
-          "lazy",
-          "mapping",
-          "Mapping"
+          "ink_storage_traits",
+          "impls",
+          "ResolverKey"
         ]
       }
     },
@@ -5192,18 +5171,14 @@
         },
         "params": [
           {
-            "name": "L",
-            "type": 9
-          },
-          {
-            "name": "R",
-            "type": 85
+            "name": "ParentKey",
+            "type": 10
           }
         ],
         "path": [
           "ink_storage_traits",
           "impls",
-          "ResolverKey"
+          "ManualKey"
         ]
       }
     },
@@ -5215,14 +5190,23 @@
         },
         "params": [
           {
-            "name": "ParentKey",
-            "type": 11
+            "name": "K",
+            "type": 72
+          },
+          {
+            "name": "V",
+            "type": 2
+          },
+          {
+            "name": "KeyType",
+            "type": 86
           }
         ],
         "path": [
-          "ink_storage_traits",
-          "impls",
-          "ManualKey"
+          "ink_storage",
+          "lazy",
+          "mapping",
+          "Mapping"
         ]
       }
     },
@@ -5234,23 +5218,18 @@
         },
         "params": [
           {
-            "name": "K",
-            "type": 73
+            "name": "L",
+            "type": 8
           },
           {
-            "name": "V",
-            "type": 2
-          },
-          {
-            "name": "KeyType",
+            "name": "R",
             "type": 87
           }
         ],
         "path": [
-          "ink_storage",
-          "lazy",
-          "mapping",
-          "Mapping"
+          "ink_storage_traits",
+          "impls",
+          "ResolverKey"
         ]
       }
     },
@@ -5262,18 +5241,14 @@
         },
         "params": [
           {
-            "name": "L",
-            "type": 9
-          },
-          {
-            "name": "R",
-            "type": 88
+            "name": "ParentKey",
+            "type": 10
           }
         ],
         "path": [
           "ink_storage_traits",
           "impls",
-          "ResolverKey"
+          "ManualKey"
         ]
       }
     },
@@ -5285,14 +5260,23 @@
         },
         "params": [
           {
-            "name": "ParentKey",
-            "type": 11
+            "name": "K",
+            "type": 72
+          },
+          {
+            "name": "V",
+            "type": 3
+          },
+          {
+            "name": "KeyType",
+            "type": 89
           }
         ],
         "path": [
-          "ink_storage_traits",
-          "impls",
-          "ManualKey"
+          "ink_storage",
+          "lazy",
+          "mapping",
+          "Mapping"
         ]
       }
     },
@@ -5304,23 +5288,18 @@
         },
         "params": [
           {
-            "name": "K",
-            "type": 73
+            "name": "L",
+            "type": 8
           },
           {
-            "name": "V",
-            "type": 4
-          },
-          {
-            "name": "KeyType",
+            "name": "R",
             "type": 90
           }
         ],
         "path": [
-          "ink_storage",
-          "lazy",
-          "mapping",
-          "Mapping"
+          "ink_storage_traits",
+          "impls",
+          "ResolverKey"
         ]
       }
     },
@@ -5332,18 +5311,14 @@
         },
         "params": [
           {
-            "name": "L",
-            "type": 9
-          },
-          {
-            "name": "R",
-            "type": 91
+            "name": "ParentKey",
+            "type": 10
           }
         ],
         "path": [
           "ink_storage_traits",
           "impls",
-          "ResolverKey"
+          "ManualKey"
         ]
       }
     },
@@ -5355,35 +5330,16 @@
         },
         "params": [
           {
-            "name": "ParentKey",
-            "type": 11
-          }
-        ],
-        "path": [
-          "ink_storage_traits",
-          "impls",
-          "ManualKey"
-        ]
-      }
-    },
-    {
-      "id": 92,
-      "type": {
-        "def": {
-          "composite": {}
-        },
-        "params": [
-          {
             "name": "K",
-            "type": 12
+            "type": 11
           },
           {
             "name": "V",
-            "type": 93
+            "type": 92
           },
           {
             "name": "KeyType",
-            "type": 94
+            "type": 93
           }
         ],
         "path": [
@@ -5395,18 +5351,18 @@
       }
     },
     {
-      "id": 93,
+      "id": 92,
       "type": {
         "def": {
           "tuple": [
             0,
-            5
+            4
           ]
         }
       }
     },
     {
-      "id": 94,
+      "id": 93,
       "type": {
         "def": {
           "composite": {}
@@ -5414,11 +5370,11 @@
         "params": [
           {
             "name": "L",
-            "type": 9
+            "type": 8
           },
           {
             "name": "R",
-            "type": 95
+            "type": 94
           }
         ],
         "path": [
@@ -5429,7 +5385,7 @@
       }
     },
     {
-      "id": 95,
+      "id": 94,
       "type": {
         "def": {
           "composite": {}
@@ -5437,7 +5393,7 @@
         "params": [
           {
             "name": "ParentKey",
-            "type": 11
+            "type": 10
           }
         ],
         "path": [
@@ -5448,7 +5404,7 @@
       }
     },
     {
-      "id": 96,
+      "id": 95,
       "type": {
         "def": {
           "composite": {
@@ -5459,48 +5415,38 @@
                 "typeName": "<AccountId as::ink::storage::traits::AutoStorableHint<::ink::\nstorage::traits::ManualKey<2833659908u32, ()>,>>::Type"
               },
               {
-                "name": "treasury_hotkey",
-                "type": 0,
-                "typeName": "<AccountId as::ink::storage::traits::AutoStorableHint<::ink::\nstorage::traits::ManualKey<3597031972u32, ()>,>>::Type"
-              },
-              {
                 "name": "recycle_address",
                 "type": 0,
                 "typeName": "<AccountId as::ink::storage::traits::AutoStorableHint<::ink::\nstorage::traits::ManualKey<3462413410u32, ()>,>>::Type"
               },
               {
-                "name": "netuid",
-                "type": 3,
-                "typeName": "<u16 as::ink::storage::traits::AutoStorableHint<::ink::storage\n::traits::ManualKey<2503007889u32, ()>,>>::Type"
-              },
-              {
                 "name": "fulfillment_timeout_blocks",
-                "type": 4,
+                "type": 3,
                 "typeName": "<u32 as::ink::storage::traits::AutoStorableHint<::ink::storage\n::traits::ManualKey<140410277u32, ()>,>>::Type"
               },
               {
                 "name": "reservation_ttl",
-                "type": 4,
+                "type": 3,
                 "typeName": "<u32 as::ink::storage::traits::AutoStorableHint<::ink::storage\n::traits::ManualKey<196722775u32, ()>,>>::Type"
               },
               {
                 "name": "min_collateral",
-                "type": 5,
+                "type": 4,
                 "typeName": "<Balance as::ink::storage::traits::AutoStorableHint<::ink::\nstorage::traits::ManualKey<1188786366u32, ()>,>>::Type"
               },
               {
                 "name": "max_collateral",
-                "type": 5,
+                "type": 4,
                 "typeName": "<Balance as::ink::storage::traits::AutoStorableHint<::ink::\nstorage::traits::ManualKey<948383453u32, ()>,>>::Type"
               },
               {
                 "name": "min_swap_amount",
-                "type": 5,
+                "type": 4,
                 "typeName": "<Balance as::ink::storage::traits::AutoStorableHint<::ink::\nstorage::traits::ManualKey<1125021002u32, ()>,>>::Type"
               },
               {
                 "name": "max_swap_amount",
-                "type": 5,
+                "type": 4,
                 "typeName": "<Balance as::ink::storage::traits::AutoStorableHint<::ink::\nstorage::traits::ManualKey<3490700323u32, ()>,>>::Type"
               },
               {
@@ -5510,167 +5456,167 @@
               },
               {
                 "name": "validator_count",
-                "type": 4,
+                "type": 3,
                 "typeName": "<u32 as::ink::storage::traits::AutoStorableHint<::ink::storage\n::traits::ManualKey<1735615909u32, ()>,>>::Type"
               },
               {
                 "name": "fee_divisor",
-                "type": 5,
+                "type": 4,
                 "typeName": "<u128 as::ink::storage::traits::AutoStorableHint<::ink::storage\n::traits::ManualKey<2803259442u32, ()>,>>::Type"
               },
               {
                 "name": "halted",
-                "type": 6,
+                "type": 5,
                 "typeName": "<bool as::ink::storage::traits::AutoStorableHint<::ink::storage\n::traits::ManualKey<3271630610u32, ()>,>>::Type"
               },
               {
                 "name": "validators",
-                "type": 7,
+                "type": 6,
                 "typeName": "<Mapping<AccountId, bool> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<1375580815u32,\n()>,>>::Type"
               },
               {
                 "name": "next_swap_id",
-                "type": 12,
+                "type": 11,
                 "typeName": "<u64 as::ink::storage::traits::AutoStorableHint<::ink::storage\n::traits::ManualKey<3204266513u32, ()>,>>::Type"
               },
               {
                 "name": "swaps",
-                "type": 14,
+                "type": 13,
                 "typeName": "<Mapping<u64, SwapData> as::ink::storage::traits::AutoStorableHint\n<::ink::storage::traits::ManualKey<1645419819u32, ()>,>>::Type"
               },
               {
                 "name": "swap_confirm_votes",
-                "type": 19,
+                "type": 18,
                 "typeName": "<Mapping<(u64, AccountId), bool> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<3580685545u32,\n()>,>>::Type"
               },
               {
                 "name": "swap_confirm_vote_count",
-                "type": 23,
+                "type": 22,
                 "typeName": "<Mapping<u64, u32> as::ink::storage::traits::AutoStorableHint<::\nink::storage::traits::ManualKey<1618119087u32, ()>,>>::Type"
               },
               {
                 "name": "swap_timeout_votes",
-                "type": 26,
+                "type": 25,
                 "typeName": "<Mapping<(u64, AccountId), bool> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<537912262u32, ()\n>,>>::Type"
               },
               {
                 "name": "swap_timeout_vote_count",
-                "type": 29,
+                "type": 28,
                 "typeName": "<Mapping<u64, u32> as::ink::storage::traits::AutoStorableHint<::\nink::storage::traits::ManualKey<3216631485u32, ()>,>>::Type"
               },
               {
                 "name": "used_source_tx",
-                "type": 32,
+                "type": 31,
                 "typeName": "<Mapping<String, bool> as::ink::storage::traits::AutoStorableHint\n<::ink::storage::traits::ManualKey<444471674u32, ()>,>>::Type"
               },
               {
                 "name": "collateral",
-                "type": 35,
+                "type": 34,
                 "typeName": "<Mapping<AccountId, Balance> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<3894748662u32,\n()>,>>::Type"
               },
               {
                 "name": "miner_active",
-                "type": 38,
+                "type": 37,
                 "typeName": "<Mapping<AccountId, bool> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<4204122727u32,\n()>,>>::Type"
               },
               {
                 "name": "miner_has_active_swap",
-                "type": 41,
+                "type": 40,
                 "typeName": "<Mapping<AccountId, bool> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<1699049251u32,\n()>,>>::Type"
               },
               {
                 "name": "miner_reserved_until",
-                "type": 44,
+                "type": 43,
                 "typeName": "<Mapping<AccountId, u32> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<1355280751u32,\n()>,>>::Type"
               },
               {
                 "name": "miner_last_resolved_block",
-                "type": 47,
+                "type": 46,
                 "typeName": "<Mapping<AccountId, u32> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<3154176384u32,\n()>,>>::Type"
               },
               {
                 "name": "miner_deactivation_block",
-                "type": 50,
+                "type": 49,
                 "typeName": "<Mapping<AccountId, u32> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<878783374u32, ()\n>,>>::Type"
               },
               {
                 "name": "next_request_id",
-                "type": 12,
+                "type": 11,
                 "typeName": "<u64 as::ink::storage::traits::AutoStorableHint<::ink::storage\n::traits::ManualKey<3094324075u32, ()>,>>::Type"
               },
               {
                 "name": "request_votes",
-                "type": 53,
+                "type": 52,
                 "typeName": "<Mapping<(u64, AccountId), bool> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<2214978342u32,\n()>,>>::Type"
               },
               {
                 "name": "request_vote_count",
-                "type": 56,
+                "type": 55,
                 "typeName": "<Mapping<u64, u32> as::ink::storage::traits::AutoStorableHint<::\nink::storage::traits::ManualKey<3442329302u32, ()>,>>::Type"
               },
               {
                 "name": "request_created",
-                "type": 59,
+                "type": 58,
                 "typeName": "<Mapping<u64, u32> as::ink::storage::traits::AutoStorableHint<::\nink::storage::traits::ManualKey<3808762728u32, ()>,>>::Type"
               },
               {
                 "name": "request_hash",
-                "type": 63,
+                "type": 62,
                 "typeName": "<Mapping<u64, Hash> as::ink::storage::traits::AutoStorableHint<\n::ink::storage::traits::ManualKey<507769943u32, ()>,>>::Type"
               },
               {
                 "name": "miner_active_request",
-                "type": 66,
+                "type": 65,
                 "typeName": "<Mapping<(AccountId, u8), u64> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<2076993396u32,\n()>,>>::Type"
               },
               {
                 "name": "reservation_hash",
-                "type": 70,
+                "type": 69,
                 "typeName": "<Mapping<AccountId, Hash> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<1262456359u32,\n()>,>>::Type"
               },
               {
                 "name": "reservation_source_addr",
-                "type": 74,
+                "type": 73,
                 "typeName": "<Mapping<AccountId, Vec<u8>> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<279068048u32, ()\n>,>>::Type"
               },
               {
                 "name": "reservation_tao_amount",
-                "type": 77,
+                "type": 76,
                 "typeName": "<Mapping<AccountId, Balance> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<3983894121u32,\n()>,>>::Type"
               },
               {
                 "name": "reservation_source_amount",
-                "type": 80,
+                "type": 79,
                 "typeName": "<Mapping<AccountId, Balance> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<89149914u32, ()\n>,>>::Type"
               },
               {
                 "name": "reservation_dest_amount",
-                "type": 83,
+                "type": 82,
                 "typeName": "<Mapping<AccountId, Balance> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<2691059183u32,\n()>,>>::Type"
               },
               {
                 "name": "address_strike_count",
-                "type": 86,
+                "type": 85,
                 "typeName": "<Mapping<Vec<u8>, u8> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<4021087211u32,\n()>,>>::Type"
               },
               {
                 "name": "address_last_expired",
-                "type": 89,
+                "type": 88,
                 "typeName": "<Mapping<Vec<u8>, u32> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<3700452243u32,\n()>,>>::Type"
               },
               {
                 "name": "accumulated_fees",
-                "type": 5,
+                "type": 4,
                 "typeName": "<Balance as::ink::storage::traits::AutoStorableHint<::ink::\nstorage::traits::ManualKey<3593079788u32, ()>,>>::Type"
               },
               {
                 "name": "total_recycled_fees",
-                "type": 5,
+                "type": 4,
                 "typeName": "<Balance as::ink::storage::traits::AutoStorableHint<::ink::\nstorage::traits::ManualKey<259358120u32, ()>,>>::Type"
               },
               {
                 "name": "pending_slashes",
-                "type": 92,
+                "type": 91,
                 "typeName": "<Mapping<u64, (AccountId, Balance)> as::ink::storage::traits::\nAutoStorableHint<::ink::storage::traits::ManualKey<3162837514u32,\n()>,>>::Type"
               }
             ]
@@ -5684,7 +5630,7 @@
       }
     },
     {
-      "id": 97,
+      "id": 96,
       "type": {
         "def": {
           "variant": {
@@ -5692,7 +5638,7 @@
               {
                 "fields": [
                   {
-                    "type": 11
+                    "type": 10
                   }
                 ],
                 "index": 0,
@@ -5701,7 +5647,7 @@
               {
                 "fields": [
                   {
-                    "type": 98
+                    "type": 97
                   }
                 ],
                 "index": 1,
@@ -5713,11 +5659,11 @@
         "params": [
           {
             "name": "T",
-            "type": 11
+            "type": 10
           },
           {
             "name": "E",
-            "type": 98
+            "type": 97
           }
         ],
         "path": [
@@ -5726,7 +5672,7 @@
       }
     },
     {
-      "id": 98,
+      "id": 97,
       "type": {
         "def": {
           "variant": {
@@ -5745,7 +5691,7 @@
       }
     },
     {
-      "id": 99,
+      "id": 98,
       "type": {
         "def": {
           "variant": {
@@ -5753,7 +5699,7 @@
               {
                 "fields": [
                   {
-                    "type": 100
+                    "type": 99
                   }
                 ],
                 "index": 0,
@@ -5762,7 +5708,7 @@
               {
                 "fields": [
                   {
-                    "type": 98
+                    "type": 97
                   }
                 ],
                 "index": 1,
@@ -5774,11 +5720,53 @@
         "params": [
           {
             "name": "T",
-            "type": 100
+            "type": 99
           },
           {
             "name": "E",
-            "type": 98
+            "type": 97
+          }
+        ],
+        "path": [
+          "Result"
+        ]
+      }
+    },
+    {
+      "id": 99,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "fields": [
+                  {
+                    "type": 10
+                  }
+                ],
+                "index": 0,
+                "name": "Ok"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 100
+                  }
+                ],
+                "index": 1,
+                "name": "Err"
+              }
+            ]
+          }
+        },
+        "params": [
+          {
+            "name": "T",
+            "type": 10
+          },
+          {
+            "name": "E",
+            "type": 100
           }
         ],
         "path": [
@@ -5788,48 +5776,6 @@
     },
     {
       "id": 100,
-      "type": {
-        "def": {
-          "variant": {
-            "variants": [
-              {
-                "fields": [
-                  {
-                    "type": 11
-                  }
-                ],
-                "index": 0,
-                "name": "Ok"
-              },
-              {
-                "fields": [
-                  {
-                    "type": 101
-                  }
-                ],
-                "index": 1,
-                "name": "Err"
-              }
-            ]
-          }
-        },
-        "params": [
-          {
-            "name": "T",
-            "type": 11
-          },
-          {
-            "name": "E",
-            "type": 101
-          }
-        ],
-        "path": [
-          "Result"
-        ]
-      }
-    },
-    {
-      "id": 101,
       "type": {
         "def": {
           "variant": {
@@ -5957,7 +5903,7 @@
       }
     },
     {
-      "id": 102,
+      "id": 101,
       "type": {
         "def": {
           "variant": {
@@ -5965,7 +5911,7 @@
               {
                 "fields": [
                   {
-                    "type": 103
+                    "type": 102
                   }
                 ],
                 "index": 0,
@@ -5974,7 +5920,7 @@
               {
                 "fields": [
                   {
-                    "type": 98
+                    "type": 97
                   }
                 ],
                 "index": 1,
@@ -5986,11 +5932,11 @@
         "params": [
           {
             "name": "T",
-            "type": 103
+            "type": 102
           },
           {
             "name": "E",
-            "type": 98
+            "type": 97
           }
         ],
         "path": [
@@ -5999,7 +5945,7 @@
       }
     },
     {
-      "id": 103,
+      "id": 102,
       "type": {
         "def": {
           "variant": {
@@ -6011,7 +5957,7 @@
               {
                 "fields": [
                   {
-                    "type": 15
+                    "type": 14
                   }
                 ],
                 "index": 1,
@@ -6023,11 +5969,53 @@
         "params": [
           {
             "name": "T",
-            "type": 15
+            "type": 14
           }
         ],
         "path": [
           "Option"
+        ]
+      }
+    },
+    {
+      "id": 103,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "fields": [
+                  {
+                    "type": 4
+                  }
+                ],
+                "index": 0,
+                "name": "Ok"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 97
+                  }
+                ],
+                "index": 1,
+                "name": "Err"
+              }
+            ]
+          }
+        },
+        "params": [
+          {
+            "name": "T",
+            "type": 4
+          },
+          {
+            "name": "E",
+            "type": 97
+          }
+        ],
+        "path": [
+          "Result"
         ]
       }
     },
@@ -6049,7 +6037,7 @@
               {
                 "fields": [
                   {
-                    "type": 98
+                    "type": 97
                   }
                 ],
                 "index": 1,
@@ -6065,7 +6053,7 @@
           },
           {
             "name": "E",
-            "type": 98
+            "type": 97
           }
         ],
         "path": [
@@ -6082,7 +6070,7 @@
               {
                 "fields": [
                   {
-                    "type": 6
+                    "type": 3
                   }
                 ],
                 "index": 0,
@@ -6091,7 +6079,7 @@
               {
                 "fields": [
                   {
-                    "type": 98
+                    "type": 97
                   }
                 ],
                 "index": 1,
@@ -6103,11 +6091,11 @@
         "params": [
           {
             "name": "T",
-            "type": 6
+            "type": 3
           },
           {
             "name": "E",
-            "type": 98
+            "type": 97
           }
         ],
         "path": [
@@ -6124,7 +6112,7 @@
               {
                 "fields": [
                   {
-                    "type": 4
+                    "type": 11
                   }
                 ],
                 "index": 0,
@@ -6133,7 +6121,7 @@
               {
                 "fields": [
                   {
-                    "type": 98
+                    "type": 97
                   }
                 ],
                 "index": 1,
@@ -6145,11 +6133,11 @@
         "params": [
           {
             "name": "T",
-            "type": 4
+            "type": 11
           },
           {
             "name": "E",
-            "type": 98
+            "type": 97
           }
         ],
         "path": [
@@ -6166,7 +6154,7 @@
               {
                 "fields": [
                   {
-                    "type": 12
+                    "type": 0
                   }
                 ],
                 "index": 0,
@@ -6175,7 +6163,7 @@
               {
                 "fields": [
                   {
-                    "type": 98
+                    "type": 97
                   }
                 ],
                 "index": 1,
@@ -6187,11 +6175,11 @@
         "params": [
           {
             "name": "T",
-            "type": 12
+            "type": 0
           },
           {
             "name": "E",
-            "type": 98
+            "type": 97
           }
         ],
         "path": [
@@ -6208,7 +6196,7 @@
               {
                 "fields": [
                   {
-                    "type": 0
+                    "type": 2
                   }
                 ],
                 "index": 0,
@@ -6217,7 +6205,7 @@
               {
                 "fields": [
                   {
-                    "type": 98
+                    "type": 97
                   }
                 ],
                 "index": 1,
@@ -6229,11 +6217,11 @@
         "params": [
           {
             "name": "T",
-            "type": 0
+            "type": 2
           },
           {
             "name": "E",
-            "type": 98
+            "type": 97
           }
         ],
         "path": [
@@ -6250,7 +6238,7 @@
               {
                 "fields": [
                   {
-                    "type": 2
+                    "type": 110
                   }
                 ],
                 "index": 0,
@@ -6259,7 +6247,7 @@
               {
                 "fields": [
                   {
-                    "type": 98
+                    "type": 97
                   }
                 ],
                 "index": 1,
@@ -6271,11 +6259,11 @@
         "params": [
           {
             "name": "T",
-            "type": 2
+            "type": 110
           },
           {
             "name": "E",
-            "type": 98
+            "type": 97
           }
         ],
         "path": [
@@ -6290,55 +6278,13 @@
           "variant": {
             "variants": [
               {
-                "fields": [
-                  {
-                    "type": 111
-                  }
-                ],
-                "index": 0,
-                "name": "Ok"
-              },
-              {
-                "fields": [
-                  {
-                    "type": 98
-                  }
-                ],
-                "index": 1,
-                "name": "Err"
-              }
-            ]
-          }
-        },
-        "params": [
-          {
-            "name": "T",
-            "type": 111
-          },
-          {
-            "name": "E",
-            "type": 98
-          }
-        ],
-        "path": [
-          "Result"
-        ]
-      }
-    },
-    {
-      "id": 111,
-      "type": {
-        "def": {
-          "variant": {
-            "variants": [
-              {
                 "index": 0,
                 "name": "None"
               },
               {
                 "fields": [
                   {
-                    "type": 112
+                    "type": 111
                   }
                 ],
                 "index": 1,
@@ -6350,7 +6296,7 @@
         "params": [
           {
             "name": "T",
-            "type": 112
+            "type": 111
           }
         ],
         "path": [
@@ -6359,21 +6305,21 @@
       }
     },
     {
-      "id": 112,
+      "id": 111,
       "type": {
         "def": {
           "tuple": [
-            73,
-            5,
-            5,
-            5,
-            4
+            72,
+            4,
+            4,
+            4,
+            3
           ]
         }
       }
     },
     {
-      "id": 113,
+      "id": 112,
       "type": {
         "def": {
           "variant": {
@@ -6381,7 +6327,7 @@
               {
                 "fields": [
                   {
-                    "type": 114
+                    "type": 113
                   }
                 ],
                 "index": 0,
@@ -6390,7 +6336,7 @@
               {
                 "fields": [
                   {
-                    "type": 98
+                    "type": 97
                   }
                 ],
                 "index": 1,
@@ -6402,11 +6348,11 @@
         "params": [
           {
             "name": "T",
-            "type": 114
+            "type": 113
           },
           {
             "name": "E",
-            "type": 98
+            "type": 97
           }
         ],
         "path": [
@@ -6415,18 +6361,18 @@
       }
     },
     {
-      "id": 114,
+      "id": 113,
       "type": {
         "def": {
           "tuple": [
             2,
-            4
+            3
           ]
         }
       }
     },
     {
-      "id": 115,
+      "id": 114,
       "type": {
         "def": {
           "variant": {
@@ -6454,7 +6400,7 @@
       }
     },
     {
-      "id": 116,
+      "id": 115,
       "type": {
         "def": {
           "variant": {}

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -36,7 +36,7 @@ def _scale_encode_reserve_hash_input(
     source_amount: int,
     dest_amount: int,
 ) -> bytes:
-    """SCALE-encode the reserve hash input tuple: (AccountId, Vec<u8>, String, String, u128, u128, u128).
+    """SCALE-encode the reserve hash input tuple: (AccountId, String, String, String, u128, u128, u128).
 
     Matches ink::env::hash_encoded::<Keccak256, _>(
         &(miner, user_source_address, source_chain, dest_chain, tao_amount, source_amount, dest_amount)
@@ -47,11 +47,11 @@ def _scale_encode_reserve_hash_input(
     return (
         miner_bytes  # AccountId: 32 bytes raw
         + compact_encode_len(len(source_addr_bytes))
-        + source_addr_bytes  # Vec<u8>: compact length + data
+        + source_addr_bytes  # String: compact length + UTF-8 bytes
         + compact_encode_len(len(src_bytes))
-        + src_bytes  # String: compact length + utf-8
+        + src_bytes  # String: compact length + UTF-8 bytes
         + compact_encode_len(len(dst_bytes))
-        + dst_bytes
+        + dst_bytes  # String: compact length + UTF-8 bytes
         + tao_amount.to_bytes(16, 'little')  # u128: 16 bytes LE
         + source_amount.to_bytes(16, 'little')  # u128: 16 bytes LE
         + dest_amount.to_bytes(16, 'little')  # u128: 16 bytes LE
@@ -340,7 +340,7 @@ async def handle_swap_reserve(
                 _reject(synapse, f'Swap amount above maximum ({synapse.tao_amount} > {max_swap} rao)', ctx)
                 return synapse
 
-            strike_count, last_expired = contract.get_cooldown(source_addr_bytes)
+            strike_count, last_expired = contract.get_cooldown(synapse.source_address)
             if strike_count > 0 and last_expired > 0:
                 cooldown = RESERVATION_COOLDOWN_BLOCKS * (2 ** (strike_count - 1))
                 if validator.block < last_expired + cooldown:
@@ -351,7 +351,7 @@ async def handle_swap_reserve(
                 wallet=validator.wallet,
                 request_hash=request_hash,
                 miner_hotkey=miner,
-                user_source_address=source_addr_bytes,
+                user_source_address=synapse.source_address,
                 source_chain=synapse.source_chain,
                 dest_chain=synapse.dest_chain,
                 tao_amount=synapse.tao_amount,

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -55,7 +55,7 @@ async def forward(self: Validator) -> None:
 
     _clear_provider_caches(self)
     _process_pending_confirms(self)
-    await tracker.poll()
+    await tracker.poll(self.block)
     uncertain = await _verify_fulfilled(tracker, verifier, voter, self.block)
     _extend_near_timeout_fulfilled(self)
     _timeout_expired(self, tracker, voter, uncertain)
@@ -247,7 +247,7 @@ async def _verify_fulfilled(
             continue
         if result:
             if voter.confirm_swap(swap.id):
-                tracker.mark_voted(swap.id)
+                tracker.resolve(swap.id, SwapStatus.COMPLETED, current_block)
                 bt.logging.success(f'Swap {swap.id}: verified complete, confirmed')
     return uncertain
 
@@ -319,7 +319,7 @@ def _timeout_expired(self: Validator, tracker: SwapTracker, voter: SwapVoter, un
             continue
 
         if voter.timeout_swap(swap.id):
-            tracker.mark_voted(swap.id)
+            tracker.resolve(swap.id, SwapStatus.TIMED_OUT, self.block)
             bt.logging.warning(f'Swap {swap.id}: timed out')
 
 

--- a/allways/validator/swap_tracker.py
+++ b/allways/validator/swap_tracker.py
@@ -67,6 +67,21 @@ class SwapTracker:
 
         bt.logging.info(f'SwapTracker initialized: active={len(self.active)}, last_scanned_id={self.last_scanned_id}')
 
+    def resolve(self, swap_id: int, status: SwapStatus, block: int):
+        """Move a swap from active tracking to the scoring window with its terminal state.
+
+        Called when the validator's vote reaches quorum (confirm or timeout).
+        The contract removes swap data on resolution, so get_swap() returns None
+        after this point — we must capture the terminal state here for scoring.
+        """
+        swap = self.active.pop(swap_id, None)
+        if swap is None:
+            return
+        swap.status = status
+        swap.completed_block = block
+        self.window.append(swap)
+        self.voted_ids.discard(swap_id)
+
     def mark_voted(self, swap_id: int):
         """Mark a swap as voted on to prevent redundant vote extrinsics."""
         self.voted_ids.add(swap_id)
@@ -75,8 +90,9 @@ class SwapTracker:
         """Check if we've already voted on this swap."""
         return swap_id in self.voted_ids
 
-    async def poll(self):
+    async def poll(self, current_block: int = 0):
         """Incremental update — called every forward step (~12s)."""
+        self._current_block = current_block
         try:
             await self._poll_inner()
         except (ConnectionError, TimeoutError, asyncio.TimeoutError) as e:
@@ -117,6 +133,14 @@ class SwapTracker:
         resolved_ids = []
         for sid, swap in zip(stale_ids, swaps):
             if swap is None:
+                # Swap removed from contract (resolved by another validator's quorum vote).
+                # If resolve() already captured it, active won't have it; otherwise infer state.
+                last_known = self.active.get(sid)
+                if last_known is not None and sid not in self.voted_ids:
+                    was_past_timeout = last_known.timeout_block > 0 and self._current_block > last_known.timeout_block
+                    last_known.status = SwapStatus.TIMED_OUT if was_past_timeout else SwapStatus.COMPLETED
+                    last_known.completed_block = self._current_block
+                    self.window.append(last_known)
                 resolved_ids.append(sid)
             elif swap.status in ACTIVE_STATUSES:
                 self.active[sid] = swap

--- a/smart-contracts/ink/lib.rs
+++ b/smart-contracts/ink/lib.rs
@@ -20,9 +20,7 @@ mod allways_swap_manager {
     pub struct AllwaysSwapManager {
         // Configuration
         owner: AccountId,
-        treasury_hotkey: AccountId,
         recycle_address: AccountId,
-        netuid: u16,
         fulfillment_timeout_blocks: u32,
         reservation_ttl: u32,
         min_collateral: Balance,
@@ -256,9 +254,7 @@ mod allways_swap_manager {
         /// Initialize the contract
         #[ink(constructor)]
         pub fn new(
-            treasury_hotkey: AccountId,
             recycle_address: AccountId,
-            netuid: u16,
             fulfillment_timeout_blocks: u32,
             reservation_ttl: u32,
             min_collateral: Balance,
@@ -269,9 +265,7 @@ mod allways_swap_manager {
         ) -> Self {
             Self {
                 owner: Self::env().caller(),
-                treasury_hotkey,
                 recycle_address,
-                netuid,
                 fulfillment_timeout_blocks,
                 reservation_ttl,
                 min_collateral,

--- a/smart-contracts/ink/lib.rs
+++ b/smart-contracts/ink/lib.rs
@@ -63,14 +63,14 @@ mod allways_swap_manager {
 
         // Confirmed reservation data (post-quorum)
         reservation_hash: Mapping<AccountId, Hash>,
-        reservation_source_addr: Mapping<AccountId, Vec<u8>>,
+        reservation_source_addr: Mapping<AccountId, String>,
         reservation_tao_amount: Mapping<AccountId, Balance>,
         reservation_source_amount: Mapping<AccountId, Balance>,
         reservation_dest_amount: Mapping<AccountId, Balance>,
 
         // Cooldown strike tracking (lazy eval)
-        address_strike_count: Mapping<Vec<u8>, u8>,
-        address_last_expired: Mapping<Vec<u8>, u32>,
+        address_strike_count: Mapping<String, u8>,
+        address_last_expired: Mapping<String, u32>,
         // Financials
         accumulated_fees: Balance,
         total_recycled_fees: Balance,
@@ -125,7 +125,7 @@ mod allways_swap_manager {
 
         fn compute_reserve_hash(
             miner: &AccountId,
-            user_source_address: &[u8],
+            user_source_address: &str,
             source_chain: &str,
             dest_chain: &str,
             tao_amount: Balance,
@@ -395,7 +395,7 @@ mod allways_swap_manager {
             &mut self,
             request_hash: Hash,
             miner: AccountId,
-            user_source_address: Vec<u8>,
+            user_source_address: String,
             source_chain: String,
             dest_chain: String,
             tao_amount: Balance,
@@ -785,9 +785,8 @@ mod allways_swap_manager {
                 self.miner_has_active_swap.insert(swap.miner, &false);
                 self.miner_last_resolved_block.insert(swap.miner, &swap.completed_block);
 
-                let source_addr = swap.user_source_address.as_bytes().to_vec();
-                self.address_strike_count.remove(&source_addr);
-                self.address_last_expired.remove(&source_addr);
+                self.address_strike_count.remove(&swap.user_source_address);
+                self.address_last_expired.remove(&swap.user_source_address);
 
                 self.env().emit_event(SwapCompleted {
                     swap_id,
@@ -1335,7 +1334,7 @@ mod allways_swap_manager {
         pub fn get_reservation_data(
             &self,
             miner: AccountId,
-        ) -> Option<(Vec<u8>, Balance, Balance, Balance, u32)> {
+        ) -> Option<(String, Balance, Balance, Balance, u32)> {
             let reserved_until = self.miner_reserved_until.get(miner).unwrap_or(0);
             if reserved_until == 0 {
                 return None;
@@ -1366,7 +1365,7 @@ mod allways_swap_manager {
         }
 
         #[ink(message)]
-        pub fn get_cooldown(&self, source_address: Vec<u8>) -> (u8, u32) {
+        pub fn get_cooldown(&self, source_address: String) -> (u8, u32) {
             (
                 self.address_strike_count.get(&source_address).unwrap_or(0),
                 self.address_last_expired.get(&source_address).unwrap_or(0),

--- a/tests/test_commitments.py
+++ b/tests/test_commitments.py
@@ -5,7 +5,7 @@ from allways.commitments import parse_commitment_data
 
 class TestParseCommitmentData:
     def test_valid_two_rates(self):
-        raw = 'v3:btc:bc1qaddr:tao:5Caddr:340:350'
+        raw = 'v1:btc:bc1qaddr:tao:5Caddr:340:350'
         pair = parse_commitment_data(raw, uid=1, hotkey='hk1')
         assert pair is not None
         assert pair.uid == 1
@@ -20,7 +20,7 @@ class TestParseCommitmentData:
         assert pair.counter_rate_str == '350'
 
     def test_valid_same_rate_both_directions(self):
-        raw = 'v3:btc:bc1qaddr:tao:5Caddr:345:345'
+        raw = 'v1:btc:bc1qaddr:tao:5Caddr:345:345'
         pair = parse_commitment_data(raw)
         assert pair is not None
         assert pair.rate == 345.0
@@ -28,7 +28,7 @@ class TestParseCommitmentData:
 
     def test_normalization_swaps_rates(self):
         """When posted as tao->btc, normalization flips to btc->tao and swaps rates."""
-        raw = 'v3:tao:5Caddr:btc:bc1qaddr:340:350'
+        raw = 'v1:tao:5Caddr:btc:bc1qaddr:340:350'
         pair = parse_commitment_data(raw)
         assert pair is not None
         assert pair.source_chain == 'btc'
@@ -42,7 +42,7 @@ class TestParseCommitmentData:
         assert pair.counter_rate_str == '340'
 
     def test_fractional_rates(self):
-        raw = 'v3:btc:bc1qaddr:tao:5Caddr:345.12:350.45'
+        raw = 'v1:btc:bc1qaddr:tao:5Caddr:345.12:350.45'
         pair = parse_commitment_data(raw)
         assert pair is not None
         assert pair.rate == 345.12
@@ -51,7 +51,7 @@ class TestParseCommitmentData:
         assert pair.counter_rate_str == '350.45'
 
     def test_get_rate_for_direction(self):
-        raw = 'v3:btc:bc1qaddr:tao:5Caddr:340:350'
+        raw = 'v1:btc:bc1qaddr:tao:5Caddr:340:350'
         pair = parse_commitment_data(raw)
         # Forward (btc -> tao)
         rate, rate_str = pair.get_rate_for_direction('btc')
@@ -64,7 +64,7 @@ class TestParseCommitmentData:
 
     def test_get_rate_for_direction_after_normalization(self):
         """Full pipeline: tao->btc commitment normalizes, then direction lookup works."""
-        raw = 'v3:tao:5Caddr:btc:bc1qaddr:340:350'
+        raw = 'v1:tao:5Caddr:btc:bc1qaddr:340:350'
         pair = parse_commitment_data(raw)
         # After normalization: source=btc, dest=tao
         # Original 340 was tao->btc (now reverse), 350 was btc->tao (now forward)
@@ -76,10 +76,10 @@ class TestParseCommitmentData:
         assert rev_str == '340'
 
     def test_wrong_part_count_too_few(self):
-        assert parse_commitment_data('v3:btc:addr:tao:addr:345') is None
+        assert parse_commitment_data('v1:btc:addr:tao:addr:345') is None
 
     def test_wrong_part_count_too_many(self):
-        assert parse_commitment_data('v3:btc:addr:tao:addr:340:350:extra') is None
+        assert parse_commitment_data('v1:btc:addr:tao:addr:340:350:extra') is None
 
     def test_wrong_version(self):
         assert parse_commitment_data('v2:btc:addr:tao:addr:340:350') is None
@@ -88,22 +88,22 @@ class TestParseCommitmentData:
         assert parse_commitment_data('3:btc:addr:tao:addr:340:350') is None
 
     def test_unsupported_source_chain(self):
-        assert parse_commitment_data('v3:eth:addr:tao:addr:340:350') is None
+        assert parse_commitment_data('v1:eth:addr:tao:addr:340:350') is None
 
     def test_unsupported_dest_chain(self):
-        assert parse_commitment_data('v3:btc:addr:eth:addr:340:350') is None
+        assert parse_commitment_data('v1:btc:addr:eth:addr:340:350') is None
 
     def test_invalid_rate_not_a_number(self):
-        assert parse_commitment_data('v3:btc:addr:tao:addr:abc:350') is None
+        assert parse_commitment_data('v1:btc:addr:tao:addr:abc:350') is None
 
     def test_invalid_reverse_rate_not_a_number(self):
-        assert parse_commitment_data('v3:btc:addr:tao:addr:340:abc') is None
+        assert parse_commitment_data('v1:btc:addr:tao:addr:340:abc') is None
 
     def test_empty_string(self):
         assert parse_commitment_data('') is None
 
     def test_rate_zero(self):
-        pair = parse_commitment_data('v3:btc:addr:tao:addr:0:0')
+        pair = parse_commitment_data('v1:btc:addr:tao:addr:0:0')
         assert pair is not None
         assert pair.rate == 0.0
         assert pair.counter_rate == 0.0
@@ -112,7 +112,7 @@ class TestParseCommitmentData:
         """Full guard chain: disabled direction → rate=0 → dest_amount=0 → contract rejects."""
         from allways.utils.rate import calculate_dest_amount
 
-        raw = 'v3:btc:bc1qaddr:tao:5Caddr:345:0'
+        raw = 'v1:btc:bc1qaddr:tao:5Caddr:345:0'
         pair = parse_commitment_data(raw)
         # Validator calls get_rate_for_direction for the disabled direction
         rate, rate_str = pair.get_rate_for_direction('tao')
@@ -126,7 +126,7 @@ class TestParseCommitmentData:
 
     def test_single_direction_forward_only(self):
         """Miner supports only BTC→TAO (counter_rate=0 means TAO→BTC not offered)."""
-        raw = 'v3:btc:bc1qaddr:tao:5Caddr:345:0'
+        raw = 'v1:btc:bc1qaddr:tao:5Caddr:345:0'
         pair = parse_commitment_data(raw)
         assert pair is not None
         assert pair.rate == 345.0
@@ -140,7 +140,7 @@ class TestParseCommitmentData:
 
     def test_single_direction_counter_only(self):
         """Miner posts tao→btc only. After normalization, rate=0, counter_rate has the value."""
-        raw = 'v3:tao:5Caddr:btc:bc1qaddr:345:0'
+        raw = 'v1:tao:5Caddr:btc:bc1qaddr:345:0'
         pair = parse_commitment_data(raw)
         assert pair is not None
         # Normalization flips: btc→tao becomes source→dest
@@ -155,9 +155,9 @@ class TestParseCommitmentData:
         assert rate == 345.0
 
     def test_default_uid_and_hotkey(self):
-        pair = parse_commitment_data('v3:btc:addr:tao:addr:1.0:2.0')
+        pair = parse_commitment_data('v1:btc:addr:tao:addr:1.0:2.0')
         assert pair.uid == 0
         assert pair.hotkey == ''
 
     def test_same_chain(self):
-        assert parse_commitment_data('v3:btc:addr:btc:addr:340:350') is None
+        assert parse_commitment_data('v1:btc:addr:btc:addr:340:350') is None


### PR DESCRIPTION
| Commit | Change | Impact |                                                                                                                                
|--------|--------|--------|
| https://github.com/entrius/allways/commit/0a45a608f374ec86d51fd1fa91bd4f2c52594809 | Remove unused treasury_hotkey and netuid from contract storage | -6 LOC in contract, cleaner ABI, smaller constructor parameter list |                                                                                                                                
| https://github.com/entrius/allways/commit/b981dbd73ccbb9c11f60ebb352a766d96d7b4c3d | Unify address types from `Vec<u8>` to `String` in contract and client | Consistent String type for all addresses across contract, client, and validator |                                                                                                          
| https://github.com/entrius/allways/commit/3f06e85eb32c317f33dea2565903d1c6164fcd13 | Reset commitment version to v1 | Clean slate before launch — no skipped versions in production history |
| https://github.com/entrius/allways/commit/e40a2c24cad0ed07acc2d9b48ecbe40cb65f8111 | Deduplicate miner matching logic in swap command | -20 LOC, bilateral matching extracted to shared helper |  
| https://github.com/entrius/allways/commit/abbf03e5c4c81b8e13ff99028b7c4bae7fec522a | Fix scoring window never populated for resolved swaps | Passes current block to tracker.poll() so resolved swaps get scored |        