### PR TITLE
Fix read_miner_commitments SS58 decoding

### DIFF
--- a/allways/commitments.py
+++ b/allways/commitments.py
@@ -3,10 +3,13 @@
 from typing import List, Optional
 
 import bittensor as bt
+from substrateinterface.utils.ss58 import ss58_encode
 
 from allways.chains import SUPPORTED_CHAINS, canonical_pair
 from allways.classes import MinerPair
 from allways.constants import COMMITMENT_VERSION
+
+SS58_PREFIX = 42
 
 
 def parse_commitment_data(raw: str, uid: int = 0, hotkey: str = '') -> Optional[MinerPair]:
@@ -145,7 +148,18 @@ def read_miner_commitments(subtensor: bt.Subtensor, netuid: int) -> List[MinerPa
             params=[netuid],
         )
         for key, metadata in result:
-            hotkey = str(key.value) if hasattr(key, 'value') else str(key)
+            # query_map returns the second-map key (hotkey AccountId) as raw
+            # bytes inside a single-element tuple, not an SS58 string. Encode
+            # it so we can look the miner up in the metagraph's hotkey index.
+            raw = key.value if hasattr(key, 'value') else key
+            if isinstance(raw, tuple) and len(raw) == 1:
+                raw = raw[0]
+            if isinstance(raw, (tuple, list)):
+                raw = bytes(raw)
+            if isinstance(raw, (bytes, bytearray)) and len(raw) == 32:
+                hotkey = ss58_encode(bytes(raw), SS58_PREFIX)
+            else:
+                hotkey = str(raw)
             uid = hotkey_to_uid.get(hotkey)
             if uid is None:
                 continue  # miner dereg'd but commitment still in storage


### PR DESCRIPTION
## Summary

Root cause of the E2E suite failing at "rate 345 not found" (cascading into every swap-dependent suite). `substrate-interface`'s `query_map` over `Commitments.CommitmentOf` returns the second-map key as raw bytes in a single-element tuple, not an SS58 string. The batched refactor in `47155d1` compared `str(key.value)` — a tuple repr — against the metagraph's SS58 hotkey index, so every lookup returned `None` and every commitment was silently dropped.

Visible effects:
- `alw view rates` → "No rates found" even with active miners posting rates
- Validator scoring's rate events never populated
- `alw swap now` can't find a miner → swap initiation fails
- E2E suite 01 failed "Miner-1 visible in rates"; suite 02 and downstream cascaded

## Fix

Decode the query_map key to 32 bytes and `ss58_encode(..., 42)` to match the SS58 string the metagraph uses.

## Test plan

- [x] `alw view rates` now returns the miner's posted rate
- [x] Unit tests pass (`pytest tests/test_commitments.py`)
- [x] Full pytest suite passes (279 tests)
- [x] Ruff clean
- [ ] E2E suite 01-02 happy path against dev env (should pass once merged)