### PR TITLE
validator: collapse axon handler RPCs via snapshot + bounds cache

### DIFF
--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -204,12 +204,12 @@ async def handle_miner_activate(
                 reject_synapse(synapse, 'No commitment found', ctx)
                 return synapse
 
-            if contract.get_miner_active_flag(miner_hotkey):
+            collateral, active, _, _, _ = contract.get_miner_snapshot(miner_hotkey)
+            if active:
                 reject_synapse(synapse, 'Miner is already active', ctx)
                 return synapse
 
-            collateral = contract.get_miner_collateral(miner_hotkey)
-            min_collateral = contract.get_min_collateral()
+            min_collateral = validator.bounds_cache.min_collateral()
             if collateral < min_collateral:
                 reject_synapse(synapse, f'Insufficient collateral: {collateral} < {min_collateral}', ctx)
                 return synapse
@@ -323,31 +323,27 @@ async def handle_swap_reserve(
                 reject_synapse(synapse, 'Insufficient source balance', ctx)
                 return synapse
 
-            if not contract.get_miner_active_flag(miner):
+            collateral, active, has_swap, reserved_until, _ = contract.get_miner_snapshot(miner)
+            if not active:
                 reject_synapse(synapse, 'Miner not active', ctx)
                 return synapse
-
-            if contract.get_miner_has_active_swap(miner):
+            if has_swap:
                 reject_synapse(synapse, 'Miner has an active swap', ctx)
                 return synapse
-
-            reserved_until = contract.get_miner_reserved_until(miner)
             if reserved_until >= validator.block:
                 reject_synapse(synapse, 'Miner already reserved', ctx)
                 return synapse
-
-            collateral = contract.get_miner_collateral(miner)
             if synapse.tao_amount > collateral:
                 reject_synapse(synapse, 'Insufficient miner collateral', ctx)
                 return synapse
 
-            min_collateral = contract.get_min_collateral()
+            min_collateral = validator.bounds_cache.min_collateral()
             if min_collateral > 0 and collateral < min_collateral:
                 reject_synapse(synapse, 'Miner collateral below minimum', ctx)
                 return synapse
 
-            min_swap = contract.get_min_swap_amount()
-            max_swap = contract.get_max_swap_amount()
+            min_swap = validator.bounds_cache.min_swap_amount()
+            max_swap = validator.bounds_cache.max_swap_amount()
             if min_swap > 0 and synapse.tao_amount < min_swap:
                 reject_synapse(synapse, f'Swap amount below minimum ({synapse.tao_amount} < {min_swap} rao)', ctx)
                 return synapse

--- a/allways/validator/bounds_cache.py
+++ b/allways/validator/bounds_cache.py
@@ -1,0 +1,37 @@
+"""Block-TTL cache for admin-set contract bounds.
+
+min_collateral, min_swap_amount, and max_swap_amount only change via admin
+tx, so re-reading them on every axon request burns RPC budget the chain
+may not have (testnet caps at 45/min).
+"""
+
+from typing import Callable
+
+from allways.contract_client import AllwaysContractClient
+
+
+class BoundsCache:
+    TTL_BLOCKS = 300
+
+    def __init__(self, contract: AllwaysContractClient, get_block: Callable[[], int]):
+        self._contract = contract
+        self._get_block = get_block
+        self._cache: dict[str, tuple[int, int]] = {}
+
+    def _cached(self, key: str, read: Callable[[], int]) -> int:
+        now = self._get_block()
+        entry = self._cache.get(key)
+        if entry is not None and now - entry[0] < self.TTL_BLOCKS:
+            return entry[1]
+        value = read()
+        self._cache[key] = (now, value)
+        return value
+
+    def min_collateral(self) -> int:
+        return self._cached('min_collateral', self._contract.get_min_collateral)
+
+    def min_swap_amount(self) -> int:
+        return self._cached('min_swap_amount', self._contract.get_min_swap_amount)
+
+    def max_swap_amount(self) -> int:
+        return self._cached('max_swap_amount', self._contract.get_max_swap_amount)

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -33,6 +33,7 @@ from allways.validator.axon_handlers import (
     priority_swap_confirm,
     priority_swap_reserve,
 )
+from allways.validator.bounds_cache import BoundsCache
 from allways.validator.chain_verification import SwapVerifier
 from allways.validator.event_watcher import ContractEventWatcher
 from allways.validator.forward import forward
@@ -119,6 +120,7 @@ class Validator(BaseValidatorNeuron):
         self.axon_subtensor = bt.Subtensor(config=self.config)
         self.axon_contract_client = AllwaysContractClient(subtensor=self.axon_subtensor)
         self.axon_chain_providers = create_chain_providers(subtensor=self.axon_subtensor)
+        self.bounds_cache = BoundsCache(self.axon_contract_client, lambda: self.block)
 
         # Attach synapse handlers to axon
         self.attach_axon_handlers()


### PR DESCRIPTION
## Summary

Cuts validator axon handler RPC traffic by ~55% to survive slow/rate-limited testnet chains.

- `handle_swap_reserve`: 10 substrate reads → 2 (one `get_miner_snapshot` + cached bounds)
- `handle_miner_activate`: 3 substrate reads → 1
- New `BoundsCache` (block-TTL) for admin-set values: `min_collateral`, `min_swap_amount`, `max_swap_amount` — TTL 300 blocks (~1h), refreshed lazily on miss

## Why

Testnet caps at 45 RPC/min. A single SwapReserve was burning ~11 calls inside `axon_lock`, wedging on occasional RPC spikes and blocking subsequent requests behind the held lock. The symptom was a ~8 min hang on the validator ending in `Timed out waiting for RPC requests 5 times. Exiting.` — validator received the request but the user saw nothing but dendrite timeouts.

## Safety

Contract (`lib.rs:451-506`) already authoritatively enforces everything the skipped pre-checks covered (min_collateral floor, min/max swap bounds, active/has_swap/reserved). Kept as pre-checks for friendly UX:

- `get_cooldown` — contract only records strikes lazily, doesn't block reservations on cooldown
- source balance (chain-side, not in contract)
- `tao_amount <= miner_collateral` (contract only checks min_collateral floor, not swap-specific cap)
- commitment read (off-chain)

## Test plan
- [ ] 300 unit tests pass locally
- [ ] Deploy validator container, watch `aw-vali` logs for clean `Voted to reserve` under `alw swap now`
- [ ] Confirm bounds cache values match contract after admin config change + 300-block wait