### PR TITLE
Align reservation fixture with the 3-tuple contract client returns

### DIFF
--- a/tests/test_axon_handlers.py
+++ b/tests/test_axon_handlers.py
@@ -79,14 +79,14 @@ def make_validator(
     *,
     block: int = 1000,
     reserved_until: int = 2000,
-    reservation_data: tuple | None = (0, 345_000_000, 100_000, 345_000_000),
+    reservation_data: tuple | None = (345_000_000, 100_000, 345_000_000),
     providers: dict | None = None,
 ) -> MagicMock:
     """Build a Validator mock with default-happy contract/chain state.
 
     Individual tests override specific attributes to simulate each branch.
     reservation_data tuple mirrors the on-chain layout used by
-    handle_swap_confirm: (_, tao_amount, source_amount, dest_amount).
+    handle_swap_confirm: (tao_amount, source_amount, dest_amount).
     """
     validator = MagicMock()
     validator.block = block
@@ -310,7 +310,7 @@ class TestSourceTxVerification:
         """The contract-reserved amounts are authoritative. A queued entry
         must persist those, not any user-supplied value, so the later
         auto-initiate hashes match what the miner was reserved under."""
-        validator = make_validator(reservation_data=(0, 777_000_000, 55_000, 999_000_000))
+        validator = make_validator(reservation_data=(777_000_000, 55_000, 999_000_000))
         validator.axon_chain_providers['btc'].verify_transaction.return_value = make_tx_info(
             confirmed=False,
             confirmations=1,


### PR DESCRIPTION
## Summary

Closes #114

`AllwaysContractClient.get_reservation_data` returns a 3-tuple `(tao_amount, from_amount, to_amount)` and `handle_swap_confirm` unpacks three names. The fixture in `tests/test_axon_handlers.py` still supplied a 4-tuple with a leading placeholder, so every test that reached the reservation lookup failed with `too many values to unpack (expected 3)`.

## Context

The tuple shape changed when reservation maps were consolidated into a single `Reservation` struct. `reserved_until` moved to its own query (`get_miner_reserved_until`) and `source_addr` was dropped from the record. The test fixture was never synchronized to the new shape.

Production code stays untouched. Only the default fixture and one per-test override change, plus a small docstring update so the comment matches the tuple order.

## Tests

Before: 

9 cases in `tests/test_axon_handlers.py` failed with `too many values to unpack (expected 3)`:

* `TestCommitmentValidation::test_rejects_when_no_commitment_on_chain`
* `TestCommitmentValidation::test_rejects_commitment_with_same_from_to_chain`
* `TestCommitmentValidation::test_rejects_unsupported_direction_when_counter_rate_zero`
* `TestChainProviderValidation::test_rejects_unsupported_from_chain`
* `TestChainProviderValidation::test_rejects_unsupported_to_chain`
* `TestChainProviderValidation::test_rejects_invalid_to_address_format`
* `TestSourceTxVerification::test_rejects_when_source_tx_not_found`
* `TestSourceTxVerification::test_queues_when_source_tx_unconfirmed`
* `TestSourceTxVerification::test_queued_entry_uses_reservation_amounts`

After:

    $ pytest tests/
    300 passed
