### PR TITLE
refactor: inline validate_address_local into is_valid_address

### DIFF
--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -308,10 +308,6 @@ class BitcoinProvider(ChainProvider):
             return 0
 
     def is_valid_address(self, address: str) -> bool:
-        """Validate a Bitcoin address locally (bech32/base58 decode)."""
-        return self.validate_address_local(address)
-
-    def validate_address_local(self, address: str) -> bool:
         """Validate BTC address format without RPC (bech32/base58 decode)."""
         if not address or not isinstance(address, str):
             return False


### PR DESCRIPTION
Closes: #98

## Summary
- `BitcoinProvider.is_valid_address` was a 2-line wrapper that only called `self.validate_address_local(address)`.
- `validate_address_local` had no other callers — `grep` across `allways/`, `neurons/`, and `tests/` returned zero hits outside the file itself.
- Inline `validate_address_local`'s body into `is_valid_address` and delete the wrapper. Kept the more precise docstring ("without RPC").

## Why
`BaseProvider.is_valid_address` is the contract surface. Having `validate_address_local` sitting next to it, publicly named and doing the actual work, doubles the API without a second implementation behind it — and risks a future caller binding to the internal name.

## Test plan
- [x] `ruff check allways/ neurons/` — clean.
- [x] `ruff format --check` — 71 files formatted.
- [x] `pytest tests/` — 291 passed (same 9 pre-existing `reservation_data`-mock failures, unchanged and orthogonal).
- [x] `grep -r "validate_address_local"` — zero hits repo-wide after the change.
