### PR TITLE
refactor: centralize SCALE codec primitives in utils/scale.py

### DIFF
--- a/allways/contract_client.py
+++ b/allways/contract_client.py
@@ -56,6 +56,22 @@ except ImportError:
 
 from allways.classes import Swap, SwapStatus
 from allways.constants import CONTRACT_ADDRESS, MIN_BALANCE_FOR_TX_RAO
+from allways.utils.scale import (
+    ACCOUNT_ID_BYTES,
+    U32_BYTES,
+    U64_BYTES,
+    U128_BYTES,
+    compact_encode_len,
+    decode_account_id,
+    decode_string,
+    decode_u32,
+    decode_u64,
+    decode_u128,
+    encode_bytes,
+    encode_str,
+    encode_u128,
+    strip_hex_prefix,
+)
 
 # =========================================================================
 # Contract selectors (from metadata — deterministic per contract build)
@@ -212,23 +228,6 @@ DEFAULT_GAS_LIMIT = {'ref_time': 10_000_000_000, 'proof_size': 500_000}
 _EXTRINSIC_NOT_FOUND = tuple(t for t in [ExtrinsicNotFound, AsyncExtrinsicNotFound] if t is not None)
 
 
-def compact_encode_len(length: int) -> bytes:
-    """SCALE compact-encode a length prefix. Shared by contract client and axon handlers."""
-    if length < 64:
-        return bytes([length << 2])
-    elif length < 16384:
-        return bytes([((length << 2) | 1) & 0xFF, length >> 6])
-    else:
-        return bytes(
-            [
-                ((length << 2) | 2) & 0xFF,
-                (length >> 6) & 0xFF,
-                (length >> 14) & 0xFF,
-                (length >> 22) & 0xFF,
-            ]
-        )
-
-
 # ContractExecResult byte layout offsets (after gas prefix)
 _GAS_PREFIX_BYTES = 16  # Skip gas consumed/required
 _RESULT_OK_OFFSET = 10  # Byte indicating Ok(0x00) vs Err in Result
@@ -370,7 +369,7 @@ class AllwaysContractClient:
             if not result.get('result'):
                 return None
 
-            raw = bytes.fromhex(result['result'].replace('0x', ''))
+            raw = bytes.fromhex(strip_hex_prefix(result['result']))
             if len(raw) < 32:
                 return None
 
@@ -380,7 +379,7 @@ class AllwaysContractClient:
             if len(r) < _DATA_COMPACT_OFFSET or r[_RESULT_OK_OFFSET] != 0x00:
                 return None
 
-            flags = struct.unpack_from('<I', r, _FLAGS_OFFSET)[0]
+            flags, _ = decode_u32(r, _FLAGS_OFFSET)
             is_revert = bool(flags & 1)
 
             data_compact = r[_DATA_COMPACT_OFFSET]
@@ -509,18 +508,17 @@ class AllwaysContractClient:
             return struct.pack('B', int(value))
         elif type_tag == 'hash':
             if isinstance(value, str):
-                return bytes.fromhex(value.replace('0x', ''))
-            return bytes(value)[:32].ljust(32, b'\x00')
+                return bytes.fromhex(strip_hex_prefix(value))
+            return bytes(value)[:ACCOUNT_ID_BYTES].ljust(ACCOUNT_ID_BYTES, b'\x00')
         elif type_tag == 'bytes':
             data = value if isinstance(value, (bytes, bytearray)) else value.encode('utf-8')
-            return compact_encode_len(len(data)) + data
+            return encode_bytes(data)
         elif type_tag == 'u32':
             return struct.pack('<I', int(value))
         elif type_tag == 'u64':
             return struct.pack('<Q', int(value))
         elif type_tag == 'u128':
-            v = int(value)
-            return struct.pack('<QQ', v & 0xFFFFFFFFFFFFFFFF, v >> 64)
+            return encode_u128(int(value))
         elif type_tag == 'bool':
             return b'\x01' if value else b'\x00'
         elif type_tag == 'AccountId':
@@ -528,8 +526,7 @@ class AllwaysContractClient:
                 return bytes.fromhex(self.subtensor.substrate.ss58_decode(value))
             return bytes(value)
         elif type_tag == 'str':
-            data = value.encode('utf-8') if isinstance(value, str) else value
-            return compact_encode_len(len(data)) + data
+            return encode_str(value) if isinstance(value, str) else encode_bytes(value)
         elif type_tag == 'vec_u64':
             items = list(value)
             encoded = compact_encode_len(len(items))
@@ -539,21 +536,19 @@ class AllwaysContractClient:
         raise ValueError(f'Unsupported type: {type_tag}')
 
     def extract_u32(self, data: bytes) -> Optional[int]:
-        if not data or len(data) < 4:
+        if not data or len(data) < U32_BYTES:
             return None
-        return struct.unpack_from('<I', data, 0)[0]
+        return decode_u32(data, 0)[0]
 
     def extract_u64(self, data: bytes) -> Optional[int]:
-        if not data or len(data) < 8:
+        if not data or len(data) < U64_BYTES:
             return None
-        return struct.unpack_from('<Q', data, 0)[0]
+        return decode_u64(data, 0)[0]
 
     def extract_u128(self, data: bytes) -> Optional[int]:
-        if not data or len(data) < 16:
+        if not data or len(data) < U128_BYTES:
             return None
-        low = struct.unpack_from('<Q', data, 0)[0]
-        high = struct.unpack_from('<Q', data, 8)[0]
-        return low + (high << 64)
+        return decode_u128(data, 0)[0]
 
     def extract_bool(self, data: bytes) -> Optional[bool]:
         if not data:
@@ -561,86 +556,38 @@ class AllwaysContractClient:
         return data[0] != 0
 
     def extract_account_id(self, data: bytes) -> Optional[str]:
-        if not data or len(data) < 32:
+        if not data or len(data) < ACCOUNT_ID_BYTES:
             return None
-        return self.subtensor.substrate.ss58_encode(data[:32].hex())
-
-    def decode_string(self, data: bytes, offset: int) -> Tuple[str, int]:
-        """Decode a SCALE compact-prefixed string. Returns (string, new_offset)."""
-        if offset >= len(data):
-            return '', offset
-        first = data[offset]
-        mode = first & 0x03
-        if mode == 0:
-            str_len = first >> 2
-            offset += 1
-        elif mode == 1:
-            if offset + 1 >= len(data):
-                return '', offset
-            str_len = (data[offset] | (data[offset + 1] << 8)) >> 2
-            offset += 2
-        else:
-            if offset + 3 >= len(data):
-                return '', offset
-            str_len = (
-                data[offset] | (data[offset + 1] << 8) | (data[offset + 2] << 16) | (data[offset + 3] << 24)
-            ) >> 2
-            offset += 4
-        if offset + str_len > len(data):
-            return '', offset
-        s = data[offset : offset + str_len].decode('utf-8', errors='replace')
-        return s, offset + str_len
+        return decode_account_id(data, 0)[0]
 
     def decode_swap_data(self, data: bytes, offset: int = 0) -> Optional[Swap]:
         """Decode a SwapData struct from raw SCALE bytes."""
         try:
             o = offset
-
-            swap_id = struct.unpack_from('<Q', data, o)[0]
-            o += 8
-            user = self.subtensor.substrate.ss58_encode(data[o : o + 32].hex())
-            o += 32
-            miner = self.subtensor.substrate.ss58_encode(data[o : o + 32].hex())
-            o += 32
-            from_chain, o = self.decode_string(data, o)
-            to_chain, o = self.decode_string(data, o)
-            from_amount_lo = struct.unpack_from('<Q', data, o)[0]
-            o += 8
-            from_amount_hi = struct.unpack_from('<Q', data, o)[0]
-            o += 8
-            from_amount = from_amount_lo + (from_amount_hi << 64)
-            to_amount_lo = struct.unpack_from('<Q', data, o)[0]
-            o += 8
-            to_amount_hi = struct.unpack_from('<Q', data, o)[0]
-            o += 8
-            to_amount = to_amount_lo + (to_amount_hi << 64)
-            tao_amount_lo = struct.unpack_from('<Q', data, o)[0]
-            o += 8
-            tao_amount_hi = struct.unpack_from('<Q', data, o)[0]
-            o += 8
-            tao_amount = tao_amount_lo + (tao_amount_hi << 64)
-            user_from_address, o = self.decode_string(data, o)
-            user_to_address, o = self.decode_string(data, o)
-            miner_from_address, o = self.decode_string(data, o)
-            miner_to_address, o = self.decode_string(data, o)
-            rate, o = self.decode_string(data, o)
-            from_tx_hash, o = self.decode_string(data, o)
-            from_tx_block = struct.unpack_from('<I', data, o)[0]
-            o += 4
-            to_tx_hash, o = self.decode_string(data, o)
-            to_tx_block = struct.unpack_from('<I', data, o)[0]
-            o += 4
+            swap_id, o = decode_u64(data, o)
+            user, o = decode_account_id(data, o)
+            miner, o = decode_account_id(data, o)
+            from_chain, o = decode_string(data, o)
+            to_chain, o = decode_string(data, o)
+            from_amount, o = decode_u128(data, o)
+            to_amount, o = decode_u128(data, o)
+            tao_amount, o = decode_u128(data, o)
+            user_from_address, o = decode_string(data, o)
+            user_to_address, o = decode_string(data, o)
+            miner_from_address, o = decode_string(data, o)
+            miner_to_address, o = decode_string(data, o)
+            rate, o = decode_string(data, o)
+            from_tx_hash, o = decode_string(data, o)
+            from_tx_block, o = decode_u32(data, o)
+            to_tx_hash, o = decode_string(data, o)
+            to_tx_block, o = decode_u32(data, o)
             status_byte = data[o]
             o += 1
             status = SwapStatus(status_byte) if status_byte <= 3 else SwapStatus.ACTIVE
-            initiated_block = struct.unpack_from('<I', data, o)[0]
-            o += 4
-            timeout_block = struct.unpack_from('<I', data, o)[0]
-            o += 4
-            fulfilled_block = struct.unpack_from('<I', data, o)[0]
-            o += 4
-            completed_block = struct.unpack_from('<I', data, o)[0]
-            o += 4
+            initiated_block, o = decode_u32(data, o)
+            timeout_block, o = decode_u32(data, o)
+            fulfilled_block, o = decode_u32(data, o)
+            completed_block, o = decode_u32(data, o)
 
             return Swap(
                 id=swap_id,
@@ -862,7 +809,7 @@ class AllwaysContractClient:
         if data is None or len(data) < 5:
             return (0, 0)
         strike_count = data[0]
-        last_expired = struct.unpack_from('<I', data, 1)[0]
+        last_expired, _ = decode_u32(data, 1)
         return (strike_count, last_expired)
 
     def get_accumulated_fees(self) -> int:
@@ -910,33 +857,11 @@ class AllwaysContractClient:
         if data[0] != 0x01:
             return None
         o = 1
-        # String from_addr: compact length + UTF-8 bytes
-        first = data[o]
-        mode = first & 0x03
-        if mode == 0:
-            addr_len = first >> 2
-            o += 1
-        elif mode == 1:
-            addr_len = (data[o] | (data[o + 1] << 8)) >> 2
-            o += 2
-        else:
-            return None
-        from_addr = data[o : o + addr_len].decode('utf-8')
-        o += addr_len
-        # 3 x u128 + 1 x u32
-        tao_lo = struct.unpack_from('<Q', data, o)[0]
-        tao_hi = struct.unpack_from('<Q', data, o + 8)[0]
-        tao_amount = tao_lo + (tao_hi << 64)
-        o += 16
-        src_lo = struct.unpack_from('<Q', data, o)[0]
-        src_hi = struct.unpack_from('<Q', data, o + 8)[0]
-        from_amount = src_lo + (src_hi << 64)
-        o += 16
-        dst_lo = struct.unpack_from('<Q', data, o)[0]
-        dst_hi = struct.unpack_from('<Q', data, o + 8)[0]
-        to_amount = dst_lo + (dst_hi << 64)
-        o += 16
-        reserved_until = struct.unpack_from('<I', data, o)[0]
+        from_addr, o = decode_string(data, o)
+        tao_amount, o = decode_u128(data, o)
+        from_amount, o = decode_u128(data, o)
+        to_amount, o = decode_u128(data, o)
+        reserved_until, _ = decode_u32(data, o)
         return (from_addr, tao_amount, from_amount, to_amount, reserved_until)
 
     # =========================================================================

--- a/allways/utils/scale.py
+++ b/allways/utils/scale.py
@@ -1,0 +1,111 @@
+"""SCALE codec primitives shared by the contract client, event watcher, and axon handlers.
+
+Only the subset of SCALE we need for the ink! swap manager contract — not a
+general SCALE implementation. Streaming decoders return ``(value, new_offset)``
+so compound structs can chain reads without manual offset bookkeeping.
+"""
+
+import struct
+from typing import Tuple
+
+from substrateinterface.utils.ss58 import ss58_encode
+
+# SS58 prefix for Bittensor (matches substrate.ss58_format on all configured networks).
+SS58_PREFIX = 42
+
+# Byte widths of fixed-size SCALE primitives.
+U32_BYTES = 4
+U64_BYTES = 8
+U128_BYTES = 16
+ACCOUNT_ID_BYTES = 32
+
+
+def strip_hex_prefix(s: str) -> str:
+    """Remove a leading ``0x`` from a hex string if present."""
+    return s[2:] if s.startswith('0x') else s
+
+
+def compact_encode_len(length: int) -> bytes:
+    """SCALE compact-encode a length prefix."""
+    if length < 64:
+        return bytes([length << 2])
+    if length < 16384:
+        return bytes([((length << 2) | 1) & 0xFF, length >> 6])
+    return bytes(
+        [
+            ((length << 2) | 2) & 0xFF,
+            (length >> 6) & 0xFF,
+            (length >> 14) & 0xFF,
+            (length >> 22) & 0xFF,
+        ]
+    )
+
+
+def encode_bytes(data: bytes) -> bytes:
+    """SCALE-encode raw bytes as compact length prefix + bytes."""
+    return compact_encode_len(len(data)) + data
+
+
+def encode_str(s: str) -> bytes:
+    """SCALE-encode a UTF-8 string as compact length prefix + bytes."""
+    return encode_bytes(s.encode('utf-8'))
+
+
+def encode_u128(value: int) -> bytes:
+    """SCALE-encode a u128 as 16 little-endian bytes."""
+    return value.to_bytes(U128_BYTES, 'little')
+
+
+# ─── Streaming decoders ────────────────────────────────────────────────────
+
+
+def decode_u32(data: bytes, offset: int) -> Tuple[int, int]:
+    return struct.unpack_from('<I', data, offset)[0], offset + U32_BYTES
+
+
+def decode_u64(data: bytes, offset: int) -> Tuple[int, int]:
+    return struct.unpack_from('<Q', data, offset)[0], offset + U64_BYTES
+
+
+def decode_u128(data: bytes, offset: int) -> Tuple[int, int]:
+    lo = struct.unpack_from('<Q', data, offset)[0]
+    hi = struct.unpack_from('<Q', data, offset + U64_BYTES)[0]
+    return lo + (hi << 64), offset + U128_BYTES
+
+
+def decode_bool(data: bytes, offset: int) -> Tuple[bool, int]:
+    return data[offset] != 0, offset + 1
+
+
+def decode_account_id(data: bytes, offset: int) -> Tuple[str, int]:
+    raw = data[offset : offset + ACCOUNT_ID_BYTES]
+    return ss58_encode(raw, SS58_PREFIX), offset + ACCOUNT_ID_BYTES
+
+
+def decode_string(data: bytes, offset: int) -> Tuple[str, int]:
+    """SCALE-decode a compact-length-prefixed UTF-8 string.
+
+    Returns ``('', offset)`` on truncated or out-of-bounds input so callers
+    streaming composite structs degrade cleanly instead of raising.
+    """
+    if offset >= len(data):
+        return '', offset
+    first = data[offset]
+    mode = first & 0x03
+    if mode == 0:
+        str_len = first >> 2
+        offset += 1
+    elif mode == 1:
+        if offset + 1 >= len(data):
+            return '', offset
+        str_len = (data[offset] | (data[offset + 1] << 8)) >> 2
+        offset += 2
+    else:
+        if offset + 3 >= len(data):
+            return '', offset
+        str_len = (data[offset] | (data[offset + 1] << 8) | (data[offset + 2] << 16) | (data[offset + 3] << 24)) >> 2
+        offset += 4
+    if offset + str_len > len(data):
+        return '', offset
+    s = data[offset : offset + str_len].decode('utf-8', errors='replace')
+    return s, offset + str_len

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -18,8 +18,9 @@ from substrateinterface import Keypair
 from allways.classes import MinerPair
 from allways.commitments import read_miner_commitment
 from allways.constants import RESERVATION_COOLDOWN_BLOCKS
-from allways.contract_client import AllwaysContractClient, ContractError, compact_encode_len, is_contract_rejection
+from allways.contract_client import AllwaysContractClient, ContractError, is_contract_rejection
 from allways.synapses import MinerActivateSynapse, SwapConfirmSynapse, SwapReserveSynapse
+from allways.utils.scale import encode_bytes, encode_str, encode_u128
 from allways.validator.state_store import PendingConfirm
 
 if TYPE_CHECKING:
@@ -46,36 +47,23 @@ def scale_encode_reserve_hash_input(
         &(miner, user_from_address, from_chain, to_chain, tao_amount, from_amount, to_amount)
     ).
     """
-    src_bytes = from_chain.encode('utf-8')
-    dst_bytes = to_chain.encode('utf-8')
     return (
-        miner_bytes  # AccountId: 32 bytes raw
-        + compact_encode_len(len(from_addr_bytes))
-        + from_addr_bytes  # String: compact length + UTF-8 bytes
-        + compact_encode_len(len(src_bytes))
-        + src_bytes  # String: compact length + UTF-8 bytes
-        + compact_encode_len(len(dst_bytes))
-        + dst_bytes  # String: compact length + UTF-8 bytes
-        + tao_amount.to_bytes(16, 'little')  # u128: 16 bytes LE
-        + from_amount.to_bytes(16, 'little')  # u128: 16 bytes LE
-        + to_amount.to_bytes(16, 'little')  # u128: 16 bytes LE
+        miner_bytes
+        + encode_bytes(from_addr_bytes)
+        + encode_str(from_chain)
+        + encode_str(to_chain)
+        + encode_u128(tao_amount)
+        + encode_u128(from_amount)
+        + encode_u128(to_amount)
     )
 
 
-def scale_encode_extend_hash_input(
-    miner_bytes: bytes,
-    from_tx_hash: str,
-) -> bytes:
+def scale_encode_extend_hash_input(miner_bytes: bytes, from_tx_hash: str) -> bytes:
     """SCALE-encode the extend hash input tuple: (AccountId, &str).
 
     Matches ink::env::hash_encoded::<Keccak256, _>(&(miner, from_tx_hash)).
     """
-    tx_bytes = from_tx_hash.encode('utf-8')
-    return (
-        miner_bytes  # AccountId: 32 bytes raw
-        + compact_encode_len(len(tx_bytes))
-        + tx_bytes  # &str (SCALE: compact length + bytes)
-    )
+    return miner_bytes + encode_str(from_tx_hash)
 
 
 def scale_encode_initiate_hash_input(
@@ -102,22 +90,17 @@ def scale_encode_initiate_hash_input(
     consensus on the full swap shape — the quorum-reaching vote cannot substitute
     any of these fields without invalidating the hash.
     """
-
-    def encode_str(s: str) -> bytes:
-        raw = s.encode('utf-8')
-        return compact_encode_len(len(raw)) + raw
-
     return (
-        miner_bytes  # AccountId: 32 bytes raw
+        miner_bytes
         + encode_str(from_tx_hash)
         + encode_str(from_chain)
         + encode_str(to_chain)
         + encode_str(miner_from_address)
         + encode_str(miner_to_address)
         + encode_str(rate)
-        + tao_amount.to_bytes(16, 'little')  # u128: 16 bytes LE
-        + from_amount.to_bytes(16, 'little')  # u128: 16 bytes LE
-        + to_amount.to_bytes(16, 'little')  # u128: 16 bytes LE
+        + encode_u128(tao_amount)
+        + encode_u128(from_amount)
+        + encode_u128(to_amount)
     )
 
 

--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -12,61 +12,23 @@ survives restarts.
 from __future__ import annotations
 
 import json
-import struct
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 import bittensor as bt
-from substrateinterface.utils.ss58 import ss58_encode
 
 from allways.constants import SCORING_WINDOW_BLOCKS
+from allways.utils.scale import (
+    decode_account_id,
+    decode_bool,
+    decode_string,
+    decode_u32,
+    decode_u64,
+    decode_u128,
+    strip_hex_prefix,
+)
 from allways.validator.state_store import ValidatorStateStore
-
-SS58_PREFIX = 42
-
-
-# ─── SCALE field decoders (ported from alw-utils watch_contract_events) ─────
-
-
-def decode_u32(data: bytes, offset: int) -> Tuple[int, int]:
-    return struct.unpack_from('<I', data, offset)[0], offset + 4
-
-
-def decode_u64(data: bytes, offset: int) -> Tuple[int, int]:
-    return struct.unpack_from('<Q', data, offset)[0], offset + 8
-
-
-def decode_u128(data: bytes, offset: int) -> Tuple[int, int]:
-    lo = struct.unpack_from('<Q', data, offset)[0]
-    hi = struct.unpack_from('<Q', data, offset + 8)[0]
-    return lo + (hi << 64), offset + 16
-
-
-def decode_bool(data: bytes, offset: int) -> Tuple[bool, int]:
-    return data[offset] != 0, offset + 1
-
-
-def decode_account_id(data: bytes, offset: int) -> Tuple[str, int]:
-    raw = data[offset : offset + 32]
-    return ss58_encode(raw, SS58_PREFIX), offset + 32
-
-
-def decode_string(data: bytes, offset: int) -> Tuple[str, int]:
-    first = data[offset]
-    mode = first & 0x03
-    if mode == 0:
-        str_len = first >> 2
-        offset += 1
-    elif mode == 1:
-        str_len = (data[offset] | (data[offset + 1] << 8)) >> 2
-        offset += 2
-    else:
-        str_len = (data[offset] | (data[offset + 1] << 8) | (data[offset + 2] << 16) | (data[offset + 3] << 24)) >> 2
-        offset += 4
-    s = data[offset : offset + str_len].decode('utf-8', errors='replace')
-    return s, offset + str_len
-
 
 DATA_DECODERS = {
     'u32': decode_u32,
@@ -79,11 +41,11 @@ DATA_DECODERS = {
 
 
 def topic_account_id(topic_bytes: bytes) -> str:
-    return ss58_encode(topic_bytes[:32], SS58_PREFIX)
+    return decode_account_id(topic_bytes, 0)[0]
 
 
 def topic_u64(topic_bytes: bytes) -> int:
-    return struct.unpack_from('<Q', topic_bytes, 0)[0]
+    return decode_u64(topic_bytes, 0)[0]
 
 
 def topic_bool(topic_bytes: bytes) -> bool:
@@ -194,9 +156,8 @@ def to_bytes(val: Any) -> bytes:
     if isinstance(val, bytes):
         return val
     if isinstance(val, str):
-        s = val.replace('0x', '')
         try:
-            return bytes.fromhex(s)
+            return bytes.fromhex(strip_hex_prefix(val))
         except ValueError:
             return val.encode('utf-8')
     if isinstance(val, (list, tuple)):

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -4,7 +4,8 @@ import struct
 from unittest.mock import MagicMock
 
 from allways.chain_providers.subtensor import SubtensorProvider
-from allways.contract_client import AllwaysContractClient, compact_encode_len
+from allways.contract_client import AllwaysContractClient
+from allways.utils.scale import compact_encode_len, decode_string
 
 
 def make_client():
@@ -228,26 +229,25 @@ class TestDecodeString:
     def test_roundtrip_short(self):
         c = make_client()
         encoded = c.encode_value('hello', 'str')
-        s, offset = c.decode_string(encoded, 0)
+        s, offset = decode_string(encoded, 0)
         assert s == 'hello'
         assert offset == len(encoded)
 
     def test_roundtrip_empty(self):
         c = make_client()
         encoded = c.encode_value('', 'str')
-        s, offset = c.decode_string(encoded, 0)
+        s, offset = decode_string(encoded, 0)
         assert s == ''
 
     def test_roundtrip_medium(self):
         c = make_client()
         text = 'x' * 100  # Still in single-byte compact mode
         encoded = c.encode_value(text, 'str')
-        s, offset = c.decode_string(encoded, 0)
+        s, offset = decode_string(encoded, 0)
         assert s == text
 
     def test_offset_past_end(self):
-        c = make_client()
-        s, offset = c.decode_string(b'\x00', 10)
+        s, offset = decode_string(b'\x00', 10)
         assert s == ''
 
     def test_roundtrip_two_byte_compact(self):
@@ -255,7 +255,7 @@ class TestDecodeString:
         # String of length 64+ triggers two-byte compact mode
         text = 'a' * 64
         encoded = c.encode_value(text, 'str')
-        s, offset = c.decode_string(encoded, 0)
+        s, offset = decode_string(encoded, 0)
         assert s == text
 
 


### PR DESCRIPTION
## Summary

SCALE primitive encoders and decoders were duplicated across three modules: `contract_client.py`, `validator/event_watcher.py`, and `validator/axon_handlers.py`.

Each copy carried its own magic byte widths, hex-prefix stripping, and compact-length encoders. This collapses them into a single `allways/utils/scale.py` that all three modules now import from.

No behavior change for well-formed contract or RPC data. Where the three copies disagreed on error handling (out-of-bounds `decode_string`, mode-2 compact address length, stray `0x` substrings), the extracted module picks the more defensive variant so malformed input fails gracefully rather than silently corrupting output.

## Changes

**New module: `allways/utils/scale.py`**

- Constants: `SS58_PREFIX`, `U32_BYTES`, `U64_BYTES`, `U128_BYTES`, `ACCOUNT_ID_BYTES`
- Helpers: `strip_hex_prefix`, `compact_encode_len`, `encode_bytes`, `encode_str`, `encode_u128`
- Streaming decoders returning `(value, new_offset)`: `decode_u32`, `decode_u64`, `decode_u128`, `decode_bool`, `decode_account_id`, `decode_string`

**`allways/contract_client.py`**

- Dropped the local `compact_encode_len` definition and inline hex-prefix / u128 / byte-width logic
- `encode_value`, `extract_*`, `decode_swap_data`, `get_reservation_data`, and `raw_contract_read` now delegate to the shared helpers
- Removed the one-line `decode_string` method that just forwarded to the utility
- Byte-width constants replace magic `4`, `8`, `16`, `32` literals

**`allways/validator/event_watcher.py`**

- Dropped the parallel copies of `decode_u32/u64/u128/bool/account_id/string` in favor of imports from `utils/scale`
- `topic_account_id` delegates to `decode_account_id`, and the hex-prefix strip in `to_bytes` uses `strip_hex_prefix`
- `struct` and `ss58_encode` imports removed (no longer needed locally)

**`allways/validator/axon_handlers.py`**

- The three `scale_encode_*_hash_input` functions now compose `encode_bytes`, `encode_str`, and `encode_u128` instead of inlining `compact_encode_len(len(...)) + ...` and `.to_bytes(16, 'little')`
- The local `encode_str` lambda inside `scale_encode_initiate_hash_input` is gone

**`tests/test_scale.py`**

- `TestDecodeString` exercises `decode_string` from the utility directly now that the client shim is gone
- `compact_encode_len` imported from its new home

## Testing

- All 267 tests pass (`pytest`)
- `ruff check allways/ tests/` clean
- `ruff format --check allways/ tests/` clean
- u128 encoding verified bit-identical against `struct.pack('<QQ', lo, hi)` across the range `[0, 2**128 - 1]` including boundaries at `2**64` and `2**127`
- String round-trip passes in all three SCALE compact-length modes (lengths 0, 5, 64, 16383, 16384)
- SS58 encoding via `ss58_encode(bytes, 42)` produces the same output as the previous `substrate.ss58_encode(bytes.hex())` path on Bittensor

