### PR TITLE
refactor: add SwapStatus predicates to Swap, replace inline status checks

### DIFF
--- a/allways/classes.py
+++ b/allways/classes.py
@@ -89,6 +89,15 @@ class Swap:
     fulfilled_block: int = 0
     completed_block: int = 0
 
+    def is_pending(self) -> bool:
+        return self.status in (SwapStatus.ACTIVE, SwapStatus.FULFILLED)
+
+    def is_active(self) -> bool:
+        return self.status == SwapStatus.ACTIVE
+
+    def is_fulfilled(self) -> bool:
+        return self.status == SwapStatus.FULFILLED
+
 
 @dataclass
 class PendingExtension:

--- a/allways/miner/swap_poller.py
+++ b/allways/miner/swap_poller.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Set, Tuple
 
 import bittensor as bt
 
-from allways.classes import Swap, SwapStatus
+from allways.classes import Swap
 from allways.contract_client import AllwaysContractClient
 
 RESCAN_WINDOW = 16
@@ -45,7 +45,7 @@ class SwapPoller:
         for swap_id in range(start, next_id):
             swap = self.client.get_swap(swap_id)
             if swap and swap.miner_hotkey == self.miner_hotkey:
-                if swap.status in (SwapStatus.ACTIVE, SwapStatus.FULFILLED):
+                if swap.is_pending():
                     if swap.id not in self.active:
                         bt.logging.info(
                             f'Discovered swap {swap.id}: {swap.from_chain} -> {swap.to_chain}, '
@@ -62,7 +62,7 @@ class SwapPoller:
             if swap_id in fresh:
                 continue
             swap = self.client.get_swap(swap_id)
-            if swap is None or swap.status not in (SwapStatus.ACTIVE, SwapStatus.FULFILLED):
+            if swap is None or not swap.is_pending():
                 terminal = swap.status.name if swap is not None else 'GONE'
                 resolved.append((swap_id, terminal))
             else:
@@ -72,6 +72,6 @@ class SwapPoller:
             bt.logging.debug(f'Swap {sid}: dropped from active (status={terminal})')
 
         # 3. Return categorized by contract status
-        active_swaps = [s for s in self.active.values() if s.status == SwapStatus.ACTIVE]
-        fulfilled = [s for s in self.active.values() if s.status == SwapStatus.FULFILLED]
+        active_swaps = [s for s in self.active.values() if s.is_active()]
+        fulfilled = [s for s in self.active.values() if s.is_fulfilled()]
         return active_swaps, fulfilled

--- a/allways/validator/swap_tracker.py
+++ b/allways/validator/swap_tracker.py
@@ -11,8 +11,6 @@ from allways.classes import Swap, SwapStatus
 from allways.constants import EXTEND_THRESHOLD_BLOCKS
 from allways.contract_client import AllwaysContractClient
 
-ACTIVE_STATUSES = (SwapStatus.ACTIVE, SwapStatus.FULFILLED)
-
 # Cold-start backward scan halts after this many consecutive None lookups.
 # Resolved swaps are pruned from contract storage (`swaps.remove`), so a long
 # run of Nones means we've passed the live-swap region. Block-age cutoffs
@@ -67,7 +65,7 @@ class SwapTracker:
                     break
                 continue
             consecutive_none = 0
-            if swap.status in ACTIVE_STATUSES:
+            if swap.is_pending():
                 self.active[swap.id] = swap
 
         self.last_scanned_id = next_id - 1
@@ -131,7 +129,7 @@ class SwapTracker:
                 continue
             if swap is None:
                 continue
-            if swap.status in ACTIVE_STATUSES:
+            if swap.is_pending():
                 if swap.id not in self.active:
                     bt.logging.info(f'Swap {swap.id} [{_swap_label(swap)}]: now {swap.status.name}, monitoring')
                 self.active[swap.id] = swap
@@ -157,7 +155,7 @@ class SwapTracker:
                 continue
             if result is None:
                 continue
-            if result.status in ACTIVE_STATUSES:
+            if result.is_pending():
                 prev = self.active.get(sid)
                 if prev is not None and prev.status != result.status:
                     bt.logging.info(f'Swap {sid} [{_swap_label(result)}]: {prev.status.name} -> {result.status.name}')
@@ -180,7 +178,7 @@ class SwapTracker:
         return [
             s
             for s in self.active.values()
-            if s.status == SwapStatus.FULFILLED and (s.timeout_block == 0 or current_block <= s.timeout_block)
+            if s.is_fulfilled() and (s.timeout_block == 0 or current_block <= s.timeout_block)
         ]
 
     def get_near_timeout_fulfilled(self, current_block: int) -> List[Swap]:
@@ -188,9 +186,7 @@ class SwapTracker:
         return [
             s
             for s in self.active.values()
-            if s.status == SwapStatus.FULFILLED
-            and s.timeout_block > 0
-            and current_block >= s.timeout_block - EXTEND_THRESHOLD_BLOCKS
+            if s.is_fulfilled() and s.timeout_block > 0 and current_block >= s.timeout_block - EXTEND_THRESHOLD_BLOCKS
         ]
 
     def get_timed_out(self, current_block: int) -> List[Swap]:
@@ -198,7 +194,5 @@ class SwapTracker:
         return [
             s
             for s in self.active.values()
-            if s.status in (SwapStatus.ACTIVE, SwapStatus.FULFILLED)
-            and s.timeout_block > 0
-            and current_block > s.timeout_block
+            if s.is_pending() and s.timeout_block > 0 and current_block > s.timeout_block
         ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+"""Stub out heavy external deps so unit tests run without the full chain."""
+
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+
+def _mock_module(name: str, **attrs) -> ModuleType:
+    mod = ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+def _stub_bittensor() -> None:
+    bt = MagicMock()
+    bt.__name__ = 'bittensor'
+    sys.modules['bittensor'] = bt
+    sys.modules['bittensor.utils'] = MagicMock()
+
+
+def _stub_substrate() -> None:
+    """async_substrate_interface and websockets pull in native extensions."""
+    _mock_module('scalecodec')
+    _mock_module('async_substrate_interface')
+    errors_mod = _mock_module('async_substrate_interface.errors')
+    errors_mod.ExtrinsicNotFound = Exception
+    _mock_module('websockets')
+    _mock_module('websockets.exceptions', ConnectionClosed=Exception)
+
+
+_stub_bittensor()
+_stub_substrate()


### PR DESCRIPTION
## Closes: #139

## Summary

`SwapStatus.ACTIVE` and `SwapStatus.FULFILLED` were checked inline via scattered status tuples in `swap_tracker.py` and `swap_poller.py`. `swap_tracker.py` had a module-level `ACTIVE_STATUSES` constant to partially address this, but `swap_poller.py` duplicated the same tuple instead of importing it.

**Changes:**
- Add `is_pending()`, `is_active()`, `is_fulfilled()` predicates to the `Swap`  dataclass in `classes.py`
- Remove the `ACTIVE_STATUSES` module constant from `swap_tracker.py` — now  redundant
- Replace all inline `swap.status in (SwapStatus.ACTIVE, SwapStatus.FULFILLED)`  and `swap.status == SwapStatus.X` checks in both files with the named predicates
- Remove the now-unused `SwapStatus` import from `swap_poller.py`

If the definition of "pending" ever needs to change (e.g. a new intermediate status is added), the fix is in one place in `classes.py` rather than hunting down every scattered tuple.
