### PR TITLE
fix: validate addresses in alw miner post before committing to chain

### DIFF
--- a/allways/cli/swap_commands/pair.py
+++ b/allways/cli/swap_commands/pair.py
@@ -2,6 +2,7 @@
 
 import click
 
+from allways.chain_providers import create_chain_providers
 from allways.chains import SUPPORTED_CHAINS, canonical_pair
 from allways.cli.help import StyledCommand
 from allways.cli.swap_commands.helpers import console, get_cli_context, loading
@@ -149,6 +150,13 @@ def post_pair(
 
     config, wallet, subtensor, _ = get_cli_context(need_client=False)
     netuid = config['netuid']
+
+    providers = create_chain_providers(check=False, subtensor=subtensor, wallet=wallet)
+    for chain, addr in ((src_chain, src_addr), (dst_chain, dst_addr)):
+        p = providers.get(chain)
+        if p and not p.is_valid_address(addr):
+            console.print(f'[red]Invalid {SUPPORTED_CHAINS[chain].name} address: {addr}[/red]')
+            return
 
     rate_str = f'{rate:g}'
     counter_rate_str = f'{counter_rate:g}'


### PR DESCRIPTION
## Closes: #155

## Summary

`alw miner post` accepted any string as a BTC or TAO address and committed it to the subnet without validation. A miner who typos their receiving address becomes unable to receive funds from matched swaps — their collateral is at risk and users matched to them will experience failed fulfillments.

## What changed

**`allways/cli/swap_commands/pair.py`**
- After chains and addresses are resolved (but before showing the confirmation summary), creates chain providers with `check=False` and calls `is_valid_address()` for both the source and destination address
- Both `BitcoinProvider` and `SubtensorProvider` validate locally — no network connections are made
- Rejects with a clear `[red]Invalid <ChainName> address: <addr>[/red]` message and returns early

**`tests/test_pair_validation.py`** (new, 4 tests)
- Invalid src address rejected
- Invalid dst address rejected  
- Valid addresses proceed to confirmation
- Both invalid shows only the first error

## Test Case

**Before**:

<img width="726" height="320" alt="image" src="https://github.com/user-attachments/assets/87920695-59a8-4fc0-9490-6c6f58887b03" />


**After**:

<img width="762" height="170" alt="image" src="https://github.com/user-attachments/assets/d4bc044d-cac2-4d11-9c89-ee1b70046e89" />
