### PR TITLE
fix: classify testnet P2SH addresses (prefix '2') as P2SH_P2WPKH

### DIFF
--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -32,7 +32,9 @@ def detect_address_type(address: str) -> str:
         return ADDR_TYPE_P2WPKH
     if address.startswith('bcrt1p') or address.startswith('tb1p'):
         return ADDR_TYPE_P2TR
-    if address.startswith('2') or address.startswith('m') or address.startswith('n'):
+    if address.startswith('2'):
+        return ADDR_TYPE_P2SH_P2WPKH
+    if address.startswith('m') or address.startswith('n'):
         return ADDR_TYPE_P2PKH
     return 'unknown'
 


### PR DESCRIPTION
## Summary

Fixes #33

Testnet P2SH addresses (prefix `2`) are misclassified as `P2PKH` in `detect_address_type()`. On mainnet, prefix `3` correctly returns `P2SH_P2WPKH`, and `_to_mainnet_address` also correctly identifies `2` as P2SH (version byte `0xC4` → `0x05`).

## Changes

**`allways/chain_providers/bitcoin.py`**: Split the testnet condition so `2` returns `ADDR_TYPE_P2SH_P2WPKH` while `m`/`n` continue to return `ADDR_TYPE_P2PKH`.

## Impact

Fixes incorrect signing/verification for testnet P2SH-P2WPKH addresses and correct script type derivation in `send_amount_lightweight`.