### PR TITLE
Gate halt on remaining vote paths and fail-close scoring check

### DIFF
--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -42,13 +42,14 @@ def score_and_reward_miners(self: Validator) -> None:
 
 
 def _contract_is_halted(self: Validator) -> bool:
-    """Best-effort halt check. RPC flakiness should not zero every miner's
-    reward, so any exception falls through to normal scoring."""
+    """Halt check, fail-closed. If the RPC errors we cannot prove the chain is
+    live, so treat it as halted — emissions stall rather than paying miners
+    through an active lockdown and causing cross-validator weight divergence."""
     try:
         return bool(self.contract_client.get_halted())
     except Exception as e:
-        bt.logging.warning(f'halt RPC check failed, proceeding as not-halted: {e}')
-        return False
+        bt.logging.warning(f'halt RPC check failed, treating as halted: {e}')
+        return True
 
 
 def build_halted_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:

--- a/smart-contracts/ink/lib.rs
+++ b/smart-contracts/ink/lib.rs
@@ -544,6 +544,7 @@ mod allways_swap_manager {
             from_tx_hash: String,
         ) -> Result<(), Error> {
             self.ensure_validator()?;
+            self.ensure_not_halted()?;
 
             // Verify hash
             let computed = Self::hash_request(&(&miner, &from_tx_hash));
@@ -606,6 +607,7 @@ mod allways_swap_manager {
             rate: String,
         ) -> Result<(), Error> {
             self.ensure_validator()?;
+            self.ensure_not_halted()?;
             let current_block = self.env().block_number();
 
             // Verify hash — covers the full swap shape so no field can be substituted
@@ -864,6 +866,7 @@ mod allways_swap_manager {
         #[ink(message)]
         pub fn vote_extend_timeout(&mut self, swap_id: u64) -> Result<(), Error> {
             self.ensure_validator()?;
+            self.ensure_not_halted()?;
             let swap = self.swaps.get(swap_id).ok_or(Error::SwapNotFound)?;
 
             if swap.status != SwapStatus::Fulfilled {


### PR DESCRIPTION
Tracks two gaps that let the swap pipeline keep voting while the contract is halted: three ink! voting paths miss ensure_not_halted(), and the validator's halt check fails open on RPC errors.

Fixes #130 