### PR TITLE
fix: guard try_extend_reservation recovery read against transient ContractError

### DIFF
--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -252,9 +252,19 @@ def try_extend_reservation(
         )
     except ContractError as e:
         if 'AlreadyVoted' in str(e):
-            self.extend_reservation_voted_at[(item.miner_hotkey, item.from_tx_hash)] = (
-                self.contract_client.get_miner_reserved_until(item.miner_hotkey)
-            )
+            # Refresh the cache so the next round can vote again once the
+            # contract extends. Guard with an inner try/except because this
+            # read can itself raise ContractError on a subtensor blip, and
+            # Python would propagate that new exception out of the handler —
+            # bypassing the outer ``except Exception`` defensive guard below.
+            try:
+                reserved_until = self.contract_client.get_miner_reserved_until(item.miner_hotkey)
+                self.extend_reservation_voted_at[(item.miner_hotkey, item.from_tx_hash)] = reserved_until
+            except Exception as inner:
+                bt.logging.debug(
+                    f'PendingConfirm [{swap_label} {miner_short}]: '
+                    f'failed to refresh extend-vote cache: {inner}'
+                )
         else:
             bt.logging.debug(f'PendingConfirm [{swap_label} {miner_short}]: extend vote: {e}')
     except Exception as e:


### PR DESCRIPTION
## Summary

`try_extend_reservation`'s `AlreadyVoted` recovery path calls `get_miner_reserved_until`, which can itself raise `ContractError` on a subtensor blip. Per Python semantics, a new exception raised inside an `except` block propagates to the enclosing try — the sibling `except Exception` on the same statement is not a fallback. The result is that a rare-but-correlated double-failure (AlreadyVoted + RPC blip) escapes `try_extend_reservation`, `initialize_pending_user_reservations`, and `forward()` entirely, aborting the validator's forward step. Base `run()` catches it with exponential backoff, so the validator self-heals, but `event_watcher.sync_to`, `tracker.poll`, `confirm_miner_fulfillments`, `extend_fulfilled_near_timeout`, `enforce_swap_timeouts`, and the scoring gate are all skipped for that tick.

Wraps the recovery read in its own try/except so RPC failure during refresh is logged and swallowed — matching the defensive intent of the outer `except Exception` already on line 260.

## Change

- `allways/validator/forward.py` — inner `try/except Exception` around the `get_miner_reserved_until` call inside the `AlreadyVoted` branch; log and continue on failure.

## Behavior notes

- Missing the cache refresh is harmless: the next forward step will re-read `reserved_until` and resume normal extend-vote logic. No correctness consequence.
- No change to the non-`AlreadyVoted` branch or to the outer `except Exception` handler.

## Test plan

- [x] `ruff check allways/`
- [x] `pytest tests/`
- [x] Manual: mock `get_miner_reserved_until` to raise `ContractError` during the `AlreadyVoted` branch; confirm the forward step completes rather than aborting at `try_extend_reservation`.
