### PR TITLE
fix(event_watcher): halt cursor at first failed block

### DIFF
--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -312,24 +312,38 @@ class ContractEventWatcher:
 
     def sync_to(self, current_block: int) -> None:
         """Catch up from cursor to ``current_block`` in MAX_BLOCKS_PER_SYNC
-        chunks so a long outage doesn't freeze the forward loop."""
+        chunks so a long outage doesn't freeze the forward loop.
+
+        Stops advancing the cursor at the first block whose events we could
+        not fetch — a transient RPC hiccup would otherwise drop SwapCompleted
+        / SwapTimedOut events forever and strand miners in busy state. The
+        next tick will retry from the same point.
+        """
         if current_block <= self.cursor:
             return
         end = min(current_block, self.cursor + MAX_BLOCKS_PER_SYNC)
+        last_success = self.cursor
         for block_num in range(self.cursor + 1, end + 1):
-            self.process_block(block_num)
-        self.cursor = end
+            if not self.process_block(block_num):
+                break
+            last_success = block_num
+        self.cursor = last_success
         self.prune_old_events(current_block)
 
-    def process_block(self, block_num: int) -> None:
+    def process_block(self, block_num: int) -> bool:
+        """Fetch and apply events for ``block_num``. Returns True if the
+        block was successfully read (regardless of whether it contained
+        any contract events); False if the read failed or the hash was
+        unavailable, so ``sync_to`` knows to stop advancing the cursor."""
         try:
             block_hash = self.substrate.get_block_hash(block_num)
             if not block_hash:
-                return
+                bt.logging.debug(f'EventWatcher: block {block_num} hash unavailable; will retry')
+                return False
             events = self.substrate.get_events(block_hash=block_hash)
         except Exception as e:
             bt.logging.debug(f'EventWatcher: block {block_num} events unavailable: {e}')
-            return
+            return False
 
         for event_record in events:
             decoded = self.decode_contract_event(event_record)
@@ -337,6 +351,7 @@ class ContractEventWatcher:
                 continue
             name, values = decoded
             self.apply_event(block_num, name, values)
+        return True
 
     def decode_contract_event(self, event_record: Any) -> Optional[Tuple[str, Dict[str, Any]]]:
         record = event_record.value if hasattr(event_record, 'value') else event_record

--- a/tests/test_event_watcher.py
+++ b/tests/test_event_watcher.py
@@ -287,3 +287,69 @@ class TestBootstrap:
         assert w.active_miners == set()
         assert w.cursor == 0
         w.state_store.close()
+
+
+class TestSyncToCursorAdvance:
+    """sync_to must not advance the cursor past a block it failed to read —
+    otherwise a transient RPC hiccup drops that block's events forever."""
+
+    def test_cursor_stops_at_first_failed_block(self, tmp_path: Path):
+        w = make_watcher(tmp_path)
+        w.cursor = 100
+
+        # Block 101 succeeds, 102 raises, 103 would succeed but shouldn't be reached.
+        calls: list[int] = []
+
+        def fake_get_hash(block_num: int):
+            calls.append(block_num)
+            if block_num == 102:
+                raise RuntimeError('websocket closed')
+            return f'0xhash{block_num}'
+
+        w.substrate.get_block_hash.side_effect = fake_get_hash
+        w.substrate.get_events.return_value = []
+
+        w.sync_to(current_block=105)
+
+        assert w.cursor == 101, 'cursor should stop at the last successful block'
+        assert 102 in calls, 'the failing block must be attempted'
+        assert 103 not in calls, 'cursor must not keep scanning past a failure'
+        w.state_store.close()
+
+    def test_retry_on_next_tick_replays_failed_block(self, tmp_path: Path):
+        w = make_watcher(tmp_path)
+        w.cursor = 100
+
+        attempts: dict[int, int] = {}
+
+        def flaky_get_hash(block_num: int):
+            attempts[block_num] = attempts.get(block_num, 0) + 1
+            if block_num == 102 and attempts[block_num] == 1:
+                raise RuntimeError('transient')
+            return f'0xhash{block_num}'
+
+        w.substrate.get_block_hash.side_effect = flaky_get_hash
+        w.substrate.get_events.return_value = []
+
+        w.sync_to(current_block=105)
+        assert w.cursor == 101
+
+        # Next tick — 102 now succeeds; cursor should catch up.
+        w.sync_to(current_block=105)
+        assert w.cursor == 105
+        assert attempts[102] == 2, 'block 102 must be retried on the next tick'
+        w.state_store.close()
+
+    def test_none_block_hash_halts_cursor(self, tmp_path: Path):
+        """A None / empty block_hash (pruned or not-yet-synced) is treated as
+        a failure so we don't silently skip its events."""
+        w = make_watcher(tmp_path)
+        w.cursor = 200
+
+        w.substrate.get_block_hash.side_effect = lambda n: None if n == 202 else f'0xhash{n}'
+        w.substrate.get_events.return_value = []
+
+        w.sync_to(current_block=205)
+
+        assert w.cursor == 201
+        w.state_store.close()


### PR DESCRIPTION
## Summary

Fixes entrius/allways#175 — `event_watcher.sync_to` advances cursor past failed blocks.

`sync_to` set `cursor = end` unconditionally, even when `process_block` caught an exception mid-loop. A transient RPC hiccup on one block dropped its `SwapCompleted` / `SwapTimedOut` events forever, leaving the affected miner marked busy with no recovery path.

## Change

- `process_block` now returns `bool` — `True` on success, `False` on exception or unavailable block hash.
- `sync_to` stops advancing at the last successful block. The next tick retries the failing one.
- A `None` / empty `block_hash` (pruned or not-yet-synced) also halts the cursor instead of being silently skipped.

## Trade-off

A persistently unreadable block will now stall the cursor rather than silently skip. That's intentional — surface the problem loudly so operators can investigate, rather than letting events go missing unnoticed. `MAX_BLOCKS_PER_SYNC` chunking still bounds how far `sync_to` falls behind per call.

## Test plan

- [x] `pytest tests/test_event_watcher.py` — 19/19 pass (16 prior + 3 new)
- New cases under `TestSyncToCursorAdvance`:
  - `test_cursor_stops_at_first_failed_block`
  - `test_retry_on_next_tick_replays_failed_block`
  - `test_none_block_hash_halts_cursor`
