### PR TITLE
Verify from_tx_proof in SwapConfirm handler

### DIFF
--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -466,6 +466,16 @@ async def handle_swap_confirm(
                 reject_synapse(synapse, f'Unsupported chain: {swap_from_chain}', ctx)
                 return synapse
 
+            # Prove the caller controls from_address by verifying a signature over
+            # the tx hash. Without this, anyone observing a user's on-chain source
+            # tx could submit a confirm with their own to_address and redirect the
+            # miner's fulfillment — the on-chain sender check alone doesn't bind
+            # the confirm caller to the source address.
+            proof_message = f'allways-swap:{synapse.from_tx_hash}'
+            if not provider.verify_from_proof(synapse.from_address, proof_message, synapse.from_tx_proof):
+                reject_synapse(synapse, 'Invalid source tx proof', ctx)
+                return synapse
+
             # Validate destination address format — prevents a user from locking a
             # miner's reservation with an unfulfillable to_address that only fails
             # once the miner attempts to send (or silently accepts garbage on-chain).

--- a/tests/test_axon_handlers.py
+++ b/tests/test_axon_handlers.py
@@ -236,6 +236,17 @@ class TestChainProviderValidation:
         assert result.accepted is False
         assert 'Unsupported chain: btc' in result.rejection_reason
 
+    def test_rejects_invalid_from_tx_proof(self):
+        """Without a valid signature over the tx hash from from_address, a caller
+        could hijack someone else's on-chain source tx and redirect fulfillment
+        to an attacker-controlled to_address."""
+        validator = make_validator(reservation_data=(345_000_000, 100_000, 345_000_000))
+        validator.axon_chain_providers['btc'].verify_from_proof.return_value = False
+        result = run_handler(validator, make_synapse())
+        assert result.accepted is False
+        assert 'Invalid source tx proof' in result.rejection_reason
+        validator.axon_chain_providers['btc'].verify_transaction.assert_not_called()
+
     def test_rejects_unsupported_to_chain(self):
         """Need the source provider present (to reach the dest check), but
         strip the dest provider — validator must not continue without a way


### PR DESCRIPTION
## Summary
Closes #59. The confirm handler requires `from_tx_proof` to be non-empty but never verifies it, so any observer of a user's on-chain source tx could submit a confirm with their own `to_address` and redirect the miner's fulfillment.

## Attack vector
1. Alice reserves miner, sends real BTC tx from `X` → miner's deposit.
2. Bob watches the chain, sees Alice's tx land.
3. Bob calls `SwapConfirm` with `from_address=X`, `from_tx_hash=<Alice's tx>`, `to_address=<Bob's TAO address>`, `from_tx_proof="garbage"`.
4. Validator: `verify_transaction(expected_sender=X)` passes (Alice's tx really is from X). No proof check → Bob doesn't need Alice's key.
5. Miner sends TAO to Bob.

## Fix
Call `provider.verify_from_proof(synapse.from_address, 'allways-swap:<tx_hash>', synapse.from_tx_proof)` right after resolving the source-chain provider. Mirrors the existing pattern in `handle_swap_reserve`.

## Test plan
- [x] New unit test asserts rejection when proof is invalid and that `verify_transaction` is never reached.
- [x] `ruff check` + `ruff format` clean.
- [ ] E2E suite on local dev environment (ran post-merge against `test`).