### PR TITLE
fix: route all weight to recycle_uid when subnet price fetch fails

### DIFF
--- a/allways/validator/recycle.py
+++ b/allways/validator/recycle.py
@@ -47,8 +47,10 @@ def apply_recycle(
     try:
         alpha_price_tao = self.subtensor.get_subnet_price(self.config.netuid).tao
     except Exception as e:
-        bt.logging.warning(f'Recycle: failed to get subnet price, skipping: {e}')
-        return rewards, uids
+        bt.logging.warning(
+            f'Recycle: failed to get subnet price, routing all weight to recycle_uid to avoid silent emission drop: {e}'
+        )
+        return np.array([1.0], dtype=np.float32), {recycle_uid}
     window_fraction = SCORING_WINDOW_BLOCKS / 7200
     emission_alpha = DAILY_EMISSION_ALPHA * window_fraction
     emission_tao = emission_alpha * alpha_price_tao


### PR DESCRIPTION
Closes #40

## Summary

`apply_recycle` previously returned `(rewards, uids)` unchanged when `get_subnet_price` raised an exception. Because `rewards` at that point contains the raw miner scores (which sum to ≤ 1.0 but exclude `recycle_uid`), calling `update_scores` with those values silently drops the recycled portion for that round — emissions are neither paid to miners nor recycled.

The fix falls back to `(np.array([1.0]), {recycle_uid})`, identical to the "no miners scored" path, ensuring emissions are always recycled rather than lost.

## Changes

**`allways/validator/recycle.py`**:
- On `get_subnet_price` exception, return `([1.0], {recycle_uid})` instead of the unchanged `(rewards, uids)`
- Update the warning log message to describe what is actually happening

## Testing

All 139 existing tests pass (`uv run pytest`).

@anderdc @LandynDev