### PR TITLE
Bind swap initiate to reservation from_address

### DIFF
--- a/smart-contracts/ink/lib.rs
+++ b/smart-contracts/ink/lib.rs
@@ -659,6 +659,13 @@ mod allways_swap_manager {
             {
                 return Err(Error::InvalidAmount);
             }
+            // Caller must be the address that actually reserved the miner.
+            // Without this check, a second user who sends the quoted amount to
+            // the miner can hijack an active reservation, consuming the slot
+            // intended for the original reserver.
+            if user_from_address != reservation.from_addr {
+                return Err(Error::NoReservation);
+            }
 
             self.consensus_vote(miner, REQ_INITIATE, request_hash, move |this| {
                 let miner_collateral = this.collateral.get(miner).unwrap_or(0);


### PR DESCRIPTION
## Summary
Closes #60. The contract validated reservation amounts on `vote_initiate` but never validated that the caller's `user_from_address` matched the address that actually reserved the miner. Any user who sends the quoted amount to the miner could consume another user's reservation slot.

## Attack vector
1. Alice calls `SwapReserve` → contract stores `Reservation { from_addr: X, amounts… }`.
2. Bob watches the chain, sees Alice's reservation.
3. Bob sends his own BTC from `Y` to the miner's deposit address for the reserved amount.
4. Bob calls `SwapConfirm` with `from_address=Y`, his own tx hash.
5. Validator: amounts match, on-chain sender (Y) matches Bob's claim → `vote_initiate(user_from_address=Y)`.
6. Contract stored `from_addr=X` but only checked amounts → swap initiates with Bob as the user.
7. Alice's reservation is consumed. If Alice sends later, the slot is already gone.

## Fix
Reject `vote_initiate` when `user_from_address != reservation.from_addr`. Enforced at the contract layer so it holds regardless of which validator casts the quorum-reaching vote.

## Notes
- Reuses `Error::NoReservation` (semantically: "no reservation applies to this caller") rather than introducing a new variant.
- Complementary to #59 (source tx proof verification); neither fix subsumes the other, both are needed to fully close the confirm path.

## Test plan
- [x] `cargo check --release` compiles clean on the ink contract.
- [ ] Rebuild contract + redeploy to dev environment, run E2E suite 02 (happy path) and manually reproduce the squat attempt.