### PR TITLE
refactor: drop dead plumbing from SwapFulfiller and SwapTracker.poll

### DIFF
--- a/allways/miner/fulfillment.py
+++ b/allways/miner/fulfillment.py
@@ -63,8 +63,6 @@ class SwapFulfiller:
         chain_providers: Dict[str, ChainProvider],
         wallet: bt.Wallet,
         subtensor: bt.Subtensor,
-        netuid: int,
-        metagraph: Optional['bt.Metagraph'] = None,
         fee_divisor: int = 100,
         sent_cache_path: Optional[Path] = None,
         my_addresses: Optional[Dict[str, str]] = None,
@@ -73,8 +71,6 @@ class SwapFulfiller:
         self.providers = chain_providers
         self.wallet = wallet
         self.subtensor = subtensor
-        self.netuid = netuid
-        self.metagraph = metagraph
         self.fee_divisor = fee_divisor
         self.timeout_cushion_blocks = load_timeout_cushion_blocks()
         # Chain → miner's own deposit/fulfillment address, populated at

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -53,7 +53,7 @@ async def forward(self: Validator) -> None:
         bt.logging.warning(f'Event watcher sync failed: {e}')
 
     # Pull newly-initiated and resolved swaps off the contract.
-    await tracker.poll(self.block)
+    await tracker.poll()
 
     # Verify FULFILLED swaps end-to-end and vote confirm_swap. The returned
     # set is swap IDs where the provider was unreachable this cycle, so the

--- a/allways/validator/swap_tracker.py
+++ b/allways/validator/swap_tracker.py
@@ -102,7 +102,7 @@ class SwapTracker:
             return False
         return True
 
-    async def poll(self, current_block: int = 0):
+    async def poll(self):
         """Incremental refresh — called every forward step."""
         try:
             await self.poll_inner()

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -54,8 +54,6 @@ class Miner(BaseMinerNeuron):
             chain_providers=self.chain_providers,
             wallet=self.wallet,
             subtensor=self.subtensor,
-            netuid=self.config.netuid,
-            metagraph=self.metagraph,
             fee_divisor=FEE_DIVISOR,
             sent_cache_path=sent_cache_path,
             my_addresses=self.my_addresses,

--- a/tests/test_fulfillment.py
+++ b/tests/test_fulfillment.py
@@ -27,8 +27,6 @@ def make_fulfiller(cushion_env: str | None = None) -> SwapFulfiller:
             chain_providers={},
             wallet=MagicMock(),
             subtensor=MagicMock(),
-            netuid=2,
-            metagraph=MagicMock(),
         )
 
 


### PR DESCRIPTION
Closes: #102
## Summary

Grep-verifiable dead-parameter removals in the miner and validator surface. Each dropped parameter was accepted by a constructor or method, assigned to `self` where applicable, and never read — by the class itself, by external callers, or by the test suite. No behavior change.

Scope deliberately excludes `SwapVerifier` since #93 already covers that class.

## Changes

- **`allways/miner/fulfillment.py`:**
  - Drop `metagraph` and `netuid` from `SwapFulfiller.__init__`. Both were assigned to `self` and never read anywhere — grep for `self.metagraph` / `self.netuid` / `fulfiller.metagraph` / `fulfiller.netuid` returns zero reads outside the assignments themselves. `self.wallet` and `self.subtensor` are kept — they're read in `process_swap` and `verify_swap_safety` respectively.

- **`allways/validator/swap_tracker.py`:**
  - Remove the `current_block` parameter from `SwapTracker.poll(...)`. The body immediately delegates to `poll_inner()` and never passes or references the block — `poll_inner` drives its own cursor off `self.last_scanned_id`.

- **Callers updated to match:**
  - `neurons/miner.py` — stop passing the 2 dropped kwargs to `SwapFulfiller(...)`
  - `allways/validator/forward.py` — `await tracker.poll(self.block)` → `await tracker.poll()`
  - `tests/test_fulfillment.py::make_fulfiller` — stop passing the dropped kwargs

## Type of Change

- Refactoring (dead parameter / dead attribute removal, no behavior change)

## Testing

- `ruff format --check` and `ruff check` both clean
- Every removal verified by grep across the full source tree + `tests/` — zero readers for every dropped symbol