### PR TITLE
refactor: drop poll_for_swap_creation, reuse poll_for_swap_with_progress in post-tx

### DIFF
--- a/allways/cli/swap_commands/post_tx.py
+++ b/allways/cli/swap_commands/post_tx.py
@@ -16,7 +16,7 @@ from allways.cli.swap_commands.helpers import (
     print_contract_error,
     resolve_source_tx_block,
 )
-from allways.cli.swap_commands.swap import from_smallest_unit, poll_for_swap_creation, sign_and_broadcast_confirm
+from allways.cli.swap_commands.swap import from_smallest_unit, poll_for_swap_with_progress, sign_and_broadcast_confirm
 from allways.constants import NETUID_FINNEY
 from allways.contract_client import ContractError
 
@@ -160,7 +160,12 @@ def post_tx_command(tx_hash: str, tx_block: int):
         return
 
     # Poll for swap creation
-    swap_id = poll_for_swap_creation(client, state.miner_hotkey)
+    swap_id = poll_for_swap_with_progress(
+        client,
+        state.miner_hotkey,
+        state.from_chain,
+        message='Waiting for swap to appear on-chain...',
+    )
     if swap_id is not None:
         clear_pending_swap()
         console.print(f'\n[green bold]Swap initiated! ID: {swap_id}[/green bold]')

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -149,24 +149,6 @@ def resolve_recent_swap_id(client, miner_hotkey: str) -> Optional[int]:
     return active[0].id if active else None
 
 
-def poll_for_swap_creation(client, miner_hotkey: str) -> Optional[int]:
-    """Poll contract until miner has an active swap. Returns swap_id or None."""
-    with console.status('[dim]Waiting for swap to appear on-chain...[/dim]'):
-        errors = 0
-        for _ in range(60):
-            time.sleep(3)
-            try:
-                swap_id = resolve_recent_swap_id(client, miner_hotkey)
-                if swap_id is not None:
-                    return swap_id
-                errors = 0
-            except ContractError:
-                errors += 1
-                if errors >= 5:
-                    console.print('[yellow]Warning: contract unreachable, still waiting...[/yellow]')
-                    errors = 0
-    return None
-
 
 def broadcast_reserve_with_retry(
     subtensor,
@@ -427,7 +409,13 @@ def display_receipt(swap):
     console.print()
 
 
-def poll_for_swap_with_progress(client, miner_hotkey: str, from_chain: str, max_polls: int = 60):
+def poll_for_swap_with_progress(
+    client,
+    miner_hotkey: str,
+    from_chain: str,
+    max_polls: int = 60,
+    message: str = 'Waiting for validators to confirm and initiate swap...',
+):
     """Poll for swap creation with a live progress display."""
     with console.status('') as status:
         errors = 0
@@ -435,9 +423,7 @@ def poll_for_swap_with_progress(client, miner_hotkey: str, from_chain: str, max_
             elapsed = i * 3
             mins = elapsed // 60
             secs = elapsed % 60
-            status.update(
-                f'[dim]Waiting for validators to confirm and initiate swap... {mins}:{secs:02d} elapsed[/dim]'
-            )
+            status.update(f'[dim]{message} {mins}:{secs:02d} elapsed[/dim]')
 
             time.sleep(3)
             try:


### PR DESCRIPTION
## Closes: #137

## Summary

`poll_for_swap_creation` in `swap.py` was a duplicate of `poll_for_swap_with_progress` — identical polling logic, but with a static spinner and no elapsed-time feedback.
It had a single call site in `post_tx.py`.

**Changes:**
- Add a `message` parameter to `poll_for_swap_with_progress` (default keeps existing callers unchanged)
- Replace the `poll_for_swap_creation` call in `post_tx.py` with `poll_for_swap_with_progress`,
  passing `message='Waiting for swap to appear on-chain...'` to preserve the original UX text
- Delete `poll_for_swap_creation` from `swap.py`

## Visual diff (`alw swap post-tx` final polling step)

**Before:**
```
⠋ Waiting for swap to appear on-chain...
```
(static — no time feedback)

**After:**
```
⠋ Waiting for swap to appear on-chain... 0:00 elapsed
⠙ Waiting for swap to appear on-chain... 0:03 elapsed
⠹ Waiting for swap to appear on-chain... 0:06 elapsed
```
(same message, now with live elapsed time, keep clean and concise code, remove unnecessary duplication)
