### PR TITLE
fix: centralize contract event names and harden watcher dispatch #170

### DIFF
--- a/allways/validator/contract_events.py
+++ b/allways/validator/contract_events.py
@@ -1,0 +1,12 @@
+"""Canonical contract event labels consumed by the validator."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class ContractEventName(str, Enum):
+    MINER_ACTIVATED = 'MinerActivated'
+    SWAP_INITIATED = 'SwapInitiated'
+    SWAP_COMPLETED = 'SwapCompleted'
+    SWAP_TIMED_OUT = 'SwapTimedOut'

--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -30,6 +30,7 @@ from allways.utils.scale import (
     decode_u128,
     strip_hex_prefix,
 )
+from allways.validator.contract_events import ContractEventName
 from allways.validator.state_store import ValidatorStateStore
 
 DATA_DECODERS = {
@@ -338,7 +339,7 @@ class ContractEventWatcher:
             name, values = decoded
             self.apply_event(block_num, name, values)
 
-    def decode_contract_event(self, event_record: Any) -> Optional[Tuple[str, Dict[str, Any]]]:
+    def decode_contract_event(self, event_record: Any) -> Optional[Tuple[ContractEventName, Dict[str, Any]]]:
         record = event_record.value if hasattr(event_record, 'value') else event_record
         event = record.get('event', record) if isinstance(record, dict) else record
         module = event.get('module_id', '') if isinstance(event, dict) else ''
@@ -376,20 +377,32 @@ class ContractEventWatcher:
         except Exception as e:
             bt.logging.warning(f'EventWatcher: failed to decode {event_def.name}: {e}')
             return None
-        return event_def.name, values
+        try:
+            event_name = ContractEventName(event_def.name)
+        except ValueError:
+            bt.logging.warning(f'EventWatcher: unsupported contract event label {event_def.name!r} in metadata')
+            return None
+        return event_name, values
 
-    def apply_event(self, block_num: int, name: str, values: Dict[str, Any]) -> None:
-        if name == 'MinerActivated':
+    def apply_event(self, block_num: int, name: str | ContractEventName, values: Dict[str, Any]) -> None:
+        if isinstance(name, str):
+            try:
+                name = ContractEventName(name)
+            except ValueError:
+                bt.logging.warning(f'EventWatcher: unsupported event name {name!r} ignored')
+                return
+
+        if name is ContractEventName.MINER_ACTIVATED:
             hotkey = values.get('miner', '')
             if not hotkey:
                 return
             active = bool(values.get('active'))
             self.record_active_transition(block_num, hotkey, active)
-        elif name == 'SwapInitiated':
+        elif name is ContractEventName.SWAP_INITIATED:
             miner = values.get('miner', '')
             if miner:
                 self.apply_busy_delta(block_num, miner, +1)
-        elif name == 'SwapCompleted':
+        elif name is ContractEventName.SWAP_COMPLETED:
             swap_id = values.get('swap_id')
             miner = values.get('miner', '')
             if isinstance(swap_id, int) and miner:
@@ -400,7 +413,7 @@ class ContractEventWatcher:
                     resolved_block=block_num,
                 )
                 self.apply_busy_delta(block_num, miner, -1)
-        elif name == 'SwapTimedOut':
+        elif name is ContractEventName.SWAP_TIMED_OUT:
             swap_id = values.get('swap_id')
             miner = values.get('miner', '')
             if isinstance(swap_id, int) and miner:


### PR DESCRIPTION
## Summary

- Replaced string-literal event routing in `allways/validator/event_watcher.py` with a shared `ContractEventName` enum to avoid silent no-op dispatch when labels drift.
- Added `allways/validator/contract_events.py` as the canonical source of contract event labels used by validator-side event handling.
- Hardened decode/dispatch flow so unknown metadata event labels are explicitly detected and warned on, instead of falling through default behavior.

Closes #170

## Why

Event routing previously depended on raw string comparisons (e.g. `'MinerActivated'`, `'SwapInitiated'`). If contract metadata labels change, decoded events could silently bypass intended branches. Centralizing labels in an imported enum makes the routing contract explicit and reduces drift risk.

## Changes

- **New module:** `allways/validator/contract_events.py`
  - Introduces `ContractEventName(str, Enum)` with:
    - `MINER_ACTIVATED = "MinerActivated"`
    - `SWAP_INITIATED = "SwapInitiated"`
    - `SWAP_COMPLETED = "SwapCompleted"`
    - `SWAP_TIMED_OUT = "SwapTimedOut"`

- **Updated:** `allways/validator/event_watcher.py`
  - Imports `ContractEventName` from the new module.
  - `decode_contract_event(...)` now validates metadata event labels by coercing to `ContractEventName`.
  - Unsupported metadata labels are logged and dropped explicitly.
  - `apply_event(...)` accepts `str | ContractEventName`, normalizes to enum, and warns on unsupported names.
  - Branch dispatch now uses enum members rather than string literals.

## Risk / Compatibility

- Low risk: behavior for known event labels is unchanged.
- Safer failure mode: unexpected labels now warn and are ignored explicitly instead of silently missing a string match.

## Test Plan

- [x] `python3 -m compileall allways/validator/event_watcher.py allways/validator/contract_events.py`
- [x] Lint check for touched files (`event_watcher.py`, `contract_events.py`) reports no new diagnostics.
- [ ] Run validator tests locally once `pytest` is available:
  - `pytest -q tests/test_event_watcher.py tests/test_scoring_v1.py`

