### PR TITLE
refactor: consolidate duplicate block-time and fee divisor constants

### DIFF
--- a/allways/cli/swap_commands/admin.py
+++ b/allways/cli/swap_commands/admin.py
@@ -2,8 +2,9 @@
 
 import click
 
+from allways.chains import SUBTENSOR_BLOCK_SECONDS
 from allways.cli.help import StyledGroup
-from allways.cli.swap_commands.helpers import SECONDS_PER_BLOCK, console, from_rao, get_cli_context, loading, to_rao
+from allways.cli.swap_commands.helpers import console, from_rao, get_cli_context, loading, to_rao
 from allways.contract_client import ContractError
 
 
@@ -33,8 +34,8 @@ def set_timeout(blocks: int):
         console.print(f'[red]Failed to read fulfillment timeout: {e}[/red]')
         return
 
-    current_minutes = current * SECONDS_PER_BLOCK / 60
-    new_minutes = blocks * SECONDS_PER_BLOCK / 60
+    current_minutes = current * SUBTENSOR_BLOCK_SECONDS / 60
+    new_minutes = blocks * SUBTENSOR_BLOCK_SECONDS / 60
 
     console.print('\n[bold]Set Fulfillment Timeout[/bold]\n')
     console.print(f'  Current: {current} blocks (~{current_minutes:.0f} min)')
@@ -72,8 +73,8 @@ def set_reservation_ttl(blocks: int):
         console.print(f'[red]Failed to read reservation TTL: {e}[/red]')
         return
 
-    current_minutes = current * SECONDS_PER_BLOCK / 60
-    new_minutes = blocks * SECONDS_PER_BLOCK / 60
+    current_minutes = current * SUBTENSOR_BLOCK_SECONDS / 60
+    new_minutes = blocks * SUBTENSOR_BLOCK_SECONDS / 60
 
     console.print('\n[bold]Set Reservation TTL[/bold]\n')
     console.print(f'  Current: {current} blocks (~{current_minutes:.0f} min)')

--- a/allways/cli/swap_commands/collateral.py
+++ b/allways/cli/swap_commands/collateral.py
@@ -3,8 +3,9 @@
 import click
 from rich.table import Table
 
+from allways.chains import SUBTENSOR_BLOCK_SECONDS
 from allways.cli.help import StyledGroup
-from allways.cli.swap_commands.helpers import SECONDS_PER_BLOCK, console, from_rao, get_cli_context, loading, to_rao
+from allways.cli.swap_commands.helpers import console, from_rao, get_cli_context, loading, to_rao
 from allways.constants import MIN_BALANCE_FOR_TX_RAO, MIN_COLLATERAL_TAO
 from allways.contract_client import ContractError
 
@@ -125,7 +126,7 @@ def collateral_withdraw(amount: float | None, yes: bool):
             cooldown_end = deactivation_block + (timeout_blocks * 2)
             if current_block < cooldown_end:
                 remaining = cooldown_end - current_block
-                remaining_min = remaining * SECONDS_PER_BLOCK / 60
+                remaining_min = remaining * SUBTENSOR_BLOCK_SECONDS / 60
                 console.print(
                     f'[red]Withdrawal cooldown active. ~{remaining} blocks (~{remaining_min:.0f} min) remaining.[/red]'
                 )

--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -21,8 +21,6 @@ PENDING_SWAP_FILE = ALLWAYS_DIR / 'pending_swap.json'
 
 console = Console()
 
-SECONDS_PER_BLOCK = 12
-
 SWAP_STATUS_COLORS = {
     SwapStatus.ACTIVE: 'yellow',
     SwapStatus.FULFILLED: 'blue',

--- a/allways/cli/swap_commands/post_tx.py
+++ b/allways/cli/swap_commands/post_tx.py
@@ -3,10 +3,10 @@
 import click
 
 from allways.chain_providers import create_chain_providers
+from allways.chains import SUBTENSOR_BLOCK_SECONDS
 from allways.cli.dendrite_lite import discover_validators, get_ephemeral_wallet
 from allways.cli.help import StyledCommand
 from allways.cli.swap_commands.helpers import (
-    SECONDS_PER_BLOCK,
     clear_pending_swap,
     console,
     get_cli_context,
@@ -55,7 +55,7 @@ def post_tx_command(tx_hash: str, netuid: int):
         return
 
     remaining = reserved_until - current_block
-    remaining_min = remaining * SECONDS_PER_BLOCK / 60
+    remaining_min = remaining * SUBTENSOR_BLOCK_SECONDS / 60
     human_amount = from_smallest_unit(state.from_amount, state.from_chain)
 
     console.print('\n[bold]Pending Swap[/bold]\n')

--- a/allways/cli/swap_commands/resume.py
+++ b/allways/cli/swap_commands/resume.py
@@ -8,11 +8,10 @@ import rich_click as click
 from rich.panel import Panel
 
 from allways.chain_providers import create_chain_providers
-from allways.chains import get_chain
+from allways.chains import SUBTENSOR_BLOCK_SECONDS, get_chain
 from allways.classes import SwapStatus
 from allways.cli.dendrite_lite import discover_validators, get_ephemeral_wallet
 from allways.cli.swap_commands.helpers import (
-    SECONDS_PER_BLOCK,
     clear_pending_swap,
     console,
     get_cli_context,
@@ -119,7 +118,7 @@ def resume_command(from_tx_hash_opt: Optional[str], skip_confirm: bool, netuid: 
         return
 
     remaining = reserved_until - current_block
-    console.print(f'\n[green]Reservation still active (~{remaining * SECONDS_PER_BLOCK // 60} min left)[/green]')
+    console.print(f'\n[green]Reservation still active (~{remaining * SUBTENSOR_BLOCK_SECONDS // 60} min left)[/green]')
 
     # Set up chain provider
     if 'BTC_MODE' not in os.environ:

--- a/allways/cli/swap_commands/status.py
+++ b/allways/cli/swap_commands/status.py
@@ -3,9 +3,9 @@
 import click
 from rich.table import Table
 
+from allways.chains import SUBTENSOR_BLOCK_SECONDS
 from allways.cli.help import StyledCommand
 from allways.cli.swap_commands.helpers import (
-    SECONDS_PER_BLOCK,
     console,
     from_rao,
     get_cli_context,
@@ -79,7 +79,7 @@ def status_command(netuid: int):
                 reserved_until = client.get_miner_reserved_until(pending.miner_hotkey)
                 if reserved_until > subtensor.get_current_block():
                     remaining = reserved_until - subtensor.get_current_block()
-                    remaining_min = remaining * SECONDS_PER_BLOCK / 60
+                    remaining_min = remaining * SUBTENSOR_BLOCK_SECONDS / 60
                     table.add_row(
                         'Pending Reservation',
                         f'{pending.from_chain.upper()}->{pending.to_chain.upper()} (~{remaining_min:.0f} min left)',

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -10,12 +10,11 @@ from rich.panel import Panel
 from rich.table import Table
 
 from allways.chain_providers import create_chain_providers
-from allways.chains import SUPPORTED_CHAINS, canonical_pair, get_chain
+from allways.chains import SUBTENSOR_BLOCK_SECONDS, SUPPORTED_CHAINS, canonical_pair, get_chain
 from allways.classes import SwapStatus
 from allways.cli.dendrite_lite import broadcast_synapse, discover_validators, get_ephemeral_wallet
 from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
-    SECONDS_PER_BLOCK,
     PendingSwapState,
     clear_pending_swap,
     console,
@@ -286,7 +285,7 @@ def display_receipt(swap):
     tao_human = swap.tao_amount / (10**9)
 
     # Calculate fee
-    fee_divisor = 100  # 1% fee
+    fee_divisor = FEE_DIVISOR
     if swap.to_chain == 'tao':
         fee_human = tao_human / fee_divisor
         fee_unit = 'TAO'
@@ -467,7 +466,7 @@ def swap_now_command(
             current_block = subtensor.get_current_block()
             if reserved_until > current_block:
                 remaining = reserved_until - current_block
-                remaining_min = remaining * SECONDS_PER_BLOCK / 60
+                remaining_min = remaining * SUBTENSOR_BLOCK_SECONDS / 60
                 console.print(
                     f'[yellow]You have a pending reservation (~{remaining} blocks, ~{remaining_min:.0f} min left).[/yellow]'
                 )

--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -8,11 +8,10 @@ from rich.live import Live
 from rich.table import Table
 from rich.text import Text
 
-from allways.chains import SUPPORTED_CHAINS, get_chain
+from allways.chains import SUBTENSOR_BLOCK_SECONDS, SUPPORTED_CHAINS, get_chain
 from allways.classes import SwapStatus
 from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
-    SECONDS_PER_BLOCK,
     SWAP_STATUS_COLORS,
     clear_pending_swap,
     console,
@@ -388,7 +387,7 @@ def watch_swap(client, swap_id: int, swap=None):
     try:
         with Live(render(swap), console=console, refresh_per_second=1) as live:
             while True:
-                time.sleep(SECONDS_PER_BLOCK)
+                time.sleep(SUBTENSOR_BLOCK_SECONDS)
                 try:
                     swap = client.get_swap(swap_id)
                 except ContractError:
@@ -442,9 +441,9 @@ def view_contract():
     try:
         with loading('Reading contract parameters...'):
             timeout_blocks = read_safe(client.get_fulfillment_timeout)
-            timeout_minutes = timeout_blocks * SECONDS_PER_BLOCK / 60
+            timeout_minutes = timeout_blocks * SUBTENSOR_BLOCK_SECONDS / 60
             reservation_ttl_blocks = read_safe(client.get_reservation_ttl)
-            reservation_ttl_minutes = reservation_ttl_blocks * SECONDS_PER_BLOCK / 60
+            reservation_ttl_minutes = reservation_ttl_blocks * SUBTENSOR_BLOCK_SECONDS / 60
             consensus_threshold = read_safe(client.get_consensus_threshold)
             min_collateral_rao = read_safe(client.get_min_collateral)
             max_collateral_rao = read_safe(client.get_max_collateral)
@@ -537,7 +536,7 @@ def view_reservation():
 
     if is_active:
         remaining = reserved_until - current_block
-        remaining_min = remaining * SECONDS_PER_BLOCK / 60
+        remaining_min = remaining * SUBTENSOR_BLOCK_SECONDS / 60
         table.add_row('Status', '[green]ACTIVE[/green]')
         table.add_row('Time Remaining', f'~{remaining} blocks (~{remaining_min:.0f} min)')
     else:

--- a/allways/miner/fulfillment.py
+++ b/allways/miner/fulfillment.py
@@ -10,7 +10,7 @@ import bittensor as bt
 
 from allways.chain_providers.base import ChainProvider, ProviderUnreachableError
 from allways.classes import Swap
-from allways.constants import DEFAULT_MINER_TIMEOUT_CUSHION_BLOCKS
+from allways.constants import DEFAULT_MINER_TIMEOUT_CUSHION_BLOCKS, FEE_DIVISOR
 from allways.contract_client import AllwaysContractClient, ContractError
 from allways.utils.rate import expected_swap_amounts
 
@@ -65,7 +65,7 @@ class SwapFulfiller:
         subtensor: bt.Subtensor,
         netuid: int,
         metagraph: Optional['bt.Metagraph'] = None,
-        fee_divisor: int = 100,
+        fee_divisor: int = FEE_DIVISOR,
         sent_cache_path: Optional[Path] = None,
         my_addresses: Optional[Dict[str, str]] = None,
     ):

--- a/allways/validator/chain_verification.py
+++ b/allways/validator/chain_verification.py
@@ -7,6 +7,7 @@ import bittensor as bt
 
 from allways.chain_providers.base import ChainProvider, ProviderUnreachableError, TransactionInfo
 from allways.classes import Swap
+from allways.constants import FEE_DIVISOR
 from allways.utils.rate import expected_swap_amounts
 
 
@@ -23,7 +24,7 @@ class SwapVerifier:
         subtensor: bt.Subtensor,
         netuid: int,
         metagraph: Optional['bt.Metagraph'] = None,
-        fee_divisor: int = 100,
+        fee_divisor: int = FEE_DIVISOR,
     ):
         self.providers = chain_providers
         self.subtensor = subtensor


### PR DESCRIPTION
## Summary

Two numeric constants were defined in more than one place. This collapses each to a single source of truth without any behavior change.

- `SECONDS_PER_BLOCK = 12` in `allways/cli/swap_commands/helpers.py` duplicated `SUBTENSOR_BLOCK_SECONDS = 12` already defined in `allways/chains.py`. Eight CLI modules imported from `helpers`; they now import the canonical constant
  from `chains.py`.
- `fee_divisor: int = 100` was hardcoded as a default argument in `SwapFulfiller.__init__` and `SwapVerifier.__init__` while `FEE_DIVISOR = 100` already existed in `allways/constants.py`. Both defaults now reference the constant.
- `display_receipt` in `swap.py` had an inline `fee_divisor = 100  # 1% fee` that drifted from the same source. Replaced with `FEE_DIVISOR`, matching the existing pattern at `swap.py:634` and `quote.py:61`.

## Changes

- `allways/cli/swap_commands/helpers.py`: drop `SECONDS_PER_BLOCK`
- `allways/cli/swap_commands/{view,post_tx,swap,admin,status,resume,collateral}.py`: import `SUBTENSOR_BLOCK_SECONDS` from `allways.chains`, rename usages
- `allways/cli/swap_commands/swap.py`: `display_receipt` uses `FEE_DIVISOR` instead of the inline `100`
- `allways/miner/fulfillment.py`: `SwapFulfiller` default `fee_divisor = FEE_DIVISOR`
- `allways/validator/chain_verification.py`: `SwapVerifier` default `fee_divisor = FEE_DIVISOR`

## Testing

- All 267 tests pass (`pytest`)
- `ruff check allways/` clean
- `ruff format --check allways/` clean

No behavior change since `FEE_DIVISOR == 100` and `SUBTENSOR_BLOCK_SECONDS == 12`.
Runtime defaults verified: both `SwapFulfiller` and `SwapVerifier` still resolve `fee_divisor` to `100`.
