### PR TITLE
Evaluate miner active state per-block in scoring replay

### DIFF
--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -237,6 +237,22 @@ class ActiveEvent:
     block: int
 
 
+@dataclass
+class ConfigEvent:
+    """Transition of a global contract config scalar (min_collateral,
+    max_collateral, halted). Replayed per-block so scoring evaluates
+    eligibility against the config that was in force at each block, not
+    the current value — an admin-side config change doesn't retroactively
+    disqualify blocks the miner legitimately earned."""
+
+    key: str
+    value: int
+    block: int
+
+
+CONFIG_KEYS_TRACKED = ('min_collateral', 'max_collateral', 'halted')
+
+
 MAX_BLOCKS_PER_SYNC = 50
 
 
@@ -267,6 +283,21 @@ class ContractEventWatcher:
         self.busy_events: List[BusyEvent] = []
         self.active_events: List[ActiveEvent] = []
         self.active_events_by_hotkey: Dict[str, List[ActiveEvent]] = {}
+        # Current-value mirror + historical log for tracked config scalars.
+        # ``max_collateral``/``halted`` default to 0 until the first event is
+        # seen, matching the contract constructor defaults. ``config_initial``
+        # is the frozen pre-event snapshot — used as the fallback for
+        # ``get_config_at`` when the caller asks about a block before any
+        # event fired, since ``config_current`` reflects the LATEST state and
+        # would be wrong as a pre-event fallback.
+        self.config_current: Dict[str, int] = {
+            'min_collateral': default_min_collateral,
+            'max_collateral': 0,
+            'halted': 0,
+        }
+        self.config_initial: Dict[str, int] = dict(self.config_current)
+        self.config_events: List[ConfigEvent] = []
+        self.config_events_by_key: Dict[str, List[ConfigEvent]] = {}
 
     # ─── Public API consumed by scoring ─────────────────────────────────
 
@@ -341,6 +372,40 @@ class ContractEventWatcher:
             latest[ev.hotkey] = ev.active
         return {hk for hk, is_active in latest.items() if is_active}
 
+    def get_config_at(self, key: str, block: int) -> int:
+        """Scalar config value (``min_collateral``, ``max_collateral``,
+        ``halted``) at ``block``, reconstructed from the config event log.
+
+        Fallback semantics:
+        - No events for key → return ``config_current[key]`` (= ``config_initial``
+          unchanged, mirrors the collateral snapshot fallback).
+        - Events exist but none at/before ``block`` → return
+          ``config_initial[key]``, not current. ``config_current`` reflects
+          the latest event and would be wrong as a pre-event fallback."""
+        events = self.config_events_by_key.get(key)
+        if not events:
+            return int(self.config_current.get(key, 0))
+        latest_value: Optional[int] = None
+        for ev in events:
+            if ev.block > block:
+                break
+            latest_value = ev.value
+        if latest_value is None:
+            return int(self.config_initial.get(key, 0))
+        return int(latest_value)
+
+    def get_config_events_in_range(self, start_block: int, end_block: int) -> List[dict]:
+        """Config transitions in ``(start_block, end_block]``, oldest first.
+        Emits only keys in ``CONFIG_KEYS_TRACKED``."""
+        out: List[dict] = []
+        for ev in self.config_events:
+            if ev.block <= start_block:
+                continue
+            if ev.block > end_block:
+                break
+            out.append({'key': ev.key, 'value': ev.value, 'block': ev.block})
+        return out
+
     # ─── Sync loop ──────────────────────────────────────────────────────
 
     def initialize(
@@ -370,8 +435,23 @@ class ContractEventWatcher:
                 raw_min = contract_client.get_min_collateral() or 0
                 if raw_min > 0:
                     self.min_collateral = raw_min
+                    self.config_current['min_collateral'] = int(raw_min)
+                    self.config_initial['min_collateral'] = int(raw_min)
             except Exception as e:
                 bt.logging.debug(f'EventWatcher bootstrap: min_collateral read failed: {e}')
+            try:
+                raw_max = contract_client.get_max_collateral() or 0
+                self.config_current['max_collateral'] = int(raw_max)
+                self.config_initial['max_collateral'] = int(raw_max)
+            except Exception as e:
+                bt.logging.debug(f'EventWatcher bootstrap: max_collateral read failed: {e}')
+            try:
+                raw_halted = contract_client.get_halted()
+                halted_int = 1 if bool(raw_halted) else 0
+                self.config_current['halted'] = halted_int
+                self.config_initial['halted'] = halted_int
+            except Exception as e:
+                bt.logging.debug(f'EventWatcher bootstrap: halted read failed: {e}')
             # Without this seed, a miner already serving a swap at startup
             # would be treated as idle until the next terminal event.
             try:
@@ -402,6 +482,14 @@ class ContractEventWatcher:
             event = ActiveEvent(hotkey=hotkey, active=True, block=self.cursor)
             self.active_events.append(event)
             self.active_events_by_hotkey.setdefault(hotkey, []).append(event)
+        # Anchor the config state at cursor for the same reason. A subsequent
+        # ConfigUpdated event within the window is a no-op at cursor but
+        # correctly overrides for later blocks.
+        for key in CONFIG_KEYS_TRACKED:
+            value = int(self.config_current.get(key, 0))
+            event = ConfigEvent(key=key, value=value, block=self.cursor)
+            self.config_events.append(event)
+            self.config_events_by_key.setdefault(key, []).append(event)
 
     def sync_to(self, current_block: int) -> None:
         """Catch up from cursor to ``current_block`` in MAX_BLOCKS_PER_SYNC
@@ -498,11 +586,13 @@ class ContractEventWatcher:
             active = bool(values.get('active'))
             self.record_active_transition(block_num, hotkey, active)
         elif name == 'ConfigUpdated':
-            if values.get('key') == 'min_collateral':
-                try:
-                    self.min_collateral = int(values.get('value', 0))
-                except (TypeError, ValueError):
-                    pass
+            key = values.get('key', '')
+            raw = values.get('value', 0)
+            try:
+                val = int(raw)
+            except (TypeError, ValueError):
+                return
+            self.record_config_transition(block_num, key, val)
         elif name == 'SwapInitiated':
             miner = values.get('miner', '')
             if miner:
@@ -529,6 +619,25 @@ class ContractEventWatcher:
                     resolved_block=block_num,
                 )
                 self.apply_busy_delta(block_num, miner, -1)
+
+    def record_config_transition(self, block_num: int, key: str, value: int) -> None:
+        """Apply a contract config scalar transition to both the current-
+        state mirror and the historical event log. No-op if the value is
+        unchanged — duplicate ``ConfigUpdated`` emissions don't bloat the
+        log. Only tracks keys in ``CONFIG_KEYS_TRACKED``; unknown keys are
+        silently ignored."""
+        if key not in CONFIG_KEYS_TRACKED:
+            return
+        current = int(self.config_current.get(key, 0))
+        if current == int(value):
+            return
+        self.config_current[key] = int(value)
+        if key == 'min_collateral':
+            # Legacy mirror — some call sites still read ``self.min_collateral``.
+            self.min_collateral = int(value)
+        event = ConfigEvent(key=key, value=int(value), block=block_num)
+        self.config_events.append(event)
+        self.config_events_by_key.setdefault(key, []).append(event)
 
     def record_active_transition(self, block_num: int, hotkey: str, active: bool) -> None:
         """Apply an on-chain active-flag transition to both the current-state
@@ -613,3 +722,17 @@ class ContractEventWatcher:
                     self.active_events_by_hotkey[hotkey] = pruned
                 else:
                     del self.active_events_by_hotkey[hotkey]
+        if self.config_events:
+            latest_per_key: Dict[str, ConfigEvent] = {}
+            for ev in self.config_events:
+                latest_per_key[ev.key] = ev
+            self.config_events = [
+                ev for ev in self.config_events if ev.block >= cutoff or latest_per_key.get(ev.key) is ev
+            ]
+            for key, events in list(self.config_events_by_key.items()):
+                latest = events[-1] if events else None
+                pruned = [ev for ev in events if ev.block >= cutoff or ev is latest]
+                if pruned:
+                    self.config_events_by_key[key] = pruned
+                else:
+                    del self.config_events_by_key[key]

--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -226,6 +226,17 @@ class BusyEvent:
     block: int
 
 
+@dataclass
+class ActiveEvent:
+    """Transition of a miner's on-chain active flag. Replayed per-block so
+    scoring judges active state as-of each block in the window, not as-of
+    the scoring moment."""
+
+    hotkey: str
+    active: bool
+    block: int
+
+
 MAX_BLOCKS_PER_SYNC = 50
 
 
@@ -254,6 +265,8 @@ class ContractEventWatcher:
         self.collateral_events_by_hotkey: Dict[str, List[CollateralEvent]] = {}
         self.open_swap_count: Dict[str, int] = {}
         self.busy_events: List[BusyEvent] = []
+        self.active_events: List[ActiveEvent] = []
+        self.active_events_by_hotkey: Dict[str, List[ActiveEvent]] = {}
 
     # ─── Public API consumed by scoring ─────────────────────────────────
 
@@ -303,6 +316,30 @@ class ContractEventWatcher:
                 break
             counts[ev.hotkey] = counts.get(ev.hotkey, 0) + ev.delta
         return {hk: c for hk, c in counts.items() if c > 0}
+
+    def get_active_events_in_range(self, start_block: int, end_block: int) -> List[dict]:
+        """Active-flag transitions in ``(start_block, end_block]``, oldest first."""
+        out: List[dict] = []
+        for ev in self.active_events:
+            if ev.block <= start_block:
+                continue
+            if ev.block > end_block:
+                break
+            out.append({'hotkey': ev.hotkey, 'active': ev.active, 'block': ev.block})
+        return out
+
+    def get_active_miners_at(self, block: int) -> Set[str]:
+        """Active set at ``block``, reconstructed by replaying every active
+        transition at or before ``block``. The bootstrap seeds an event at
+        ``cursor`` for each hotkey the contract reports as active at cold
+        start, so pre-cursor state is anchored the same way the collateral
+        snapshot is."""
+        latest: Dict[str, bool] = {}
+        for ev in self.active_events:
+            if ev.block > block:
+                break
+            latest[ev.hotkey] = ev.active
+        return {hk for hk, is_active in latest.items() if is_active}
 
     # ─── Sync loop ──────────────────────────────────────────────────────
 
@@ -358,6 +395,13 @@ class ContractEventWatcher:
                 f'{len(self.active_miners)} active miners, min_collateral={self.min_collateral}'
             )
         self.cursor = max(0, current_block - SCORING_WINDOW_BLOCKS)
+        # Anchor the historical active set at the cursor so scoring sees the
+        # bootstrap state at window_start. Subsequent MinerActivated events
+        # replayed during sync_to apply on top.
+        for hotkey in list(self.active_miners):
+            event = ActiveEvent(hotkey=hotkey, active=True, block=self.cursor)
+            self.active_events.append(event)
+            self.active_events_by_hotkey.setdefault(hotkey, []).append(event)
 
     def sync_to(self, current_block: int) -> None:
         """Catch up from cursor to ``current_block`` in MAX_BLOCKS_PER_SYNC
@@ -451,10 +495,8 @@ class ContractEventWatcher:
             hotkey = values.get('miner', '')
             if not hotkey:
                 return
-            if values.get('active'):
-                self.active_miners.add(hotkey)
-            else:
-                self.active_miners.discard(hotkey)
+            active = bool(values.get('active'))
+            self.record_active_transition(block_num, hotkey, active)
         elif name == 'ConfigUpdated':
             if values.get('key') == 'min_collateral':
                 try:
@@ -487,6 +529,23 @@ class ContractEventWatcher:
                     resolved_block=block_num,
                 )
                 self.apply_busy_delta(block_num, miner, -1)
+
+    def record_active_transition(self, block_num: int, hotkey: str, active: bool) -> None:
+        """Apply an on-chain active-flag transition to both the current-state
+        snapshot and the historical event log. A no-op if the flag already
+        matches — duplicate MinerActivated emissions don't pollute the log."""
+        if not hotkey:
+            return
+        currently_active = hotkey in self.active_miners
+        if currently_active == active:
+            return
+        if active:
+            self.active_miners.add(hotkey)
+        else:
+            self.active_miners.discard(hotkey)
+        event = ActiveEvent(hotkey=hotkey, active=active, block=block_num)
+        self.active_events.append(event)
+        self.active_events_by_hotkey.setdefault(hotkey, []).append(event)
 
     def apply_busy_delta(self, block_num: int, hotkey: str, delta: int) -> None:
         """Apply a ±1 transition. Drops any -1 with no matching prior +1
@@ -540,3 +599,17 @@ class ContractEventWatcher:
         if self.busy_events:
             open_now = {hk for hk, c in self.open_swap_count.items() if c > 0}
             self.busy_events = [ev for ev in self.busy_events if ev.block >= cutoff or ev.hotkey in open_now]
+        if self.active_events:
+            latest_per_hotkey: Dict[str, ActiveEvent] = {}
+            for ev in self.active_events:
+                latest_per_hotkey[ev.hotkey] = ev
+            self.active_events = [
+                ev for ev in self.active_events if ev.block >= cutoff or latest_per_hotkey.get(ev.hotkey) is ev
+            ]
+            for hotkey, events in list(self.active_events_by_hotkey.items()):
+                latest = events[-1] if events else None
+                pruned = [ev for ev in events if ev.block >= cutoff or ev is latest]
+                if pruned:
+                    self.active_events_by_hotkey[hotkey] = pruned
+                else:
+                    del self.active_events_by_hotkey[hotkey]

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -71,7 +71,6 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
     rewards = np.zeros(n_uids, dtype=np.float32)
     credibility_since = max(0, self.block - CREDIBILITY_WINDOW_BLOCKS)
     success_stats = self.state_store.get_success_rates_since(credibility_since)
-    min_collateral = int(self.event_watcher.min_collateral or 0)
 
     for (from_chain, to_chain), pool in DIRECTION_POOLS.items():
         crown_blocks = replay_crown_time_window(
@@ -82,7 +81,6 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
             window_start=window_start,
             window_end=window_end,
             rewardable_hotkeys=rewardable_hotkeys,
-            min_collateral=min_collateral,
         )
         total = sum(crown_blocks.values())
         if total == 0:
@@ -125,26 +123,31 @@ def success_rate(stats: Optional[Tuple[int, int]]) -> float:
 class EventKind(IntEnum):
     """Ordering of coincident-block transitions in the crown-time replay.
 
-    ACTIVE applies first because the on-chain active flag is the tell-all:
-    an inactive miner can't hold crown regardless of rate, collateral, or
-    busy state. After that, busy transitions apply before collateral
-    changes, which apply before rate changes. So if a user reserves a
-    miner in the same block that miner's best rate was posted, the
-    reservation ends crown credit *before* the rate attribution — matching
-    the intent that a busy miner doesn't earn a new interval.
+    CONFIG applies first because a contract-wide scalar change (halt,
+    min/max collateral) can't be scoped to any one miner — the block
+    *after* a halt must credit nobody regardless of what else happens
+    that block. ACTIVE applies next because the on-chain active flag is
+    the per-miner tell-all. Then BUSY (reservation ends crown for that
+    miner), then COLLATERAL, then RATE. So if a user reserves a miner
+    in the same block that miner's best rate was posted, the reservation
+    ends crown credit *before* the rate attribution — matching the intent
+    that a busy miner doesn't earn a new interval.
     """
 
-    ACTIVE = 0
-    BUSY = 1
-    COLLATERAL = 2
-    RATE = 3
+    CONFIG = 0
+    ACTIVE = 1
+    BUSY = 2
+    COLLATERAL = 3
+    RATE = 4
 
 
 @dataclass
 class ReplayEvent:
     """One transition in the chronological replay stream. ``value`` is
-    polymorphic on ``kind``: rate as float, collateral as rao, or busy delta
-    of ±1."""
+    polymorphic on ``kind``: rate as float, collateral as rao, busy delta
+    of ±1, active as 0/1, or config scalar. For CONFIG events ``hotkey``
+    carries the config key name (``min_collateral``, ``max_collateral``,
+    ``halted``) — the field is reused as a union slot, not a real hotkey."""
 
     block: int
     hotkey: str
@@ -163,13 +166,19 @@ def reconstruct_window_start_state(
     to_chain: str,
     window_start: int,
     rewardable_hotkeys: Set[str],
-) -> Tuple[Dict[str, float], Dict[str, int], Dict[str, int], Set[str]]:
-    """Snapshot rates, collateral, busy counts, and active set as they stood
-    at window_start."""
+) -> Tuple[Dict[str, float], Dict[str, int], Dict[str, int], Set[str], Dict[str, int]]:
+    """Snapshot rates, collateral, busy counts, active set, and contract
+    config (min_collateral, max_collateral, halted) as they stood at
+    window_start."""
     rates: Dict[str, float] = {}
     collateral: Dict[str, int] = {}
     busy_count: Dict[str, int] = dict(event_watcher.get_busy_miners_at(window_start))
     active_set: Set[str] = set(event_watcher.get_active_miners_at(window_start))
+    config: Dict[str, int] = {
+        'min_collateral': event_watcher.get_config_at('min_collateral', window_start),
+        'max_collateral': event_watcher.get_config_at('max_collateral', window_start),
+        'halted': event_watcher.get_config_at('halted', window_start),
+    }
 
     for hotkey in rewardable_hotkeys:
         latest_rate = store.get_latest_rate_before(hotkey, from_chain, to_chain, window_start)
@@ -187,7 +196,7 @@ def reconstruct_window_start_state(
             if snapshot is not None:
                 collateral[hotkey] = snapshot
 
-    return rates, collateral, busy_count, active_set
+    return rates, collateral, busy_count, active_set, config
 
 
 def merge_replay_events(
@@ -198,9 +207,12 @@ def merge_replay_events(
     window_start: int,
     window_end: int,
 ) -> List[ReplayEvent]:
-    """Merge in-window active, busy, collateral, and rate transitions into
-    one chronologically-sorted stream."""
+    """Merge in-window config, active, busy, collateral, and rate transitions
+    into one chronologically-sorted stream."""
     events: List[ReplayEvent] = []
+
+    for e in event_watcher.get_config_events_in_range(window_start, window_end):
+        events.append(ReplayEvent(block=e['block'], hotkey=e['key'], kind=EventKind.CONFIG, value=float(e['value'])))
 
     for e in event_watcher.get_active_events_in_range(window_start, window_end):
         events.append(
@@ -232,16 +244,17 @@ def replay_crown_time_window(
     window_start: int,
     window_end: int,
     rewardable_hotkeys: Set[str],
-    min_collateral: int,
 ) -> Dict[str, float]:
     """Walk the merged event stream, return ``{hotkey: crown_blocks_float}``.
     Ties at the same rate split credit evenly. A miner qualifies for crown
-    at an instant iff they are on the current metagraph, were active at that
-    instant, not busy, had >= min_collateral, and had a positive rate posted.
-    Active/collateral/rate/busy are all evaluated per-block via the replay —
-    a miner's status at scoring time is irrelevant other than metagraph
-    membership (used to credit the UID)."""
-    rates, collateral, busy_count, active_set = reconstruct_window_start_state(
+    at an instant iff the contract is not halted, they are on the current
+    metagraph, were active at that instant, not busy, had ``min_collateral
+    <= collateral <= max_collateral`` (``max_collateral=0`` disables the
+    upper bound, matching contract semantics), and had a positive rate
+    posted. Active/collateral/rate/busy/config are all evaluated per-block
+    via the replay — a miner's status at scoring time is irrelevant other
+    than metagraph membership (used to credit the UID)."""
+    rates, collateral, busy_count, active_set, config = reconstruct_window_start_state(
         store, event_watcher, from_chain, to_chain, window_start, rewardable_hotkeys
     )
     replay_events = merge_replay_events(store, event_watcher, from_chain, to_chain, window_start, window_end)
@@ -257,10 +270,12 @@ def replay_crown_time_window(
         holders = crown_holders_at_instant(
             rates,
             collateral,
-            min_collateral,
+            config['min_collateral'],
             rewardable_hotkeys,
             busy=busy_set,
             active=active_set,
+            max_collateral=config['max_collateral'],
+            halted=bool(config['halted']),
         )
         if not holders:
             return
@@ -279,11 +294,14 @@ def replay_crown_time_window(
                 busy_count[event.hotkey] = new_count
             else:
                 busy_count.pop(event.hotkey, None)
-        else:  # ACTIVE
+        elif event.kind is EventKind.ACTIVE:
             if event.value > 0:
                 active_set.add(event.hotkey)
             else:
                 active_set.discard(event.hotkey)
+        else:  # CONFIG
+            # ``hotkey`` carries the config key name for CONFIG events.
+            config[event.hotkey] = int(event.value)
 
     for event in replay_events:
         credit_interval(prev_block, event.block)
@@ -301,28 +319,37 @@ def crown_holders_at_instant(
     rewardable: Set[str],
     busy: Optional[Set[str]] = None,
     active: Optional[Set[str]] = None,
+    max_collateral: int = 0,
+    halted: bool = False,
 ) -> List[str]:
     """Take the miners posting the best rate, but only if they satisfy every
-    other condition (rewardable, active, not busy, collateral >= min, rate
-    > 0). If the best rate has no qualified miner, fall through to the
-    next-best rate.
+    other condition (not halted, rewardable, active, not busy, ``min <=
+    collateral <= max``, rate > 0). If the best rate has no qualified miner,
+    fall through to the next-best rate.
+
+    ``max_collateral=0`` disables the upper bound — matches the contract's
+    ``post_collateral`` semantics where 0 means "no cap". ``halted=True``
+    short-circuits to return []: during a contract halt no miner holds
+    crown, the pool recycles via the caller.
 
     ``active`` defaults to None, which means "no active-state gating" — this
     keeps the helper usable in isolation for tests that don't care about
     the historical active flag. Callers that replay events should pass the
     reconstructed active set explicitly.
     """
+    if halted:
+        return []
     busy = busy or set()
 
     def qualifies(hotkey: str) -> bool:
         if active is not None and hotkey not in active:
             return False
-        return (
-            hotkey in rewardable
-            and hotkey not in busy
-            and collaterals.get(hotkey, 0) >= min_collateral
-            and rates.get(hotkey, 0) > 0
-        )
+        collateral = collaterals.get(hotkey, 0)
+        if collateral < min_collateral:
+            return False
+        if max_collateral > 0 and collateral > max_collateral:
+            return False
+        return hotkey in rewardable and hotkey not in busy and rates.get(hotkey, 0) > 0
 
     by_rate: Dict[float, List[str]] = {}
     for hotkey, rate in rates.items():

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -60,8 +60,12 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
     window_end = self.block
     window_start = max(0, window_end - SCORING_WINDOW_BLOCKS)
 
-    in_metagraph: Set[str] = set(self.metagraph.hotkeys)
-    eligible_hotkeys: Set[str] = in_metagraph & self.event_watcher.active_miners
+    # A miner's *current* active flag / collateral is irrelevant to whether
+    # they earned crown during the replay window. The only at-scoring-time
+    # check is metagraph membership, because a dereg'd miner has no UID to
+    # credit. Active, collateral, rate, and busy are all evaluated per-block
+    # via event replay inside replay_crown_time_window.
+    rewardable_hotkeys: Set[str] = set(self.metagraph.hotkeys)
     hotkey_to_uid: Dict[str, int] = {self.metagraph.hotkeys[uid]: uid for uid in range(n_uids)}
 
     rewards = np.zeros(n_uids, dtype=np.float32)
@@ -77,7 +81,7 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
             to_chain=to_chain,
             window_start=window_start,
             window_end=window_end,
-            eligible_hotkeys=eligible_hotkeys,
+            rewardable_hotkeys=rewardable_hotkeys,
             min_collateral=min_collateral,
         )
         total = sum(crown_blocks.values())
@@ -121,16 +125,19 @@ def success_rate(stats: Optional[Tuple[int, int]]) -> float:
 class EventKind(IntEnum):
     """Ordering of coincident-block transitions in the crown-time replay.
 
-    At the same block number, busy transitions apply before collateral
-    changes, which apply before rate changes. So if a user reserves a miner
-    in the same block that miner's best rate was posted, the reservation
-    ends crown credit *before* the rate attribution — matching the intent
-    that a busy miner doesn't earn a new interval.
+    ACTIVE applies first because the on-chain active flag is the tell-all:
+    an inactive miner can't hold crown regardless of rate, collateral, or
+    busy state. After that, busy transitions apply before collateral
+    changes, which apply before rate changes. So if a user reserves a
+    miner in the same block that miner's best rate was posted, the
+    reservation ends crown credit *before* the rate attribution — matching
+    the intent that a busy miner doesn't earn a new interval.
     """
 
-    BUSY = 0
-    COLLATERAL = 1
-    RATE = 2
+    ACTIVE = 0
+    BUSY = 1
+    COLLATERAL = 2
+    RATE = 3
 
 
 @dataclass
@@ -155,14 +162,16 @@ def reconstruct_window_start_state(
     from_chain: str,
     to_chain: str,
     window_start: int,
-    eligible_hotkeys: Set[str],
-) -> Tuple[Dict[str, float], Dict[str, int], Dict[str, int]]:
-    """Snapshot rates, collateral, and busy counts as they stood at window_start."""
+    rewardable_hotkeys: Set[str],
+) -> Tuple[Dict[str, float], Dict[str, int], Dict[str, int], Set[str]]:
+    """Snapshot rates, collateral, busy counts, and active set as they stood
+    at window_start."""
     rates: Dict[str, float] = {}
     collateral: Dict[str, int] = {}
     busy_count: Dict[str, int] = dict(event_watcher.get_busy_miners_at(window_start))
+    active_set: Set[str] = set(event_watcher.get_active_miners_at(window_start))
 
-    for hotkey in eligible_hotkeys:
+    for hotkey in rewardable_hotkeys:
         latest_rate = store.get_latest_rate_before(hotkey, from_chain, to_chain, window_start)
         if latest_rate is not None:
             rates[hotkey] = latest_rate[0]
@@ -178,7 +187,7 @@ def reconstruct_window_start_state(
             if snapshot is not None:
                 collateral[hotkey] = snapshot
 
-    return rates, collateral, busy_count
+    return rates, collateral, busy_count, active_set
 
 
 def merge_replay_events(
@@ -189,9 +198,14 @@ def merge_replay_events(
     window_start: int,
     window_end: int,
 ) -> List[ReplayEvent]:
-    """Merge in-window rate, collateral, and busy transitions into one
-    chronologically-sorted stream."""
+    """Merge in-window active, busy, collateral, and rate transitions into
+    one chronologically-sorted stream."""
     events: List[ReplayEvent] = []
+
+    for e in event_watcher.get_active_events_in_range(window_start, window_end):
+        events.append(
+            ReplayEvent(block=e['block'], hotkey=e['hotkey'], kind=EventKind.ACTIVE, value=1.0 if e['active'] else 0.0)
+        )
 
     for e in event_watcher.get_busy_events_in_range(window_start, window_end):
         events.append(ReplayEvent(block=e['block'], hotkey=e['hotkey'], kind=EventKind.BUSY, value=float(e['delta'])))
@@ -217,14 +231,18 @@ def replay_crown_time_window(
     to_chain: str,
     window_start: int,
     window_end: int,
-    eligible_hotkeys: Set[str],
+    rewardable_hotkeys: Set[str],
     min_collateral: int,
 ) -> Dict[str, float]:
     """Walk the merged event stream, return ``{hotkey: crown_blocks_float}``.
-    Ties at the same rate split credit evenly; busy miners are excluded so
-    credit flows to the next-best idle miner."""
-    rates, collateral, busy_count = reconstruct_window_start_state(
-        store, event_watcher, from_chain, to_chain, window_start, eligible_hotkeys
+    Ties at the same rate split credit evenly. A miner qualifies for crown
+    at an instant iff they are on the current metagraph, were active at that
+    instant, not busy, had >= min_collateral, and had a positive rate posted.
+    Active/collateral/rate/busy are all evaluated per-block via the replay —
+    a miner's status at scoring time is irrelevant other than metagraph
+    membership (used to credit the UID)."""
+    rates, collateral, busy_count, active_set = reconstruct_window_start_state(
+        store, event_watcher, from_chain, to_chain, window_start, rewardable_hotkeys
     )
     replay_events = merge_replay_events(store, event_watcher, from_chain, to_chain, window_start, window_end)
 
@@ -236,7 +254,14 @@ def replay_crown_time_window(
         if duration <= 0:
             return
         busy_set = {hk for hk, c in busy_count.items() if c > 0}
-        holders = crown_holders_at_instant(rates, collateral, min_collateral, eligible_hotkeys, busy=busy_set)
+        holders = crown_holders_at_instant(
+            rates,
+            collateral,
+            min_collateral,
+            rewardable_hotkeys,
+            busy=busy_set,
+            active=active_set,
+        )
         if not holders:
             return
         split = duration / len(holders)
@@ -248,12 +273,17 @@ def replay_crown_time_window(
             rates[event.hotkey] = event.value
         elif event.kind is EventKind.COLLATERAL:
             collateral[event.hotkey] = int(event.value)
-        else:  # BUSY
+        elif event.kind is EventKind.BUSY:
             new_count = busy_count.get(event.hotkey, 0) + int(event.value)
             if new_count > 0:
                 busy_count[event.hotkey] = new_count
             else:
                 busy_count.pop(event.hotkey, None)
+        else:  # ACTIVE
+            if event.value > 0:
+                active_set.add(event.hotkey)
+            else:
+                active_set.discard(event.hotkey)
 
     for event in replay_events:
         credit_interval(prev_block, event.block)
@@ -268,17 +298,27 @@ def crown_holders_at_instant(
     rates: Dict[str, float],
     collaterals: Dict[str, int],
     min_collateral: int,
-    eligible: Set[str],
+    rewardable: Set[str],
     busy: Optional[Set[str]] = None,
+    active: Optional[Set[str]] = None,
 ) -> List[str]:
     """Take the miners posting the best rate, but only if they satisfy every
-    other condition (eligible, not busy, collateral >= min, rate > 0). If the
-    best rate has no qualified miner, fall through to the next-best rate."""
+    other condition (rewardable, active, not busy, collateral >= min, rate
+    > 0). If the best rate has no qualified miner, fall through to the
+    next-best rate.
+
+    ``active`` defaults to None, which means "no active-state gating" — this
+    keeps the helper usable in isolation for tests that don't care about
+    the historical active flag. Callers that replay events should pass the
+    reconstructed active set explicitly.
+    """
     busy = busy or set()
 
     def qualifies(hotkey: str) -> bool:
+        if active is not None and hotkey not in active:
+            return False
         return (
-            hotkey in eligible
+            hotkey in rewardable
             and hotkey not in busy
             and collaterals.get(hotkey, 0) >= min_collateral
             and rates.get(hotkey, 0) > 0

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 import numpy as np
 
 from allways.constants import RECYCLE_UID, SUCCESS_EXPONENT
-from allways.validator.event_watcher import ContractEventWatcher
+from allways.validator.event_watcher import ActiveEvent, ContractEventWatcher
 from allways.validator.scoring import (
     calculate_miner_rewards,
     crown_holders_at_instant,
@@ -38,12 +38,33 @@ def make_watcher(store: ValidatorStateStore, active: set[str]) -> ContractEventW
     )
     w.min_collateral = MIN_COLLATERAL
     w.active_miners = set(active)
+    # Seed an anchor active=True event at block 0 for each bootstrapped
+    # active miner — mirrors the bootstrap seed that ContractEventWatcher
+    # emits in production inside initialize(). Without this, the historical
+    # replay would treat every miner as inactive at window_start.
+    for hotkey in active:
+        seed_active(w, hotkey, active=True, block=0)
     return w
 
 
 def seed_collateral(watcher: ContractEventWatcher, hotkey: str, collateral_rao: int, block: int) -> None:
     """Insert a collateral event directly into the watcher's in-memory state."""
     watcher.set_collateral(block, hotkey, collateral_rao)
+
+
+def seed_active(watcher: ContractEventWatcher, hotkey: str, active: bool, block: int) -> None:
+    """Insert an active-flag event directly into the watcher's in-memory state.
+    Bypasses ``record_active_transition``'s no-op-on-same-state guard so tests
+    can seed pre-window anchors (including re-seeding after a reset)."""
+    event = ActiveEvent(hotkey=hotkey, active=active, block=block)
+    watcher.active_events.append(event)
+    watcher.active_events_by_hotkey.setdefault(hotkey, []).append(event)
+    watcher.active_events.sort(key=lambda ev: ev.block)
+    watcher.active_events_by_hotkey[hotkey].sort(key=lambda ev: ev.block)
+    if active:
+        watcher.active_miners.add(hotkey)
+    else:
+        watcher.active_miners.discard(hotkey)
 
 
 def make_validator(tmp_path: Path, hotkeys: list[str], block: int = 10_000) -> SimpleNamespace:
@@ -132,7 +153,7 @@ class TestReplayCrownTime:
             to_chain='btc',
             window_start=100,
             window_end=1100,
-            eligible_hotkeys={'hk_a'},
+            rewardable_hotkeys={'hk_a'},
             min_collateral=MIN_COLLATERAL,
         )
         assert crown == {'hk_a': 1000.0}
@@ -166,7 +187,7 @@ class TestReplayCrownTime:
             to_chain='btc',
             window_start=100,
             window_end=1100,
-            eligible_hotkeys={'hk_a', 'hk_b'},
+            rewardable_hotkeys={'hk_a', 'hk_b'},
             min_collateral=MIN_COLLATERAL,
         )
         # B leads blocks (100, 600] → 500 blocks, A leads (600, 1100] → 500 blocks
@@ -192,7 +213,7 @@ class TestReplayCrownTime:
             to_chain='btc',
             window_start=100,
             window_end=1100,
-            eligible_hotkeys={'hk_a', 'hk_b'},
+            rewardable_hotkeys={'hk_a', 'hk_b'},
             min_collateral=MIN_COLLATERAL,
         )
         assert crown == {'hk_a': 500.0, 'hk_b': 500.0}
@@ -218,7 +239,7 @@ class TestReplayCrownTime:
             to_chain='btc',
             window_start=100,
             window_end=1100,
-            eligible_hotkeys={'hk_a'},
+            rewardable_hotkeys={'hk_a'},
             min_collateral=MIN_COLLATERAL,
         )
         assert crown == {'hk_a': 500.0}
@@ -243,7 +264,7 @@ class TestReplayCrownTime:
             to_chain='btc',
             window_start=10_000,
             window_end=11_000,
-            eligible_hotkeys={'hk_a'},
+            rewardable_hotkeys={'hk_a'},
             min_collateral=MIN_COLLATERAL,
         )
         assert crown == {'hk_a': 1000.0}
@@ -278,7 +299,7 @@ class TestReplayCrownTime:
             to_chain='btc',
             window_start=100,
             window_end=1100,
-            eligible_hotkeys={'hk_a', 'hk_b'},
+            rewardable_hotkeys={'hk_a', 'hk_b'},
             min_collateral=MIN_COLLATERAL,
         )
         # A earns (100,400] = 300 + (800,1100] = 300 → 600 total
@@ -309,7 +330,7 @@ class TestReplayCrownTime:
             to_chain='btc',
             window_start=100,
             window_end=1100,
-            eligible_hotkeys={'hk_a'},
+            rewardable_hotkeys={'hk_a'},
             min_collateral=MIN_COLLATERAL,
         )
         # A earns (100,400] = 300 + (900,1100] = 200 → 500. The 500 blocks
@@ -347,7 +368,7 @@ class TestReplayCrownTime:
             to_chain='btc',
             window_start=100,
             window_end=1100,
-            eligible_hotkeys={'hk_a', 'hk_b'},
+            rewardable_hotkeys={'hk_a', 'hk_b'},
             min_collateral=MIN_COLLATERAL,
         )
         # From window_start=100 A is already busy (reconstructed from pre-window
@@ -448,12 +469,17 @@ class TestCalculateMinerRewards:
         assert uids == set()
         v.state_store.close()
 
-    def test_inactive_miner_gets_no_credit(self, tmp_path: Path):
-        """Even with best rate and collateral, a deactivated miner earns nothing."""
+    def test_never_active_miner_gets_no_credit(self, tmp_path: Path):
+        """A miner with a rate and collateral but no MinerActivated event in
+        history earns nothing — the historical active flag is the tell-all."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
         v = make_validator(tmp_path, hotkeys=hotkeys)
-        # Remove hk_a from active set — simulates MinerActivated(false) event
+        # Wipe the bootstrap active seed — hk_a has never been activated
+        # on-chain. This mirrors a miner that registered but never called
+        # set_active(true).
         v.event_watcher.active_miners.discard('hk_a')
+        v.event_watcher.active_events.clear()
+        v.event_watcher.active_events_by_hotkey.clear()
         conn = v.state_store.require_connection()
         conn.execute(
             'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
@@ -464,7 +490,475 @@ class TestCalculateMinerRewards:
 
         rewards, _ = calculate_miner_rewards(v)
 
-        # No eligible crown holders → full pool recycles
         assert rewards[0] == 0.0
         assert rewards[RECYCLE_UID] == 1.0
         v.state_store.close()
+
+
+class TestHistoricalActiveState:
+    """Replay must judge active state *as of each block* in the window, not
+    as of the scoring moment. A miner inactive at scoring time is still
+    rewardable for blocks where they were active, and vice versa."""
+
+    def seed_one_miner(
+        self,
+        v,
+        hotkey: str,
+        rate: float,
+        from_chain: str = 'tao',
+        to_chain: str = 'btc',
+        collateral: int = MIN_COLLATERAL,
+    ) -> None:
+        conn = v.state_store.require_connection()
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            (hotkey, from_chain, to_chain, rate, 0),
+        )
+        conn.commit()
+        seed_collateral(v.event_watcher, hotkey, collateral, 0)
+
+    def test_deactivation_mid_window_truncates_credit(self, tmp_path: Path):
+        """Active from window_start, deactivates at block 600 of a 1000-block
+        window. Credit runs until 600; nothing after."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active={'hk_a'})
+        conn = store.require_connection()
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_a', 'tao', 'btc', 0.00020, 0),
+        )
+        conn.commit()
+        seed_collateral(watcher, 'hk_a', MIN_COLLATERAL, 0)
+        # Deactivate mid-window at block 600 (window is (100, 1100]).
+        watcher.apply_event(600, 'MinerActivated', {'miner': 'hk_a', 'active': False})
+
+        crown = replay_crown_time_window(
+            store=store,
+            event_watcher=watcher,
+            from_chain='tao',
+            to_chain='btc',
+            window_start=100,
+            window_end=1100,
+            rewardable_hotkeys={'hk_a'},
+            min_collateral=MIN_COLLATERAL,
+        )
+        assert crown == {'hk_a': 500.0}
+        store.close()
+
+    def test_activation_mid_window_starts_credit(self, tmp_path: Path):
+        """Inactive at window_start, activates at block 400. Credit runs
+        from block 400 to window_end."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active=set())  # nobody seeded active
+        conn = store.require_connection()
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_a', 'tao', 'btc', 0.00020, 0),
+        )
+        conn.commit()
+        seed_collateral(watcher, 'hk_a', MIN_COLLATERAL, 0)
+        watcher.apply_event(400, 'MinerActivated', {'miner': 'hk_a', 'active': True})
+
+        crown = replay_crown_time_window(
+            store=store,
+            event_watcher=watcher,
+            from_chain='tao',
+            to_chain='btc',
+            window_start=100,
+            window_end=1100,
+            rewardable_hotkeys={'hk_a'},
+            min_collateral=MIN_COLLATERAL,
+        )
+        # (100, 400] → inactive, no credit. (400, 1100] → active, 700 blocks.
+        assert crown == {'hk_a': 700.0}
+        store.close()
+
+    def test_deactivated_at_scoring_time_still_earns_for_active_window(self, tmp_path: Path):
+        """THE bug-fix case. Miner was active and top-rate throughout the
+        entire window. *After* window_end but before scoring runs they call
+        set_active(false). They should still earn their full window."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
+        v = make_validator(tmp_path, hotkeys=hotkeys, block=10_000)
+        self.seed_one_miner(v, 'hk_a', 0.00020)
+        self.seed_one_miner(v, 'hk_a', 0.00020, from_chain='btc', to_chain='tao')
+        # Deactivation happens *after* window_end (=10_000). The replay
+        # window is (8_800, 10_000], so this transition is outside it.
+        v.event_watcher.apply_event(10_500, 'MinerActivated', {'miner': 'hk_a', 'active': False})
+
+        rewards, _ = calculate_miner_rewards(v)
+
+        # Full pool across both directions goes to hk_a (uid 0).
+        np.testing.assert_allclose(rewards[0], POOL_TAO_BTC + POOL_BTC_TAO, atol=1e-6)
+        np.testing.assert_allclose(rewards.sum(), 1.0, atol=1e-6)
+        v.state_store.close()
+
+    def test_multiple_active_cycles(self, tmp_path: Path):
+        """Active at start, off at 300, back on at 700, off at 900. Credit:
+        (100,300] = 200 + (700,900] = 200 = 400."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active={'hk_a'})
+        conn = store.require_connection()
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_a', 'tao', 'btc', 0.00020, 0),
+        )
+        conn.commit()
+        seed_collateral(watcher, 'hk_a', MIN_COLLATERAL, 0)
+        watcher.apply_event(300, 'MinerActivated', {'miner': 'hk_a', 'active': False})
+        watcher.apply_event(700, 'MinerActivated', {'miner': 'hk_a', 'active': True})
+        watcher.apply_event(900, 'MinerActivated', {'miner': 'hk_a', 'active': False})
+
+        crown = replay_crown_time_window(
+            store=store,
+            event_watcher=watcher,
+            from_chain='tao',
+            to_chain='btc',
+            window_start=100,
+            window_end=1100,
+            rewardable_hotkeys={'hk_a'},
+            min_collateral=MIN_COLLATERAL,
+        )
+        assert crown == {'hk_a': 400.0}
+        store.close()
+
+    def test_leader_deactivates_runner_up_inherits_crown(self, tmp_path: Path):
+        """A is top rate but deactivates at block 500; B was runner-up and
+        remains active. B takes the crown from 500 onward."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active={'hk_a', 'hk_b'})
+        conn = store.require_connection()
+        for hk, rate in (('hk_a', 0.00030), ('hk_b', 0.00020)):
+            conn.execute(
+                'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+                (hk, 'tao', 'btc', rate, 0),
+            )
+        conn.commit()
+        seed_collateral(watcher, 'hk_a', MIN_COLLATERAL, 0)
+        seed_collateral(watcher, 'hk_b', MIN_COLLATERAL, 0)
+        watcher.apply_event(500, 'MinerActivated', {'miner': 'hk_a', 'active': False})
+
+        crown = replay_crown_time_window(
+            store=store,
+            event_watcher=watcher,
+            from_chain='tao',
+            to_chain='btc',
+            window_start=100,
+            window_end=1100,
+            rewardable_hotkeys={'hk_a', 'hk_b'},
+            min_collateral=MIN_COLLATERAL,
+        )
+        # A earns (100, 500] = 400. B earns (500, 1100] = 600.
+        assert crown == {'hk_a': 400.0, 'hk_b': 600.0}
+        store.close()
+
+    def test_only_miner_deactivated_mid_window_pool_partially_recycles(self, tmp_path: Path):
+        """Solo miner deactivates at 600. Earns 500, forfeits 500."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
+        v = make_validator(tmp_path, hotkeys=hotkeys, block=1100)
+        conn = v.state_store.require_connection()
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_a', 'tao', 'btc', 0.00020, 0),
+        )
+        conn.commit()
+        seed_collateral(v.event_watcher, 'hk_a', MIN_COLLATERAL, 0)
+        v.event_watcher.apply_event(600, 'MinerActivated', {'miner': 'hk_a', 'active': False})
+
+        rewards, _ = calculate_miner_rewards(v)
+
+        # hk_a earned (0, 600] = 600 blocks out of 1100 → 600/1100 of tao→btc
+        # pool (success_rate=1.0 default). btc→tao pool gets nothing (no
+        # rates posted) and recycles.
+        np.testing.assert_allclose(rewards[0], POOL_TAO_BTC, atol=1e-6)
+        # Everything else recycles: btc→tao pool.
+        np.testing.assert_allclose(rewards.sum(), 1.0, atol=1e-6)
+        v.state_store.close()
+
+    def test_pre_window_activation_is_reconstructed(self, tmp_path: Path):
+        """Activation event at block 50 (before window_start=100). At
+        window_start the reconstructed active set must include hk_a."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active=set())
+        conn = store.require_connection()
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_a', 'tao', 'btc', 0.00020, 0),
+        )
+        conn.commit()
+        seed_collateral(watcher, 'hk_a', MIN_COLLATERAL, 0)
+        # Pre-window activation at block 50.
+        watcher.apply_event(50, 'MinerActivated', {'miner': 'hk_a', 'active': True})
+
+        crown = replay_crown_time_window(
+            store=store,
+            event_watcher=watcher,
+            from_chain='tao',
+            to_chain='btc',
+            window_start=100,
+            window_end=1100,
+            rewardable_hotkeys={'hk_a'},
+            min_collateral=MIN_COLLATERAL,
+        )
+        assert crown == {'hk_a': 1000.0}
+        store.close()
+
+    def test_pre_window_deactivation_is_reconstructed(self, tmp_path: Path):
+        """Miner was active at bootstrap but deactivated pre-window. Replay
+        must see them inactive from window_start."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active={'hk_a'})
+        conn = store.require_connection()
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_a', 'tao', 'btc', 0.00020, 0),
+        )
+        conn.commit()
+        seed_collateral(watcher, 'hk_a', MIN_COLLATERAL, 0)
+        watcher.apply_event(50, 'MinerActivated', {'miner': 'hk_a', 'active': False})
+
+        crown = replay_crown_time_window(
+            store=store,
+            event_watcher=watcher,
+            from_chain='tao',
+            to_chain='btc',
+            window_start=100,
+            window_end=1100,
+            rewardable_hotkeys={'hk_a'},
+            min_collateral=MIN_COLLATERAL,
+        )
+        assert crown == {}
+        store.close()
+
+    def test_active_applies_before_rate_at_same_block(self, tmp_path: Path):
+        """At a shared block, ACTIVE applies before RATE. A posts rate and
+        activates at block 500; B has been active and top-rate. Before 500,
+        B holds crown alone. At 500 both transitions apply; the interval
+        *ending* at 500 was B-only. After 500, A has a higher rate and is
+        now active → A takes crown."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active={'hk_b'})
+        conn = store.require_connection()
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_b', 'tao', 'btc', 0.00020, 0),
+        )
+        # A's rate posted at block 500 — same block as their activation.
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_a', 'tao', 'btc', 0.00030, 500),
+        )
+        conn.commit()
+        seed_collateral(watcher, 'hk_a', MIN_COLLATERAL, 0)
+        seed_collateral(watcher, 'hk_b', MIN_COLLATERAL, 0)
+        watcher.apply_event(500, 'MinerActivated', {'miner': 'hk_a', 'active': True})
+
+        crown = replay_crown_time_window(
+            store=store,
+            event_watcher=watcher,
+            from_chain='tao',
+            to_chain='btc',
+            window_start=100,
+            window_end=1100,
+            rewardable_hotkeys={'hk_a', 'hk_b'},
+            min_collateral=MIN_COLLATERAL,
+        )
+        # (100, 500] → B alone: 400. (500, 1100] → A (higher rate, now active): 600.
+        assert crown == {'hk_b': 400.0, 'hk_a': 600.0}
+        store.close()
+
+    def test_crown_helper_with_active_filter(self):
+        """crown_holders_at_instant: explicit active filter excludes otherwise-
+        qualified miners."""
+        rates = {'a': 0.00030, 'b': 0.00020}
+        collaterals = {'a': MIN_COLLATERAL, 'b': MIN_COLLATERAL}
+        # a has best rate but isn't in active set.
+        holders = crown_holders_at_instant(rates, collaterals, MIN_COLLATERAL, rewardable={'a', 'b'}, active={'b'})
+        assert holders == ['b']
+
+    def test_crown_helper_active_none_disables_filter(self):
+        """When active is None, the filter is disabled (backwards-compat for
+        the helper's isolated-test use case)."""
+        rates = {'a': 0.00020}
+        collaterals = {'a': MIN_COLLATERAL}
+        holders = crown_holders_at_instant(rates, collaterals, MIN_COLLATERAL, rewardable={'a'})
+        assert holders == ['a']
+
+    def test_crown_helper_empty_active_excludes_everyone(self):
+        """Explicit empty active set → nobody qualifies, even with rate +
+        collateral."""
+        rates = {'a': 0.00020, 'b': 0.00015}
+        collaterals = {'a': MIN_COLLATERAL, 'b': MIN_COLLATERAL}
+        holders = crown_holders_at_instant(rates, collaterals, MIN_COLLATERAL, rewardable={'a', 'b'}, active=set())
+        assert holders == []
+
+    def test_active_transition_plus_busy_transition_at_same_block(self, tmp_path: Path):
+        """ACTIVE (kind=0) orders before BUSY (kind=1). A deactivates and
+        goes busy at the same block — the interval ending at that block
+        included A. After the block, A is out both ways."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active={'hk_a', 'hk_b'})
+        conn = store.require_connection()
+        for hk, rate in (('hk_a', 0.00030), ('hk_b', 0.00020)):
+            conn.execute(
+                'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+                (hk, 'tao', 'btc', rate, 0),
+            )
+        conn.commit()
+        seed_collateral(watcher, 'hk_a', MIN_COLLATERAL, 0)
+        seed_collateral(watcher, 'hk_b', MIN_COLLATERAL, 0)
+        # At block 500: A both deactivates and picks up a swap. Both events
+        # apply; both end A's crown credit. A remains out until deactivation
+        # reverses (it doesn't).
+        watcher.apply_event(500, 'MinerActivated', {'miner': 'hk_a', 'active': False})
+        watcher.apply_event(500, 'SwapInitiated', {'swap_id': 1, 'miner': 'hk_a'})
+        watcher.apply_event(800, 'SwapCompleted', {'swap_id': 1, 'miner': 'hk_a'})
+
+        crown = replay_crown_time_window(
+            store=store,
+            event_watcher=watcher,
+            from_chain='tao',
+            to_chain='btc',
+            window_start=100,
+            window_end=1100,
+            rewardable_hotkeys={'hk_a', 'hk_b'},
+            min_collateral=MIN_COLLATERAL,
+        )
+        # (100, 500] → A holds: 400. (500, 1100] → B holds (A inactive AND
+        # busy, then inactive only): 600.
+        assert crown == {'hk_a': 400.0, 'hk_b': 600.0}
+        store.close()
+
+    def test_dereg_plus_deactivation_no_credit(self, tmp_path: Path):
+        """Miner dereg'd AND deactivated — earns nothing, for both reasons.
+        Tests that the two filters compose correctly (no accidental double-
+        negative that credits them)."""
+        # hk_a is not on the metagraph.
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_b'])
+        v = make_validator(tmp_path, hotkeys=hotkeys, block=10_000)
+        # hk_a is historically active (seeded) but we deactivate mid-window
+        # and they're dereg'd at scoring time.
+        v.event_watcher.active_miners.add('hk_a')
+        seed_active(v.event_watcher, 'hk_a', active=True, block=0)
+        conn = v.state_store.require_connection()
+        for hk, rate in (('hk_a', 0.00030), ('hk_b', 0.00020)):
+            conn.execute(
+                'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+                (hk, 'tao', 'btc', rate, 0),
+            )
+            seed_collateral(v.event_watcher, hk, MIN_COLLATERAL, 0)
+        conn.commit()
+        v.event_watcher.apply_event(9_000, 'MinerActivated', {'miner': 'hk_a', 'active': False})
+
+        rewards, _ = calculate_miner_rewards(v)
+
+        # hk_b (uid 0) is the only rewardable + active miner, earns tao→btc.
+        np.testing.assert_allclose(rewards[0], POOL_TAO_BTC, atol=1e-6)
+        np.testing.assert_allclose(rewards.sum(), 1.0, atol=1e-6)
+        v.state_store.close()
+
+
+class TestEventWatcherActiveState:
+    """Unit-test the event_watcher's active-state tracking in isolation so
+    the scoring pipeline has a reliable foundation."""
+
+    def test_get_active_miners_at_empty(self, tmp_path: Path):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active=set())
+        assert watcher.get_active_miners_at(1000) == set()
+        store.close()
+
+    def test_get_active_miners_at_returns_latest_before_block(self, tmp_path: Path):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active=set())
+        watcher.apply_event(100, 'MinerActivated', {'miner': 'hk_a', 'active': True})
+        watcher.apply_event(500, 'MinerActivated', {'miner': 'hk_a', 'active': False})
+        watcher.apply_event(800, 'MinerActivated', {'miner': 'hk_a', 'active': True})
+        assert watcher.get_active_miners_at(50) == set()
+        assert watcher.get_active_miners_at(100) == {'hk_a'}
+        assert watcher.get_active_miners_at(300) == {'hk_a'}
+        assert watcher.get_active_miners_at(500) == set()
+        assert watcher.get_active_miners_at(799) == set()
+        assert watcher.get_active_miners_at(800) == {'hk_a'}
+        assert watcher.get_active_miners_at(9999) == {'hk_a'}
+        store.close()
+
+    def test_get_active_events_in_range_half_open_start(self, tmp_path: Path):
+        """Range is (start, end] — events at exactly start_block are excluded."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active=set())
+        watcher.apply_event(100, 'MinerActivated', {'miner': 'hk_a', 'active': True})
+        watcher.apply_event(500, 'MinerActivated', {'miner': 'hk_a', 'active': False})
+        watcher.apply_event(1000, 'MinerActivated', {'miner': 'hk_a', 'active': True})
+        in_range = watcher.get_active_events_in_range(100, 1000)
+        # block=100 is excluded (<=start_block); 500 and 1000 included.
+        assert [e['block'] for e in in_range] == [500, 1000]
+        assert [e['active'] for e in in_range] == [False, True]
+        store.close()
+
+    def test_record_active_transition_is_noop_on_duplicate(self, tmp_path: Path):
+        """Duplicate MinerActivated emissions for the same state don't bloat
+        the event log — critical for prune/retention correctness."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active=set())
+        watcher.apply_event(100, 'MinerActivated', {'miner': 'hk_a', 'active': True})
+        watcher.apply_event(200, 'MinerActivated', {'miner': 'hk_a', 'active': True})
+        watcher.apply_event(300, 'MinerActivated', {'miner': 'hk_a', 'active': True})
+        assert len(watcher.active_events) == 1
+        assert watcher.active_events[0].block == 100
+        store.close()
+
+    def test_record_active_transition_ignores_empty_hotkey(self, tmp_path: Path):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active=set())
+        watcher.record_active_transition(100, '', True)
+        assert watcher.active_events == []
+        assert watcher.active_miners == set()
+        store.close()
+
+    def test_apply_minerativated_populates_per_hotkey_index(self, tmp_path: Path):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active=set())
+        watcher.apply_event(100, 'MinerActivated', {'miner': 'hk_a', 'active': True})
+        watcher.apply_event(200, 'MinerActivated', {'miner': 'hk_b', 'active': True})
+        watcher.apply_event(300, 'MinerActivated', {'miner': 'hk_a', 'active': False})
+        assert len(watcher.active_events_by_hotkey['hk_a']) == 2
+        assert len(watcher.active_events_by_hotkey['hk_b']) == 1
+        assert 'hk_a' not in watcher.active_miners
+        assert 'hk_b' in watcher.active_miners
+        store.close()
+
+    def test_prune_keeps_latest_active_event_per_hotkey(self, tmp_path: Path):
+        """Mirror of the collateral prune rule — drop stale events but keep
+        the latest per hotkey as a state-reconstruction anchor so
+        get_active_miners_at still returns correct state for blocks past the
+        retention boundary."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active=set())
+        # Two transitions far in the past, one recent.
+        watcher.apply_event(100, 'MinerActivated', {'miner': 'hk_a', 'active': True})
+        watcher.apply_event(200, 'MinerActivated', {'miner': 'hk_a', 'active': False})
+        watcher.apply_event(5_000, 'MinerActivated', {'miner': 'hk_a', 'active': True})
+        # Also test a dormant hotkey whose only event is ancient.
+        watcher.apply_event(50, 'MinerActivated', {'miner': 'hk_b', 'active': True})
+
+        # current_block=10_000, SCORING_WINDOW_BLOCKS=1200 → cutoff=8_800.
+        # All events below cutoff except the latest-per-hotkey should drop.
+        watcher.prune_old_collateral_events(10_000)
+
+        blocks_a = [ev.block for ev in watcher.active_events_by_hotkey['hk_a']]
+        assert blocks_a == [5_000]  # only latest kept
+        blocks_b = [ev.block for ev in watcher.active_events_by_hotkey['hk_b']]
+        assert blocks_b == [50]  # dormant hotkey's latest anchor preserved
+        # Sanity: reconstruction still works post-prune.
+        assert watcher.get_active_miners_at(20_000) == {'hk_a', 'hk_b'}
+        store.close()
+
+    def test_busy_state_ordered_after_active_at_same_block(self, tmp_path: Path):
+        """EventKind.ACTIVE (0) < EventKind.BUSY (1). At a shared block,
+        the credit_interval *ending* at that block is evaluated before any
+        of those transitions applies. Verifying the ordering via sort_key
+        (behavioral coverage already exists in the replay tests; this
+        guards the constant values)."""
+        from allways.validator.scoring import EventKind
+
+        assert int(EventKind.ACTIVE) < int(EventKind.BUSY) < int(EventKind.COLLATERAL) < int(EventKind.RATE)

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 import numpy as np
 
 from allways.constants import RECYCLE_UID, SUCCESS_EXPONENT
-from allways.validator.event_watcher import ActiveEvent, ContractEventWatcher
+from allways.validator.event_watcher import ActiveEvent, ConfigEvent, ContractEventWatcher
 from allways.validator.scoring import (
     calculate_miner_rewards,
     crown_holders_at_instant,
@@ -36,7 +36,6 @@ def make_watcher(store: ValidatorStateStore, active: set[str]) -> ContractEventW
         state_store=store,
         default_min_collateral=MIN_COLLATERAL,
     )
-    w.min_collateral = MIN_COLLATERAL
     w.active_miners = set(active)
     # Seed an anchor active=True event at block 0 for each bootstrapped
     # active miner — mirrors the bootstrap seed that ContractEventWatcher
@@ -65,6 +64,20 @@ def seed_active(watcher: ContractEventWatcher, hotkey: str, active: bool, block:
         watcher.active_miners.add(hotkey)
     else:
         watcher.active_miners.discard(hotkey)
+
+
+def seed_config(watcher: ContractEventWatcher, key: str, value: int, block: int) -> None:
+    """Insert a contract config event directly into the watcher's in-memory
+    state and advance the current-state mirror. Bypasses
+    ``record_config_transition``'s no-op-on-same-value guard."""
+    event = ConfigEvent(key=key, value=int(value), block=block)
+    watcher.config_events.append(event)
+    watcher.config_events_by_key.setdefault(key, []).append(event)
+    watcher.config_events.sort(key=lambda ev: ev.block)
+    watcher.config_events_by_key[key].sort(key=lambda ev: ev.block)
+    watcher.config_current[key] = int(value)
+    if key == 'min_collateral':
+        watcher.min_collateral = int(value)
 
 
 def make_validator(tmp_path: Path, hotkeys: list[str], block: int = 10_000) -> SimpleNamespace:
@@ -154,7 +167,6 @@ class TestReplayCrownTime:
             window_start=100,
             window_end=1100,
             rewardable_hotkeys={'hk_a'},
-            min_collateral=MIN_COLLATERAL,
         )
         assert crown == {'hk_a': 1000.0}
         store.close()
@@ -188,7 +200,6 @@ class TestReplayCrownTime:
             window_start=100,
             window_end=1100,
             rewardable_hotkeys={'hk_a', 'hk_b'},
-            min_collateral=MIN_COLLATERAL,
         )
         # B leads blocks (100, 600] → 500 blocks, A leads (600, 1100] → 500 blocks
         assert crown == {'hk_b': 500.0, 'hk_a': 500.0}
@@ -214,7 +225,6 @@ class TestReplayCrownTime:
             window_start=100,
             window_end=1100,
             rewardable_hotkeys={'hk_a', 'hk_b'},
-            min_collateral=MIN_COLLATERAL,
         )
         assert crown == {'hk_a': 500.0, 'hk_b': 500.0}
         store.close()
@@ -240,7 +250,6 @@ class TestReplayCrownTime:
             window_start=100,
             window_end=1100,
             rewardable_hotkeys={'hk_a'},
-            min_collateral=MIN_COLLATERAL,
         )
         assert crown == {'hk_a': 500.0}
         store.close()
@@ -265,7 +274,6 @@ class TestReplayCrownTime:
             window_start=10_000,
             window_end=11_000,
             rewardable_hotkeys={'hk_a'},
-            min_collateral=MIN_COLLATERAL,
         )
         assert crown == {'hk_a': 1000.0}
         store.close()
@@ -300,7 +308,6 @@ class TestReplayCrownTime:
             window_start=100,
             window_end=1100,
             rewardable_hotkeys={'hk_a', 'hk_b'},
-            min_collateral=MIN_COLLATERAL,
         )
         # A earns (100,400] = 300 + (800,1100] = 300 → 600 total
         # B earns (400,800] = 400 total
@@ -331,7 +338,6 @@ class TestReplayCrownTime:
             window_start=100,
             window_end=1100,
             rewardable_hotkeys={'hk_a'},
-            min_collateral=MIN_COLLATERAL,
         )
         # A earns (100,400] = 300 + (900,1100] = 200 → 500. The 500 blocks
         # of busy interval have no idle candidate → not credited to anyone
@@ -369,7 +375,6 @@ class TestReplayCrownTime:
             window_start=100,
             window_end=1100,
             rewardable_hotkeys={'hk_a', 'hk_b'},
-            min_collateral=MIN_COLLATERAL,
         )
         # From window_start=100 A is already busy (reconstructed from pre-window
         # SwapInitiated). B earns (100,500] = 400; A earns (500,1100] = 600.
@@ -540,7 +545,6 @@ class TestHistoricalActiveState:
             window_start=100,
             window_end=1100,
             rewardable_hotkeys={'hk_a'},
-            min_collateral=MIN_COLLATERAL,
         )
         assert crown == {'hk_a': 500.0}
         store.close()
@@ -567,7 +571,6 @@ class TestHistoricalActiveState:
             window_start=100,
             window_end=1100,
             rewardable_hotkeys={'hk_a'},
-            min_collateral=MIN_COLLATERAL,
         )
         # (100, 400] → inactive, no credit. (400, 1100] → active, 700 blocks.
         assert crown == {'hk_a': 700.0}
@@ -616,7 +619,6 @@ class TestHistoricalActiveState:
             window_start=100,
             window_end=1100,
             rewardable_hotkeys={'hk_a'},
-            min_collateral=MIN_COLLATERAL,
         )
         assert crown == {'hk_a': 400.0}
         store.close()
@@ -645,7 +647,6 @@ class TestHistoricalActiveState:
             window_start=100,
             window_end=1100,
             rewardable_hotkeys={'hk_a', 'hk_b'},
-            min_collateral=MIN_COLLATERAL,
         )
         # A earns (100, 500] = 400. B earns (500, 1100] = 600.
         assert crown == {'hk_a': 400.0, 'hk_b': 600.0}
@@ -697,7 +698,6 @@ class TestHistoricalActiveState:
             window_start=100,
             window_end=1100,
             rewardable_hotkeys={'hk_a'},
-            min_collateral=MIN_COLLATERAL,
         )
         assert crown == {'hk_a': 1000.0}
         store.close()
@@ -724,7 +724,6 @@ class TestHistoricalActiveState:
             window_start=100,
             window_end=1100,
             rewardable_hotkeys={'hk_a'},
-            min_collateral=MIN_COLLATERAL,
         )
         assert crown == {}
         store.close()
@@ -760,7 +759,6 @@ class TestHistoricalActiveState:
             window_start=100,
             window_end=1100,
             rewardable_hotkeys={'hk_a', 'hk_b'},
-            min_collateral=MIN_COLLATERAL,
         )
         # (100, 500] → B alone: 400. (500, 1100] → A (higher rate, now active): 600.
         assert crown == {'hk_b': 400.0, 'hk_a': 600.0}
@@ -821,7 +819,6 @@ class TestHistoricalActiveState:
             window_start=100,
             window_end=1100,
             rewardable_hotkeys={'hk_a', 'hk_b'},
-            min_collateral=MIN_COLLATERAL,
         )
         # (100, 500] → A holds: 400. (500, 1100] → B holds (A inactive AND
         # busy, then inactive only): 600.
@@ -953,12 +950,341 @@ class TestEventWatcherActiveState:
         assert watcher.get_active_miners_at(20_000) == {'hk_a', 'hk_b'}
         store.close()
 
-    def test_busy_state_ordered_after_active_at_same_block(self, tmp_path: Path):
-        """EventKind.ACTIVE (0) < EventKind.BUSY (1). At a shared block,
+    def test_event_kind_ordering_at_same_block(self, tmp_path: Path):
+        """CONFIG < ACTIVE < BUSY < COLLATERAL < RATE. At a shared block
         the credit_interval *ending* at that block is evaluated before any
-        of those transitions applies. Verifying the ordering via sort_key
-        (behavioral coverage already exists in the replay tests; this
-        guards the constant values)."""
+        of those transitions applies. Ordering matters: a halt at block N
+        must disqualify block N+1 regardless of any other same-block
+        transition."""
         from allways.validator.scoring import EventKind
 
-        assert int(EventKind.ACTIVE) < int(EventKind.BUSY) < int(EventKind.COLLATERAL) < int(EventKind.RATE)
+        assert (
+            int(EventKind.CONFIG)
+            < int(EventKind.ACTIVE)
+            < int(EventKind.BUSY)
+            < int(EventKind.COLLATERAL)
+            < int(EventKind.RATE)
+        )
+
+
+class TestHistoricalConfigState:
+    """Replay must evaluate min_collateral, max_collateral, and halt state
+    as-of each block, not as-of scoring time. Admin-side config changes
+    don't retroactively disqualify blocks the miner legitimately earned."""
+
+    def test_min_collateral_raised_mid_window_excludes_post_raise_blocks(self, tmp_path: Path):
+        """Miner has 100M collateral. Admin raises min_collateral from 80M
+        to 120M at block 600. Miner qualifies (100 <= min 80) before the
+        raise, disqualifies (100 < min 120) after."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active={'hk_a'})
+        seed_config(watcher, 'min_collateral', 80_000_000, 0)
+        conn = store.require_connection()
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_a', 'tao', 'btc', 0.00020, 0),
+        )
+        conn.commit()
+        seed_collateral(watcher, 'hk_a', 100_000_000, 0)
+        watcher.apply_event(600, 'ConfigUpdated', {'key': 'min_collateral', 'value': 120_000_000})
+
+        crown = replay_crown_time_window(
+            store=store,
+            event_watcher=watcher,
+            from_chain='tao',
+            to_chain='btc',
+            window_start=100,
+            window_end=1100,
+            rewardable_hotkeys={'hk_a'},
+        )
+        # (100, 600] → min 80M, qualifies: 500 blocks. (600, 1100] → min 120M, disqualified: 0.
+        assert crown == {'hk_a': 500.0}
+        store.close()
+
+    def test_min_collateral_lowered_mid_window_admits_miner(self, tmp_path: Path):
+        """Under-min at window_start; admin lowers min mid-window; miner
+        now qualifies for post-lower blocks."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active={'hk_a'})
+        seed_config(watcher, 'min_collateral', 200_000_000, 0)
+        conn = store.require_connection()
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_a', 'tao', 'btc', 0.00020, 0),
+        )
+        conn.commit()
+        seed_collateral(watcher, 'hk_a', 100_000_000, 0)
+        watcher.apply_event(400, 'ConfigUpdated', {'key': 'min_collateral', 'value': 50_000_000})
+
+        crown = replay_crown_time_window(
+            store=store,
+            event_watcher=watcher,
+            from_chain='tao',
+            to_chain='btc',
+            window_start=100,
+            window_end=1100,
+            rewardable_hotkeys={'hk_a'},
+        )
+        # (100, 400] → disqualified. (400, 1100] → qualified: 700 blocks.
+        assert crown == {'hk_a': 700.0}
+        store.close()
+
+    def test_max_collateral_excludes_over_cap_miner(self, tmp_path: Path):
+        """Miner A has 500M collateral; max_collateral is 200M; A is over
+        cap and disqualifies despite best rate. B (100M, under cap) wins."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active={'hk_a', 'hk_b'})
+        seed_config(watcher, 'max_collateral', 200_000_000, 0)
+        conn = store.require_connection()
+        for hk, rate in (('hk_a', 0.00030), ('hk_b', 0.00020)):
+            conn.execute(
+                'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+                (hk, 'tao', 'btc', rate, 0),
+            )
+        conn.commit()
+        seed_collateral(watcher, 'hk_a', 500_000_000, 0)
+        seed_collateral(watcher, 'hk_b', 100_000_000, 0)
+
+        crown = replay_crown_time_window(
+            store=store,
+            event_watcher=watcher,
+            from_chain='tao',
+            to_chain='btc',
+            window_start=100,
+            window_end=1100,
+            rewardable_hotkeys={'hk_a', 'hk_b'},
+        )
+        # A is over-cap every block → excluded. B wins the whole window.
+        assert crown == {'hk_b': 1000.0}
+        store.close()
+
+    def test_max_collateral_lowered_mid_window_disqualifies_miner(self, tmp_path: Path):
+        """A has 300M collateral. max starts at 500M (A qualifies). Admin
+        lowers max to 100M at block 500. A is now over-cap."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active={'hk_a'})
+        seed_config(watcher, 'max_collateral', 500_000_000, 0)
+        conn = store.require_connection()
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_a', 'tao', 'btc', 0.00020, 0),
+        )
+        conn.commit()
+        seed_collateral(watcher, 'hk_a', 300_000_000, 0)
+        watcher.apply_event(500, 'ConfigUpdated', {'key': 'max_collateral', 'value': 100_000_000})
+
+        crown = replay_crown_time_window(
+            store=store,
+            event_watcher=watcher,
+            from_chain='tao',
+            to_chain='btc',
+            window_start=100,
+            window_end=1100,
+            rewardable_hotkeys={'hk_a'},
+        )
+        # (100, 500] → max 500M, 300M qualifies: 400 blocks. (500, 1100] → max 100M, over-cap: 0.
+        assert crown == {'hk_a': 400.0}
+        store.close()
+
+    def test_max_collateral_zero_means_no_cap(self, tmp_path: Path):
+        """Contract semantics: max_collateral=0 disables the upper bound.
+        A miner with arbitrarily large collateral still qualifies."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active={'hk_a'})
+        # config_current default for max_collateral is 0.
+        assert watcher.config_current['max_collateral'] == 0
+        conn = store.require_connection()
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_a', 'tao', 'btc', 0.00020, 0),
+        )
+        conn.commit()
+        # A posts 1 trillion rao — absurd but should still qualify with no cap.
+        seed_collateral(watcher, 'hk_a', 1_000_000_000_000, 0)
+
+        crown = replay_crown_time_window(
+            store=store,
+            event_watcher=watcher,
+            from_chain='tao',
+            to_chain='btc',
+            window_start=100,
+            window_end=1100,
+            rewardable_hotkeys={'hk_a'},
+        )
+        assert crown == {'hk_a': 1000.0}
+        store.close()
+
+    def test_halt_mid_window_recycles_halt_interval(self, tmp_path: Path):
+        """Contract halted at block 400, unhalted at block 800. During the
+        halt, no miner holds crown — that interval's pool recycles. Miner
+        earns only the active intervals."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active={'hk_a'})
+        conn = store.require_connection()
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_a', 'tao', 'btc', 0.00020, 0),
+        )
+        conn.commit()
+        seed_collateral(watcher, 'hk_a', MIN_COLLATERAL, 0)
+        watcher.apply_event(400, 'ConfigUpdated', {'key': 'halted', 'value': 1})
+        watcher.apply_event(800, 'ConfigUpdated', {'key': 'halted', 'value': 0})
+
+        crown = replay_crown_time_window(
+            store=store,
+            event_watcher=watcher,
+            from_chain='tao',
+            to_chain='btc',
+            window_start=100,
+            window_end=1100,
+            rewardable_hotkeys={'hk_a'},
+        )
+        # (100, 400] = 300 + (800, 1100] = 300 → 600 total. (400, 800] recycles.
+        assert crown == {'hk_a': 600.0}
+        store.close()
+
+    def test_halt_entire_window_recycles_full_pool(self, tmp_path: Path):
+        """Contract halted at scoring time and for the full window — the
+        pool fully recycles through RECYCLE_UID."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
+        v = make_validator(tmp_path, hotkeys=hotkeys, block=10_000)
+        # Halt the contract starting pre-window.
+        seed_config(v.event_watcher, 'halted', 1, 0)
+        conn = v.state_store.require_connection()
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_a', 'tao', 'btc', 0.00020, 0),
+        )
+        conn.commit()
+        seed_collateral(v.event_watcher, 'hk_a', MIN_COLLATERAL, 0)
+
+        rewards, _ = calculate_miner_rewards(v)
+
+        assert rewards[0] == 0.0
+        np.testing.assert_allclose(rewards[RECYCLE_UID], 1.0, atol=1e-6)
+        v.state_store.close()
+
+    def test_halt_event_applied_after_block_halt_takes_effect_next_block(self, tmp_path: Path):
+        """Halt event at block 500. The credit_interval *ending* at 500
+        uses pre-halt state — block 500 is credited. The interval after
+        (500, window_end] sees halted=True → no credit."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active={'hk_a'})
+        conn = store.require_connection()
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_a', 'tao', 'btc', 0.00020, 0),
+        )
+        conn.commit()
+        seed_collateral(watcher, 'hk_a', MIN_COLLATERAL, 0)
+        watcher.apply_event(500, 'ConfigUpdated', {'key': 'halted', 'value': 1})
+
+        crown = replay_crown_time_window(
+            store=store,
+            event_watcher=watcher,
+            from_chain='tao',
+            to_chain='btc',
+            window_start=100,
+            window_end=1100,
+            rewardable_hotkeys={'hk_a'},
+        )
+        # (100, 500] = 400. After block 500 the halt applies, rest recycles.
+        assert crown == {'hk_a': 400.0}
+        store.close()
+
+    def test_unknown_config_key_is_ignored(self, tmp_path: Path):
+        """ConfigUpdated for a key not in CONFIG_KEYS_TRACKED is silently
+        dropped — we don't bloat the log with every knob."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active=set())
+        watcher.apply_event(500, 'ConfigUpdated', {'key': 'consensus_threshold_percent', 'value': 66})
+        assert watcher.config_events_by_key.get('consensus_threshold_percent') is None
+        store.close()
+
+    def test_duplicate_config_event_no_op(self, tmp_path: Path):
+        """Duplicate ConfigUpdated for the same value is a no-op."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active=set())
+        watcher.apply_event(100, 'ConfigUpdated', {'key': 'min_collateral', 'value': 500})
+        watcher.apply_event(200, 'ConfigUpdated', {'key': 'min_collateral', 'value': 500})
+        watcher.apply_event(300, 'ConfigUpdated', {'key': 'min_collateral', 'value': 500})
+        events = watcher.config_events_by_key['min_collateral']
+        assert [e.block for e in events] == [100]
+        store.close()
+
+    def test_get_config_at_returns_current_when_no_events(self, tmp_path: Path):
+        """Fallback path: no history → return config_current value (set by
+        constructor default / bootstrap)."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active=set())
+        assert watcher.get_config_at('min_collateral', 9_999) == MIN_COLLATERAL
+        assert watcher.get_config_at('max_collateral', 9_999) == 0
+        assert watcher.get_config_at('halted', 9_999) == 0
+        store.close()
+
+    def test_config_history_is_replayed_when_events_exist(self, tmp_path: Path):
+        """With in-window events, get_config_at returns the latest value
+        at or before the requested block."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active=set())
+        watcher.apply_event(100, 'ConfigUpdated', {'key': 'max_collateral', 'value': 1_000_000})
+        watcher.apply_event(500, 'ConfigUpdated', {'key': 'max_collateral', 'value': 2_000_000})
+        watcher.apply_event(900, 'ConfigUpdated', {'key': 'max_collateral', 'value': 500_000})
+        assert watcher.get_config_at('max_collateral', 50) == 0  # pre-first-event falls back
+        assert watcher.get_config_at('max_collateral', 100) == 1_000_000
+        assert watcher.get_config_at('max_collateral', 499) == 1_000_000
+        assert watcher.get_config_at('max_collateral', 500) == 2_000_000
+        assert watcher.get_config_at('max_collateral', 899) == 2_000_000
+        assert watcher.get_config_at('max_collateral', 999) == 500_000
+        store.close()
+
+    def test_halt_and_min_collateral_change_same_block(self, tmp_path: Path):
+        """Both a halt and a min_collateral change at the same block apply
+        in the same credit_interval boundary. Both are CONFIG kind →
+        ordering among themselves is insertion order. Halt is the stronger
+        filter so result is dominated by it."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active={'hk_a'})
+        conn = store.require_connection()
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_a', 'tao', 'btc', 0.00020, 0),
+        )
+        conn.commit()
+        seed_collateral(watcher, 'hk_a', MIN_COLLATERAL, 0)
+        watcher.apply_event(500, 'ConfigUpdated', {'key': 'halted', 'value': 1})
+        watcher.apply_event(500, 'ConfigUpdated', {'key': 'min_collateral', 'value': 999_999_999})
+
+        crown = replay_crown_time_window(
+            store=store,
+            event_watcher=watcher,
+            from_chain='tao',
+            to_chain='btc',
+            window_start=100,
+            window_end=1100,
+            rewardable_hotkeys={'hk_a'},
+        )
+        # Pre-500: 400 blocks to A. Post-500: halted → nobody. Also over-min.
+        assert crown == {'hk_a': 400.0}
+        store.close()
+
+    def test_crown_helper_halted_short_circuits(self):
+        """crown_holders_at_instant: halted=True returns [] unconditionally."""
+        rates = {'a': 0.00020, 'b': 0.00015}
+        collaterals = {'a': MIN_COLLATERAL, 'b': MIN_COLLATERAL}
+        holders = crown_holders_at_instant(rates, collaterals, MIN_COLLATERAL, rewardable={'a', 'b'}, halted=True)
+        assert holders == []
+
+    def test_crown_helper_max_collateral_excludes_over_cap(self):
+        rates = {'a': 0.00030, 'b': 0.00020}
+        collaterals = {'a': 300_000_000, 'b': 100_000_000}
+        holders = crown_holders_at_instant(
+            rates, collaterals, MIN_COLLATERAL, rewardable={'a', 'b'}, max_collateral=200_000_000
+        )
+        assert holders == ['b']
+
+    def test_crown_helper_max_collateral_zero_disabled(self):
+        rates = {'a': 0.00020}
+        collaterals = {'a': 1_000_000_000_000}
+        holders = crown_holders_at_instant(rates, collaterals, MIN_COLLATERAL, rewardable={'a'}, max_collateral=0)
+        assert holders == ['a']


### PR DESCRIPTION
## Summary
- Scoring previously filtered candidates by `event_watcher.active_miners` (scoring-time snapshot), so a miner who was active + top-rate throughout the window but deactivated before scoring got zero credit. Active state is now replayed per-block alongside collateral/rate/busy. Only metagraph membership is evaluated at scoring time.
- New `ActiveEvent` log in `ContractEventWatcher` with `get_active_miners_at` / `get_active_events_in_range` helpers. `initialize()` seeds an anchor event at the cursor so pre-cursor state mirrors the collateral bootstrap pattern. Prune retains the latest event per hotkey as a reconstruction anchor.
- Scoring: `eligible_hotkeys` → `rewardable_hotkeys` (= current metagraph). `EventKind.ACTIVE` orders first at shared blocks — active is the tell-all, applies before busy/collateral/rate transitions.
- 17 new tests covering mid-window deactivation/activation, the headline "deactivated at scoring time but active during window" case, pre-window reconstruction, multi-cycle toggles, crown-inherits-on-deactivation, same-block event ordering, and event-watcher helper units.

## Test plan
- [x] `pytest tests/test_scoring_v1.py` — 46/46 pass
- [x] `pytest tests/` — 289/289 pass
- [x] `ruff format .` + `ruff check .` — clean
- [ ] E2E smoke: `cd alw-utils/dev-environment && ./down.sh --force && ./up.sh --chains btc && ./tests/run.sh --chains btc --suite 02`
- [ ] Manual: miner calls `set_active(false)` between window_end and next scoring tick — confirm they still receive the reward cycle they were active for