### PR TITLE
fix: extend swap scan window to include next_id-5 (off-by-one in range stop)

### DIFF
--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -127,7 +127,7 @@ def poll_for_swap_creation(client, miner_hotkey: str) -> Optional[int]:
             try:
                 if client.get_miner_has_active_swap(miner_hotkey):
                     next_id = client.get_next_swap_id()
-                    for check_id in range(next_id - 1, max(next_id - 5, 0), -1):
+                    for check_id in range(next_id - 1, max(next_id - 6, 0), -1):
                         swap = client.get_swap(check_id)
                         if swap and swap.miner_hotkey == miner_hotkey:
                             return check_id
@@ -335,7 +335,7 @@ def poll_for_swap_with_progress(client, miner_hotkey: str, from_chain: str, max_
             try:
                 if client.get_miner_has_active_swap(miner_hotkey):
                     next_id = client.get_next_swap_id()
-                    for check_id in range(next_id - 1, max(next_id - 5, 0), -1):
+                    for check_id in range(next_id - 1, max(next_id - 6, 0), -1):
                         swap = client.get_swap(check_id)
                         if swap and swap.miner_hotkey == miner_hotkey:
                             return check_id


### PR DESCRIPTION
Closes #150

## Problem

The recent swap scan used:

```python
for check_id in range(next_id - 1, max(next_id - 5, 0), -1):
Python's range(start, stop, step) excludes the stop value. This means the loop only checked 4 IDs (next_id-1 through next_id-4) and never reached next_id-5. When a miner's active swap existed exactly at next_id-5 or older, the CLI would fail to find it and return None — even though get_miner_has_active_swap(miner_hotkey) confirmed an active swap exists on-chain.
This caused false negative swap detection during the confirmation flow, leading to misleading "swap not found / not initiated yet" output and unnecessary retries or manual checks.
Fix
Changed the range stop from next_id - 5 to next_id - 6 at both occurrences (lines 130 and 338):
for check_id in range(next_id - 1, max(next_id - 6, 0), -1):
This makes the range inclusive of next_id-5, scanning exactly 5 IDs as intended (next_id-1 through next_id-5).
Files Changed
allways/cli/swap_commands/swap.py — fixed off-by-one at both scan sites (lines 130 and 338)