### PR TITLE
refactor: extract tao_leg_address helper for vote_initiate user_hotkey

### DIFF
--- a/allways/utils/rate.py
+++ b/allways/utils/rate.py
@@ -100,6 +100,11 @@ def derive_tao_leg(from_chain: str, from_amount: int, to_chain: str, to_amount: 
     return 0
 
 
+def tao_leg_address(from_chain: str, to_chain: str, from_address: str, to_address: str) -> str:
+    """Return the SS58 address on the TAO side of a swap — the user_hotkey for vote_initiate."""
+    return to_address if to_chain == 'tao' else from_address
+
+
 def check_swap_viability(
     tao_amount_rao: int,
     miner_collateral_rao: int,

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -20,6 +20,7 @@ from allways.commitments import read_miner_commitment
 from allways.constants import RESERVATION_COOLDOWN_BLOCKS
 from allways.contract_client import AllwaysContractClient, ContractError, is_contract_rejection
 from allways.synapses import MinerActivateSynapse, SwapConfirmSynapse, SwapReserveSynapse
+from allways.utils.rate import tao_leg_address
 from allways.utils.scale import encode_bytes, encode_str, encode_u128
 from allways.validator.state_store import PendingConfirm
 
@@ -544,7 +545,9 @@ async def handle_swap_confirm(
             )
 
             # user_hotkey must be SS58 (TAO address): to_address for BTC→TAO, from_address for TAO→BTC
-            user_tao_address = synapse.to_address if swap_to_chain == 'tao' else synapse.from_address
+            user_tao_address = tao_leg_address(
+                swap_from_chain, swap_to_chain, synapse.from_address, synapse.to_address
+            )
             contract.vote_initiate(
                 wallet=validator.wallet,
                 request_hash=request_hash,

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -545,9 +545,7 @@ async def handle_swap_confirm(
             )
 
             # user_hotkey must be SS58 (TAO address): to_address for BTC→TAO, from_address for TAO→BTC
-            user_tao_address = tao_leg_address(
-                swap_from_chain, swap_to_chain, synapse.from_address, synapse.to_address
-            )
+            user_tao_address = tao_leg_address(swap_from_chain, swap_to_chain, synapse.from_address, synapse.to_address)
             contract.vote_initiate(
                 wallet=validator.wallet,
                 request_hash=request_hash,

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -17,6 +17,7 @@ from allways.constants import (
 )
 from allways.contract_client import ContractError, is_contract_rejection
 from allways.utils.logging import log_on_change
+from allways.utils.rate import tao_leg_address
 from allways.validator import voting
 from allways.validator.axon_handlers import (
     keccak256,
@@ -181,7 +182,9 @@ def initialize_pending_user_reservations(self: Validator) -> None:
             )
             request_hash = keccak256(hash_input)
 
-            user_tao_address = item.to_address if item.to_chain == 'tao' else item.from_address
+            user_tao_address = tao_leg_address(
+                item.from_chain, item.to_chain, item.from_address, item.to_address
+            )
             self.contract_client.vote_initiate(
                 wallet=self.wallet,
                 request_hash=request_hash,

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -182,9 +182,7 @@ def initialize_pending_user_reservations(self: Validator) -> None:
             )
             request_hash = keccak256(hash_input)
 
-            user_tao_address = tao_leg_address(
-                item.from_chain, item.to_chain, item.from_address, item.to_address
-            )
+            user_tao_address = tao_leg_address(item.from_chain, item.to_chain, item.from_address, item.to_address)
             self.contract_client.vote_initiate(
                 wallet=self.wallet,
                 request_hash=request_hash,


### PR DESCRIPTION
Closes: #75 
## Summary
- Add `tao_leg_address(from_chain, to_chain, from_address, to_address)` in `allways/utils/rate.py`, co-located with `derive_tao_leg` (its amount counterpart).
- Replace the duplicated inline expression in `allways/validator/forward.py` and `allways/validator/axon_handlers.py` with calls to the helper.
- No behavior change — single source of truth for "which side of a swap is TAO" so the `vote_initiate` `user_hotkey` mapping stays consistent across call sites.

## Test plan
- [x] `ruff check allways/` clean
- [x] `pytest tests/` — 291 passed; 9 pre-existing failures in `tests/test_axon_handlers.py` unrelated to this refactor (verified on baseline)
- [x] Helper verified for both directions: `tao_leg_address('btc','tao',btc_addr,ss58)` → ss58; `tao_leg_address('tao','btc',ss58,btc_addr)` → ss58