### PR TITLE
CLI UX: miner activate/status spinners, collateral hotkey hint, INFO-level rejection logs

### DIFF
--- a/allways/cli/dendrite_lite.py
+++ b/allways/cli/dendrite_lite.py
@@ -81,6 +81,7 @@ def broadcast_synapse(
     import asyncio
 
     dendrite = bt.Dendrite(wallet=wallet)
+    timeout = resolve_dendrite_timeout(timeout)
 
     loop = asyncio.new_event_loop()
     try:
@@ -89,3 +90,16 @@ def broadcast_synapse(
         loop.close()
 
     return responses
+
+
+def resolve_dendrite_timeout(default: float) -> float:
+    """Honor ALW_DENDRITE_TIMEOUT as an override for slow chains (e.g. testnet)."""
+    import os
+
+    override = os.environ.get('ALW_DENDRITE_TIMEOUT')
+    if not override:
+        return default
+    try:
+        return float(override)
+    except ValueError:
+        return default

--- a/allways/cli/swap_commands/collateral.py
+++ b/allways/cli/swap_commands/collateral.py
@@ -69,8 +69,13 @@ def collateral_deposit(amount: float | None, yes: bool):
         required = amount_rao + MIN_BALANCE_FOR_TX_RAO
         if free_balance < required:
             console.print(
-                f'[red]Insufficient balance. Free: {from_rao(free_balance):.4f} TAO, '
+                f'[red]Insufficient hotkey balance. Free: {from_rao(free_balance):.4f} TAO, '
                 f'need: {from_rao(required):.4f} TAO (amount + tx fees).[/red]'
+            )
+            console.print('[dim]Collateral is posted from the hotkey, not the coldkey.[/dim]')
+            console.print(
+                f'[dim]Transfer TAO with: btcli wallet transfer --destination {wallet.hotkey.ss58_address} '
+                '--amount <tao>[/dim]'
             )
             return
     except ContractError as e:

--- a/allways/cli/swap_commands/miner_commands.py
+++ b/allways/cli/swap_commands/miner_commands.py
@@ -192,18 +192,18 @@ def miner_activate():
 
     # Discover whitelisted validators from metagraph
     dendrite = bt.Dendrite(wallet=wallet)
-    validator_axons = discover_validators(subtensor, netuid, contract_client=client)
+    with loading('Discovering validators...'):
+        validator_axons = discover_validators(subtensor, netuid, contract_client=client)
 
     if not validator_axons:
         console.print('[red]No validators found on metagraph[/red]\n')
         return
 
-    console.print(f'Broadcasting to {len(validator_axons)} validators...')
-
     # Broadcast
-    responses = asyncio.get_event_loop().run_until_complete(
-        dendrite(axons=validator_axons, synapse=synapse, deserialize=False, timeout=30.0)
-    )
+    with loading(f'Broadcasting to {len(validator_axons)} validators...'):
+        responses = asyncio.get_event_loop().run_until_complete(
+            dendrite(axons=validator_axons, synapse=synapse, deserialize=False, timeout=30.0)
+        )
 
     # Show per-validator results
     accepted = 0
@@ -220,7 +220,11 @@ def miner_activate():
 
     if accepted == 0:
         console.print('[red]Activation failed — no validators accepted the request.[/red]')
-        console.print('[dim]Check prerequisites: alw miner status[/dim]\n')
+        console.print('[dim]Prerequisites:[/dim]')
+        console.print('[dim]  - Hotkey registered on this subnet (btcli subnets register)[/dim]')
+        console.print('[dim]  - Trading pair posted (alw miner post)[/dim]')
+        console.print('[dim]  - Collateral deposited >= 0.1 TAO (alw collateral deposit)[/dim]')
+        console.print('[dim]Run `alw miner status` to see which are missing.[/dim]\n')
         return
 
     # Poll contract for activation

--- a/allways/cli/swap_commands/miner_commands.py
+++ b/allways/cli/swap_commands/miner_commands.py
@@ -73,7 +73,8 @@ def miner_status(hotkey: str):
     console.print()
 
     # Section 2: Committed Pair
-    pair = read_miner_commitment(subtensor, netuid, hotkey)
+    with loading('Reading committed pair...'):
+        pair = read_miner_commitment(subtensor, netuid, hotkey)
 
     if pair:
         console.print('[bold]Committed Pair[/bold]\n')
@@ -103,7 +104,8 @@ def miner_status(hotkey: str):
 
     # Section 3: Active Swaps
     try:
-        swaps = client.get_miner_active_swaps(hotkey)
+        with loading('Reading active swaps...'):
+            swaps = client.get_miner_active_swaps(hotkey)
     except ContractError as e:
         console.print(f'[yellow]Could not read active swaps: {e}[/yellow]')
         swaps = []

--- a/allways/cli/swap_commands/miner_commands.py
+++ b/allways/cli/swap_commands/miner_commands.py
@@ -210,14 +210,18 @@ def miner_activate():
 
     # Show per-validator results
     accepted = 0
+    no_response = 0
     for i, resp in enumerate(responses):
         if getattr(resp, 'accepted', None):
             console.print(f'  Validator {i + 1}: [green]accepted[/green]')
             accepted += 1
+            continue
+        raw_reason = getattr(resp, 'rejection_reason', '') or ''
+        if not raw_reason:
+            console.print(f'  Validator {i + 1}: [yellow]no response — timeout or validator down[/yellow]')
+            no_response += 1
         else:
-            raw_reason = getattr(resp, 'rejection_reason', '') or ''
-            friendly = friendly_rejection(raw_reason)
-            console.print(f'  Validator {i + 1}: [red]rejected[/red] — {friendly}')
+            console.print(f'  Validator {i + 1}: [red]rejected[/red] — {friendly_rejection(raw_reason)}')
 
     console.print(f'\n{accepted}/{len(validator_axons)} validators accepted')
 
@@ -239,7 +243,12 @@ def miner_activate():
         console.print('[green]Miner activated successfully[/green]\n')
         return
 
-    if accepted == 0:
+    if accepted == 0 and no_response == len(validator_axons):
+        console.print('[yellow]No validators responded within the dendrite timeout.[/yellow]')
+        console.print('[dim]The chain may be slow — the vote could still land after this check.[/dim]')
+        console.print('[dim]Retry with a longer timeout: ALW_DENDRITE_TIMEOUT=90 alw miner activate[/dim]')
+        console.print('[dim]Or re-run `alw miner status` in a minute to see if activation completed.[/dim]\n')
+    elif accepted == 0:
         console.print('[red]Activation failed — no validators accepted the request.[/red]')
         console.print('[dim]Prerequisites:[/dim]')
         console.print('[dim]  - Hotkey registered on this subnet (btcli subnets register)[/dim]')

--- a/allways/cli/swap_commands/miner_commands.py
+++ b/allways/cli/swap_commands/miner_commands.py
@@ -220,6 +220,24 @@ def miner_activate():
 
     console.print(f'\n{accepted}/{len(validator_axons)} validators accepted')
 
+    # Poll chain — the on-chain flag is authoritative. A validator can
+    # finalize vote_activate after the dendrite response times out, so
+    # synapse accepted counts aren't reliable on their own.
+    activated = False
+    with loading('Checking on-chain activation...'):
+        for _ in range(15):
+            time.sleep(2)
+            try:
+                if client.get_miner_active_flag(hotkey):
+                    activated = True
+                    break
+            except ContractError:
+                pass
+
+    if activated:
+        console.print('[green]Miner activated successfully[/green]\n')
+        return
+
     if accepted == 0:
         console.print('[red]Activation failed — no validators accepted the request.[/red]')
         console.print('[dim]Prerequisites:[/dim]')
@@ -227,24 +245,10 @@ def miner_activate():
         console.print('[dim]  - Trading pair posted (alw miner post)[/dim]')
         console.print('[dim]  - Collateral deposited >= 0.1 TAO (alw collateral deposit)[/dim]')
         console.print('[dim]Run `alw miner status` to see which are missing.[/dim]\n')
-        return
-
-    # Poll contract for activation
-    with loading('Waiting for quorum...'):
-        for _ in range(15):
-            time.sleep(2)
-            try:
-                if client.get_miner_active_flag(hotkey):
-                    break
-            except ContractError:
-                pass
-        else:
-            console.print(
-                '[yellow]Votes submitted but quorum not yet reached. Check status with: alw miner status[/yellow]\n'
-            )
-            return
-
-    console.print('[green]Miner activated successfully[/green]\n')
+    else:
+        console.print(
+            '[yellow]Votes submitted but quorum not yet reached. Check status with: alw miner status[/yellow]\n'
+        )
 
 
 @miner_group.command('deactivate')

--- a/allways/cli/swap_commands/miner_commands.py
+++ b/allways/cli/swap_commands/miner_commands.py
@@ -9,7 +9,7 @@ from rich.table import Table
 
 from allways.chains import get_chain
 from allways.classes import SwapStatus
-from allways.cli.dendrite_lite import discover_validators
+from allways.cli.dendrite_lite import discover_validators, resolve_dendrite_timeout
 from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
     SWAP_STATUS_COLORS,
@@ -202,9 +202,10 @@ def miner_activate():
         return
 
     # Broadcast
+    timeout = resolve_dendrite_timeout(30.0)
     with loading(f'Broadcasting to {len(validator_axons)} validators...'):
         responses = asyncio.get_event_loop().run_until_complete(
-            dendrite(axons=validator_axons, synapse=synapse, deserialize=False, timeout=30.0)
+            dendrite(axons=validator_axons, synapse=synapse, deserialize=False, timeout=timeout)
         )
 
     # Show per-validator results

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -137,11 +137,11 @@ def load_swap_commitment(validator: 'Validator', miner_hotkey: str) -> Optional[
 
 
 def reject_synapse(synapse: bt.Synapse, reason: str, context: str = '') -> None:
-    """Mark a synapse as rejected with a reason and debug log."""
+    """Mark a synapse as rejected with a reason and log it."""
     synapse.accepted = False
     synapse.rejection_reason = reason
     if context:
-        bt.logging.debug(f'{context}: {reason}')
+        bt.logging.info(f'{context}: {reason}')
 
 
 # =============================================================================
@@ -157,7 +157,7 @@ async def blacklist_miner_activate(
     if synapse.dendrite is None or synapse.dendrite.hotkey is None:
         return True, 'Missing dendrite or hotkey'
     if synapse.dendrite.hotkey not in validator.metagraph.hotkeys:
-        bt.logging.debug(f'Blacklisted unregistered hotkey: {synapse.dendrite.hotkey}')
+        bt.logging.info(f'Blacklisted unregistered hotkey: {synapse.dendrite.hotkey}')
         return True, 'Unregistered hotkey'
     return False, 'Hotkey recognized'
 


### PR DESCRIPTION
## Summary

Five miner-onboarding UX fixes, each addressing an issue hit during a fresh testnet miner setup.

### `alw miner activate`
- Wrapped validator discovery and the dendrite broadcast in the existing `loading()` spinner so operators aren't staring at a dead terminal during either network call.
- On failure, replaced the one-line `Check prerequisites: alw miner status` hint with the three actual prereqs and the command to satisfy each (subnet registration, rate post, collateral deposit).
- **Treat the on-chain flag as authoritative.** Under slow-chain conditions a validator can finalize `vote_activate` after the miner's 30s dendrite timeout fires, leaving the miner with zero "accepted" responses but a successfully activated miner on-chain. Previously we reported "Activation failed" in that case. Now we always poll the contract flag first and only fall through to the failure / quorum-pending messaging if the contract itself doesn't show the miner active within ~30s.

### `alw miner status`
- Section 1 already had a spinner, but the follow-up `read_miner_commitment` and `get_miner_active_swaps` calls ran bare — on `test.finney` the commitment lookup can sit for several seconds, leaving the terminal silent between tables. Added spinners to both.

### `alw collateral deposit`
- Renamed `Insufficient balance` to `Insufficient hotkey balance` and spelled out that collateral is signed by the hotkey, not the coldkey — with the `btcli wallet transfer` command pre-filled to the right destination. Operators with full coldkeys and empty hotkeys kept hitting this.

### Validator rejection logs
- `reject_synapse` and the unregistered-hotkey blacklist log now emit at INFO instead of DEBUG. These are the primary signal when a miner activation or user reservation fails — requiring a global DEBUG flip just to see them meant operators had no path to self-diagnose. Did NOT touch per-block / per-swap DEBUG logs in `event_watcher.py`, `forward.py`, `swap_tracker.py`, or `chain_verification.py` — those would be spammy at INFO.

## Test plan
- [ ] `alw miner activate` shows `Discovering validators...` then `Broadcasting to N validators...` spinners
- [ ] Skip `alw miner post` (or drop collateral below 0.1) → `alw miner activate` → output lists all three prereqs
- [ ] **Slow-chain scenario:** validators time out the dendrite but finalize vote_activate — CLI should eventually report `Miner activated successfully` once the on-chain flag flips, not "Activation failed"
- [ ] `alw miner status` shows `Reading committed pair...` then `Reading active swaps...` spinners between tables on testnet
- [ ] `alw collateral deposit --amount 2 --yes` on an empty hotkey → output mentions hotkey explicitly and shows a ready-to-paste `btcli wallet transfer` command
- [ ] Validator rejection log (e.g. "No commitment found") appears at default INFO log level without requiring `LOG_LEVEL=debug`