### PR TITLE
fix: classify testnet P2SH addresses (prefix '2') as P2SH-P2WPKH

### DIFF
--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -32,7 +32,9 @@ def detect_address_type(address: str) -> str:
         return ADDR_TYPE_P2WPKH
     if address.startswith('bcrt1p') or address.startswith('tb1p'):
         return ADDR_TYPE_P2TR
-    if address.startswith('2') or address.startswith('m') or address.startswith('n'):
+    if address.startswith('2'):
+        return ADDR_TYPE_P2SH_P2WPKH
+    if address.startswith('m') or address.startswith('n'):
         return ADDR_TYPE_P2PKH
     return 'unknown'
 

--- a/tests/test_bitcoin_signing.py
+++ b/tests/test_bitcoin_signing.py
@@ -34,6 +34,15 @@ class TestDetectAddressType:
     def test_regtest_p2tr(self):
         assert detect_address_type('bcrt1pxyz') == ADDR_TYPE_P2TR
 
+    def test_testnet_p2sh(self):
+        assert detect_address_type('2N5kNSLz3bMPFuAuTrack4RVVDi8Grv3p3F') == ADDR_TYPE_P2SH_P2WPKH
+
+    def test_testnet_p2pkh_m(self):
+        assert detect_address_type('mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn') == ADDR_TYPE_P2PKH
+
+    def test_testnet_p2pkh_n(self):
+        assert detect_address_type('n1C8nsmi4sc4hjBfMKrRmL75MjcRYheJEF') == ADDR_TYPE_P2PKH
+
     def test_testnet_p2wpkh(self):
         assert detect_address_type('tb1q6tvmnmetj8vfz98vuetpvtuplqtj4uvvtest') == ADDR_TYPE_P2WPKH
 


### PR DESCRIPTION
## Summary
Testnet addresses starting with `2` (e.g., `2N5kNSL...`) are P2SH-P2WPKH addresses, but `detect_address_type()` incorrectly classifies them as P2PKH because they fall through the same branch as `m`/`n` prefixes.

This fix separates the prefix `2` check to return `ADDR_TYPE_P2SH_P2WPKH`, keeping `m`/`n` as P2PKH.

## Related Issues
Fixes #33

## Type of Change
- [x] Bug fix

## Testing
- [x] Added 3 unit tests covering testnet P2SH (`2`), P2PKH (`m`), and P2PKH (`n`) prefixes
- [x] All existing tests pass

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed

cc @anderdc @landyndev