### PR TITLE
fix: coerce neuron.events_retention_size to int for RotatingFileHandler

### DIFF
--- a/allways/utils/config.py
+++ b/allways/utils/config.py
@@ -43,7 +43,7 @@ def add_args(cls, parser):
 
     parser.add_argument(
         '--neuron.events_retention_size',
-        type=str,
+        type=int,
         help='Events retention size.',
         default=2 * 1024 * 1024 * 1024,  # 2 GB
     )


### PR DESCRIPTION
Fixes #154

## Summary

- Changed `type=str` to `type=int` for the `--neuron.events_retention_size` argument in `allways/utils/config.py`.
- This ensures that `argparse` returns an integer instead of a string when parsing the command line.

## Why

The string value was being passed directly to `RotatingFileHandler(maxBytes=...)` in `allways/utils/logging.py`. The standard library's logging handler requires an integer to perform the internal `if maxBytes > 0` comparison, triggering a `TypeError` and crashing the logging thread at startup if a string was provided.

## Behavior note

Users providing `--neuron.events_retention_size` via CLI will no longer experience a fatal crash during initialization. The logging rotation will now correctly enforce the specified byte limit.

## Net

-1 line (+1 line with corrected type) in `allways/utils/config.py`.

## Test plan

- [x] `ruff check allways/ neurons/` and `ruff format --check` - both clean.
- [x] `pytest tests/` - no new failures vs. current `test` branch.
- [x] Manual smoke: executed local reproduction script demonstrating the `TypeError` is resolved.
- [x] Verified via native regression test (logs attached/available).

## Attachments
[reproduce_issue_154.py](https://github.com/user-attachments/files/26951534/reproduce_issue_154.py)
[pre_fix_failure.log](https://github.com/user-attachments/files/26951586/pre_fix_failure.log)
[post_fix_success.log](https://github.com/user-attachments/files/26951585/post_fix_success.log)