### PR TITLE
refactor: remove dead subtensor/netuid/metagraph params from SwapVerifier

### DIFF
--- a/allways/validator/chain_verification.py
+++ b/allways/validator/chain_verification.py
@@ -1,7 +1,7 @@
 """Verifies both sides of a swap using chain providers and on-chain swap data."""
 
 import asyncio
-from typing import Dict, Optional
+from typing import Dict
 
 import bittensor as bt
 
@@ -20,15 +20,9 @@ class SwapVerifier:
     def __init__(
         self,
         chain_providers: Dict[str, ChainProvider],
-        subtensor: bt.Subtensor,
-        netuid: int,
-        metagraph: Optional['bt.Metagraph'] = None,
         fee_divisor: int = 100,
     ):
         self.providers = chain_providers
-        self.subtensor = subtensor
-        self.netuid = netuid
-        self.metagraph = metagraph
         self.fee_divisor = fee_divisor
         self.last_logged_confs: Dict[str, int] = {}  # swap_id:chain -> confs
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -103,9 +103,6 @@ class Validator(BaseValidatorNeuron):
 
         self.swap_verifier = SwapVerifier(
             chain_providers=self.chain_providers,
-            subtensor=self.subtensor,
-            netuid=self.config.netuid,
-            metagraph=self.metagraph,
             fee_divisor=self.fee_divisor,
         )
 


### PR DESCRIPTION
Fixes #85

SwapVerifier.__init__ accepted subtensor, netuid, and metagraph but never read them anywhere in the class. The docstring already explains why they aren't needed ('verification is self-contained'). Remove them from the signature and update the one call site in neurons/validator.py.

Changes:
- allways/validator/chain_verification.py — remove three dead params and their self.* assignments; remove now-unused Optional import
- neurons/validator.py — remove the three dead keyword args from SwapVerifier()