### PR TITLE
refactor: fold typed read wrappers through a shared helper

### DIFF
--- a/allways/contract_client.py
+++ b/allways/contract_client.py
@@ -617,45 +617,28 @@ class AllwaysContractClient:
     # Read helpers (typed wrappers over _raw_contract_read)
     # =========================================================================
 
-    def read_u32(self, method: str, args: dict = None) -> int:
+    def _read_typed(self, method: str, extractor, default, args: dict = None):
         self.ensure_initialized()
         data = self.raw_contract_read(method, args)
         if data is None:
             raise ContractError(f'{method}: no response')
-        v = self.extract_u32(data)
-        return v if v is not None else 0
+        v = extractor(data)
+        return v if v is not None else default
+
+    def read_u32(self, method: str, args: dict = None) -> int:
+        return self._read_typed(method, self.extract_u32, 0, args)
 
     def read_u64(self, method: str, args: dict = None) -> int:
-        self.ensure_initialized()
-        data = self.raw_contract_read(method, args)
-        if data is None:
-            raise ContractError(f'{method}: no response')
-        v = self.extract_u64(data)
-        return v if v is not None else 0
+        return self._read_typed(method, self.extract_u64, 0, args)
 
     def read_u128(self, method: str, args: dict = None) -> int:
-        self.ensure_initialized()
-        data = self.raw_contract_read(method, args)
-        if data is None:
-            raise ContractError(f'{method}: no response')
-        v = self.extract_u128(data)
-        return v if v is not None else 0
+        return self._read_typed(method, self.extract_u128, 0, args)
 
     def read_bool(self, method: str, args: dict = None) -> bool:
-        self.ensure_initialized()
-        data = self.raw_contract_read(method, args)
-        if data is None:
-            raise ContractError(f'{method}: no response')
-        v = self.extract_bool(data)
-        return v if v is not None else False
+        return self._read_typed(method, self.extract_bool, False, args)
 
     def read_account_id(self, method: str, args: dict = None) -> str:
-        self.ensure_initialized()
-        data = self.raw_contract_read(method, args)
-        if data is None:
-            raise ContractError(f'{method}: no response')
-        v = self.extract_account_id(data)
-        return v if v is not None else ''
+        return self._read_typed(method, self.extract_account_id, '', args)
 
     def read_option_swap(self, method: str, args: dict = None, caller=None) -> Optional[Swap]:
         """Read a method that returns Option<SwapData>."""


### PR DESCRIPTION
Closes: #74
## Summary

The scalar read wrappers on `AllwaysContractClient` (`read_u32`, `read_u64`, `read_u128`, `read_bool`, `read_account_id`) each repeated the same five-line body: `ensure_initialized`, `raw_contract_read`, raise `ContractError` if the response is `None`, run the matching `extract_*`, fall back to a type-specific default. Adding a new scalar meant copy-pasting the block and swapping two identifiers.

Factor the shared body into a private `_read_typed(method, extractor, default, args=None)` and keep the five public wrappers as one-liners that bind their extractor and default value. No behavior change — the same `ContractError` is raised on a missing response, and the same `0` / `False` / `''` fallback is returned when the payload decodes to `None`.

## Changes

- **`allways/contract_client.py`:**
  - Add `_read_typed(method, extractor, default, args=None)` as the shared body
  - Collapse `read_u32`, `read_u64`, `read_u128`, `read_bool`, `read_account_id` to one-line delegations
  - Net −17 lines (5 methods × 5 duplicated lines → 1 helper)

## Type of Change

- Refactoring (consolidation, no behavior change)

## Testing

- `pytest tests/` — 289/289 pass (11 pre-existing failures in `test_axon_handlers.py` on `upstream/test` unrelated to this change)
- Public API and signatures unchanged; all existing call sites exercise the same path