### PR TITLE
refactor: share reserve and swap proof message helpers

### DIFF
--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -37,6 +37,7 @@ from allways.commitments import read_miner_commitments
 from allways.constants import FEE_DIVISOR, NETUID_FINNEY
 from allways.contract_client import ContractError
 from allways.synapses import SwapConfirmSynapse, SwapReserveSynapse
+from allways.utils.proofs import reserve_proof_message, swap_proof_message
 from allways.utils.rate import apply_fee_deduction, calculate_to_amount, check_swap_viability, derive_tao_leg
 
 
@@ -85,11 +86,10 @@ def sign_and_broadcast_confirm(
     """
     # Signing is fast for the internal path and may prompt interactively for
     # the external (paste-a-signature) path — never wrap it in a spinner.
-    proof_message = f'allways-swap:{from_tx_hash}'
     from_proof = sign_or_prompt_external(
         provider,
         user_from_address,
-        proof_message,
+        swap_proof_message(from_tx_hash),
         key=from_key,
         chain=from_chain,
         skip_confirm=skip_confirm,
@@ -216,13 +216,12 @@ def broadcast_reserve_with_retry(
     reserved_until = 0
     for attempt in range(max_retries + 1):
         current_block = subtensor.get_current_block()
-        reserve_proof_message = f'allways-reserve:{user_from_address}:{current_block}'
         # Signing is fast internally and may prompt interactively for external
         # signers — never wrap it in a spinner.
         from_address_proof = sign_or_prompt_external(
             provider,
             user_from_address,
-            reserve_proof_message,
+            reserve_proof_message(user_from_address, current_block),
             key=from_key,
             chain=from_chain,
             skip_confirm=skip_confirm,

--- a/allways/utils/proofs.py
+++ b/allways/utils/proofs.py
@@ -1,0 +1,13 @@
+"""Canonical proof-message formats signed by users and verified by validators.
+
+Kept in one place so the CLI signer and validator verifier cannot drift — a
+typo on either side would silently invalidate every proof.
+"""
+
+
+def reserve_proof_message(from_address: str, block_anchor: int) -> str:
+    return f'allways-reserve:{from_address}:{block_anchor}'
+
+
+def swap_proof_message(from_tx_hash: str) -> str:
+    return f'allways-swap:{from_tx_hash}'

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -20,6 +20,7 @@ from allways.commitments import read_miner_commitment
 from allways.constants import RESERVATION_COOLDOWN_BLOCKS
 from allways.contract_client import AllwaysContractClient, ContractError
 from allways.synapses import MinerActivateSynapse, SwapConfirmSynapse, SwapReserveSynapse
+from allways.utils.proofs import reserve_proof_message, swap_proof_message
 from allways.utils.scale import encode_bytes, encode_str, encode_u128
 from allways.validator.state_store import PendingConfirm
 
@@ -278,7 +279,7 @@ async def handle_swap_reserve(
         if provider is None:
             reject_synapse(synapse, f'Unsupported chain: {synapse.from_chain}', ctx)
             return synapse
-        proof_message = f'allways-reserve:{synapse.from_address}:{synapse.block_anchor}'
+        proof_message = reserve_proof_message(synapse.from_address, synapse.block_anchor)
         if not provider.verify_from_proof(synapse.from_address, proof_message, synapse.from_address_proof):
             reject_synapse(synapse, 'Invalid source address proof', ctx)
             return synapse
@@ -479,7 +480,7 @@ async def handle_swap_confirm(
             # tx could submit a confirm with their own to_address and redirect the
             # miner's fulfillment — the on-chain sender check alone doesn't bind
             # the confirm caller to the source address.
-            proof_message = f'allways-swap:{synapse.from_tx_hash}'
+            proof_message = swap_proof_message(synapse.from_tx_hash)
             if not provider.verify_from_proof(synapse.from_address, proof_message, synapse.from_tx_proof):
                 reject_synapse(synapse, 'Invalid source tx proof', ctx)
                 return synapse


### PR DESCRIPTION
## Summary

Closes #116 

* Add allways/utils/proofs.py with reserve_proof_message and swap_proof_message as the single source of truth for the strings signed by the CLI and verified by the validator.
* Route the three CLI signer sites in allways/cli/swap_commands/swap.py and the two validator verifier sites in allways/validator/axon_handlers.py through the new helpers.
* Keep the BIP-137 roundtrip tests in tests/test_bitcoin_signing.py as is, since they exercise the Bitcoin provider rather than the proof format.

## Motivation
The reserve and swap proof formats were previously written as f-strings in both the CLI signer and the validator verifier. A typo or format change on one side would silently invalidate every proof on the other, with no structural guarantee that the two strings stayed in sync. Centralising the format removes that foot gun.

## Test plan
* [x] pytest tests/
* [x] ruff check allways/ neurons/
* [ ] Manual end to end: run a swap against a local validator and confirm both the reserve proof and the confirm proof verify.
