### PR TITLE
fix: validate source address in swap flow for non-TAO chains

### DIFF
--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -681,6 +681,11 @@ def swap_now_command(
         )
         user_from_address = click.prompt(f'Your {from_chain.upper()} source address')
 
+    _fp = chain_providers.get(from_chain)
+    if _fp and not _fp.is_valid_address(user_from_address):
+        console.print(f'[red]Invalid {from_chain.upper()} address: {user_from_address}[/red]')
+        return
+
     # Step 6b: Verify sender has enough funds
     if from_chain == 'tao':
         tao_balance = subtensor.get_balance(wallet.coldkeypub.ss58_address)


### PR DESCRIPTION
## Closes: #141 

## Summary

- Added source address validation in `swap_now_command` for all source chains - After `user_from_address` is set (wallet, CLI flag, or user prompt), the   chain provider's `is_valid_address` check now runs before the swap proceeds
- Mirrors the existing destination-address validation already at the `to_provider.is_valid_address(receive_address)` guard

## Problem

The swap flow validated the destination (receive) address but not the source address. For non-TAO source chains (BTC, etc.) the user manually enters their source address with no format check. 
A typo'd address would pass the confirmation screen, trigger the reservation, and only fail at signing time — after validators have already allocated a miner and the user has waited through the quorum round.

## Code paths verified

| Scenario | Result |
|---|---|
| BTC→TAO, user types valid BTC addr | proceeds ✅ |
| BTC→TAO, user types garbage | rejected with clear error ✅ |
| BTC→TAO, `--from-address` typo | rejected ✅ |
| TAO→BTC, wallet SS58 address | `SubtensorProvider.is_valid_address` → True, no behaviour change ✅ |
| Unknown chain (no provider) | `_fp` is None → skipped, caught at step 8 as before ✅ |

## Test plan

- [ ] `alw swap btc tao` — enter a garbage BTC source address → rejected immediately with `[red]Invalid BTC address: ...[/red]`
- [ ] `alw swap btc tao` — enter a valid BTC bech32 address (`bc1q...`) → proceeds to confirmation
- [ ] `alw swap btc tao` — enter a valid BTC legacy address (`1A1z...`) → proceeds to confirmation
- [ ] `alw swap tao btc` — TAO source uses wallet address automatically → no validation prompt, no behaviour change
- [ ] `alw swap btc tao --from-address <garbage>` → rejected at address validation step
- [ ] Existing test suite: `pytest tests/` on an environment with full dependencies installed
