### PR TITLE
Fix/centralize already voted predicate

### DIFF
--- a/allways/contract_client.py
+++ b/allways/contract_client.py
@@ -293,6 +293,17 @@ def is_contract_rejection(e: BaseException) -> bool:
     return 'contract rejected' in msg or 'ContractReverted' in msg
 
 
+def is_already_voted(e: BaseException) -> bool:
+    """Return True if ``e`` is the contract's "already voted" rejection.
+
+    This keeps all "already voted" matching in one place so call sites do not
+    hardcode error names or re-implement fragile string checks.
+    """
+    msg = str(e)
+    already_voted_name = CONTRACT_ERROR_VARIANTS.get(3, ('AlreadyVoted', ''))[0]
+    return f': {already_voted_name} ' in msg or f': {already_voted_name} —' in msg
+
+
 # =========================================================================
 # Client
 # =========================================================================

--- a/allways/validator/contract_events.py
+++ b/allways/validator/contract_events.py
@@ -1,0 +1,12 @@
+"""Canonical contract event labels consumed by the validator."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class ContractEventName(str, Enum):
+    MINER_ACTIVATED = 'MinerActivated'
+    SWAP_INITIATED = 'SwapInitiated'
+    SWAP_COMPLETED = 'SwapCompleted'
+    SWAP_TIMED_OUT = 'SwapTimedOut'

--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -30,6 +30,7 @@ from allways.utils.scale import (
     decode_u128,
     strip_hex_prefix,
 )
+from allways.validator.contract_events import ContractEventName
 from allways.validator.state_store import ValidatorStateStore
 
 DATA_DECODERS = {
@@ -338,7 +339,7 @@ class ContractEventWatcher:
             name, values = decoded
             self.apply_event(block_num, name, values)
 
-    def decode_contract_event(self, event_record: Any) -> Optional[Tuple[str, Dict[str, Any]]]:
+    def decode_contract_event(self, event_record: Any) -> Optional[Tuple[ContractEventName, Dict[str, Any]]]:
         record = event_record.value if hasattr(event_record, 'value') else event_record
         event = record.get('event', record) if isinstance(record, dict) else record
         module = event.get('module_id', '') if isinstance(event, dict) else ''
@@ -376,20 +377,32 @@ class ContractEventWatcher:
         except Exception as e:
             bt.logging.warning(f'EventWatcher: failed to decode {event_def.name}: {e}')
             return None
-        return event_def.name, values
+        try:
+            event_name = ContractEventName(event_def.name)
+        except ValueError:
+            bt.logging.warning(f'EventWatcher: unsupported contract event label {event_def.name!r} in metadata')
+            return None
+        return event_name, values
 
-    def apply_event(self, block_num: int, name: str, values: Dict[str, Any]) -> None:
-        if name == 'MinerActivated':
+    def apply_event(self, block_num: int, name: str | ContractEventName, values: Dict[str, Any]) -> None:
+        if isinstance(name, str):
+            try:
+                name = ContractEventName(name)
+            except ValueError:
+                bt.logging.warning(f'EventWatcher: unsupported event name {name!r} ignored')
+                return
+
+        if name is ContractEventName.MINER_ACTIVATED:
             hotkey = values.get('miner', '')
             if not hotkey:
                 return
             active = bool(values.get('active'))
             self.record_active_transition(block_num, hotkey, active)
-        elif name == 'SwapInitiated':
+        elif name is ContractEventName.SWAP_INITIATED:
             miner = values.get('miner', '')
             if miner:
                 self.apply_busy_delta(block_num, miner, +1)
-        elif name == 'SwapCompleted':
+        elif name is ContractEventName.SWAP_COMPLETED:
             swap_id = values.get('swap_id')
             miner = values.get('miner', '')
             if isinstance(swap_id, int) and miner:
@@ -400,7 +413,7 @@ class ContractEventWatcher:
                     resolved_block=block_num,
                 )
                 self.apply_busy_delta(block_num, miner, -1)
-        elif name == 'SwapTimedOut':
+        elif name is ContractEventName.SWAP_TIMED_OUT:
             swap_id = values.get('swap_id')
             miner = values.get('miner', '')
             if isinstance(swap_id, int) and miner:

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -15,7 +15,7 @@ from allways.constants import (
     PENDING_CONFIRM_NULL_RETRY_LIMIT,
     SCORING_WINDOW_BLOCKS,
 )
-from allways.contract_client import ContractError, is_contract_rejection
+from allways.contract_client import ContractError, is_already_voted, is_contract_rejection
 from allways.utils.logging import log_on_change
 from allways.validator import voting
 from allways.validator.axon_handlers import (
@@ -253,7 +253,7 @@ def try_extend_reservation(
             f'voted to extend reservation ({reserved_until - current_block} blocks remaining)'
         )
     except ContractError as e:
-        if 'AlreadyVoted' in str(e):
+        if is_already_voted(e):
             self.extend_reservation_voted_at[(item.miner_hotkey, item.from_tx_hash)] = (
                 self.contract_client.get_miner_reserved_until(item.miner_hotkey)
             )
@@ -394,7 +394,7 @@ def extend_fulfilled_near_timeout(self: Validator) -> None:
                 f'({tx_info.confirmations}/{chain_def.min_confirmations} dest confirmations)'
             )
         except ContractError as e:
-            if 'AlreadyVoted' in str(e):
+            if is_already_voted(e):
                 tracker.mark_extend_timeout_voted(swap.id)
             elif not is_contract_rejection(e):
                 bt.logging.debug(f'{ctx}: extend timeout vote: {e}')


### PR DESCRIPTION
## Summary
- Replace fragile inline checks (`'AlreadyVoted' in str(e)`) with a centralized predicate.
- Add `is_already_voted(e)` in `allways/contract_client.py` as the single source of truth for this contract rejection case.
- Route both validator forward-path call sites through the helper:
  - reservation extension handling in `try_extend_reservation`
  - timeout extension handling in `extend_fulfilled_near_timeout`
  - 
Closes #172

## Problem
`forward.py` still used inline substring checks for `"AlreadyVoted"` at two locations after PR #101 introduced a predicate approach. This created drift and risk: contract error naming changes could silently break these branches.

## Solution
- Implement and use `is_already_voted(e)` from `contract_client` in all affected paths.
- Keep rejection semantics consistent with existing centralized helpers like `is_contract_rejection(e)`.

## Why this is safer
- One place to maintain the "already voted" contract error contract.
- Avoids duplicated ad-hoc string matching in business logic.
- Reduces chance of silent regressions if contract error formatting changes.

## Files Changed
- `allways/contract_client.py`
- `allways/validator/forward.py`

## Validation
- Verified updated call sites now use `is_already_voted(e)`.
- Confirmed no remaining inline `"AlreadyVoted" in str(e)` checks in repository.
- Lint diagnostics for edited files reported no errors.
## Summary

- Replaced string-literal event routing in `allways/validator/event_watcher.py` with a shared `ContractEventName` enum to avoid silent no-op dispatch when labels drift.
- Added `allways/validator/contract_events.py` as the canonical source of contract event labels used by validator-side event handling.
- Hardened decode/dispatch flow so unknown metadata event labels are explicitly detected and warned on, instead of falling through default behavior.

## Why

Event routing previously depended on raw string comparisons (e.g. `'MinerActivated'`, `'SwapInitiated'`). If contract metadata labels change, decoded events could silently bypass intended branches. Centralizing labels in an imported enum makes the routing contract explicit and reduces drift risk.

## Changes

- **New module:** `allways/validator/contract_events.py`
  - Introduces `ContractEventName(str, Enum)` with:
    - `MINER_ACTIVATED = "MinerActivated"`
    - `SWAP_INITIATED = "SwapInitiated"`
    - `SWAP_COMPLETED = "SwapCompleted"`
    - `SWAP_TIMED_OUT = "SwapTimedOut"`

- **Updated:** `allways/validator/event_watcher.py`
  - Imports `ContractEventName` from the new module.
  - `decode_contract_event(...)` now validates metadata event labels by coercing to `ContractEventName`.
  - Unsupported metadata labels are logged and dropped explicitly.
  - `apply_event(...)` accepts `str | ContractEventName`, normalizes to enum, and warns on unsupported names.
  - Branch dispatch now uses enum members rather than string literals.

## Risk / Compatibility

- Low risk: behavior for known event labels is unchanged.
- Safer failure mode: unexpected labels now warn and are ignored explicitly instead of silently missing a string match.

## Test Plan

- [x] `python3 -m compileall allways/validator/event_watcher.py allways/validator/contract_events.py`
- [x] Lint check for touched files (`event_watcher.py`, `contract_events.py`) reports no new diagnostics.
- [ ] Run validator tests locally once `pytest` is available:
  - `pytest -q tests/test_event_watcher.py tests/test_scoring_v1.py`

