### PR TITLE
refactor: extract _manage_validator to deduplicate add-vali and remove-vali commands

### DIFF
--- a/allways/cli/swap_commands/admin.py
+++ b/allways/cli/swap_commands/admin.py
@@ -291,6 +291,40 @@ def set_threshold(percent: int):
         print_contract_error('Failed to set consensus threshold', e)
 
 
+def _manage_validator(hotkey: str, *, adding: bool) -> None:
+    _, wallet, _, client = get_cli_context()
+    try:
+        is_registered = client.is_validator(hotkey)
+    except ContractError as e:
+        print_contract_error('Failed to check validator status', e)
+        return
+
+    action = 'Add' if adding else 'Remove'
+    console.print(f'\n[bold]{action} Validator[/bold]\n')
+    console.print(f'  Hotkey: {hotkey}')
+
+    if adding and is_registered:
+        console.print('  [yellow]Warning: This hotkey is already a registered validator[/yellow]')
+    elif not adding and not is_registered:
+        console.print('  [yellow]Warning: This hotkey is not a registered validator[/yellow]')
+
+    console.print()
+
+    if not click.confirm(f'Confirm {"adding" if adding else "removing"} validator?'):
+        console.print('[yellow]Cancelled[/yellow]')
+        return
+
+    try:
+        with loading('Submitting transaction...'):
+            if adding:
+                client.add_validator(wallet=wallet, validator=hotkey)
+            else:
+                client.remove_validator(wallet=wallet, validator=hotkey)
+        console.print(f'[green]Validator {hotkey} {"added" if adding else "removed"}[/green]\n')
+    except ContractError as e:
+        print_contract_error(f'Failed to {"add" if adding else "remove"} validator', e)
+
+
 @admin_group.command('add-vali', show_disclaimer=True)
 @click.argument('hotkey', type=str)
 def add_vali(hotkey: str):
@@ -299,32 +333,7 @@ def add_vali(hotkey: str):
     [dim]Examples:
         $ alw admin add-vali 5Cxyz...[/dim]
     """
-    _, wallet, _, client = get_cli_context()
-
-    try:
-        already_registered = client.is_validator(hotkey)
-    except ContractError as e:
-        print_contract_error('Failed to check validator status', e)
-        return
-
-    console.print('\n[bold]Add Validator[/bold]\n')
-    console.print(f'  Hotkey: {hotkey}')
-
-    if already_registered:
-        console.print('  [yellow]Warning: This hotkey is already a registered validator[/yellow]')
-
-    console.print()
-
-    if not click.confirm('Confirm adding validator?'):
-        console.print('[yellow]Cancelled[/yellow]')
-        return
-
-    try:
-        with loading('Submitting transaction...'):
-            client.add_validator(wallet=wallet, validator=hotkey)
-        console.print(f'[green]Validator {hotkey} added[/green]\n')
-    except ContractError as e:
-        print_contract_error('Failed to add validator', e)
+    _manage_validator(hotkey, adding=True)
 
 
 @admin_group.command('remove-vali', show_disclaimer=True)
@@ -335,32 +344,7 @@ def remove_vali(hotkey: str):
     [dim]Examples:
         $ alw admin remove-vali 5Cxyz...[/dim]
     """
-    _, wallet, _, client = get_cli_context()
-
-    try:
-        is_registered = client.is_validator(hotkey)
-    except ContractError as e:
-        print_contract_error('Failed to check validator status', e)
-        return
-
-    console.print('\n[bold]Remove Validator[/bold]\n')
-    console.print(f'  Hotkey: {hotkey}')
-
-    if not is_registered:
-        console.print('  [yellow]Warning: This hotkey is not a registered validator[/yellow]')
-
-    console.print()
-
-    if not click.confirm('Confirm removing validator?'):
-        console.print('[yellow]Cancelled[/yellow]')
-        return
-
-    try:
-        with loading('Submitting transaction...'):
-            client.remove_validator(wallet=wallet, validator=hotkey)
-        console.print(f'[green]Validator {hotkey} removed[/green]\n')
-    except ContractError as e:
-        print_contract_error('Failed to remove validator', e)
+    _manage_validator(hotkey, adding=False)
 
 
 @admin_group.command('set-recycle-address', show_disclaimer=True)


### PR DESCRIPTION
## Closes: #79

## Summary

- Extracted `_manage_validator(hotkey, *, adding)` shared helper to eliminate the duplicated body between `add-vali` and `remove-vali` commands
- Each command now delegates entirely to the helper via a single `adding=True/False` flag
- No behavior changes: all output strings, warnings, confirm prompts, and error messages are identical to the originals

## Changes

- `allways/cli/swap_commands/admin.py`: -42 / +26 lines
  - New `_manage_validator` helper handling the full flow: validator status check → conditional warning → confirm → submit transaction
  - `add_vali` and `remove_vali` reduced to one-line delegation calls

## Motivation

Both commands shared an identical 30-line skeleton. Any future change — e.g. adding SS58 validation, a dry-run flag, or adjusting the warning wording — would have required updating both functions independently.

## Test plan

- [ ] `alw admin add-vali <hotkey>` on an unregistered hotkey — no warning shown, confirms and submits
- [ ] `alw admin add-vali <hotkey>` on an already-registered hotkey — yellow warning shown before confirm
- [ ] `alw admin remove-vali <hotkey>` on a registered hotkey — no warning, confirms and submits
- [ ] `alw admin remove-vali <hotkey>` on an unregistered hotkey — yellow warning shown before confirm
- [ ] Cancelling either prompt prints `Cancelled` and exits without submitting
- [ ] RPC failure on `is_validator` prints error and exits before showing any UI
