### PR TITLE
feat: implement save_state/load_state for miner swap poller cursor

### DIFF
--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -96,6 +96,7 @@ class Miner(BaseMinerNeuron):
             pass
         except Exception as e:
             bt.logging.warning(f'Miner load_state failed, starting fresh: {e}')
+
     def unlock_coldkey(self) -> None:
         """Decrypt and cache the bittensor coldkey at startup so per-swap TAO
         transfers don't re-prompt for a password each time. Without this, every

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -6,6 +6,7 @@ Usage:
     python neurons/miner.py --netuid 7 --wallet.name default --wallet.hotkey default
 """
 
+import json
 import time
 from pathlib import Path
 from typing import Dict
@@ -61,7 +62,34 @@ class Miner(BaseMinerNeuron):
 
         self.consecutive_poll_failures = 0
 
+        self.load_state()
+
         bt.logging.info(f'Miner initialized: hotkey={self.wallet.hotkey.ss58_address} | addresses={self.my_addresses}')
+
+    def _state_path(self) -> Path:
+        hotkey = self.wallet.hotkey.ss58_address
+        return Path.home() / '.allways' / 'miner' / f'state_{hotkey[:12]}.json'
+
+    def save_state(self) -> None:
+        """Persist the swap poller cursor so restarts resume from the last scanned swap ID."""
+        try:
+            path = self._state_path()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(json.dumps({'last_scanned_id': self.swap_poller.last_scanned_id}))
+        except Exception as e:
+            bt.logging.warning(f'Miner save_state failed: {e}')
+
+    def load_state(self) -> None:
+        """Restore the swap poller cursor from the last saved state."""
+        path = self._state_path()
+        try:
+            state = json.loads(path.read_text())
+            self.swap_poller.last_scanned_id = int(state.get('last_scanned_id', 0))
+            bt.logging.info(f'Miner state loaded: last_scanned_id={self.swap_poller.last_scanned_id}')
+        except FileNotFoundError:
+            pass
+        except Exception as e:
+            bt.logging.warning(f'Miner load_state failed, starting fresh: {e}')
 
     def load_my_addresses(self) -> Dict[str, str]:
         """Read this miner's committed pair once and map chain → address.


### PR DESCRIPTION
## Summary

Implements `save_state` / `load_state` on the `Miner` neuron to persist the swap poller cursor across restarts.

## Why

`BaseNeuron.sync()` calls `save_state()` after every forward iteration, but the miner's implementation was a no-op stub. On restart, `SwapPoller.last_scanned_id` reset to `0`, forcing an O(N) full re-scan of every swap ID in the contract before the miner could resume work. For a long-running subnet this scan grows unboundedly over time.

The miner's critical send-side state (`SwapFulfiller.sent_cache`) was already persisted to disk independently via JSON — so double-sends were never a risk. Only the polling cursor was being lost.

## What changed

**`neurons/miner.py`**
- `_state_path()` — returns `~/.allways/miner/state_{hotkey[:12]}.json`, consistent with the existing `sent_cache` path convention
- `save_state()` — writes `{"last_scanned_id": N}` to the state file; called automatically by `sync()` after each forward
- `load_state()` — reads the cursor back on startup; silently ignores missing file (fresh start) or corrupt JSON (logs a warning, leaves cursor at 0)
- `__init__` — calls `load_state()` after `swap_poller` is created so the first forward resumes from the saved position

## What's not changed

The validator's `save_state` / `load_state` (scores + hotkeys + step → NPZ) was already fully implemented in `BaseValidatorNeuron` — no changes needed there.
