### PR TITLE
fix: route SIGTERM through KeyboardInterrupt for clean container shutdowns

### DIFF
--- a/neurons/base/neuron.py
+++ b/neurons/base/neuron.py
@@ -1,4 +1,5 @@
 import copy
+import signal
 import time
 from abc import ABC, abstractmethod
 
@@ -67,6 +68,11 @@ class BaseNeuron(ABC):
             f'using network: {self.subtensor.chain_endpoint}'
         )
         self.step = 0
+
+        try:
+            signal.signal(signal.SIGTERM, signal.default_int_handler)
+        except ValueError:
+            pass
 
     def reconnect_subtensor(self):
         """Recreate subtensor connection when WebSocket goes stale."""


### PR DESCRIPTION
## Summary

Closes  #134 

`SIGTERM` received no Python-level notification, so `docker stop` / `systemctl stop` / K8s pod termination skipped the neuron's `__exit__` cleanup (`axon.stop`, `state_store.close`, thread join) and waited out the full grace period before SIGKILL.

Routes SIGTERM to `signal.default_int_handler` in `BaseNeuron.__init__` so it raises `KeyboardInterrupt` like SIGINT. The existing `except KeyboardInterrupt` paths in `BaseMinerNeuron.run` and `BaseValidatorNeuron.run` already run cleanup — no other changes needed.

## Change

- `neurons/base/neuron.py`: import `signal`; in `BaseNeuron.__init__` call `signal.signal(signal.SIGTERM, signal.default_int_handler)` guarded by `try/except ValueError` for test environments that instantiate neurons off the main thread.

## Test plan

- [x] `ruff check neurons/`
- [x] `pytest tests/` — 279 passed
- [x] `docker stop aw-miner` exits in under 2s with clean goodbye log instead of hitting the 10s grace timeout
- [x] Ctrl+C still works identically
