### PR TITLE
Reject malformed BTC_PRIVATE_KEY with clear error

### DIFF
--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -328,6 +328,12 @@ class BitcoinProvider(ChainProvider):
         """Get WIF private key from env var or Bitcoin Core wallet."""
         wif = os.environ.get('BTC_PRIVATE_KEY')
         if wif:
+            if wif[0] not in '5KLc9':
+                bt.logging.error(
+                    f'BTC_PRIVATE_KEY is not a valid WIF (prefix {wif[:4]!r}); '
+                    'expected 5/K/L (mainnet) or 9/c (test/regtest)'
+                )
+                return None
             return wif
         if self.mode == 'lightweight':
             bt.logging.error('BTC_MODE=lightweight requires BTC_PRIVATE_KEY env var for key operations')


### PR DESCRIPTION
## Summary
- `BitcoinProvider.get_wif()` trusted whatever was in `BTC_PRIVATE_KEY` and returned it verbatim. If the value wasn't a WIF (e.g. an address pasted by mistake), signing failed downstream in `to_mainnet_wif()` with `Invalid character '0'` — not actionable.
- Validate the prefix (`5/K/L` mainnet, `9/c` test/regtest) and log the reason, returning `None` so the caller hits the existing "no key available" path.

## Test plan
- [x] Reproduced the original failure: `BTC_PRIVATE_KEY=bcrt1q...` → `BTC sign_from_proof failed: Invalid character '0'`
- [x] With the fix: clear error `BTC_PRIVATE_KEY is not a valid WIF (prefix 'bcrt'); expected 5/K/L (mainnet) or 9/c (test/regtest)`
- [x] `ruff format` / `ruff check` clean
- [x] E2E suite 02 happy path: swap initiated successfully against local regtest (validators reserved, ID assigned)