### PR TITLE
vote_deactivate: drop collateral gate, trust validator quorum

### DIFF
--- a/allways/contract_client.py
+++ b/allways/contract_client.py
@@ -272,9 +272,8 @@ CONTRACT_ERROR_VARIANTS = {
     25: ('PendingConflict', 'A pending vote exists for a different request'),
     26: ('SameChain', 'Source and destination chains must be different'),
     27: ('SystemHalted', 'System is halted — no new activity allowed'),
-    28: ('SufficientCollateral', 'Miner collateral is at or above floor; vote_deactivate not applicable'),
-    29: ('HasActiveSwap', 'Cannot deactivate: miner has an active swap in progress'),
-    30: ('CurrentlyReserved', 'Cannot deactivate: miner is currently reserved'),
+    28: ('HasActiveSwap', 'Cannot deactivate: miner has an active swap in progress'),
+    29: ('CurrentlyReserved', 'Cannot deactivate: miner is currently reserved'),
 }
 
 
@@ -1081,9 +1080,9 @@ class AllwaysContractClient:
         return tx_hash
 
     def vote_deactivate(self, wallet: bt.Wallet, miner_hotkey: str) -> str:
-        """Vote to deactivate a miner that has fallen below the collateral
-        floor. Validator-quorum gated; contract rejects unless
-        ``collateral < min_collateral``."""
+        """Vote to deactivate a miner. Validator-quorum only — the contract
+        trusts the quorum and applies no collateral/status gate beyond the
+        miner currently being active."""
         self.ensure_initialized()
         tx_hash = self.exec_contract_raw('vote_deactivate', args={'miner': miner_hotkey}, keypair=wallet.hotkey)
         bt.logging.info(f'Vote deactivate for miner {miner_hotkey}: {tx_hash}')

--- a/smart-contracts/ink/errors.rs
+++ b/smart-contracts/ink/errors.rs
@@ -60,8 +60,6 @@ pub enum Error {
     SameChain,
     /// System is halted — no new activity allowed
     SystemHalted,
-    /// Miner collateral meets or exceeds floor; vote_deactivate not applicable
-    SufficientCollateral,
     /// Miner has an active swap; self-deactivation blocked until swap resolves
     HasActiveSwap,
     /// Miner is currently reserved; self-deactivation blocked until reservation expires

--- a/smart-contracts/ink/lib.rs
+++ b/smart-contracts/ink/lib.rs
@@ -1046,15 +1046,16 @@ mod allways_swap_manager {
 
         /// Vote to deactivate a miner — validator-only, quorum required.
         ///
-        /// Dormant escape hatch for the `min_collateral` raise case: if the owner
-        /// raises the collateral floor above an active miner's balance, validators
-        /// can use this to bring the active flag back in sync with on-chain reality.
-        /// Gated on `collateral < min_collateral` so validators cannot use it to
-        /// deactivate compliant miners by collusion.
+        /// Trust-based: on quorum the miner's active flag is cleared, full stop.
+        /// No collateral, status, or balance gates beyond "currently active".
+        /// Deliberately unconstrained so the validator consensus can cover any
+        /// remediation case (min_collateral raise, protocol abuse, operational
+        /// emergencies). Abuse protection comes from the quorum itself — the
+        /// same trust envelope as `vote_activate` / `vote_reserve`.
         ///
-        /// Not blocked mid-swap: the existing swap lifecycle proceeds via persisted
-        /// assignment. Miner cannot re-activate until they top up collateral because
-        /// `vote_activate` already checks the floor.
+        /// Not blocked mid-swap: the existing swap lifecycle proceeds via its
+        /// persisted assignment. Miner cannot re-activate while below the
+        /// collateral floor because `vote_activate` still checks it.
         #[ink(message)]
         pub fn vote_deactivate(&mut self, miner: AccountId) -> Result<(), Error> {
             self.ensure_validator()?;
@@ -1062,10 +1063,6 @@ mod allways_swap_manager {
 
             if !self.miner_active.get(miner).unwrap_or(false) {
                 return Err(Error::InvalidStatus);
-            }
-            let miner_collateral = self.collateral.get(miner).unwrap_or(0);
-            if miner_collateral >= self.min_collateral {
-                return Err(Error::SufficientCollateral);
             }
 
             let request_id = match self.get_active_request(miner, REQ_DEACTIVATE) {


### PR DESCRIPTION
## Summary

Remove the ``collateral >= min_collateral`` precondition from ``vote_deactivate`` so validator consensus alone is authoritative. The contract trusts the quorum — the threshold itself is the abuse protection, same envelope as ``vote_activate`` / ``vote_reserve``.

## Why

The original gate was designed to prevent validator collusion against compliant miners, but it narrows ``vote_deactivate`` to exactly one remediation case (min-raise cleanup). Removing it gives the validator layer freedom to invoke deactivation for any reason the quorum deems valid — min-raise, protocol abuse, operational emergencies — without needing a new on-chain gate per case.

Miner protection against malicious quorum unchanged in practice: the validator set is already trusted for reserve / initiate / confirm / slash paths. If the quorum is compromised, there are bigger problems than one extra deactivate vector.

## Changes

- ``smart-contracts/ink/lib.rs`` — drop the ``if miner_collateral >= self.min_collateral { Err(SufficientCollateral) }`` check from ``vote_deactivate``; keep the ``!miner_active → InvalidStatus`` guard.
- ``smart-contracts/ink/errors.rs`` — remove the now-unused ``SufficientCollateral`` variant.
- ``allways/contract_client.py`` — drop the variant from ``CONTRACT_ERROR_VARIANTS`` (renumbers ``HasActiveSwap`` from 29 → 28, ``CurrentlyReserved`` from 30 → 29). Update ``vote_deactivate`` client docstring.
- ``plans/scoring-simplification-and-contract-hardening.md`` — reflect the simplified semantics (local-only file, not in repo).

## Follow-ups

- entrius/alw-utils PR for suite 21 already pushed: drops the above-floor rejection assertion.

## Test plan

- [x] ``cargo check`` — contract compiles
- [x] ``pytest -q`` — 279 tests pass
- [x] ``ruff check`` — clean
- [ ] Rebuild contract in dev env; E2E suite 21 passes (contract redeploy required because the error enum changed)