### PR TITLE
fix: validate src/dst addresses in alw miner post before chain commit

### DIFF
--- a/allways/cli/swap_commands/pair.py
+++ b/allways/cli/swap_commands/pair.py
@@ -2,6 +2,7 @@
 
 import click
 
+from allways.chain_providers import create_chain_providers
 from allways.chains import SUPPORTED_CHAINS, canonical_pair
 from allways.cli.help import StyledCommand
 from allways.cli.swap_commands.helpers import console, get_cli_context, loading
@@ -149,6 +150,16 @@ def post_pair(
 
     config, wallet, subtensor, _ = get_cli_context(need_client=False)
     netuid = config['netuid']
+
+    chain_providers = create_chain_providers(subtensor=subtensor)
+    for chain, addr in ((src_chain, src_addr), (dst_chain, dst_addr)):
+        provider = chain_providers.get(chain)
+        if provider is None:
+            console.print(f'[red]No chain provider for {chain.upper()}; cannot validate address[/red]')
+            return
+        if not provider.is_valid_address(addr):
+            console.print(f'[red]Invalid {chain.upper()} address: {addr}[/red]')
+            return
 
     rate_str = f'{rate:g}'
     counter_rate_str = f'{counter_rate:g}'


### PR DESCRIPTION
## Summary

Closes #132 

`alw miner post` accepted `src_addr` / `dst_addr` (from interactive prompts or positional args) without any format validation against their declared chains. A typo or cross-chain paste posted successfully and then silently broke every subsequent swap — reserve/confirm/send paths fail individually at the validator or miner, with no local indicator to the posting miner.

This change calls `provider.is_valid_address()` for both addresses against their respective chains before constructing the commitment string, mirroring the pattern used at [`allways/cli/swap_commands/swap.py:664-670`](allways/cli/swap_commands/swap.py#L664-L670) for user destination addresses.

## Change

- `allways/cli/swap_commands/pair.py`: import `create_chain_providers`; after `get_cli_context` resolves `subtensor`, instantiate chain providers and validate `src_addr` and `dst_addr` via `provider.is_valid_address`. Abort with a clear error on either failure.

## Behavior notes

- Both `BitcoinProvider.is_valid_address` and `SubtensorProvider.is_valid_address` are local (base58 / bech32 / SS58 format checks; no RPC). Validation is ~milliseconds.
- Validation runs after chain selection and after `get_cli_context` so the existing `subtensor` is reused — no extra connection.
- Addresses are validated against their user-declared chain, before the canonical-direction normalization. This matches user intent and keeps error messages keyed to what the user typed.
- No behavior change for already-valid postings.

## Test plan

- [x] `ruff check allways/`
- [x] `pytest tests/`
- [x] Manual: `alw miner post` with a good BTC + TAO pair — succeeds.
- [x] Manual: `alw miner post btc 5FsomethingSS58Looking tao bc1q...` — aborts with `Invalid BTC address: 5F...`.
- [x] Manual: `alw miner post tao 5F... btc bc1qTYPO` — aborts with `Invalid BTC address: bc1qTYPO`.
- [x] Manual: interactive wizard with a typo — aborts at the validation step before the confirmation prompt, giving the user a chance to retry without a pending commitment cost.
