### PR TITLE
fix: skip axon when is_validator RPC fails in discover_validators

### DIFF
--- a/allways/cli/dendrite_lite.py
+++ b/allways/cli/dendrite_lite.py
@@ -62,7 +62,7 @@ def discover_validators(
                 if not contract_client.is_validator(metagraph.hotkeys[uid]):
                     continue
             except Exception:
-                pass
+                continue
         axons.append(axon)
 
     return axons


### PR DESCRIPTION
Fixes #73

An exception from contract_client.is_validator() was caught with pass, which fell through to axons.append() — including the axon as if the whitelist check had passed. Replace pass with continue so a failing RPC is treated as unknown (exclude) rather than whitelisted (include).

Changes:
- allways/cli/dendrite_lite.py — pass → continue in the is_validator exception handler