### PR TITLE
alw swap now: explain what happened on timeout

### DIFF
--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -333,6 +333,33 @@ def broadcast_reserve_with_retry(
 # =========================================================================
 
 
+def display_timeout_notice(swap, dashboard_url: str):
+    """Explain a TIMED_OUT result to the user after `alw swap now` watches through termination.
+
+    The timeout path looks silent from the CLI's perspective — the contract
+    refunds directly and removes the swap from storage — so surface what
+    actually happened: the miner failed to fulfill, they're slashed, and the
+    user is made whole in TAO from the slashed collateral.
+    """
+    tao_human = swap.tao_amount / (10**9) if swap.tao_amount else 0.0
+    amount_line = f'[bold]{tao_human:g} TAO[/bold]' if tao_human else 'TAO equivalent to your swap'
+
+    notice = (
+        '[bold]Miner failed to fulfill within the timeout window.[/bold]\n'
+        '\n'
+        f"  You're made whole: {amount_line} is slashed from the miner's\n"
+        '  collateral and sent directly to your TAO wallet.\n'
+        '\n'
+        '  If the on-chain transfer could not settle, the slash is held\n'
+        f'  pending — claim it with: [cyan]alw claim {swap.id}[/cyan]\n'
+        '\n'
+        f'  Details: [cyan]{dashboard_url}/swap/{swap.id}[/cyan]'
+    )
+    console.print()
+    console.print(Panel(notice, title='[bold red]Swap Timed Out[/bold red]', expand=False))
+    console.print()
+
+
 def display_receipt(swap):
     """Show a rich completion receipt after a successful swap."""
     src_chain_def = get_chain(swap.from_chain)
@@ -996,10 +1023,13 @@ def swap_now_command(
         return
 
     # Watch swap through lifecycle
-    from allways.cli.swap_commands.view import watch_swap
+    from allways.cli.swap_commands.view import DEFAULT_DASHBOARD_URL, watch_swap
 
     final_swap = watch_swap(client, swap_id)
 
-    # Show completion receipt
+    # Show completion receipt / timeout notice
     if final_swap and final_swap.status == SwapStatus.COMPLETED:
         display_receipt(final_swap)
+    elif final_swap and final_swap.status == SwapStatus.TIMED_OUT:
+        dashboard_url = os.environ.get('ALLWAYS_DASHBOARD_URL', DEFAULT_DASHBOARD_URL).rstrip('/')
+        display_timeout_notice(final_swap, dashboard_url)


### PR DESCRIPTION
## Summary
Before: `alw swap now` watches the swap until it terminates, and on `TIMED_OUT` just renders the terminal timeline and drops back to the shell — no indication whether the user was refunded, whether the miner was penalized, or what to do next.

After: mirrors `display_receipt`'s panel on the completed path with a red "Swap Timed Out" panel that:
- states the miner failed to fulfill within the window,
- confirms the user is made whole in TAO from the slashed collateral,
- points at `alw claim <id>` for the (rare on localnet) pending-slash case,
- links to the dashboard `/swap/<id>` for details.

## Test plan
- [ ] Force a timeout on localnet (stop miners, drop timeout to 10 blocks, initiate swap). Verify the panel renders with the correct TAO amount, swap id, and dashboard URL.
- [ ] `alw view swap <id> --watch` path unchanged (notice only fires from `alw swap now`).
- [ ] `ALLWAYS_DASHBOARD_URL` override respected.