### PR TITLE
fix(ink): exclude removed validators from vote tally (#181)

### DIFF
--- a/smart-contracts/ink/lib.rs
+++ b/smart-contracts/ink/lib.rs
@@ -158,16 +158,20 @@ mod allways_swap_manager {
             id
         }
 
-        /// Record a vote on a request. Returns the new vote count.
+        /// Record a vote on a request. Returns the effective vote count —
+        /// votes from accounts no longer in the validator set are retained in
+        /// storage (for AlreadyVoted idempotency) but excluded from the tally,
+        /// so a removed validator's stale vote can't coast a round to quorum
+        /// under the post-removal (smaller) threshold.
         fn record_vote(&mut self, request_id: u64, caller: AccountId) -> Result<u32, Error> {
             let mut voters = self.request_voters.get(request_id).unwrap_or_default();
             if voters.contains(&caller) {
                 return Err(Error::AlreadyVoted);
             }
             voters.push(caller);
-            let count = u32::try_from(voters.len()).unwrap_or(u32::MAX);
             self.request_voters.insert(request_id, &voters);
-            Ok(count)
+            let effective = voters.iter().filter(|v| self.validators.contains(v)).count();
+            Ok(u32::try_from(effective).unwrap_or(u32::MAX))
         }
 
         /// Return the active request ID for (miner, req_type), or clear it and


### PR DESCRIPTION
## Summary

Fixes #181 — a removed validator's in-flight votes used to keep counting toward quorum, so removing a compromised validator *lowered* the quorum denominator (`get_required_votes()` reads `self.validators.len()` live) while their stale votes still sat in `request_voters`. Net effect: every round V had pre-voted on reached quorum with one fewer legitimate vote than the policy intends.

## Change

`record_vote` now filters the stored voter list against the current validator set before returning the count. Votes from removed validators are retained in storage (so `AlreadyVoted` idempotency still catches duplicate votes if an account is removed and re-added) but excluded from the tally.

One-file change, three lines of logic. No storage layout change, no migration.

## Test plan

- [ ] `cd smart-contracts/ink && cargo check` — passes locally
- [ ] `cargo test` — no existing tests, still 0 passed / 0 failed
- [ ] Unit test to add (follow-up): `test_removed_validator_vote_excluded_from_tally` — set up 5 validators, have V1 vote on a reserve round, remove V1, verify the round needs 3 more real votes to reach quorum (not 2).
- [ ] Manual inspection: `consensus_vote` / `consensus_swap_vote` both call `record_vote` so the fix applies to all vote paths (reserve, initiate, activate, deactivate, extend, confirm, timeout, extend_timeout).
