### PR TITLE
Dockerfile: stop re-resolving deps on editable install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ RUN uv venv --python python3 $VENV_DIR && uv sync
 
 # Copy application code and install
 COPY . .
-RUN uv pip install -e .
+RUN uv pip install --no-deps -e .


### PR DESCRIPTION
## Summary
- `uv sync` installs `async-substrate-interface==1.6.3` (uses `scalecodec`) per `uv.lock`
- `uv pip install -e .` then re-resolves without the lock, pulling `async-substrate-interface==2.0.1` which switched to `cyscale`
- Both end up installed, 2.0.1's runtime conflict check crashes the validator on boot
- `--no-deps` installs the local project only, leaving the synced dep set intact

## Repro
The `aw-vali` container on production crash-loops with `RuntimeError: Conflict detected: 'scalecodec' ... conflicts with 'cyscale'` after the image rebuild triggered by release-20260424-142934.

## Test plan
- [ ] docker-publish.yml build succeeds on merge
- [ ] Watchtower on aw-vali pulls new image and container stays up (STATUS shows `Up`, not `Restarting`)
- [ ] `docker exec aw-vali python -c "import bittensor"` succeeds