### PR TITLE
refactor: collapse duplicated reserve proof signing into retry loop

### DIFF
--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -193,34 +193,6 @@ def broadcast_reserve_with_retry(
 
     Returns (reserved_until, validator_axons, ephemeral_wallet) on success, None on failure.
     """
-    current_block = subtensor.get_current_block()
-    reserve_proof_message = f'allways-reserve:{user_from_address}:{current_block}'
-    # Signing is fast internally and may prompt interactively for external
-    # signers — never wrap it in a spinner.
-    from_address_proof = sign_or_prompt_external(
-        provider,
-        user_from_address,
-        reserve_proof_message,
-        key=from_key,
-        chain=from_chain,
-        skip_confirm=skip_confirm,
-    )
-    if not from_address_proof:
-        console.print('[red]Could not obtain reserve signature — cannot reserve miner.[/red]')
-        return None
-
-    synapse = SwapReserveSynapse(
-        miner_hotkey=selected_pair.hotkey,
-        tao_amount=tao_amount,
-        from_amount=from_amount,
-        to_amount=to_amount,
-        from_address=user_from_address,
-        from_address_proof=from_address_proof,
-        block_anchor=current_block,
-        from_chain=from_chain,
-        to_chain=to_chain,
-    )
-
     ephemeral_wallet = get_ephemeral_wallet()
     with loading('Discovering validators...'):
         validator_axons = discover_validators(subtensor, netuid, contract_client=client)
@@ -243,31 +215,32 @@ def broadcast_reserve_with_retry(
     reserved = False
     reserved_until = 0
     for attempt in range(max_retries + 1):
-        if attempt > 0:
-            current_block = subtensor.get_current_block()
-            reserve_proof_message = f'allways-reserve:{user_from_address}:{current_block}'
-            from_address_proof = sign_or_prompt_external(
-                provider,
-                user_from_address,
-                reserve_proof_message,
-                key=from_key,
-                chain=from_chain,
-                skip_confirm=skip_confirm,
-            )
-            if not from_address_proof:
-                console.print('[red]Could not obtain reserve signature on retry.[/red]')
-                return None
-            synapse = SwapReserveSynapse(
-                miner_hotkey=selected_pair.hotkey,
-                tao_amount=tao_amount,
-                from_amount=from_amount,
-                to_amount=to_amount,
-                from_address=user_from_address,
-                from_address_proof=from_address_proof,
-                block_anchor=current_block,
-                from_chain=from_chain,
-                to_chain=to_chain,
-            )
+        current_block = subtensor.get_current_block()
+        reserve_proof_message = f'allways-reserve:{user_from_address}:{current_block}'
+        # Signing is fast internally and may prompt interactively for external
+        # signers — never wrap it in a spinner.
+        from_address_proof = sign_or_prompt_external(
+            provider,
+            user_from_address,
+            reserve_proof_message,
+            key=from_key,
+            chain=from_chain,
+            skip_confirm=skip_confirm,
+        )
+        if not from_address_proof:
+            console.print('[red]Could not obtain reserve signature — cannot reserve miner.[/red]')
+            return None
+        synapse = SwapReserveSynapse(
+            miner_hotkey=selected_pair.hotkey,
+            tao_amount=tao_amount,
+            from_amount=from_amount,
+            to_amount=to_amount,
+            from_address=user_from_address,
+            from_address_proof=from_address_proof,
+            block_anchor=current_block,
+            from_chain=from_chain,
+            to_chain=to_chain,
+        )
 
         with loading(f'Broadcasting reservation to {len(validator_axons)} validators...'):
             responses = broadcast_synapse(ephemeral_wallet, validator_axons, synapse, timeout=60.0)


### PR DESCRIPTION
## Summary

Closes #118 

`broadcast_reserve_with_retry` previously signed the reserve proof and built `SwapReserveSynapse` twice: once before the retry loop, then again inside the loop guarded by `if attempt > 0`. The two copies were identical apart from a shorter error message and the refreshed `current_block` anchor on retry.

This change removes the pre-loop copy and moves signing plus synapse construction to the top of the loop body, so attempt 0 follows the same path as every retry. Validator discovery and the ephemeral wallet stay outside the loop, since those do not need to refresh per attempt.

## Behavior notes

* The empty proof guard (`if not from_address_proof`) now applies on every attempt. The pre-loop copy had it, the retry copy did not, so this closes a small gap on retries.
* The richer error message including `type(e).__name__` now applies on every attempt instead of only the first.
* If both signing and validator discovery would fail, the user now sees the validator discovery error first. Both paths still return `None`.

## Test plan

- [x] `ruff check allways/ neurons/`
- [x] `pytest tests/`
- [x] Manual smoke: run a reserve flow against a local validator set and confirm retries still sign against a fresh block anchor.
