### PR TITLE
fix(forward): re-raise non-provider errors in confirm_miner_fulfillments

### DIFF
--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -337,9 +337,12 @@ async def confirm_miner_fulfillments(
             bt.logging.warning(f'Swap {swap.id}: provider unreachable, deferring verification')
             uncertain.add(swap.id)
             continue
-        if isinstance(result, Exception):
-            bt.logging.error(f'Swap {swap.id}: verification error: {result}')
-            continue
+        if isinstance(result, BaseException):
+            # Any other exception is a programming error, not a transient
+            # network failure. Re-raise so the forward loop crashes loudly
+            # rather than silently skipping votes and letting honest miners
+            # roll to timeout.
+            raise result
         if result:
             if voting.confirm_swap(self.contract_client, self.wallet, swap.id):
                 tracker.resolve(swap.id, SwapStatus.COMPLETED, current_block)

--- a/tests/test_forward_confirm.py
+++ b/tests/test_forward_confirm.py
@@ -1,0 +1,109 @@
+"""Tests for ``confirm_miner_fulfillments`` in allways.validator.forward.
+
+Focus: the exception dispatch after ``asyncio.gather(..., return_exceptions=True)``
+must distinguish transient provider failures (defer the swap) from programming
+errors (surface them by re-raising), not lump them together as "verification
+error" the way a broad Exception catch would.
+"""
+
+import asyncio
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from allways.chain_providers.base import ProviderUnreachableError
+from allways.validator.forward import confirm_miner_fulfillments
+
+
+@dataclass
+class FakeSwap:
+    id: int
+
+
+class FakeTracker:
+    def __init__(self, swaps, voted_ids=None, resolved=None):
+        self._swaps = swaps
+        self._voted = set(voted_ids or [])
+        self.resolved = resolved if resolved is not None else []
+
+    def get_fulfilled(self, current_block):
+        return list(self._swaps)
+
+    def is_voted(self, swap_id):
+        return swap_id in self._voted
+
+    def resolve(self, swap_id, status, block):
+        self.resolved.append((swap_id, status, block))
+
+
+class TestConfirmMinerFulfillmentsErrorHandling:
+    def test_provider_unreachable_is_deferred(self):
+        swap = FakeSwap(id=1)
+        tracker = FakeTracker([swap])
+        verifier = MagicMock()
+
+        async def raises_unreachable(_swap):
+            raise ProviderUnreachableError('btc node down')
+
+        verifier.verify_miner_fulfillment = raises_unreachable
+        self_ns = SimpleNamespace(contract_client=MagicMock(), wallet=MagicMock())
+
+        uncertain = asyncio.run(
+            confirm_miner_fulfillments(self_ns, tracker, verifier, current_block=100)
+        )
+
+        assert uncertain == {1}
+        assert tracker.resolved == []
+
+    def test_programming_error_is_reraised(self):
+        """A typo / AttributeError / any non-provider exception must propagate,
+        not get swallowed as a generic verification error. Otherwise a bug in
+        the verifier silently skips votes across every affected swap."""
+        swap = FakeSwap(id=2)
+        tracker = FakeTracker([swap])
+        verifier = MagicMock()
+
+        async def raises_typo(_swap):
+            raise AttributeError("'Swap' object has no attribute 'block_numebr'")
+
+        verifier.verify_miner_fulfillment = raises_typo
+        self_ns = SimpleNamespace(contract_client=MagicMock(), wallet=MagicMock())
+
+        with pytest.raises(AttributeError, match='block_numebr'):
+            asyncio.run(
+                confirm_miner_fulfillments(self_ns, tracker, verifier, current_block=100)
+            )
+
+    def test_successful_verification_still_votes(self):
+        """Regression guard: the strict exception policy must not disturb
+        the happy path."""
+        swap = FakeSwap(id=3)
+        tracker = FakeTracker([swap])
+        verifier = MagicMock()
+
+        async def returns_true(_swap):
+            return True
+
+        verifier.verify_miner_fulfillment = returns_true
+
+        voting_mock = MagicMock()
+        voting_mock.confirm_swap.return_value = True
+
+        self_ns = SimpleNamespace(contract_client=MagicMock(), wallet=MagicMock())
+
+        import allways.validator.forward as forward_mod
+
+        orig_voting = forward_mod.voting
+        forward_mod.voting = voting_mock
+        try:
+            uncertain = asyncio.run(
+                confirm_miner_fulfillments(self_ns, tracker, verifier, current_block=100)
+            )
+        finally:
+            forward_mod.voting = orig_voting
+
+        assert uncertain == set()
+        assert len(tracker.resolved) == 1
+        assert tracker.resolved[0][0] == 3


### PR DESCRIPTION
## Summary

Fixes entrius/allways#178 — `asyncio.gather` in `confirm_miner_fulfillments` swallows programming errors.

`asyncio.gather(..., return_exceptions=True)` turns every exception into a result. The old dispatch caught `ProviderUnreachableError` specifically, then used a broad `isinstance(result, Exception)` fallback that logged any other exception as "verification error" and continued the loop. A typo in the verifier (`AttributeError`, `KeyError`, etc.) was therefore silent — every affected swap skipped its vote and rolled to timeout, slashing honest miners for what looked like validator flakiness.

## Change

Replace the broad fallback with a re-raise for anything outside the known-transient set (currently just `ProviderUnreachableError`). A programming error now crashes the forward loop loudly on the first hit — strictly preferable to silent mis-scoring.

```python
if isinstance(result, ProviderUnreachableError):
    uncertain.add(swap.id)
    continue
if isinstance(result, BaseException):
    raise result              # ← was: log + continue
