### PR TITLE
BTC source swaps: external signing fallback + CLI polish

### DIFF
--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -328,6 +328,12 @@ class BitcoinProvider(ChainProvider):
         """Get WIF private key from env var or Bitcoin Core wallet."""
         wif = os.environ.get('BTC_PRIVATE_KEY')
         if wif:
+            if wif[0] not in '5KLc9':
+                bt.logging.error(
+                    f'BTC_PRIVATE_KEY is not a valid WIF (prefix {wif[:4]!r}); '
+                    'expected 5/K/L (mainnet) or 9/c (test/regtest)'
+                )
+                return None
             return wif
         if self.mode == 'lightweight':
             bt.logging.error('BTC_MODE=lightweight requires BTC_PRIVATE_KEY env var for key operations')

--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Optional, Tuple
 
 import bittensor as bt
+import click
 from rich.console import Console
 
 from allways.classes import MinerPair, SwapStatus
@@ -49,6 +50,67 @@ def print_contract_error(action: str, e: BaseException) -> None:
     else:
         console.print(f'[red]{action}: {e}[/red]')
         console.print('[dim]This looks like an RPC or client failure — try again.[/dim]')
+
+
+def sign_or_prompt_external(
+    provider,
+    address: str,
+    message: str,
+    key=None,
+    chain: str = '',
+    skip_confirm: bool = False,
+) -> str:
+    """Sign a proof-of-ownership message, falling back to externally-pasted signature.
+
+    Tries internal signing first (env var WIF, wallet coldkey, Bitcoin Core RPC).
+    On failure for BTC source swaps in interactive mode, prompts the user to
+    sign the exact message in an external wallet (Electrum, Sparrow, Trezor,
+    Bitcoin Core) and paste the base64 BIP-137 signature. Verifies the pasted
+    signature before returning it so a typo fails here rather than at the
+    validator.
+
+    Returns an empty string when no valid signature is obtained.
+    """
+    try:
+        signature = provider.sign_from_proof(address, message, key)
+    except Exception as e:
+        bt.logging.warning(f'Internal signing failed ({type(e).__name__}): {e}')
+        signature = ''
+
+    if signature:
+        return signature
+
+    if skip_confirm or chain != 'btc':
+        return ''
+
+    console.print('\n  [bold yellow]External signature required[/bold yellow]')
+    console.print(
+        '  [dim]No BTC signing key loaded. Sign the message below in your wallet\n'
+        '  (Electrum: Tools -> Sign/verify message; Sparrow, Trezor, Bitcoin Core\n'
+        '  all support this) and paste the base64 signature back.[/dim]'
+    )
+    console.print(f'\n  Address: [cyan]{address}[/cyan]')
+    console.print(f'  Message: [yellow]{message}[/yellow]\n')
+
+    pasted = click.prompt('  Paste signature (blank to cancel)', default='', show_default=False).strip()
+    if not pasted:
+        return ''
+
+    try:
+        verified = provider.verify_from_proof(address, message, pasted)
+    except Exception as e:
+        console.print(f'[red]Signature verification errored: {e}[/red]')
+        return ''
+
+    if not verified:
+        console.print(
+            '[red]Signature did not verify for this address/message. Make sure you signed the exact\n'
+            'message shown above with the private key for that address.[/red]'
+        )
+        return ''
+
+    console.print('[green]  Signature verified.[/green]')
+    return pasted
 
 
 def is_valid_ss58(address: str) -> bool:

--- a/allways/cli/swap_commands/quote.py
+++ b/allways/cli/swap_commands/quote.py
@@ -36,31 +36,32 @@ def quote_command(from_chain: str, to_chain: str, amount: float):
         alw swap quote --from btc --to tao --amount 0.1
         alw swap quote --from tao --to btc --amount 50
     """
-    supported = sorted(SUPPORTED_CHAINS.keys())
-    chain_choices = click.Choice(supported, case_sensitive=False)
+    if from_chain and to_chain:
+        from_chain = from_chain.lower()
+        to_chain = to_chain.lower()
+        if from_chain not in SUPPORTED_CHAINS:
+            console.print(f'[red]Unknown source chain: {from_chain}[/red]')
+            return
+        if to_chain not in SUPPORTED_CHAINS:
+            console.print(f'[red]Unknown destination chain: {to_chain}[/red]')
+            return
+        if from_chain == to_chain:
+            console.print('[red]Source and destination chains must be different[/red]')
+            return
+    else:
+        chain_ids = list(SUPPORTED_CHAINS.keys())
+        directions = [(s, d) for s in chain_ids for d in chain_ids if s != d]
 
-    if not from_chain:
-        from_chain = click.prompt(f'Source chain ({"/".join(supported)})', type=chain_choices)
-    from_chain = from_chain.lower()
-    if from_chain not in SUPPORTED_CHAINS:
-        console.print(f'[red]Unknown source chain: {from_chain}[/red]')
-        return
+        console.print('\n[bold]Allways Swap Quote[/bold]\n')
+        console.print('[bold]What would you like to swap?[/bold]\n')
+        for idx, (src, dst) in enumerate(directions, 1):
+            console.print(f'  {idx}. {SUPPORTED_CHAINS[src].name} -> {SUPPORTED_CHAINS[dst].name}')
 
-    if not to_chain:
-        remaining = [c for c in supported if c != from_chain]
-        default_to = remaining[0] if remaining else None
-        to_chain = click.prompt(
-            f'Destination chain ({"/".join(remaining) if remaining else ""})',
-            type=click.Choice(remaining, case_sensitive=False) if remaining else chain_choices,
-            default=default_to,
-        )
-    to_chain = to_chain.lower()
-    if to_chain not in SUPPORTED_CHAINS:
-        console.print(f'[red]Unknown destination chain: {to_chain}[/red]')
-        return
-    if from_chain == to_chain:
-        console.print('[red]Source and destination chains must be different[/red]')
-        return
+        choice = click.prompt('\nSelect', type=int, default=1)
+        if choice < 1 or choice > len(directions):
+            console.print('[red]Invalid selection[/red]')
+            return
+        from_chain, to_chain = directions[choice - 1]
 
     if amount is None:
         amount = click.prompt(f'Amount to send ({from_chain.upper()})', type=float)
@@ -148,7 +149,7 @@ def quote_command(from_chain: str, to_chain: str, amount: float):
     table = Table(show_header=True)
     table.add_column('#', style='dim')
     table.add_column('UID', style='cyan')
-    table.add_column(f'Rate ({to_chain.upper()}/{from_chain.upper()})', style='green')
+    table.add_column('Rate', style='green')
     table.add_column('You Receive', style='bold green')
     table.add_column('Collateral', style='yellow')
     table.add_column('Status', style='bold')

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -25,6 +25,7 @@ from allways.cli.swap_commands.helpers import (
     is_local_network,
     load_pending_swap,
     save_pending_swap,
+    sign_or_prompt_external,
 )
 from allways.commitments import read_miner_commitments
 from allways.constants import FEE_DIVISOR, NETUID_FINNEY
@@ -66,6 +67,7 @@ def sign_and_broadcast_confirm(
     ephemeral_wallet,
     from_chain: str = '',
     to_chain: str = '',
+    skip_confirm: bool = False,
 ) -> tuple:
     """Sign source tx proof and broadcast SwapConfirmSynapse to validators.
 
@@ -74,18 +76,16 @@ def sign_and_broadcast_confirm(
     """
     console.print('[dim]Submitting swap to validators...[/dim]')
     proof_message = f'allways-swap:{from_tx_hash}'
-    try:
-        from_proof = provider.sign_from_proof(
-            user_from_address,
-            proof_message,
-            from_key,
-        )
-    except Exception as e:
-        console.print(f'[red]Failed to sign source proof ({type(e).__name__}): {e}[/red]')
-        return 0, 0
-
+    from_proof = sign_or_prompt_external(
+        provider,
+        user_from_address,
+        proof_message,
+        key=from_key,
+        chain=from_chain,
+        skip_confirm=skip_confirm,
+    )
     if not from_proof:
-        console.print('[red]Source proof is empty — signing failed (check chain provider RPC connection)[/red]')
+        console.print('[red]Could not obtain source tx proof signature — cannot confirm swap.[/red]')
         return 0, 0
 
     confirm_synapse = SwapConfirmSynapse(
@@ -162,18 +162,16 @@ def broadcast_reserve_with_retry(
     """
     current_block = subtensor.get_current_block()
     reserve_proof_message = f'allways-reserve:{user_from_address}:{current_block}'
-    try:
-        from_address_proof = provider.sign_from_proof(
-            user_from_address,
-            reserve_proof_message,
-            from_key,
-        )
-    except Exception as e:
-        console.print(f'[red]Failed to sign source address proof ({type(e).__name__}): {e}[/red]')
-        return None
-
+    from_address_proof = sign_or_prompt_external(
+        provider,
+        user_from_address,
+        reserve_proof_message,
+        key=from_key,
+        chain=from_chain,
+        skip_confirm=skip_confirm,
+    )
     if not from_address_proof:
-        console.print('[red]Source address proof is empty — signing failed (check chain provider RPC connection)[/red]')
+        console.print('[red]Could not obtain reserve signature — cannot reserve miner.[/red]')
         return None
 
     synapse = SwapReserveSynapse(
@@ -200,14 +198,16 @@ def broadcast_reserve_with_retry(
         if attempt > 0:
             current_block = subtensor.get_current_block()
             reserve_proof_message = f'allways-reserve:{user_from_address}:{current_block}'
-            try:
-                from_address_proof = provider.sign_from_proof(
-                    user_from_address,
-                    reserve_proof_message,
-                    from_key,
-                )
-            except Exception as e:
-                console.print(f'[red]Failed to sign source address proof: {e}[/red]')
+            from_address_proof = sign_or_prompt_external(
+                provider,
+                user_from_address,
+                reserve_proof_message,
+                key=from_key,
+                chain=from_chain,
+                skip_confirm=skip_confirm,
+            )
+            if not from_address_proof:
+                console.print('[red]Could not obtain reserve signature on retry.[/red]')
                 return None
             synapse = SwapReserveSynapse(
                 miner_hotkey=selected_pair.hotkey,
@@ -513,13 +513,29 @@ def swap_now_command(
         if from_chain == 'tao':
             console.print('\n  [green]TAO will be sent automatically from your wallet.[/green]')
         else:
-            is_local = is_local_network(config.get('network', 'finney'))
             has_private_key = bool(os.environ.get('BTC_PRIVATE_KEY'))
+            btc_mode = os.environ.get('BTC_MODE', 'lightweight')
+            is_local = is_local_network(config.get('network', 'finney'))
 
-            if not is_local and has_private_key:
-                console.print('\n  [green]BTC_PRIVATE_KEY set — will attempt BTC sends locally.[/green]')
+            if has_private_key and not is_local:
+                console.print('\n  [green]BTC_PRIVATE_KEY set — will sign and attempt BTC sends locally.[/green]')
+            elif btc_mode == 'lightweight' and not has_private_key:
+                # No internal signing key — fall through to BYO-sig at reserve/confirm.
+                console.print('\n  [yellow]No BTC_PRIVATE_KEY set — external signing required.[/yellow]')
+                console.print(
+                    '  [dim]At reserve and confirm time the CLI will show a short message;\n'
+                    '  sign it in your wallet (Electrum, Sparrow, Trezor, Bitcoin Core) and\n'
+                    '  paste the base64 signature back. Taproot (bc1p...) is not supported.[/dim]'
+                )
+                console.print(
+                    '  [yellow]Automatic BTC send is also unavailable — you will send BTC manually and\n'
+                    '  run [cyan]alw swap post-tx <tx_hash>[/cyan] with the transaction hash.[/yellow]'
+                )
+                if not click.confirm('  Continue?', default=True):
+                    console.print('[yellow]Cancelled[/yellow]')
+                    return
             else:
-                console.print('\n  [yellow]No BTC_PRIVATE_KEY found.[/yellow]')
+                console.print('\n  [yellow]Automatic BTC send unavailable in this environment.[/yellow]')
                 console.print(
                     '  [yellow]You will need to manually send BTC to the miner address'
                     ' and then run [cyan]alw swap post-tx <tx_hash>[/cyan] with the transaction hash.[/yellow]'


### PR DESCRIPTION
## Summary
- Reserve and confirm paths now fall back to a **bring-your-own-signature** flow when no `BTC_PRIVATE_KEY` is loaded: CLI shows the exact message to sign, user pastes a BIP-137 base64 signature from Electrum / Sparrow / Trezor / Bitcoin Core, and the sig is verified locally before broadcasting. BTC-source swaps no longer require loading a WIF into the CLI process.
- Earlier in the branch, the upfront check was tightened so BTC-source swaps without signing capability fail fast with a clear message instead of erroring mid-flow at Step 1/3. The BYO-sig addition replaces that fail-fast with an interactive path for users who have keys in an external wallet.
- `alw swap quote` now uses the same numbered direction prompt as `alw swap now` and drops the redundant pair suffix from the Rate column header.

## Notes
- The validator does **not** freshness-check `block_anchor`, so external signing has no hard time pressure. The only residual race is another user reserving the same miner while you sign; existing retry loop handles it.
- Taproot (`bc1p...`) addresses are still rejected — BIP-137 does not cover them. BIP-322 support is out of scope here.
- Pasted signatures are verified via `provider.verify_from_proof` before broadcast, so a typo fails locally instead of at the validator.

## Test plan
- [ ] Run E2E suite 02 against local dev env with `BTC_PRIVATE_KEY` set (internal signing path unchanged)
- [ ] Run `alw swap now` BTC -> TAO with `BTC_PRIVATE_KEY` unset: verify external-signature prompt appears at reserve and confirm, verify sig-check rejects a bad paste, verify good paste completes the swap
- [ ] Run `alw swap quote` interactively and confirm the direction prompt matches `alw swap now`
- [ ] TAO -> BTC unaffected (wallet coldkey path)