### PR TITLE
refactor: centralize blocks-to-minutes formatting in a shared helper

### DIFF
--- a/allways/cli/swap_commands/admin.py
+++ b/allways/cli/swap_commands/admin.py
@@ -4,7 +4,7 @@ import click
 
 from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
-    SECONDS_PER_BLOCK,
+    blocks_to_minutes_str,
     console,
     from_rao,
     get_cli_context,
@@ -59,8 +59,8 @@ def set_timeout(blocks: int):
         getter=lambda c: c.get_fulfillment_timeout(),
         setter=lambda c, w: c.set_fulfillment_timeout(wallet=w, blocks=blocks),
         noun='fulfillment timeout',
-        format_current=lambda v: f'{v} blocks (~{v * SECONDS_PER_BLOCK / 60:.0f} min)',
-        new_display=f'{blocks} blocks (~{blocks * SECONDS_PER_BLOCK / 60:.0f} min)',
+        format_current=lambda v: f'{v} blocks ({blocks_to_minutes_str(v)})',
+        new_display=f'{blocks} blocks ({blocks_to_minutes_str(blocks)})',
         success_msg=f'Fulfillment timeout set to {blocks} blocks',
     )
 
@@ -81,8 +81,8 @@ def set_reservation_ttl(blocks: int):
         getter=lambda c: c.get_reservation_ttl(),
         setter=lambda c, w: c.set_reservation_ttl(wallet=w, blocks=blocks),
         noun='reservation TTL',
-        format_current=lambda v: f'{v} blocks (~{v * SECONDS_PER_BLOCK / 60:.0f} min)',
-        new_display=f'{blocks} blocks (~{blocks * SECONDS_PER_BLOCK / 60:.0f} min)',
+        format_current=lambda v: f'{v} blocks ({blocks_to_minutes_str(v)})',
+        new_display=f'{blocks} blocks ({blocks_to_minutes_str(blocks)})',
         success_msg=f'Reservation TTL set to {blocks} blocks',
     )
 

--- a/allways/cli/swap_commands/collateral.py
+++ b/allways/cli/swap_commands/collateral.py
@@ -5,7 +5,7 @@ from rich.table import Table
 
 from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
-    SECONDS_PER_BLOCK,
+    blocks_to_minutes_str,
     console,
     from_rao,
     get_cli_context,
@@ -150,9 +150,8 @@ def collateral_withdraw(amount: float | None, yes: bool):
             cooldown_end = deactivation_block + (timeout_blocks * 2)
             if current_block < cooldown_end:
                 remaining = cooldown_end - current_block
-                remaining_min = remaining * SECONDS_PER_BLOCK / 60
                 console.print(
-                    f'[red]Withdrawal cooldown active. ~{remaining} blocks (~{remaining_min:.0f} min) remaining.[/red]'
+                    f'[red]Withdrawal cooldown active. ~{remaining} blocks ({blocks_to_minutes_str(remaining)}) remaining.[/red]'
                 )
                 return
 

--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -30,6 +30,12 @@ console = Console()
 
 SECONDS_PER_BLOCK = 12
 
+
+def blocks_to_minutes_str(blocks: int) -> str:
+    """Render a block count as an approximate minutes string like '~5 min'."""
+    return f'~{blocks * SECONDS_PER_BLOCK / 60:.0f} min'
+
+
 SWAP_STATUS_COLORS = {
     SwapStatus.ACTIVE: 'yellow',
     SwapStatus.FULFILLED: 'blue',

--- a/allways/cli/swap_commands/miner_commands.py
+++ b/allways/cli/swap_commands/miner_commands.py
@@ -13,6 +13,7 @@ from allways.cli.dendrite_lite import discover_validators, resolve_dendrite_time
 from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
     SWAP_STATUS_COLORS,
+    blocks_to_minutes_str,
     console,
     from_rao,
     get_cli_context,
@@ -280,7 +281,7 @@ def miner_deactivate():
         console.print(f'[green]Deactivated successfully[/green] (tx: {tx_hash[:16]}...)')
         timeout = client.get_fulfillment_timeout()
         console.print(
-            f'[dim]Collateral withdrawal available after {timeout * 2} blocks (~{timeout * 2 * 12 // 60} min)[/dim]\n'
+            f'[dim]Collateral withdrawal available after {timeout * 2} blocks ({blocks_to_minutes_str(timeout * 2)})[/dim]\n'
         )
     except ContractError as e:
         print_contract_error('Failed to deactivate', e)

--- a/allways/cli/swap_commands/post_tx.py
+++ b/allways/cli/swap_commands/post_tx.py
@@ -6,7 +6,7 @@ from allways.chain_providers import create_chain_providers
 from allways.cli.dendrite_lite import discover_validators, get_ephemeral_wallet
 from allways.cli.help import StyledCommand
 from allways.cli.swap_commands.helpers import (
-    SECONDS_PER_BLOCK,
+    blocks_to_minutes_str,
     clear_pending_swap,
     console,
     get_cli_context,
@@ -76,7 +76,6 @@ def post_tx_command(tx_hash: str, tx_block: int):
         return
 
     remaining = reserved_until - current_block
-    remaining_min = remaining * SECONDS_PER_BLOCK / 60
     human_amount = from_smallest_unit(state.from_amount, state.from_chain)
 
     console.print('\n[bold]Pending Swap[/bold]\n')
@@ -84,7 +83,7 @@ def post_tx_command(tx_hash: str, tx_block: int):
     console.print(f'  Send:    {human_amount} {state.from_chain.upper()}')
     console.print(f'  To:      {state.miner_from_address}')
     console.print(f'  Miner:   UID {state.miner_uid}')
-    console.print(f'  Expires: ~{remaining} blocks (~{remaining_min:.0f} min)\n')
+    console.print(f'  Expires: ~{remaining} blocks ({blocks_to_minutes_str(remaining)})\n')
 
     # Get transaction hash
     if not tx_hash:

--- a/allways/cli/swap_commands/resume.py
+++ b/allways/cli/swap_commands/resume.py
@@ -12,7 +12,7 @@ from allways.chains import get_chain
 from allways.classes import SwapStatus
 from allways.cli.dendrite_lite import discover_validators, get_ephemeral_wallet
 from allways.cli.swap_commands.helpers import (
-    SECONDS_PER_BLOCK,
+    blocks_to_minutes_str,
     clear_pending_swap,
     console,
     get_cli_context,
@@ -156,7 +156,7 @@ def resume_reservation_command(from_tx_hash_opt: Optional[str], auto_send: bool,
         return
 
     remaining = reserved_until - current_block
-    console.print(f'\n[green]Reservation still active (~{remaining * SECONDS_PER_BLOCK // 60} min left)[/green]')
+    console.print(f'\n[green]Reservation still active ({blocks_to_minutes_str(remaining)} left)[/green]')
 
     # Set up chain provider
     if 'BTC_MODE' not in os.environ:

--- a/allways/cli/swap_commands/status.py
+++ b/allways/cli/swap_commands/status.py
@@ -5,7 +5,7 @@ from rich.table import Table
 
 from allways.cli.help import StyledCommand
 from allways.cli.swap_commands.helpers import (
-    SECONDS_PER_BLOCK,
+    blocks_to_minutes_str,
     console,
     from_rao,
     get_cli_context,
@@ -86,11 +86,10 @@ def status_command():
             res_status = probe_pending_reservation(client, pending, current_block)
             if res_status.kind == 'ours_active':
                 remaining = max(0, res_status.reserved_until - current_block)
-                remaining_min = remaining * SECONDS_PER_BLOCK / 60
                 table.add_row(
                     'Pending Reservation',
                     f'send {pending.from_chain.upper()} → receive {pending.to_chain.upper()} '
-                    f'(~{remaining_min:.0f} min left)',
+                    f'({blocks_to_minutes_str(remaining)} left)',
                 )
             elif res_status.kind == 'our_swap':
                 table.add_row(

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -16,8 +16,8 @@ from allways.classes import SwapStatus
 from allways.cli.dendrite_lite import broadcast_synapse, discover_validators, get_ephemeral_wallet
 from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
-    SECONDS_PER_BLOCK,
     PendingSwapState,
+    blocks_to_minutes_str,
     clear_pending_swap,
     console,
     find_matching_miners,
@@ -331,9 +331,8 @@ def broadcast_reserve_with_retry(
             return None
         if reserved:
             ttl_remaining = reserved_until - subtensor.get_current_block()
-            minutes_remaining = ttl_remaining * 12 // 60
             console.print(
-                f'[green]Miner reserved! You have ~{minutes_remaining} minutes to send your funds '
+                f'[green]Miner reserved! You have {blocks_to_minutes_str(ttl_remaining)} to send your funds '
                 f'before the reservation expires.[/green]'
             )
             console.print(
@@ -676,9 +675,8 @@ def swap_now_command(
             console.print('[yellow]Could not verify existing reservation (contract unreachable)[/yellow]')
         elif status.kind == 'ours_active':
             remaining = max(0, status.reserved_until - current_block)
-            remaining_min = remaining * SECONDS_PER_BLOCK / 60
             console.print(
-                f'[yellow]You have a pending reservation (~{remaining} blocks, ~{remaining_min:.0f} min left).[/yellow]'
+                f'[yellow]You have a pending reservation (~{remaining} blocks, {blocks_to_minutes_str(remaining)} left).[/yellow]'
             )
             console.print('  Complete it with: [cyan]alw swap post-tx <tx_hash>[/cyan]\n')
             if not skip_confirm and not click.confirm('Start a new swap instead?'):

--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -16,6 +16,7 @@ from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
     SECONDS_PER_BLOCK,
     SWAP_STATUS_COLORS,
+    blocks_to_minutes_str,
     clear_pending_swap,
     console,
     from_rao,
@@ -860,9 +861,7 @@ def view_contract():
     try:
         with loading('Reading contract parameters...'):
             timeout_blocks = client.get_fulfillment_timeout()
-            timeout_minutes = timeout_blocks * SECONDS_PER_BLOCK / 60
             reservation_ttl_blocks = client.get_reservation_ttl()
-            reservation_ttl_minutes = reservation_ttl_blocks * SECONDS_PER_BLOCK / 60
             consensus_threshold = client.get_consensus_threshold()
             min_collateral_rao = client.get_min_collateral()
             max_collateral_rao = client.get_max_collateral()
@@ -887,8 +886,10 @@ def view_contract():
     table.add_column('Parameter', style='cyan')
     table.add_column('Value', style='green')
 
-    table.add_row('Fulfillment Timeout', f'{timeout_blocks} blocks (~{timeout_minutes:.0f} min)')
-    table.add_row('Reservation TTL', f'{reservation_ttl_blocks} blocks (~{reservation_ttl_minutes:.0f} min)')
+    table.add_row('Fulfillment Timeout', f'{timeout_blocks} blocks ({blocks_to_minutes_str(timeout_blocks)})')
+    table.add_row(
+        'Reservation TTL', f'{reservation_ttl_blocks} blocks ({blocks_to_minutes_str(reservation_ttl_blocks)})'
+    )
     fee_pct = 100 / FEE_DIVISOR
     table.add_row('Fee', f'{fee_pct:g}% (hardcoded)')
     # Collapsed: the threshold is the knob, required_votes is what it resolves
@@ -1104,9 +1105,8 @@ def view_reservation():
 
     if status.kind == 'ours_active':
         remaining = max(0, status.reserved_until - current_block)
-        remaining_min = remaining * SECONDS_PER_BLOCK / 60
         table.add_row('Status', '[green]ACTIVE[/green]')
-        table.add_row('Time Remaining', f'~{remaining} blocks (~{remaining_min:.0f} min)')
+        table.add_row('Time Remaining', f'~{remaining} blocks ({blocks_to_minutes_str(remaining)})')
         # Optimistic-extension visibility — silent on read failure: best-effort
         # signal, not core to the reservation status.
         try:
@@ -1122,14 +1122,13 @@ def view_reservation():
             finalize_at = pending.proposed_at + CHALLENGE_WINDOW_BLOCKS
             blocks_until_finalize = max(0, finalize_at - current_block)
             target_blocks = max(0, pending.target_block - current_block)
-            target_min = target_blocks * SECONDS_PER_BLOCK / 60
             if blocks_until_finalize > 0:
                 finalize_hint = f'finalizable in {blocks_until_finalize} blocks'
             else:
                 finalize_hint = 'finalize window open'
             table.add_row(
                 'Pending Extension',
-                f'target block {pending.target_block} (~{target_min:.0f} min) · {finalize_hint} · '
+                f'target block {pending.target_block} ({blocks_to_minutes_str(target_blocks)}) · {finalize_hint} · '
                 f'by {pending.submitter[:16]}...',
             )
         if sent_tx_hash:


### PR DESCRIPTION
## Summary

The blocks-to-minutes conversion for CLI output was duplicated across a dozen callsites and had already drifted three ways: two callsites inlined the `12` constant, one used integer division against `SECONDS_PER_BLOCK`, and the rest used float division with a `{:.0f}` format. That mix invited silent drift the next time block time gets revisited.

This change introduces `blocks_to_minutes_str(blocks: int) -> str` in `allways/cli/swap_commands/helpers.py`, returning a `"~N min"` string, and routes every callsite through it. The helper owns the arithmetic, the rounding rule, and the display format in one place.

## Changes

* Added `blocks_to_minutes_str` next to `SECONDS_PER_BLOCK` in `helpers.py`.
* Replaced all ad-hoc conversions in `admin.py`, `collateral.py`, `miner_commands.py`, `post_tx.py`, `resume.py`, `status.py`, `swap.py`, and `view.py`.
* Dropped intermediate `*_min(utes)` locals that only existed to feed `{:.0f}` formatting.
* Removed the two hardcoded `12` literals.
* Kept `SECONDS_PER_BLOCK` imported in `view.py`, where it is still used directly by `time.sleep`.

## Notes

Per-chain `est_min = confirmations * chain_def.seconds_per_block / 60` calculations in `swap.py` and `resume.py` are intentionally left alone. Those use each source chain's own block time, not Bittensor's, so they do not belong behind this helper.

The three previous floor-division sites now round to nearest, matching the format used by every other callsite (a difference of at most one minute in the displayed value).

## Relative issue
Closes #112 

## Testing

* `ruff check allways/cli/swap_commands/` passes.
* `ruff format --check allways/cli/swap_commands/` passes.
* Rendered output verified identical for the eleven float-division callsites.
