### PR TITLE
alw claim: clearer messaging for every caller

### DIFF
--- a/allways/cli/swap_commands/claim.py
+++ b/allways/cli/swap_commands/claim.py
@@ -1,9 +1,13 @@
 """alw claim - Claim a pending slash payout for a timed-out swap."""
 
+import os
+
 import click
 
+from allways.classes import SwapStatus
 from allways.cli.help import StyledCommand
 from allways.cli.swap_commands.helpers import console, from_rao, get_cli_context, loading, print_contract_error
+from allways.cli.swap_commands.view import DEFAULT_DASHBOARD_URL
 from allways.contract_client import ContractError
 
 
@@ -14,7 +18,8 @@ def claim_command(swap_id: int, yes: bool):
     """Claim a pending slash payout for a timed-out swap.
 
     [dim]If a miner failed to fulfill your swap before the timeout,
-    you can claim a slash payout from their collateral.[/dim]
+    you can claim a slash payout from their collateral.
+    Only the original swap user can claim.[/dim]
 
     [dim]Examples:
         $ alw claim 42[/dim]
@@ -30,12 +35,31 @@ def claim_command(swap_id: int, yes: bool):
         return
 
     if pending_rao == 0:
-        console.print('[yellow]No pending slash for this swap[/yellow]\n')
+        try:
+            swap = client.get_swap(swap_id)
+        except ContractError:
+            swap = None
+
+        if swap is not None and swap.status in (SwapStatus.ACTIVE, SwapStatus.FULFILLED):
+            console.print(
+                f'[yellow]Swap #{swap_id} is still in progress (status: {swap.status.name}).[/yellow]\n'
+                '[dim]A slash is only created if the swap times out unfulfilled.[/dim]\n'
+            )
+            return
+
+        dashboard_url = os.environ.get('ALLWAYS_DASHBOARD_URL', DEFAULT_DASHBOARD_URL).rstrip('/')
+        console.print(
+            f'[yellow]Nothing to claim for swap #{swap_id}.[/yellow]\n'
+            '[dim]The slash was either paid directly to the user at timeout, already claimed,\n'
+            'or the swap never timed out. Only the original swap user can claim a pending slash.\n'
+            f'Refund history:[/dim] {dashboard_url}/swap/{swap_id}\n'
+        )
         return
 
     console.print(f'  Swap ID:    {swap_id}')
     console.print(f'  Amount:     [green]{from_rao(pending_rao):.4f} TAO[/green] ({pending_rao} rao)')
-    console.print(f'  Claiming:   {wallet.hotkey.ss58_address}\n')
+    console.print(f'  Claiming:   {wallet.hotkey.ss58_address}')
+    console.print('[dim]  Only the original swap user can claim; others will be rejected on-chain.[/dim]\n')
 
     if not yes and not click.confirm('Confirm claiming slash?'):
         console.print('[yellow]Cancelled[/yellow]')


### PR DESCRIPTION
## Summary
- `alw claim <id>` used to say the same "No pending slash for this swap" regardless of caller (user / miner / owner / random) or swap state, which implied the swap might have let the wrong person claim.
- Now distinguishes: swap still in progress, no pending entry (paid direct or already claimed), or entry present (warns that only the original user can claim before submitting).
- Links to the dashboard `/swap/<id>` for refund history.

Part of a 5-repo sweep improving the timed-out / slash UX across CLI + DB + watcher + API + UI.

## Test plan
- [ ] `alw claim <bad_id>` → reasonable message.
- [ ] `alw claim <in_progress_id>` → "still in progress".
- [ ] `alw claim <timed_out_with_direct_payout>` → "paid directly / already claimed" + dashboard link.
- [ ] `alw claim <timed_out_with_pending>` as user → claims.
- [ ] `alw claim <timed_out_with_pending>` as miner/random → caller-mismatch message before submit.