### PR TITLE
swap_commands: use plain click in quote/resume

### DIFF
--- a/allways/cli/swap_commands/quote.py
+++ b/allways/cli/swap_commands/quote.py
@@ -2,7 +2,7 @@
 
 from decimal import Decimal
 
-import rich_click as click
+import click
 from rich.table import Table
 
 from allways.chains import SUPPORTED_CHAINS, canonical_pair, get_chain

--- a/allways/cli/swap_commands/resume.py
+++ b/allways/cli/swap_commands/resume.py
@@ -4,7 +4,7 @@ import os
 import time
 from typing import Optional
 
-import rich_click as click
+import click
 from rich.panel import Panel
 
 from allways.chain_providers import create_chain_providers


### PR DESCRIPTION
## Summary
- `quote.py` and `resume.py` did `import rich_click as click`, but `rich_click` isn't in `pyproject.toml` — `alw --help` crashes with `ModuleNotFoundError: No module named 'rich_click'` on a clean install.
- Every other CLI file imports plain `click`; neither of these two uses anything `rich_click`-specific (decorators + `click.prompt` only), so switching to `click` matches the rest of the codebase with no behavior change.

## Test plan
- [ ] `uv sync && source .venv/bin/activate`
- [ ] `alw --help` runs cleanly
- [ ] `alw swap quote --help` / `alw swap resume-reservation --help` render
- [ ] `ruff check allways/` passes