### PR TITLE
fix: validate source address for non-TAO chains before swap proceeds

### DIFF
--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -681,6 +681,17 @@ def swap_now_command(
         )
         user_from_address = click.prompt(f'Your {from_chain.upper()} source address')
 
+    # Validate source address for non-TAO chains
+    if from_chain != 'tao':
+        src_provider = chain_providers.get(from_chain)
+        if (
+            src_provider
+            and hasattr(src_provider, 'is_valid_address')
+            and not src_provider.is_valid_address(user_from_address)
+        ):
+            console.print(f'[red]Invalid source address for {from_chain.upper()}. Please check and try again.[/red]')
+            return
+
     # Step 6b: Verify sender has enough funds
     if from_chain == 'tao':
         tao_balance = subtensor.get_balance(wallet.coldkeypub.ss58_address)


### PR DESCRIPTION
Fixes #141

## Problem
The swap flow validates the destination address (`receive_address`)
using `dest_provider.is_valid_address` but does not validate the source
address (`user_source_address`) for non-TAO chains. Invalid or malformed
source addresses pass through confirmation, reservation creation, and
validator allocation — only failing at signing time, wasting resources
and causing poor UX.

## Fix
Added source address validation for non-TAO chains immediately after
the source address is collected (Step 6), mirroring the existing
destination address validation pattern. If the provider has
`is_valid_address` and the address fails validation, the swap exits
early with a clear error message before any reservation is made.

## Changes
- `allways/cli/swap_commands/swap.py` — added source address validation
  for non-TAO chains after source address collection