### PR TITLE
Consolidate SwapCompleted/SwapTimedOut handling in apply_event

### DIFF
--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -389,25 +389,14 @@ class ContractEventWatcher:
             miner = values.get('miner', '')
             if miner:
                 self.apply_busy_delta(block_num, miner, +1)
-        elif name == 'SwapCompleted':
+        elif name in ('SwapCompleted', 'SwapTimedOut'):
             swap_id = values.get('swap_id')
             miner = values.get('miner', '')
             if isinstance(swap_id, int) and miner:
                 self.state_store.insert_swap_outcome(
                     swap_id=swap_id,
                     miner_hotkey=miner,
-                    completed=True,
-                    resolved_block=block_num,
-                )
-                self.apply_busy_delta(block_num, miner, -1)
-        elif name == 'SwapTimedOut':
-            swap_id = values.get('swap_id')
-            miner = values.get('miner', '')
-            if isinstance(swap_id, int) and miner:
-                self.state_store.insert_swap_outcome(
-                    swap_id=swap_id,
-                    miner_hotkey=miner,
-                    completed=False,
+                    completed=(name == 'SwapCompleted'),
                     resolved_block=block_num,
                 )
                 self.apply_busy_delta(block_num, miner, -1)


### PR DESCRIPTION
Closes #76

## Change

`ContractEventWatcher.apply_event()` in [`allways/validator/event_watcher.py`](allways/validator/event_watcher.py) had two elif branches (`SwapCompleted` and `SwapTimedOut`) with identical 11-line bodies. They share the same guard, the same `insert_swap_outcome` call, and the same `apply_busy_delta(-1)`; they differ only in the `completed=True/False` flag.

Collapse them into one branch that matches both event names and derives the flag from the name:

```python
elif name in ('SwapCompleted', 'SwapTimedOut'):
    swap_id = values.get('swap_id')
    miner = values.get('miner', '')
    if isinstance(swap_id, int) and miner:
        self.state_store.insert_swap_outcome(
            swap_id=swap_id,
            miner_hotkey=miner,
            completed=(name == 'SwapCompleted'),
            resolved_block=block_num,
        )
        self.apply_busy_delta(block_num, miner, -1)
```

## Scope

- Single file: `allways/validator/event_watcher.py` (single method, `apply_event`).
- `insert_swap_outcome` already takes `completed: bool` ([state_store.py:236](allways/validator/state_store.py#L236)) — the call shape is identical across both event names.
- No test changes needed; the path is the same.

## Behavior preservation

Verified via a runtime smoke test:
- `SwapCompleted` → `(completed=1, timed_out=0)` recorded in `swap_outcomes`
- `SwapTimedOut` → `(completed=0, timed_out=1)` recorded
- Unknown event names → no-op (unchanged)

## Testing

- `uv run pre-commit run --all-files` ✅
- `uv run pre-commit run --all-files --hook-stage pre-push` (pytest) ✅ **300/300 passed**
- Pyright: 0 → 0 errors (file was clean baseline)
