### PR TITLE
Wire missing contract views into CLI, fix fee display, tighten error handling

### DIFF
--- a/allways/cli/swap_commands/admin.py
+++ b/allways/cli/swap_commands/admin.py
@@ -3,7 +3,16 @@
 import click
 
 from allways.cli.help import StyledGroup
-from allways.cli.swap_commands.helpers import SECONDS_PER_BLOCK, console, from_rao, get_cli_context, loading, to_rao
+from allways.cli.swap_commands.helpers import (
+    SECONDS_PER_BLOCK,
+    console,
+    from_rao,
+    get_cli_context,
+    is_valid_ss58,
+    loading,
+    print_contract_error,
+    to_rao,
+)
 from allways.contract_client import ContractError
 
 
@@ -30,7 +39,7 @@ def set_timeout(blocks: int):
     try:
         current = client.get_fulfillment_timeout()
     except ContractError as e:
-        console.print(f'[red]Failed to read fulfillment timeout: {e}[/red]')
+        print_contract_error('Failed to read fulfillment timeout', e)
         return
 
     current_minutes = current * SECONDS_PER_BLOCK / 60
@@ -49,7 +58,7 @@ def set_timeout(blocks: int):
             client.set_fulfillment_timeout(wallet=wallet, blocks=blocks)
         console.print(f'[green]Fulfillment timeout set to {blocks} blocks[/green]\n')
     except ContractError as e:
-        console.print(f'[red]Failed to set fulfillment timeout: {e}[/red]\n')
+        print_contract_error('Failed to set fulfillment timeout', e)
 
 
 @admin_group.command('set-reservation-ttl', show_disclaimer=True)
@@ -69,7 +78,7 @@ def set_reservation_ttl(blocks: int):
     try:
         current = client.get_reservation_ttl()
     except ContractError as e:
-        console.print(f'[red]Failed to read reservation TTL: {e}[/red]')
+        print_contract_error('Failed to read reservation TTL', e)
         return
 
     current_minutes = current * SECONDS_PER_BLOCK / 60
@@ -88,7 +97,7 @@ def set_reservation_ttl(blocks: int):
             client.set_reservation_ttl(wallet=wallet, blocks=blocks)
         console.print(f'[green]Reservation TTL set to {blocks} blocks[/green]\n')
     except ContractError as e:
-        console.print(f'[red]Failed to set reservation TTL: {e}[/red]\n')
+        print_contract_error('Failed to set reservation TTL', e)
 
 
 @admin_group.command('set-min-collateral', show_disclaimer=True)
@@ -110,7 +119,7 @@ def set_min_collateral(amount_tao: float):
     try:
         current_rao = client.get_min_collateral()
     except ContractError as e:
-        console.print(f'[red]Failed to read min collateral: {e}[/red]')
+        print_contract_error('Failed to read min collateral', e)
         return
 
     console.print('\n[bold]Set Minimum Collateral[/bold]\n')
@@ -126,7 +135,7 @@ def set_min_collateral(amount_tao: float):
             client.set_min_collateral_amount(wallet=wallet, amount_rao=amount_rao)
         console.print(f'[green]Minimum collateral set to {amount_tao:.4f} TAO[/green]\n')
     except ContractError as e:
-        console.print(f'[red]Failed to set minimum collateral: {e}[/red]\n')
+        print_contract_error('Failed to set minimum collateral', e)
 
 
 @admin_group.command('set-max-collateral', show_disclaimer=True)
@@ -149,7 +158,7 @@ def set_max_collateral(amount_tao: float):
     try:
         current_rao = client.get_max_collateral()
     except ContractError as e:
-        console.print(f'[red]Failed to read max collateral: {e}[/red]')
+        print_contract_error('Failed to read max collateral', e)
         return
 
     console.print('\n[bold]Set Maximum Collateral[/bold]\n')
@@ -165,7 +174,7 @@ def set_max_collateral(amount_tao: float):
             client.set_max_collateral_amount(wallet=wallet, amount_rao=amount_rao)
         console.print(f'[green]Maximum collateral set to {amount_tao:.4f} TAO[/green]\n')
     except ContractError as e:
-        console.print(f'[red]Failed to set maximum collateral: {e}[/red]\n')
+        print_contract_error('Failed to set maximum collateral', e)
 
 
 @admin_group.command('set-min-swap', show_disclaimer=True)
@@ -188,7 +197,7 @@ def set_min_swap(amount_tao: float):
     try:
         current_rao = client.get_min_swap_amount()
     except ContractError as e:
-        console.print(f'[red]Failed to read min swap amount: {e}[/red]')
+        print_contract_error('Failed to read min swap amount', e)
         return
 
     console.print('\n[bold]Set Minimum Swap Amount[/bold]\n')
@@ -204,7 +213,7 @@ def set_min_swap(amount_tao: float):
             client.set_min_swap_amount(wallet=wallet, amount_rao=amount_rao)
         console.print(f'[green]Minimum swap amount set to {amount_tao:.4f} TAO[/green]\n')
     except ContractError as e:
-        console.print(f'[red]Failed to set minimum swap amount: {e}[/red]\n')
+        print_contract_error('Failed to set minimum swap amount', e)
 
 
 @admin_group.command('set-max-swap', show_disclaimer=True)
@@ -227,7 +236,7 @@ def set_max_swap(amount_tao: float):
     try:
         current_rao = client.get_max_swap_amount()
     except ContractError as e:
-        console.print(f'[red]Failed to read max swap amount: {e}[/red]')
+        print_contract_error('Failed to read max swap amount', e)
         return
 
     console.print('\n[bold]Set Maximum Swap Amount[/bold]\n')
@@ -243,7 +252,7 @@ def set_max_swap(amount_tao: float):
             client.set_max_swap_amount(wallet=wallet, amount_rao=amount_rao)
         console.print(f'[green]Maximum swap amount set to {amount_tao:.4f} TAO[/green]\n')
     except ContractError as e:
-        console.print(f'[red]Failed to set maximum swap amount: {e}[/red]\n')
+        print_contract_error('Failed to set maximum swap amount', e)
 
 
 @admin_group.command('set-threshold', show_disclaimer=True)
@@ -263,7 +272,7 @@ def set_threshold(percent: int):
     try:
         current = client.get_consensus_threshold()
     except ContractError as e:
-        console.print(f'[red]Failed to read threshold: {e}[/red]')
+        print_contract_error('Failed to read threshold', e)
         return
 
     console.print('\n[bold]Set Consensus Threshold[/bold]\n')
@@ -279,7 +288,7 @@ def set_threshold(percent: int):
             client.set_consensus_threshold(wallet=wallet, percent=percent)
         console.print(f'[green]Consensus threshold set to {percent}%[/green]\n')
     except ContractError as e:
-        console.print(f'[red]Failed to set consensus threshold: {e}[/red]\n')
+        print_contract_error('Failed to set consensus threshold', e)
 
 
 @admin_group.command('add-vali', show_disclaimer=True)
@@ -295,7 +304,7 @@ def add_vali(hotkey: str):
     try:
         already_registered = client.is_validator(hotkey)
     except ContractError as e:
-        console.print(f'[red]Failed to check validator status: {e}[/red]')
+        print_contract_error('Failed to check validator status', e)
         return
 
     console.print('\n[bold]Add Validator[/bold]\n')
@@ -315,7 +324,7 @@ def add_vali(hotkey: str):
             client.add_validator(wallet=wallet, validator=hotkey)
         console.print(f'[green]Validator {hotkey} added[/green]\n')
     except ContractError as e:
-        console.print(f'[red]Failed to add validator: {e}[/red]\n')
+        print_contract_error('Failed to add validator', e)
 
 
 @admin_group.command('remove-vali', show_disclaimer=True)
@@ -331,7 +340,7 @@ def remove_vali(hotkey: str):
     try:
         is_registered = client.is_validator(hotkey)
     except ContractError as e:
-        console.print(f'[red]Failed to check validator status: {e}[/red]')
+        print_contract_error('Failed to check validator status', e)
         return
 
     console.print('\n[bold]Remove Validator[/bold]\n')
@@ -351,7 +360,7 @@ def remove_vali(hotkey: str):
             client.remove_validator(wallet=wallet, validator=hotkey)
         console.print(f'[green]Validator {hotkey} removed[/green]\n')
     except ContractError as e:
-        console.print(f'[red]Failed to remove validator: {e}[/red]\n')
+        print_contract_error('Failed to remove validator', e)
 
 
 @admin_group.command('set-recycle-address', show_disclaimer=True)
@@ -362,10 +371,25 @@ def set_recycle_address(account_id: str):
     [dim]Examples:
         $ alw admin set-recycle-address 5Cxyz...[/dim]
     """
+    if not is_valid_ss58(account_id):
+        console.print('[red]Not a valid SS58 address[/red]')
+        return
+
     _, wallet, _, client = get_cli_context()
 
+    try:
+        current = client.get_recycle_address()
+    except ContractError:
+        current = ''
+
     console.print('\n[bold]Set Recycle Address[/bold]\n')
-    console.print(f'  Address: {account_id}\n')
+    if current:
+        console.print(f'  Current: {current}')
+    console.print(f'  New:     {account_id}\n')
+
+    if current == account_id:
+        console.print('[yellow]This address is already set. Nothing to do.[/yellow]')
+        return
 
     if not click.confirm('Confirm?'):
         console.print('[yellow]Cancelled[/yellow]')
@@ -376,7 +400,7 @@ def set_recycle_address(account_id: str):
             client.set_recycle_address(wallet=wallet, address=account_id)
         console.print(f'[green]Recycle address set to {account_id}[/green]\n')
     except ContractError as e:
-        console.print(f'[red]Failed to set recycle address: {e}[/red]\n')
+        print_contract_error('Failed to set recycle address', e)
 
 
 @admin_group.command('recycle-fees', show_disclaimer=True)
@@ -388,8 +412,22 @@ def recycle_fees():
     """
     _, wallet, _, client = get_cli_context()
 
+    try:
+        accumulated = client.get_accumulated_fees()
+        destination = client.get_recycle_address()
+        total_recycled = client.get_total_recycled_fees()
+    except ContractError as e:
+        print_contract_error('Failed to read fee state', e)
+        return
+
     console.print('\n[bold]Recycle Fees[/bold]\n')
-    console.print('  Action: transfer all accumulated fees to recycle address\n')
+    console.print(f'  Amount:       {from_rao(accumulated):.6f} TAO')
+    console.print(f'  Destination:  {destination}')
+    console.print(f'  Total recycled so far: {from_rao(total_recycled):.6f} TAO\n')
+
+    if accumulated == 0:
+        console.print('[yellow]No fees to recycle.[/yellow]')
+        return
 
     if not click.confirm('Confirm recycling fees?'):
         console.print('[yellow]Cancelled[/yellow]')
@@ -398,9 +436,9 @@ def recycle_fees():
     try:
         with loading('Submitting transaction...'):
             client.recycle_fees(wallet=wallet)
-        console.print('[green]Fees recycled successfully[/green]\n')
+        console.print(f'[green]Recycled {from_rao(accumulated):.6f} TAO to {destination}[/green]\n')
     except ContractError as e:
-        console.print(f'[red]Failed to recycle fees: {e}[/red]\n')
+        print_contract_error('Failed to recycle fees', e)
 
 
 @admin_group.command('transfer-ownership', show_disclaimer=True)
@@ -411,12 +449,20 @@ def transfer_ownership(account_id: str):
     [dim]Examples:
         $ alw admin transfer-ownership 5Cxyz...[/dim]
     """
+    if not is_valid_ss58(account_id):
+        console.print('[red]Not a valid SS58 address[/red]')
+        return
+
     _, wallet, _, client = get_cli_context()
 
     try:
         current_owner = client.get_owner()
     except ContractError as e:
-        console.print(f'[red]Failed to read current owner: {e}[/red]')
+        print_contract_error('Failed to read current owner', e)
+        return
+
+    if current_owner == account_id:
+        console.print('[yellow]This account is already the owner. Nothing to do.[/yellow]')
         return
 
     console.print('\n[bold red]Transfer Ownership[/bold red]\n')
@@ -434,7 +480,7 @@ def transfer_ownership(account_id: str):
             client.transfer_ownership(wallet=wallet, new_owner=account_id)
         console.print(f'[green]Ownership transferred to {account_id}[/green]\n')
     except ContractError as e:
-        console.print(f'[red]Failed to transfer ownership: {e}[/red]\n')
+        print_contract_error('Failed to transfer ownership', e)
 
 
 @click.group('danger', cls=StyledGroup, show_disclaimer=True)
@@ -457,16 +503,22 @@ def halt_system():
     try:
         already_halted = client.get_halted()
     except ContractError as e:
-        console.print(f'[red]Failed to read halt status: {e}[/red]')
+        print_contract_error('Failed to read halt status', e)
         return
 
     if already_halted:
         console.print('[yellow]System is already halted[/yellow]')
         return
 
+    try:
+        active_swaps = client.get_active_swaps()
+    except ContractError:
+        active_swaps = []
+
     console.print('\n[bold red]Halt System[/bold red]\n')
     console.print('  This will block all new swap reservations.')
     console.print('  Existing swaps will continue to completion.\n')
+    console.print(f'  In-flight swaps that will be unaffected: {len(active_swaps)}\n')
 
     if not click.confirm('Confirm halting the system?'):
         console.print('[yellow]Cancelled[/yellow]')
@@ -477,7 +529,7 @@ def halt_system():
             client.set_halted(wallet=wallet, halted=True)
         console.print('[red]System is now halted — no new reservations[/red]\n')
     except ContractError as e:
-        console.print(f'[red]Failed to halt system: {e}[/red]\n')
+        print_contract_error('Failed to halt system', e)
 
 
 @danger_group.command('resume', show_disclaimer=True)
@@ -492,7 +544,7 @@ def resume_system():
     try:
         is_halted = client.get_halted()
     except ContractError as e:
-        console.print(f'[red]Failed to read halt status: {e}[/red]')
+        print_contract_error('Failed to read halt status', e)
         return
 
     if not is_halted:
@@ -511,7 +563,7 @@ def resume_system():
             client.set_halted(wallet=wallet, halted=False)
         console.print('[green]System resumed — new reservations are now allowed[/green]\n')
     except ContractError as e:
-        console.print(f'[red]Failed to resume system: {e}[/red]\n')
+        print_contract_error('Failed to resume system', e)
 
 
 admin_group.add_command(danger_group)

--- a/allways/cli/swap_commands/claim.py
+++ b/allways/cli/swap_commands/claim.py
@@ -3,7 +3,7 @@
 import click
 
 from allways.cli.help import StyledCommand
-from allways.cli.swap_commands.helpers import console, from_rao, get_cli_context, loading
+from allways.cli.swap_commands.helpers import console, from_rao, get_cli_context, loading, print_contract_error
 from allways.contract_client import ContractError
 
 
@@ -26,7 +26,7 @@ def claim_command(swap_id: int, yes: bool):
     try:
         pending_rao = client.get_pending_slash(swap_id)
     except ContractError as e:
-        console.print(f'[red]Failed to read pending slash: {e}[/red]')
+        print_contract_error('Failed to read pending slash', e)
         return
 
     if pending_rao == 0:
@@ -46,4 +46,4 @@ def claim_command(swap_id: int, yes: bool):
             client.claim_slash(wallet=wallet, swap_id=swap_id)
         console.print(f'[green]Successfully claimed {from_rao(pending_rao):.4f} TAO from swap #{swap_id}![/green]\n')
     except ContractError as e:
-        console.print(f'[red]Failed to claim slash: {e}[/red]\n')
+        print_contract_error('Failed to claim slash', e)

--- a/allways/cli/swap_commands/collateral.py
+++ b/allways/cli/swap_commands/collateral.py
@@ -4,9 +4,17 @@ import click
 from rich.table import Table
 
 from allways.cli.help import StyledGroup
-from allways.cli.swap_commands.helpers import SECONDS_PER_BLOCK, console, from_rao, get_cli_context, loading, to_rao
+from allways.cli.swap_commands.helpers import (
+    SECONDS_PER_BLOCK,
+    console,
+    from_rao,
+    get_cli_context,
+    loading,
+    print_contract_error,
+    to_rao,
+)
 from allways.constants import MIN_BALANCE_FOR_TX_RAO, MIN_COLLATERAL_TAO
-from allways.contract_client import ContractError
+from allways.contract_client import ContractError, is_contract_rejection
 
 
 @click.group('collateral', cls=StyledGroup, show_disclaimer=True)
@@ -66,6 +74,12 @@ def collateral_deposit(amount: float | None, yes: bool):
             )
             return
     except ContractError as e:
+        # Contract rejection on a read means the contract told us this
+        # deposit is invalid (e.g. ExceedsMaxCollateral) — abort. A plain
+        # RPC failure is transient, so we warn and continue.
+        if is_contract_rejection(e):
+            print_contract_error('Pre-flight check rejected deposit', e)
+            return
         console.print(f'[yellow]Warning: pre-flight check failed ({e}), proceeding anyway[/yellow]')
     except Exception as e:
         console.print(f'[yellow]Warning: balance check failed ({e}), proceeding anyway[/yellow]')
@@ -79,7 +93,7 @@ def collateral_deposit(amount: float | None, yes: bool):
             client.post_collateral(wallet=wallet, amount_rao=amount_rao)
         console.print(f'[green]Successfully deposited {amount} TAO collateral![/green]')
     except ContractError as e:
-        console.print(f'[red]Failed to deposit collateral: {e}[/red]')
+        print_contract_error('Failed to deposit collateral', e)
 
 
 @collateral_group.command('withdraw', show_disclaimer=True)
@@ -149,6 +163,9 @@ def collateral_withdraw(amount: float | None, yes: bool):
             )
             return
     except ContractError as e:
+        if is_contract_rejection(e):
+            print_contract_error('Pre-flight check rejected withdrawal', e)
+            return
         console.print(f'[yellow]Warning: pre-flight check failed ({e}), proceeding anyway[/yellow]')
     except Exception as e:
         console.print(f'[yellow]Warning: pre-flight check failed ({e}), proceeding anyway[/yellow]')
@@ -162,7 +179,7 @@ def collateral_withdraw(amount: float | None, yes: bool):
             client.withdraw_collateral(wallet=wallet, amount_rao=amount_rao)
         console.print(f'[green]Successfully withdrew {amount} TAO collateral![/green]')
     except ContractError as e:
-        console.print(f'[red]Failed to withdraw collateral: {e}[/red]')
+        print_contract_error('Failed to withdraw collateral', e)
 
 
 @collateral_group.command('view')
@@ -184,7 +201,7 @@ def collateral_view(hotkey: str):
             collateral_rao = client.get_miner_collateral(hotkey)
             is_active = client.get_miner_active_flag(hotkey)
     except ContractError as e:
-        console.print(f'[red]Failed to read collateral: {e}[/red]')
+        print_contract_error('Failed to read collateral', e)
         return
 
     console.print('\n[bold]Collateral Status[/bold]\n')

--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -13,7 +13,7 @@ from allways.classes import MinerPair, SwapStatus
 from allways.commitments import parse_commitment_data, read_miner_commitment, read_miner_commitments  # noqa: F401
 from allways.constants import CONTRACT_ADDRESS as DEFAULT_CONTRACT_ADDRESS
 from allways.constants import NETUID_FINNEY, TAO_TO_RAO
-from allways.contract_client import AllwaysContractClient
+from allways.contract_client import AllwaysContractClient, ContractError, is_contract_rejection
 
 ALLWAYS_DIR = Path.home() / '.allways'
 CONFIG_FILE = ALLWAYS_DIR / 'config.json'
@@ -34,6 +34,37 @@ SWAP_STATUS_COLORS = {
 def loading(message: str, spinner: str = 'dots', color: str = 'cyan'):
     """Return a Rich spinner context manager for long-running operations."""
     return console.status(f'[{color}]{message}[/{color}]', spinner=spinner, spinner_style=color)
+
+
+def print_contract_error(action: str, e: BaseException) -> None:
+    """Print a contract error with contract-rejection vs RPC-failure distinction.
+
+    Contract rejections (NotOwner, NotValidator, InvalidStatus, etc.) are the
+    user's expected failure mode for bad state and we surface the variant
+    name plainly. RPC or client-side failures get a retryable framing so the
+    user knows to check connectivity rather than their input.
+    """
+    if isinstance(e, ContractError) and is_contract_rejection(e):
+        console.print(f'[red]{action}: contract rejected — {e}[/red]')
+    else:
+        console.print(f'[red]{action}: {e}[/red]')
+        console.print('[dim]This looks like an RPC or client failure — try again.[/dim]')
+
+
+def is_valid_ss58(address: str) -> bool:
+    """Check if a string is a syntactically valid SS58 address.
+
+    Does not verify the account exists on-chain — only that the encoding is
+    well-formed. Useful as a pre-flight guard before submitting an admin
+    extrinsic whose typo would silently fail.
+    """
+    try:
+        from scalecodec.utils.ss58 import ss58_decode
+
+        ss58_decode(address)
+        return True
+    except Exception:
+        return False
 
 
 # Global flags that can appear anywhere in the command line.

--- a/allways/cli/swap_commands/miner_commands.py
+++ b/allways/cli/swap_commands/miner_commands.py
@@ -14,6 +14,7 @@ from allways.cli.swap_commands.helpers import (
     from_rao,
     get_cli_context,
     loading,
+    print_contract_error,
     read_miner_commitment,
 )
 from allways.contract_client import ContractError
@@ -50,7 +51,7 @@ def miner_status(hotkey: str):
             is_active = client.get_miner_active_flag(hotkey)
             has_active_swap = client.get_miner_has_active_swap(hotkey)
     except ContractError as e:
-        console.print(f'[red]Failed to read miner data: {e}[/red]')
+        print_contract_error('Failed to read miner data', e)
         return
 
     table = Table(title='Collateral & Status', show_header=True)
@@ -260,7 +261,7 @@ def miner_deactivate():
             f'[dim]Collateral withdrawal available after {timeout * 2} blocks (~{timeout * 2 * 12 // 60} min)[/dim]\n'
         )
     except ContractError as e:
-        console.print(f'[red]Failed to deactivate: {e}[/red]\n')
+        print_contract_error('Failed to deactivate', e)
 
 
 @miner_group.command('mark-fulfilled')
@@ -303,4 +304,4 @@ def miner_mark_fulfilled(swap_id: int, tx_hash: str, amount: int, block: int, ye
             )
         console.print(f'[green]Swap #{swap_id} marked as fulfilled[/green] (tx: {result[:16]}...)\n')
     except ContractError as e:
-        console.print(f'[red]Failed to mark fulfilled: {e}[/red]\n')
+        print_contract_error('Failed to mark fulfilled', e)

--- a/allways/cli/swap_commands/post_tx.py
+++ b/allways/cli/swap_commands/post_tx.py
@@ -11,6 +11,7 @@ from allways.cli.swap_commands.helpers import (
     console,
     get_cli_context,
     load_pending_swap,
+    print_contract_error,
 )
 from allways.cli.swap_commands.swap import from_smallest_unit, poll_for_swap_creation, sign_and_broadcast_confirm
 from allways.constants import NETUID_FINNEY
@@ -45,7 +46,7 @@ def post_tx_command(tx_hash: str, netuid: int):
         reserved_until = client.get_miner_reserved_until(state.miner_hotkey)
         current_block = subtensor.get_current_block()
     except ContractError as e:
-        console.print(f'[red]Failed to read reservation status: {e}[/red]')
+        print_contract_error('Failed to read reservation status', e)
         return
 
     if reserved_until <= current_block:

--- a/allways/cli/swap_commands/quote.py
+++ b/allways/cli/swap_commands/quote.py
@@ -16,7 +16,7 @@ from allways.cli.swap_commands.helpers import (
 )
 from allways.constants import FEE_DIVISOR
 from allways.contract_client import ContractError
-from allways.utils.rate import apply_fee_deduction, calculate_to_amount
+from allways.utils.rate import apply_fee_deduction, calculate_to_amount, check_swap_viability, derive_tao_leg
 
 
 @click.command('quote')
@@ -107,13 +107,41 @@ def quote_command(from_chain: str, to_chain: str, amount: float):
     canon_from_decimals = get_chain(canon_from).decimals
     dst_chain_def = get_chain(to_chain)
 
-    # Contract-side bounds. Missing bounds mean unlimited (0 sentinel).
+    # Contract-side bounds are global — check before per-miner viability so
+    # a user who requested an out-of-bounds amount gets one clear reason
+    # instead of N rows each blaming collateral. Bounds are enforced against
+    # the TAO leg (see vote_reserve in lib.rs).
     try:
         min_swap_rao = client.get_min_swap_amount()
         max_swap_rao = client.get_max_swap_amount()
     except ContractError:
         min_swap_rao = 0
         max_swap_rao = 0
+
+    # Global bounds (min/max swap) are the same for every miner — check once
+    # up front so a bounds-violating amount gets one clear reason instead of
+    # N rows each blaming collateral. Use any row's rate to derive the TAO
+    # leg; only the direction matters, not the miner.
+    sample_pair = available[0][0]
+    sample_to_amount = calculate_to_amount(
+        from_amount, sample_pair.rate_str, is_reverse, canon_to_decimals, canon_from_decimals
+    )
+    request_tao_rao = derive_tao_leg(from_chain, from_amount, to_chain, sample_to_amount)
+
+    if min_swap_rao > 0 and request_tao_rao < min_swap_rao:
+        console.print(
+            f'\n[red]Amount below contract minimum: {from_rao(request_tao_rao):.4f} TAO equivalent '
+            f'< {from_rao(min_swap_rao):.4f} TAO min.[/red]\n'
+            f'[dim]No miner can accept this — increase --amount.[/dim]\n'
+        )
+        return
+    if max_swap_rao > 0 and request_tao_rao > max_swap_rao:
+        console.print(
+            f'\n[red]Amount above contract maximum: {from_rao(request_tao_rao):.4f} TAO equivalent '
+            f'> {from_rao(max_swap_rao):.4f} TAO max.[/red]\n'
+            f'[dim]No miner can accept this — decrease --amount.[/dim]\n'
+        )
+        return
 
     console.print(f'\n[bold]Quote: {amount} {from_chain.upper()} -> {to_chain.upper()}[/bold]\n')
 
@@ -131,24 +159,13 @@ def quote_command(from_chain: str, to_chain: str, amount: float):
         user_receives = apply_fee_deduction(to_amount, fee_divisor)
         human_receives = user_receives / (10**dst_chain_def.decimals)
 
-        # tao_amount per contract's vote_initiate: the TAO side of the swap
-        # regardless of direction.
-        if from_chain == 'tao':
-            tao_amount_rao = from_amount
-        elif to_chain == 'tao':
-            tao_amount_rao = to_amount
-        else:
-            tao_amount_rao = 0
-
-        if tao_amount_rao > collateral:
-            status = f'[red]insufficient collateral ({from_rao(tao_amount_rao):.4f} TAO needed)[/red]'
-        elif min_swap_rao > 0 and tao_amount_rao < min_swap_rao:
-            status = f'[red]below min swap ({from_rao(min_swap_rao):.4f} TAO)[/red]'
-        elif max_swap_rao > 0 and tao_amount_rao > max_swap_rao:
-            status = f'[red]above max swap ({from_rao(max_swap_rao):.4f} TAO)[/red]'
-        else:
+        tao_amount_rao = derive_tao_leg(from_chain, from_amount, to_chain, to_amount)
+        viable, reason = check_swap_viability(tao_amount_rao, collateral, min_swap_rao, max_swap_rao)
+        if viable:
             status = '[green]available[/green]'
             viable_count += 1
+        else:
+            status = f'[red]{reason}[/red]'
 
         table.add_row(
             str(idx),

--- a/allways/cli/swap_commands/quote.py
+++ b/allways/cli/swap_commands/quote.py
@@ -107,6 +107,14 @@ def quote_command(from_chain: str, to_chain: str, amount: float):
     canon_from_decimals = get_chain(canon_from).decimals
     dst_chain_def = get_chain(to_chain)
 
+    # Contract-side bounds. Missing bounds mean unlimited (0 sentinel).
+    try:
+        min_swap_rao = client.get_min_swap_amount()
+        max_swap_rao = client.get_max_swap_amount()
+    except ContractError:
+        min_swap_rao = 0
+        max_swap_rao = 0
+
     console.print(f'\n[bold]Quote: {amount} {from_chain.upper()} -> {to_chain.upper()}[/bold]\n')
 
     table = Table(show_header=True)
@@ -115,11 +123,32 @@ def quote_command(from_chain: str, to_chain: str, amount: float):
     table.add_column(f'Rate ({to_chain.upper()}/{from_chain.upper()})', style='green')
     table.add_column('You Receive', style='bold green')
     table.add_column('Collateral', style='yellow')
+    table.add_column('Status', style='bold')
 
+    viable_count = 0
     for idx, (pair, collateral) in enumerate(available, 1):
         to_amount = calculate_to_amount(from_amount, pair.rate_str, is_reverse, canon_to_decimals, canon_from_decimals)
         user_receives = apply_fee_deduction(to_amount, fee_divisor)
         human_receives = user_receives / (10**dst_chain_def.decimals)
+
+        # tao_amount per contract's vote_initiate: the TAO side of the swap
+        # regardless of direction.
+        if from_chain == 'tao':
+            tao_amount_rao = from_amount
+        elif to_chain == 'tao':
+            tao_amount_rao = to_amount
+        else:
+            tao_amount_rao = 0
+
+        if tao_amount_rao > collateral:
+            status = f'[red]insufficient collateral ({from_rao(tao_amount_rao):.4f} TAO needed)[/red]'
+        elif min_swap_rao > 0 and tao_amount_rao < min_swap_rao:
+            status = f'[red]below min swap ({from_rao(min_swap_rao):.4f} TAO)[/red]'
+        elif max_swap_rao > 0 and tao_amount_rao > max_swap_rao:
+            status = f'[red]above max swap ({from_rao(max_swap_rao):.4f} TAO)[/red]'
+        else:
+            status = '[green]available[/green]'
+            viable_count += 1
 
         table.add_row(
             str(idx),
@@ -127,7 +156,15 @@ def quote_command(from_chain: str, to_chain: str, amount: float):
             f'{pair.rate:g}',
             f'{human_receives:.8f} {to_chain.upper()}',
             f'{from_rao(collateral):.4f} TAO',
+            status,
         )
 
     console.print(table)
-    console.print(f'  [dim](after {fee_pct:g}% fee)[/dim]\n')
+    console.print(f'  [dim](after {fee_pct:g}% fee)[/dim]')
+    if viable_count == 0:
+        console.print(
+            '  [yellow]No miner can fulfill this swap at the requested amount — try a smaller amount '
+            'or wait for more collateral to be posted.[/yellow]\n'
+        )
+    else:
+        console.print()

--- a/allways/cli/swap_commands/quote.py
+++ b/allways/cli/swap_commands/quote.py
@@ -20,33 +20,50 @@ from allways.utils.rate import apply_fee_deduction, calculate_to_amount
 
 
 @click.command('quote')
-@click.option('--from', 'from_chain', required=True, type=str, help='Source chain (e.g. btc, tao)')
-@click.option('--to', 'to_chain', required=True, type=str, help='Destination chain (e.g. btc, tao)')
-@click.option('--amount', required=True, type=float, help='Amount to send in source chain units')
+@click.option('--from', 'from_chain', default=None, type=str, help='Source chain (e.g. btc, tao)')
+@click.option('--to', 'to_chain', default=None, type=str, help='Destination chain (e.g. btc, tao)')
+@click.option('--amount', default=None, type=float, help='Amount to send in source chain units')
 def quote_command(from_chain: str, to_chain: str, amount: float):
     """Preview rates and estimated receive amounts for a swap.
 
     \b
     Shows all available miners, their rates, and what you would receive
-    after fees — without committing to a swap.
+    after fees — without committing to a swap. Omit any flag to be prompted.
 
     \b
     Examples:
+        alw swap quote
         alw swap quote --from btc --to tao --amount 0.1
         alw swap quote --from tao --to btc --amount 50
     """
-    from_chain = from_chain.lower()
-    to_chain = to_chain.lower()
+    supported = sorted(SUPPORTED_CHAINS.keys())
+    chain_choices = click.Choice(supported, case_sensitive=False)
 
+    if not from_chain:
+        from_chain = click.prompt(f'Source chain ({"/".join(supported)})', type=chain_choices)
+    from_chain = from_chain.lower()
     if from_chain not in SUPPORTED_CHAINS:
         console.print(f'[red]Unknown source chain: {from_chain}[/red]')
         return
+
+    if not to_chain:
+        remaining = [c for c in supported if c != from_chain]
+        default_to = remaining[0] if remaining else None
+        to_chain = click.prompt(
+            f'Destination chain ({"/".join(remaining) if remaining else ""})',
+            type=click.Choice(remaining, case_sensitive=False) if remaining else chain_choices,
+            default=default_to,
+        )
+    to_chain = to_chain.lower()
     if to_chain not in SUPPORTED_CHAINS:
         console.print(f'[red]Unknown destination chain: {to_chain}[/red]')
         return
     if from_chain == to_chain:
         console.print('[red]Source and destination chains must be different[/red]')
         return
+
+    if amount is None:
+        amount = click.prompt(f'Amount to send ({from_chain.upper()})', type=float)
     if amount <= 0:
         console.print('[red]Amount must be positive[/red]')
         return

--- a/allways/cli/swap_commands/resume.py
+++ b/allways/cli/swap_commands/resume.py
@@ -113,8 +113,15 @@ def resume_command(from_tx_hash_opt: Optional[str], skip_confirm: bool, netuid: 
         return
 
     if not reservation_active:
+        # Reservation is cleared either on expiry or when vote_initiate succeeds.
+        # A silent initiate means the swap is already in flight or has completed —
+        # surface both possibilities rather than assuming expiry.
         clear_pending_swap()
-        console.print('\n[red]Reservation has expired.[/red]')
+        console.print('\n[yellow]Reservation is no longer active.[/yellow]')
+        console.print(
+            '[dim]Either the reservation expired, or your swap already initiated and may be in progress '
+            'or completed. Check with: alw view swaps[/dim]\n'
+        )
         console.print('[dim]Start a new swap with: alw swap now[/dim]')
         return
 

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -81,7 +81,7 @@ def sign_and_broadcast_confirm(
             from_key,
         )
     except Exception as e:
-        console.print(f'[red]Failed to sign source proof: {e}[/red]')
+        console.print(f'[red]Failed to sign source proof ({type(e).__name__}): {e}[/red]')
         return 0, 0
 
     if not from_proof:
@@ -169,7 +169,7 @@ def broadcast_reserve_with_retry(
             from_key,
         )
     except Exception as e:
-        console.print(f'[red]Failed to sign source address proof: {e}[/red]')
+        console.print(f'[red]Failed to sign source address proof ({type(e).__name__}): {e}[/red]')
         return None
 
     if not from_address_proof:
@@ -237,7 +237,7 @@ def broadcast_reserve_with_retry(
                 continue
             return None
 
-        with console.status(f'[dim]Waiting for quorum ({accepted} votes submitted)...[/dim]'):
+        with console.status(f'[dim]Waiting for quorum ({accepted} votes submitted)...[/dim]') as status:
             quorum_errors = 0
             for _ in range(30):
                 time.sleep(2)
@@ -246,6 +246,11 @@ def broadcast_reserve_with_retry(
                     if reserved_until > current_block:
                         reserved = True
                         break
+                    vote_count = client.get_pending_reserve_vote_count(selected_pair.hotkey)
+                    status.update(
+                        f'[dim]Waiting for quorum — {vote_count} on-chain vote(s) so far '
+                        f'({accepted} broadcast)...[/dim]'
+                    )
                     quorum_errors = 0
                 except ContractError:
                     quorum_errors += 1
@@ -285,14 +290,13 @@ def display_receipt(swap):
     dst_human = swap.to_amount / (10**dst_chain_def.decimals)
     tao_human = swap.tao_amount / (10**9)
 
-    # Calculate fee
-    fee_divisor = 100  # 1% fee
-    if swap.to_chain == 'tao':
-        fee_human = tao_human / fee_divisor
-        fee_unit = 'TAO'
-    else:
-        fee_human = dst_human / fee_divisor
-        fee_unit = swap.to_chain.upper()
+    # swap.to_amount is the post-fee amount the miner sent (see
+    # fulfillment.py::send_dest_funds). The raw rate-quoted amount was
+    # to_amount / (1 - 1/FEE_DIVISOR), and the protocol fee is 1/FEE_DIVISOR
+    # of that raw amount. Shown in TAO since that's the side the fee is
+    # recorded against (mirrors accumulated_fees on-chain).
+    fee_pct = 100 / FEE_DIVISOR
+    protocol_fee_tao = tao_human / FEE_DIVISOR
 
     src_tx = swap.from_tx_hash[:20] + '...' if len(swap.from_tx_hash) > 20 else swap.from_tx_hash
     dst_tx = swap.to_tx_hash[:20] + '...' if len(swap.to_tx_hash) > 20 else swap.to_tx_hash
@@ -300,7 +304,7 @@ def display_receipt(swap):
     receipt = (
         f'  [green]Sent:      {src_human:g} {swap.from_chain.upper()}[/green]\n'
         f'  [green]Received:  {dst_human:.8f} {swap.to_chain.upper()}[/green]\n'
-        f'  [dim]Fee:       {fee_human:.8f} {fee_unit} (1%)[/dim]\n'
+        f'  [dim]Protocol fee: {protocol_fee_tao:.6f} TAO ({fee_pct:g}% of swap)[/dim]\n'
         f'\n'
         f'  Source TX: [cyan]{src_tx}[/cyan]\n'
         f'  Dest TX:   [cyan]{dst_tx}[/cyan]\n'
@@ -637,6 +641,11 @@ def swap_now_command(
     fee_percent = 100 / fee_divisor
 
     # Step 5: Enter receive address
+    if not receive_address_opt:
+        console.print(
+            f'  [dim]Enter only your PUBLIC {to_chain.upper()} address. '
+            f'Never paste a private key, seed phrase, or WIF here.[/dim]'
+        )
     receive_address = receive_address_opt or click.prompt(f'Your {to_chain.upper()} receive address')
     to_provider = chain_providers.get(to_chain)
     if to_provider and hasattr(to_provider, 'is_valid_address') and not to_provider.is_valid_address(receive_address):
@@ -649,6 +658,9 @@ def swap_now_command(
         user_from_address = wallet.coldkeypub.ss58_address
         console.print(f'  Source: [dim]{user_from_address}[/dim] (from wallet)')
     else:
+        console.print(
+            f'  [dim]Enter only your PUBLIC {from_chain.upper()} address. Never paste a private key or WIF here.[/dim]'
+        )
         user_from_address = click.prompt(f'Your {from_chain.upper()} source address')
 
     # Step 6b: Verify sender has enough funds
@@ -779,7 +791,7 @@ def swap_now_command(
                     )
                 console.print(f'[green]TAO sent (tx: {from_tx_hash[:16]}...)[/green]')
             except Exception as e:
-                console.print(f'[red]Transfer error: {e}[/red]')
+                console.print(f'[red]Transfer error ({type(e).__name__}): {e}[/red]')
                 console.print('[yellow]Resume with: alw swap post-tx <tx_hash>[/yellow]')
                 return
         else:

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -30,7 +30,7 @@ from allways.commitments import read_miner_commitments
 from allways.constants import FEE_DIVISOR, NETUID_FINNEY
 from allways.contract_client import ContractError
 from allways.synapses import SwapConfirmSynapse, SwapReserveSynapse
-from allways.utils.rate import apply_fee_deduction, calculate_to_amount
+from allways.utils.rate import apply_fee_deduction, calculate_to_amount, check_swap_viability, derive_tao_leg
 
 
 def to_smallest_unit(amount: float, chain_id: str) -> int:
@@ -610,31 +610,29 @@ def swap_now_command(
         f' (after {preview_fee_pct:g}% fee)'
     )
 
-    if from_chain == 'tao':
-        tao_amount = from_amount
-    elif to_chain == 'tao':
-        tao_amount = to_amount
-    else:
-        tao_amount = 0
+    tao_amount = derive_tao_leg(from_chain, from_amount, to_chain, to_amount)
 
-    # Validate against contract min/max swap bounds
+    # Validate against contract min/max swap bounds + selected miner's
+    # collateral. Mirrors vote_reserve (bounds) and vote_initiate
+    # (collateral) so we fail loudly here instead of after the user has
+    # reserved and sent funds.
     try:
         min_swap = client.get_min_swap_amount()
         max_swap = client.get_max_swap_amount()
-        if min_swap > 0 and tao_amount < min_swap:
-            console.print(
-                f'[red]Amount too low. Minimum swap: {from_rao(min_swap):.4f} TAO equivalent '
-                f'(you entered {from_rao(tao_amount):.4f} TAO equivalent).[/red]'
-            )
-            return
-        if max_swap > 0 and tao_amount > max_swap:
-            console.print(
-                f'[red]Amount too high. Maximum swap: {from_rao(max_swap):.4f} TAO equivalent '
-                f'(you entered {from_rao(tao_amount):.4f} TAO equivalent).[/red]'
-            )
-            return
     except ContractError:
         console.print('[yellow]Warning: could not verify swap bounds (contract unreachable)[/yellow]')
+        min_swap, max_swap = 0, 0
+
+    viable, reason = check_swap_viability(tao_amount, selected_collateral, min_swap, max_swap)
+    if not viable:
+        console.print(
+            f'[red]Swap cannot be initiated at this amount: {reason} '
+            f'(you entered {from_rao(tao_amount):.4f} TAO equivalent).[/red]'
+        )
+        console.print(
+            '[dim]Try a different amount, pick another miner, or run `alw swap quote` to see viable rows.[/dim]'
+        )
+        return
 
     fee_divisor = FEE_DIVISOR
     user_receives = apply_fee_deduction(to_amount, fee_divisor)

--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -544,12 +544,24 @@ def view_reservation():
         console.print('[dim]Run `alw swap now` to initiate a swap.[/dim]\n')
         return
 
-    # Validate against on-chain state
+    # Validate against on-chain state. When the reservation struct is gone,
+    # disambiguate expired-by-TTL from consumed-by-vote_initiate by probing
+    # the miner for an active swap we can match back to this reservation.
+    consumed_swap = None
     try:
         with loading('Reading reservation...'):
             reserved_until = client.get_miner_reserved_until(state.miner_hotkey)
             current_block = subtensor.get_current_block()
             on_chain_reservation = client.get_reservation_data(state.miner_hotkey)
+            if reserved_until == 0 and on_chain_reservation is None:
+                if client.get_miner_has_active_swap(state.miner_hotkey):
+                    for swap in client.get_miner_active_swaps(state.miner_hotkey):
+                        if (
+                            swap.user_from_address == state.user_from_address
+                            or swap.user_to_address == state.receive_address
+                        ):
+                            consumed_swap = swap
+                            break
     except ContractError as e:
         console.print(f'[red]Failed to read reservation status: {e}[/red]')
         return
@@ -587,9 +599,12 @@ def view_reservation():
         remaining_min = remaining * SECONDS_PER_BLOCK / 60
         table.add_row('Status', '[green]ACTIVE[/green]')
         table.add_row('Time Remaining', f'~{remaining} blocks (~{remaining_min:.0f} min)')
+    elif consumed_swap is not None:
+        table.add_row('Status', f'[green]INITIATED (swap #{consumed_swap.id})[/green]')
+        table.add_row('Swap Status', consumed_swap.status.name)
     else:
-        table.add_row('Status', '[red]EXPIRED[/red]')
-        table.add_row('Time Remaining', 'Expired')
+        table.add_row('Status', '[yellow]NO LONGER ACTIVE[/yellow]')
+        table.add_row('Time Remaining', '—')
 
     console.print(table)
 
@@ -598,7 +613,18 @@ def view_reservation():
             f'\n[bold]Next step:[/bold] Send {human_send} {state.from_chain.upper()} to the address above, then run:'
         )
         console.print('  [bold cyan]alw swap post-tx <your_transaction_hash>[/bold cyan]\n')
-    else:
-        console.print('\n[yellow]This reservation has expired. Run `alw swap now` to start a new one.[/yellow]')
+    elif consumed_swap is not None:
+        console.print(
+            f'\n[green]Reservation was consumed into swap #{consumed_swap.id} — it is in progress on-chain.[/green]'
+        )
+        console.print(f'[dim]Watch with: alw view swap {consumed_swap.id} --watch[/dim]')
         clear_pending_swap()
-        console.print('[dim]Stale state file cleared.[/dim]\n')
+        console.print('[dim]Local reservation state cleared.[/dim]\n')
+    else:
+        console.print(
+            '\n[yellow]Reservation is no longer active on-chain.[/yellow]\n'
+            '[dim]Either the reservation expired before you sent funds, or your swap already '
+            'initiated and has since completed. Check: alw view swaps[/dim]'
+        )
+        clear_pending_swap()
+        console.print('[dim]Local reservation state cleared.[/dim]\n')

--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -33,11 +33,17 @@ def view_group():
 
 
 @view_group.command('miners')
-def view_miners():
+@click.option('--full', is_flag=True, help='Show untruncated addresses and hotkeys')
+def view_miners(full: bool):
     """View active miners and their trading pairs.
 
+    [dim]Status column shows live runtime state per miner: reserved (with
+    locked TAO amount), has-swap, or cooldown (withdrawal cooldown blocks
+    remaining after deactivation).[/dim]
+
     [dim]Examples:
-        $ alw view miners[/dim]
+        $ alw view miners
+        $ alw view miners --full[/dim]
     """
     config, _, subtensor, client = get_cli_context(need_wallet=False)
     netuid = config['netuid']
@@ -53,27 +59,62 @@ def view_miners():
     src_up = pairs[0].from_chain.upper()
     dst_up = pairs[0].to_chain.upper()
 
+    # Withdrawal cooldown = 2 * fulfillment_timeout_blocks after deactivation.
+    try:
+        fulfillment_timeout = client.get_fulfillment_timeout()
+        current_block = subtensor.get_current_block()
+    except ContractError:
+        fulfillment_timeout = 0
+        current_block = 0
+
     table = Table(show_header=True)
     table.add_column('UID', style='cyan')
     table.add_column(f'{src_up}→{dst_up}', style='green')
     table.add_column(f'{dst_up}→{src_up}', style='green')
     table.add_column('Collateral (TAO)', style='magenta')
     table.add_column('Active', style='bold')
+    table.add_column('Status', style='yellow')
     table.add_column(f'{src_up} Addr', style='dim')
     table.add_column(f'{dst_up} Addr', style='dim')
 
+    def _trunc(s: str) -> str:
+        if full or not s:
+            return s
+        return s[:16] + '...' if len(s) > 16 else s
+
     for pair in pairs:
         try:
-            collateral_rao = client.get_miner_collateral(pair.hotkey)
+            collateral_rao, is_active, has_swap, reserved_until, deactivation_block = client.get_miner_snapshot(
+                pair.hotkey
+            )
             collateral_str = f'{from_rao(collateral_rao):.4f}'
-        except ContractError:
-            collateral_str = '[dim]—[/dim]'
-
-        try:
-            is_active = client.get_miner_active_flag(pair.hotkey)
             active_str = '[green]Yes[/green]' if is_active else '[red]No[/red]'
         except ContractError:
+            collateral_str = '[dim]—[/dim]'
             active_str = '[dim]—[/dim]'
+            reserved_until = 0
+            deactivation_block = 0
+            has_swap = False
+
+        status_parts = []
+        if has_swap:
+            status_parts.append('[blue]in-swap[/blue]')
+        if reserved_until and current_block and reserved_until > current_block:
+            try:
+                resv = client.get_reservation_data(pair.hotkey)
+            except ContractError:
+                resv = None
+            if resv:
+                tao_amount, _, _ = resv
+                status_parts.append(f'[yellow]reserved {from_rao(tao_amount):.4f} TAO[/yellow]')
+            else:
+                status_parts.append('[yellow]reserved[/yellow]')
+        if deactivation_block and fulfillment_timeout and current_block:
+            cooldown_end = deactivation_block + 2 * fulfillment_timeout
+            remaining = cooldown_end - current_block
+            if remaining > 0:
+                status_parts.append(f'[red]cooldown {remaining}b[/red]')
+        status_str = ' · '.join(status_parts) if status_parts else '[dim]—[/dim]'
 
         fwd_display = f'{pair.rate:g}' if pair.rate > 0 else '[dim]—[/dim]'
         if pair.counter_rate > 0:
@@ -89,12 +130,15 @@ def view_miners():
             ctr_display,
             collateral_str,
             active_str,
-            pair.from_address[:16] + '...',
-            pair.to_address[:16] + '...',
+            status_str,
+            _trunc(pair.from_address),
+            _trunc(pair.to_address),
         )
 
     console.print(table)
     console.print(f'\n[dim]Total miners: {len(pairs)}[/dim]\n')
+    if not full:
+        console.print('[dim]Use --full to show untruncated addresses.[/dim]\n')
 
 
 @view_group.command('rates')
@@ -431,32 +475,25 @@ def view_contract():
 
     console.print('\n[bold]Contract Parameters[/bold]\n')
 
-    def read_safe(fn, default=None):
-        try:
-            return fn()
-        except ContractError:
-            if default is not None:
-                return default
-            raise
-
     try:
         with loading('Reading contract parameters...'):
-            timeout_blocks = read_safe(client.get_fulfillment_timeout)
+            timeout_blocks = client.get_fulfillment_timeout()
             timeout_minutes = timeout_blocks * SECONDS_PER_BLOCK / 60
-            reservation_ttl_blocks = read_safe(client.get_reservation_ttl)
+            reservation_ttl_blocks = client.get_reservation_ttl()
             reservation_ttl_minutes = reservation_ttl_blocks * SECONDS_PER_BLOCK / 60
-            consensus_threshold = read_safe(client.get_consensus_threshold)
-            min_collateral_rao = read_safe(client.get_min_collateral)
-            max_collateral_rao = read_safe(client.get_max_collateral)
-            validator_count = read_safe(client.get_validator_count)
+            consensus_threshold = client.get_consensus_threshold()
+            min_collateral_rao = client.get_min_collateral()
+            max_collateral_rao = client.get_max_collateral()
+            validator_count = client.get_validator_count()
             required_votes = max(1, (validator_count * consensus_threshold + 99) // 100) if validator_count > 0 else 1
-            next_swap_id = read_safe(client.get_next_swap_id)
-            min_swap_rao = read_safe(client.get_min_swap_amount)
-            max_swap_rao = read_safe(client.get_max_swap_amount)
-            accumulated_fees_rao = read_safe(client.get_accumulated_fees)
-            total_recycled_rao = read_safe(client.get_total_recycled_fees)
-            owner = read_safe(client.get_owner)
-            recycle_address = read_safe(client.get_recycle_address, default=None)
+            next_swap_id = client.get_next_swap_id()
+            min_swap_rao = client.get_min_swap_amount()
+            max_swap_rao = client.get_max_swap_amount()
+            accumulated_fees_rao = client.get_accumulated_fees()
+            total_recycled_rao = client.get_total_recycled_fees()
+            owner = client.get_owner()
+            recycle_address = client.get_recycle_address()
+            halted = client.get_halted()
     except ContractError as e:
         console.print(f'[red]Failed to read contract parameters: {e}[/red]')
         return
@@ -484,6 +521,7 @@ def view_contract():
     table.add_row('Owner', owner)
     if recycle_address:
         table.add_row('Recycle Address', recycle_address)
+    table.add_row('System Status', '[red]HALTED[/red]' if halted else '[green]Running[/green]')
 
     console.print(table)
     console.print()
@@ -511,6 +549,7 @@ def view_reservation():
         with loading('Reading reservation...'):
             reserved_until = client.get_miner_reserved_until(state.miner_hotkey)
             current_block = subtensor.get_current_block()
+            on_chain_reservation = client.get_reservation_data(state.miner_hotkey)
     except ContractError as e:
         console.print(f'[red]Failed to read reservation status: {e}[/red]')
         return
@@ -534,6 +573,14 @@ def view_reservation():
     table.add_row('Receive', f'{human_receive:.8f} {state.to_chain.upper()}')
     table.add_row('Receive Address', state.receive_address)
     table.add_row('Miner', f'UID {state.miner_uid} ({state.miner_hotkey[:16]}...)')
+
+    if on_chain_reservation:
+        chain_tao, chain_from, chain_to = on_chain_reservation
+        mismatch = chain_tao != state.tao_amount or chain_from != state.from_amount or chain_to != state.to_amount
+        if mismatch:
+            table.add_row('Chain Amounts', '[red]mismatch with local state[/red]')
+        else:
+            table.add_row('Chain Amounts', f'[green]✓ locked {from_rao(chain_tao):.4f} TAO[/green]')
 
     if is_active:
         remaining = reserved_until - current_block

--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -114,7 +114,13 @@ def view_miners(full: bool):
             remaining = cooldown_end - current_block
             if remaining > 0:
                 status_parts.append(f'[red]cooldown {remaining}b[/red]')
-        status_str = ' · '.join(status_parts) if status_parts else '[dim]—[/dim]'
+
+        if status_parts:
+            status_str = ' · '.join(status_parts)
+        elif is_active:
+            status_str = '[green]available[/green]'
+        else:
+            status_str = '[dim]offline[/dim]'
 
         fwd_display = f'{pair.rate:g}' if pair.rate > 0 else '[dim]—[/dim]'
         if pair.counter_rate > 0:

--- a/allways/utils/rate.py
+++ b/allways/utils/rate.py
@@ -84,3 +84,39 @@ def apply_fee_deduction(to_amount: int, fee_divisor: int) -> int:
     Both MUST use this function to guarantee identical results.
     """
     return to_amount - to_amount // fee_divisor
+
+
+def derive_tao_leg(from_chain: str, from_amount: int, to_chain: str, to_amount: int) -> int:
+    """Return the TAO leg (in rao) of a swap, mirroring vote_initiate.
+
+    tao_amount is always the TAO side regardless of direction. Returns 0 if
+    neither side is TAO (no tao leg — currently unreachable since every
+    supported chain bridges through TAO, but kept deterministic).
+    """
+    if from_chain == 'tao':
+        return from_amount
+    if to_chain == 'tao':
+        return to_amount
+    return 0
+
+
+def check_swap_viability(
+    tao_amount_rao: int,
+    miner_collateral_rao: int,
+    min_swap_rao: int,
+    max_swap_rao: int,
+) -> tuple[bool, str]:
+    """Check whether a swap can pass vote_initiate for a given miner.
+
+    Mirrors the guards in lib.rs::vote_reserve (bounds) and vote_initiate
+    (collateral). Returns (viable, reason) — reason is empty on success.
+    Bounds are global and should be checked against any single rate before
+    the per-miner loop; collateral is per-miner.
+    """
+    if min_swap_rao > 0 and tao_amount_rao < min_swap_rao:
+        return False, f'below min swap ({min_swap_rao / 1_000_000_000:.4f} TAO)'
+    if max_swap_rao > 0 and tao_amount_rao > max_swap_rao:
+        return False, f'above max swap ({max_swap_rao / 1_000_000_000:.4f} TAO)'
+    if tao_amount_rao > miner_collateral_rao:
+        return False, f'insufficient collateral ({tao_amount_rao / 1_000_000_000:.4f} TAO needed)'
+    return True, ''


### PR DESCRIPTION
## Summary

End-to-end audit of the `alw` CLI against the refactored smart contract (`lib.rs`). All 27 messages + 26 queries are wired; this PR surfaces state the contract exposed but the CLI never read, fixes a handful of display + state-handling bugs, and rewrites error messages so contract rejection vs RPC failure is obvious.

**New data surfaced**
- `view miners` — `Status` column with `reserved <tao_amount>`, `in-swap`, and `cooldown <n>b` derived from `get_reservation_data` / `get_miner_snapshot` / `get_fulfillment_timeout`. New `--full` flag to opt out of address truncation
- `view reservation` — `Chain Amounts` row verifies on-chain reservation (`get_reservation_data`) matches local state; mismatch flagged in red
- `view contract` — `System Status` row from `get_halted`
- `swap now` reserve loop — live on-chain vote count from `get_pending_reserve_vote_count` so you can tell whether validators are actively voting

**Bug fixes**
- `swap.py::display_receipt` — hardcoded `fee_divisor = 100` replaced with `FEE_DIVISOR`; receipt now shows protocol fee in TAO against raw swap amount instead of computing it off the post-deduction destination amount
- `resume.py` — "reservation expired" message now covers both possibilities (actually expired vs already initiated/completed) since the contract clears reservations in both cases
- `view.py::view_contract` — dead `default=None` kwarg to `read_safe` removed

**Error handling**
- New `print_contract_error` helper in `helpers.py` routes `ContractError` through `is_contract_rejection` so NotOwner/InsufficientCollateral/etc. read cleanly, while RPC failures get a retry hint
- `collateral.py` pre-flight checks now abort on contract rejection (e.g. `ExceedsMaxCollateral`) instead of warning and proceeding
- `admin.py`, `claim.py`, `miner_commands.py`, `post_tx.py` rewired to the helper
- `swap.py` bare `except Exception` at proof-signing and transfer paths now include the exception type name for debuggability

**UX polish**
- `admin recycle-fees` — previews accumulated amount, destination, and total recycled before confirming; short-circuits if 0
- `admin danger halt` — shows count of in-flight swaps that will be unaffected
- `admin set-recycle-address` / `transfer-ownership` — validate SS58 before submitting; detect no-op (same address)
- Swap `now` address prompts — reminder to paste only PUBLIC addresses, never private keys / seed phrases

Docs update (aligned on `entrius/allways-docs-ui` branch `docs/cleanup-pass-1` — PR #18).

## Test plan

- [ ] `ruff format . && ruff check .` (passes)
- [ ] `alw --help` / `alw view --help` / `alw view miners --help` render correctly
- [ ] Dry-run against local dev environment: `alw view miners --full`, `alw view reservation`, `alw view contract`
- [ ] `alw swap quote` still works unchanged
- [ ] `alw admin recycle-fees` preview shows accumulated fees
- [ ] `alw admin danger halt` shows in-flight count
- [ ] E2E suite 02 still passes: `./alw-utils/dev-environment/tests/run.sh --chains btc --suite 02`