### PR TITLE
Dockerfile: install deps into /opt/venv via UV_PROJECT_ENVIRONMENT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,15 +12,16 @@ RUN pip install --break-system-packages uv
 
 WORKDIR /app
 
-# Copy dependency files
-COPY pyproject.toml uv.lock ./
-
-# Create venv and sync dependencies
+# Point uv at /opt/venv so `uv sync` installs there (default is .venv in cwd).
 ENV VENV_DIR=/opt/venv
 ENV VIRTUAL_ENV=$VENV_DIR
+ENV UV_PROJECT_ENVIRONMENT=$VENV_DIR
 ENV PATH="$VENV_DIR/bin:$PATH"
-RUN uv venv --python python3 $VENV_DIR && uv sync
 
-# Copy application code and install
+# Install locked deps first (source not yet present) — cache-friendly.
+COPY pyproject.toml uv.lock ./
+RUN uv venv --python python3 $VENV_DIR && uv sync --frozen --no-install-project
+
+# Install the project itself against the locked dep set.
 COPY . .
-RUN uv pip install --no-deps -e .
+RUN uv sync --frozen


### PR DESCRIPTION
## Summary
- Previous Dockerfile set `VIRTUAL_ENV=/opt/venv` but `uv sync` defaults to `.venv/` in the project dir, so locked deps landed in `/app/.venv` and `/opt/venv` stayed empty.
- The old `uv pip install -e .` masked this by re-resolving all deps into `/opt/venv` without respecting `uv.lock` — which is how `async-substrate-interface==2.0.1` (and `cyscale`) got pulled once PyPI drifted past the locked `1.6.3`.
- #189's `--no-deps` stopped the re-resolve but left `/opt/venv` without bittensor → `ModuleNotFoundError: No module named 'bittensor'` on boot.
- Setting `UV_PROJECT_ENVIRONMENT=/opt/venv` + `uv sync --frozen` makes the lockfile the single source of truth for the venv.

## Why it matters
Production validator (`aw-vali`) is currently crash-looping. Any newcomer running `docker build` today also gets a broken image.

## Test plan
- [ ] docker-publish.yml succeeds on merge
- [ ] aw-vali stays `Up` (not `Restarting`) after pulling the rebuilt image
- [ ] `docker exec aw-vali python -c "import bittensor; print(bittensor.__version__)"` prints `10.1.0`