### PR TITLE
Fix/used from tx storage leak

### DIFF
--- a/smart-contracts/ink/lib.rs
+++ b/smart-contracts/ink/lib.rs
@@ -39,7 +39,11 @@ mod allways_swap_manager {
         // Swap state
         next_swap_id: u64,
         swaps: Mapping<u64, SwapData>,
-        used_from_tx: Mapping<String, bool>,
+        // Permanent ledger of consumed source tx hashes. Cannot be cleared on
+        // swap completion: `swaps.remove(swap_id)` runs in confirm/timeout, so
+        // this map is the only on-chain record preventing a second initiate
+        // from reusing the same user payment. Uses `()` values (set semantics).
+        used_from_tx: Mapping<String, ()>,
 
         // Miner state
         collateral: Mapping<AccountId, Balance>,
@@ -645,7 +649,7 @@ mod allways_swap_manager {
             if from_tx_hash.len() > 128 {
                 return Err(Error::InputTooLong);
             }
-            if self.used_from_tx.get(&from_tx_hash).unwrap_or(false) {
+            if self.used_from_tx.contains(&from_tx_hash) {
                 return Err(Error::DuplicateSourceTx);
             }
 
@@ -708,7 +712,7 @@ mod allways_swap_manager {
                     completed_block: 0,
                 };
 
-                this.used_from_tx.insert(from_tx_hash, &true);
+                this.used_from_tx.insert(from_tx_hash, &());
                 this.miner_has_active_swap.insert(miner, &true);
                 this.swaps.insert(swap_id, &swap);
 


### PR DESCRIPTION
## Summary

Fixes entrius/allways#174 — `used_from_tx` storage leak.

- `Mapping<String, bool>` → `Mapping<String, ()>`. The value was always `true`; unit reflects the set semantics and drops one byte per entry.
- Replace `get(&k).unwrap_or(false)` with `.contains(&k)` at the guard site for readability.
- Add a comment documenting why entries must persist across swap completion.

## Why not delete entries on confirm / timeout

The issue report suggests cleaning entries in `confirm_swap` / `timeout_swap`, analogous to the `request_votes` cleanup in #149. That approach is unsafe here:

- `swaps.remove(swap_id)` already runs on both confirm ([lib.rs:804](smart-contracts/ink/lib.rs#L804)) and timeout ([lib.rs:861](smart-contracts/ink/lib.rs#L861)).
- After that removal, `used_from_tx` is the **only** on-chain record that a given source tx hash has already been consumed.
- The guard at [lib.rs:648](smart-contracts/ink/lib.rs#L648) is what prevents a second `vote_initiate` from replaying the same user payment to pay a miner twice.

Removing entries on completion would reopen that replay vector, so this PR keeps the dedup permanent and takes the modest win of shrinking each entry's storage footprint.

The `request_votes` case in #149 is different — request IDs are monotonic, so cleaned-up entries can never collide with a future round.

## Caveats

- **Storage-layout change — requires fresh deploy.** Same constraint as #149; an in-flight upgrade would lose any existing `used_from_tx` entries. Halt first if upgrading a live instance.
- **Entry-count growth is inherent to replay protection**, not fixed by this PR. If the team later decides to bound growth, it needs an explicit policy (e.g., a reorg-horizon window per source chain, or moving dedup off-chain to validator-level state). That's a larger design discussion; this PR is the narrow, safe improvement.

## Test plan

- [x] `cargo check --release` passes
- [ ] `cargo contract build --release` produces optimized wasm
- [ ] E2E suite against a redeployed contract confirms initiate → confirm → replay-attempt flow still rejects `DuplicateSourceTx`
