### PR TITLE
Fix reserve-proof replay and raw-extrinsic sender off-by-one

### DIFF
--- a/allways/chain_providers/subtensor.py
+++ b/allways/chain_providers/subtensor.py
@@ -81,10 +81,11 @@ class SubtensorProvider(ChainProvider):
             if not (body[0] & 0x80):
                 return None
 
-            # Sender AccountId is at bytes 1..33
-            if len(body) < 33:
+            # Signed v4 extrinsic: [0x84][MultiAddress variant][32-byte AccountId]...
+            # Only MultiAddress::Id (0x00) is supported; reject Index/Raw/Address{20,32}.
+            if len(body) < 34 or body[1] != 0x00:
                 return None
-            sender_bytes = body[1:33]
+            sender_bytes = body[2:34]
             sender = ss58_encode(sender_bytes, ss58_format=42)
 
             # Find the transfer call: pallet_index=5, call_index in {0,3,7}

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -29,7 +29,7 @@ from allways.cli.swap_commands.helpers import (
 from allways.commitments import read_miner_commitments
 from allways.constants import FEE_DIVISOR, NETUID_FINNEY
 from allways.contract_client import ContractError
-from allways.synapses import SwapConfirmSynapse, SwapReserveSynapse
+from allways.synapses import SwapConfirmSynapse, SwapReserveSynapse, build_reserve_proof_message
 from allways.utils.rate import apply_fee_deduction, calculate_to_amount, check_swap_viability, derive_tao_leg
 
 
@@ -161,7 +161,16 @@ def broadcast_reserve_with_retry(
     Returns (reserved_until, validator_axons, ephemeral_wallet) on success, None on failure.
     """
     current_block = subtensor.get_current_block()
-    reserve_proof_message = f'allways-reserve:{user_from_address}:{current_block}'
+    reserve_proof_message = build_reserve_proof_message(
+        miner_hotkey=selected_pair.hotkey,
+        from_address=user_from_address,
+        from_chain=from_chain,
+        to_chain=to_chain,
+        tao_amount=tao_amount,
+        from_amount=from_amount,
+        to_amount=to_amount,
+        block_anchor=current_block,
+    )
     try:
         from_address_proof = provider.sign_from_proof(
             user_from_address,
@@ -199,7 +208,16 @@ def broadcast_reserve_with_retry(
     for attempt in range(max_retries + 1):
         if attempt > 0:
             current_block = subtensor.get_current_block()
-            reserve_proof_message = f'allways-reserve:{user_from_address}:{current_block}'
+            reserve_proof_message = build_reserve_proof_message(
+                miner_hotkey=selected_pair.hotkey,
+                from_address=user_from_address,
+                from_chain=from_chain,
+                to_chain=to_chain,
+                tao_amount=tao_amount,
+                from_amount=from_amount,
+                to_amount=to_amount,
+                block_anchor=current_block,
+            )
             try:
                 from_address_proof = provider.sign_from_proof(
                     user_from_address,

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -50,6 +50,10 @@ RESERVATION_COOLDOWN_BLOCKS = 150  # ~30 min base cooldown on failed reservation
 RESERVATION_COOLDOWN_MULTIPLIER = 2  # 150 → 300 → 600 ...
 MAX_RESERVATIONS_PER_ADDRESS = 1
 EXTEND_THRESHOLD_BLOCKS = 20  # ~4 min — vote to extend when this many blocks remain
+# Max age of the CLI-signed reserve-proof's block_anchor vs the validator's
+# current block. Tight enough that a leaked/observed proof can't be replayed
+# indefinitely; loose enough to cover CLI→validator network latency.
+RESERVE_PROOF_MAX_AGE_BLOCKS = 30  # ~6 min
 # A user's tx is often invisible to a validator's RPC for the first few seconds
 # after submission (mempool propagation lag, regional RPC differences). Treat
 # "not found" as transient until the same entry has polled null this many times.

--- a/allways/synapses.py
+++ b/allways/synapses.py
@@ -11,6 +11,31 @@ from typing import Optional
 import bittensor as bt
 
 
+def build_reserve_proof_message(
+    miner_hotkey: str,
+    from_address: str,
+    from_chain: str,
+    to_chain: str,
+    tao_amount: int,
+    from_amount: int,
+    to_amount: int,
+    block_anchor: int,
+) -> str:
+    """Build the reserve-proof message that the user signs with from_address.
+
+    All fields that define the scope of the reservation are bound into the
+    signed message so a valid proof cannot be reused against a different
+    miner, direction, or amount. `block_anchor` bounds freshness.
+
+    The validator MUST rebuild the exact same string and reject on mismatch.
+    Version tag ("v2") distinguishes from the pre-binding format.
+    """
+    return (
+        f'allways-reserve:v2:{miner_hotkey}:{from_address}:'
+        f'{from_chain}:{to_chain}:{tao_amount}:{from_amount}:{to_amount}:{block_anchor}'
+    )
+
+
 class MinerActivateSynapse(bt.Synapse):
     """Miner broadcasts activation request to all validators.
 

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -17,9 +17,14 @@ from substrateinterface import Keypair
 
 from allways.classes import MinerPair
 from allways.commitments import read_miner_commitment
-from allways.constants import RESERVATION_COOLDOWN_BLOCKS
+from allways.constants import RESERVATION_COOLDOWN_BLOCKS, RESERVE_PROOF_MAX_AGE_BLOCKS
 from allways.contract_client import AllwaysContractClient, ContractError, is_contract_rejection
-from allways.synapses import MinerActivateSynapse, SwapConfirmSynapse, SwapReserveSynapse
+from allways.synapses import (
+    MinerActivateSynapse,
+    SwapConfirmSynapse,
+    SwapReserveSynapse,
+    build_reserve_proof_message,
+)
 from allways.utils.scale import encode_bytes, encode_str, encode_u128
 from allways.validator.state_store import PendingConfirm
 
@@ -279,7 +284,21 @@ async def handle_swap_reserve(
         if provider is None:
             reject_synapse(synapse, f'Unsupported chain: {synapse.from_chain}', ctx)
             return synapse
-        proof_message = f'allways-reserve:{synapse.from_address}:{synapse.block_anchor}'
+
+        if abs(synapse.block_anchor - validator.block) > RESERVE_PROOF_MAX_AGE_BLOCKS:
+            reject_synapse(synapse, 'Reserve proof block_anchor out of range', ctx)
+            return synapse
+
+        proof_message = build_reserve_proof_message(
+            miner_hotkey=miner,
+            from_address=synapse.from_address,
+            from_chain=synapse.from_chain,
+            to_chain=synapse.to_chain,
+            tao_amount=synapse.tao_amount,
+            from_amount=synapse.from_amount,
+            to_amount=synapse.to_amount,
+            block_anchor=synapse.block_anchor,
+        )
         if not provider.verify_from_proof(synapse.from_address, proof_message, synapse.from_address_proof):
             reject_synapse(synapse, 'Invalid source address proof', ctx)
             return synapse


### PR DESCRIPTION
Two proof-handling bugs on the reservation / transfer-verification path.

Reserve proof was signed over `allways-reserve:{from_address}:{block_anchor}` with no check that `block_anchor` is close to the validator's current block and no binding to miner_hotkey, chain direction, or amounts. An attacker who observes one valid proof could replay it against any miner, in any direction, for any amount; each expiry strikes the victim's address with a doubling cooldown and locks them out after a few replays.

- Add RESERVE_PROOF_MAX_AGE_BLOCKS freshness check against validator.block.
- Expand the signed message to bind miner_hotkey, from_chain, to_chain, tao_amount, from_amount, to_amount, block_anchor. Tag `v2` so pre-fix proofs stop verifying.
- Move the format into a shared `build_reserve_proof_message` helper so the CLI signer and validator verifier share one source of truth.

parse_raw_extrinsic in SubtensorProvider read `body[1:33]` to extract the sender, which captured the MultiAddress variant byte plus only 31 of the 32 AccountId bytes - every raw-parsed block produced a garbage SS58. Raw-parse is the fallback path for pruned/archival nodes; when it runs, expected-sender checks false-reject legitimate TAO swaps.

- Read `body[2:34]` after asserting the MultiAddress variant is Id (0x00); reject Index/Raw/Address{20,32} which the rest of the parser does not support.

CLI and validator must be upgraded together - old CLI against new validator will receive "Invalid source address proof" on every reservation.

Fixes #128