### PR TITLE
chore: use PAT for release push so admin bypass applies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: test
+          token: ${{ secrets.RELEASE_SCHEDULER_TOKEN }}
 
       - name: Verify main is ancestor of test
         run: |


### PR DESCRIPTION
One-line fix. release.yml now checks out with RELEASE_SCHEDULER_TOKEN so the push authenticates as the admin user (not github-actions[bot]), allowing admin bypass on main to apply.