### PR TITLE
fix: raise ProviderUnreachableError from get_balance so outages don't read as zero balance

### DIFF
--- a/allways/chain_providers/base.py
+++ b/allways/chain_providers/base.py
@@ -111,7 +111,15 @@ class ChainProvider(ABC):
         return tx_info
 
     @abstractmethod
-    def get_balance(self, address: str) -> int: ...
+    def get_balance(self, address: str) -> int:
+        """Balance at address in smallest unit (satoshis / rao).
+
+        Raises ``ProviderUnreachableError`` on transient backend failures.
+        Callers must not conflate "balance zero" with "backend unreachable" —
+        the former is a legitimate state, the latter means the balance is
+        unknown.
+        """
+        ...
 
     @abstractmethod
     def is_valid_address(self, address: str) -> bool: ...

--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -292,7 +292,11 @@ class BitcoinProvider(ChainProvider):
         return 'https://blockstream.info/api'
 
     def blockstream_get_balance(self, address: str) -> int:
-        """Get balance via Blockstream API. Returns satoshis."""
+        """Get balance via Blockstream API. Returns satoshis.
+
+        Raises ``ProviderUnreachableError`` on transient API failures so
+        callers don't mistake an outage for a zero-balance address.
+        """
         try:
             url = f'{self.blockstream_api_url()}/address/{address}'
             resp = requests.get(url, timeout=15)
@@ -303,9 +307,10 @@ class BitcoinProvider(ChainProvider):
             mempool_funded = data.get('mempool_stats', {}).get('funded_txo_sum', 0)
             mempool_spent = data.get('mempool_stats', {}).get('spent_txo_sum', 0)
             return (funded - spent) + (mempool_funded - mempool_spent)
-        except Exception as e:
-            bt.logging.error(f'Blockstream balance lookup failed for {address}: {e}')
-            return 0
+        except (requests.ConnectionError, requests.Timeout) as e:
+            raise ProviderUnreachableError(f'Blockstream API unreachable: {e}') from e
+        except requests.HTTPError as e:
+            raise ProviderUnreachableError(f'Blockstream API error: {e}') from e
 
     def is_valid_address(self, address: str) -> bool:
         """Validate a Bitcoin address locally (bech32/base58 decode)."""

--- a/allways/chain_providers/subtensor.py
+++ b/allways/chain_providers/subtensor.py
@@ -258,13 +258,18 @@ class SubtensorProvider(ChainProvider):
         return dest, amount, sender
 
     def get_balance(self, address: str) -> int:
-        """Get balance for a TAO address in rao."""
+        """Get balance for a TAO address in rao.
+
+        Raises ``ProviderUnreachableError`` on any subtensor failure. A
+        non-existent address returns 0 cleanly from the RPC, so any raised
+        exception means the backend is unreachable rather than the address
+        holding zero balance.
+        """
         try:
             balance = self.subtensor.get_balance(address)
             return int(balance)
         except Exception as e:
-            bt.logging.error(f'TAO get_balance failed: {e}')
-            return 0
+            raise ProviderUnreachableError(f'Subtensor get_balance unreachable: {e}') from e
 
     def is_valid_address(self, address: str) -> bool:
         """Validate an SS58 address."""

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -15,6 +15,7 @@ import bittensor as bt
 from Crypto.Hash import keccak
 from substrateinterface import Keypair
 
+from allways.chain_providers.base import ProviderUnreachableError
 from allways.classes import MinerPair
 from allways.commitments import read_miner_commitment
 from allways.constants import RESERVATION_COOLDOWN_BLOCKS
@@ -318,10 +319,17 @@ async def handle_swap_reserve(
                 reject_synapse(synapse, 'Miner does not support this swap direction', ctx)
                 return synapse
 
-            balance = provider.get_balance(synapse.from_address)
-            if balance < synapse.from_amount:
-                reject_synapse(synapse, 'Insufficient source balance', ctx)
-                return synapse
+            # Balance check is a pre-flight optimization, not a security gate —
+            # SwapConfirm still requires a real on-chain source tx. On a
+            # backend outage, skip the gate rather than falsely reject the
+            # user as underfunded.
+            try:
+                balance = provider.get_balance(synapse.from_address)
+                if balance < synapse.from_amount:
+                    reject_synapse(synapse, 'Insufficient source balance', ctx)
+                    return synapse
+            except ProviderUnreachableError as e:
+                bt.logging.warning(f'{ctx}: balance backend unreachable, skipping pre-flight gate: {e}')
 
             if not contract.get_miner_active_flag(miner):
                 reject_synapse(synapse, 'Miner not active', ctx)

--- a/uv.lock
+++ b/uv.lock
@@ -182,7 +182,6 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "requests" },
     { name = "rich" },
-    { name = "rich-click" },
     { name = "substrate-interface" },
     { name = "wandb" },
 ]
@@ -209,7 +208,6 @@ requires-dist = [
     { name = "python-dotenv", specifier = "==1.2.1" },
     { name = "requests" },
     { name = "rich" },
-    { name = "rich-click" },
     { name = "substrate-interface" },
     { name = "wandb", specifier = "==0.21.3" },
 ]
@@ -2510,21 +2508,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
-]
-
-[[package]]
-name = "rich-click"
-version = "1.9.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "rich" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/04/27/091e140ea834272188e63f8dd6faac1f5c687582b687197b3e0ec3c78ebf/rich_click-1.9.7.tar.gz", hash = "sha256:022997c1e30731995bdbc8ec2f82819340d42543237f033a003c7b1f843fc5dc", size = 74838, upload-time = "2026-01-31T04:29:27.707Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/e5/d708d262b600a352abe01c2ae360d8ff75b0af819b78e9af293191d928e6/rich_click-1.9.7-py3-none-any.whl", hash = "sha256:2f99120fca78f536e07b114d3b60333bc4bb2a0969053b1250869bcdc1b5351b", size = 71491, upload-time = "2026-01-31T04:29:26.777Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`BitcoinProvider.blockstream_get_balance` and `SubtensorProvider.get_balance` returned `0` on any backend failure. The validator axon at `handle_swap_reserve` checks `balance < from_amount` — so during a Blockstream or subtensor RPC outage, **every legitimate user is rejected with "Insufficient source balance"** regardless of their actual funds.

## Change

- `chain_providers/base.py` — abstract `get_balance` docstring: documents the `ProviderUnreachableError` contract.
- `chain_providers/bitcoin.py` — `blockstream_get_balance` raises `ProviderUnreachableError` on `ConnectionError`/`Timeout`/`HTTPError`, matching `blockstream_verify_transaction`.
- `chain_providers/subtensor.py` — `get_balance` raises `ProviderUnreachableError` on any subtensor failure (non-existent addresses return zero cleanly from RPC, so exceptions mean backend unreachable).
- `validator/axon_handlers.py` — `handle_swap_reserve` catches `ProviderUnreachableError`, logs a warning, and skips the balance gate.

Closes #147 