### PR TITLE
skip extend reservation vote when reservation already expired

### DIFF
--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -78,7 +78,7 @@ def _try_extend_reservation(self: Validator, item, current_block: int, swap_labe
     try:
         reserved_until = self.contract_client.get_miner_reserved_until(item.miner_hotkey)
         blocks_left = reserved_until - current_block
-        if reserved_until < current_block + EXTEND_THRESHOLD_BLOCKS:
+        if 0 < blocks_left < EXTEND_THRESHOLD_BLOCKS:
             miner_bytes = bytes.fromhex(Keypair(ss58_address=item.miner_hotkey).public_key.hex())
             extend_hash = _keccak256(_scale_encode_extend_hash_input(miner_bytes, item.source_tx_hash))
             self.contract_client.vote_extend_reservation(


### PR DESCRIPTION
## summary

I noticed `_try_extend_reservation` fires `vote_extend_reservation` even when the miner's reservation has already lapsed. the condition `reserved_until < current_block + EXTEND_THRESHOLD_BLOCKS` is true for any `reserved_until` behind `current_block`, so expired reservations trigger a contract call that gets rejected with `NoReservation`

changed the guard to `0 < blocks_left < EXTEND_THRESHOLD_BLOCKS` so it only fires when the reservation is still alive but within the threshold window

## test plan

verified the condition against blocks_left values of -5, 0, 1, 19, 20, 21, only 1 through 19 should trigger the extend vote