### PR TITLE
Retry PendingConfirm null lookups before dropping

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -50,6 +50,10 @@ RESERVATION_COOLDOWN_BLOCKS = 150  # ~30 min base cooldown on failed reservation
 RESERVATION_COOLDOWN_MULTIPLIER = 2  # 150 → 300 → 600 ...
 MAX_RESERVATIONS_PER_ADDRESS = 1
 EXTEND_THRESHOLD_BLOCKS = 20  # ~4 min — vote to extend when this many blocks remain
+# A user's tx is often invisible to a validator's RPC for the first few seconds
+# after submission (mempool propagation lag, regional RPC differences). Treat
+# "not found" as transient until the same entry has polled null this many times.
+PENDING_CONFIRM_NULL_RETRY_LIMIT = 3
 
 # ─── Protocol Fee ──────────────────────────────────────────
 # Hardcoded 1% — matches the contract's immutable FEE_DIVISOR.

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -10,7 +10,11 @@ import bittensor as bt
 from allways.chain_providers.base import ProviderUnreachableError
 from allways.classes import SwapStatus
 from allways.commitments import read_miner_commitments
-from allways.constants import EXTEND_THRESHOLD_BLOCKS, SCORING_WINDOW_BLOCKS
+from allways.constants import (
+    EXTEND_THRESHOLD_BLOCKS,
+    PENDING_CONFIRM_NULL_RETRY_LIMIT,
+    SCORING_WINDOW_BLOCKS,
+)
 from allways.contract_client import ContractError, is_contract_rejection
 from allways.utils.logging import log_on_change
 from allways.validator import voting
@@ -74,11 +78,13 @@ def initialize_pending_user_reservations(self: Validator) -> None:
     from substrateinterface import Keypair
 
     items = self.state_store.get_all()
-    # Drop extend-reservation vote receipts whose pending_confirm has been
-    # removed (vote_initiate landed, tx not found, expired, etc.).
+    # Drop per-entry receipts whose pending_confirm has been removed
+    # (vote_initiate landed, tx not found, expired, etc.).
     live_keys = {(item.miner_hotkey, item.from_tx_hash) for item in items}
     for stale_key in [k for k in self.extend_reservation_voted_at if k not in live_keys]:
         del self.extend_reservation_voted_at[stale_key]
+    for stale_key in [k for k in self.pending_confirm_null_polls if k not in live_keys]:
+        del self.pending_confirm_null_polls[stale_key]
 
     if not items:
         return
@@ -126,11 +132,24 @@ def initialize_pending_user_reservations(self: Validator) -> None:
             continue
 
         if tx_info is None:
+            null_key = (item.miner_hotkey, item.from_tx_hash)
+            attempts = self.pending_confirm_null_polls.get(null_key, 0) + 1
+            if attempts < PENDING_CONFIRM_NULL_RETRY_LIMIT:
+                self.pending_confirm_null_polls[null_key] = attempts
+                bt.logging.info(
+                    f'PendingConfirm [{swap_label} {miner_short}]: tx {item.from_tx_hash[:16]}... '
+                    f'not found (attempt {attempts}/{PENDING_CONFIRM_NULL_RETRY_LIMIT}), retrying'
+                )
+                try_extend_reservation(self, item, current_block, swap_label, miner_short)
+                continue
             self.state_store.remove(item.miner_hotkey)
             bt.logging.warning(
-                f'PendingConfirm [{swap_label} {miner_short}]: tx {item.from_tx_hash[:16]}... not found, dropping'
+                f'PendingConfirm [{swap_label} {miner_short}]: tx {item.from_tx_hash[:16]}... '
+                f'not found after {PENDING_CONFIRM_NULL_RETRY_LIMIT} attempts, dropping'
             )
             continue
+
+        self.pending_confirm_null_polls.pop((item.miner_hotkey, item.from_tx_hash), None)
 
         log_on_change(
             f'confs:{item.miner_hotkey}',

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -73,6 +73,9 @@ class Validator(BaseValidatorNeuron):
         # contract bumps reserved_until past the voted value, so the next
         # extension round is open.
         self.extend_reservation_voted_at: dict[tuple[str, str], int] = {}
+        # (miner_hotkey, from_tx_hash) → consecutive "tx not found" poll count.
+        # Used to absorb mempool propagation lag before dropping a pending entry.
+        self.pending_confirm_null_polls: dict[tuple[str, str], int] = {}
 
         # Event-sourced miner state. ``sync_to(current_block)`` runs each
         # forward step; scoring reads the active set from the watcher's


### PR DESCRIPTION
## Summary

When the validator's `PendingConfirm` loop polls a user's source tx and the chain provider returns `tx_info=None`, the entry is dropped immediately and the reservation expires silently. If the tx is still propagating through the mempool — or the validator's RPC happens to be on a node that hasn't seen it yet — the user's already-sent funds are stranded with no protocol recourse.

This makes `tx_info=None` transient for the first 3 consecutive polls, mirroring the existing handling for `ProviderUnreachableError`: extend the reservation and keep the entry queued. Drop only after the limit. Counter resets on any non-null response.

- `PENDING_CONFIRM_NULL_RETRY_LIMIT = 3` in `constants.py`
- `pending_confirm_null_polls` in-memory counter on `Validator`, mirrors `extend_reservation_voted_at` in shape and lifecycle
- Stale-key cleanup at the top of `initialize_pending_user_reservations` covers both dicts in one pass — no leak

Narrows the still-propagating-tx window without touching the genuinely-not-found path (typo, dropped from mempool) — those still drop, just ~36s later.

## Test plan

- [ ] `ruff format` + `ruff check` pass (verified locally)
- [ ] Existing `tests/test_pending_confirm_queue.py` still passes (state-store-only; unaffected)
- [ ] E2E suite 02 (happy path) — reservation→confirm flow unchanged
- [ ] Manual: stop the validator's BTC RPC briefly during a swap; entry should retry instead of drop