### PR TITLE
validator: fix axon handler websocket collision + CLI slowness

### DIFF
--- a/allways/cli/swap_commands/miner_commands.py
+++ b/allways/cli/swap_commands/miner_commands.py
@@ -202,7 +202,7 @@ def miner_activate():
         return
 
     # Broadcast
-    timeout = resolve_dendrite_timeout(30.0)
+    timeout = resolve_dendrite_timeout(60.0)
     with loading(f'Broadcasting to {len(validator_axons)} validators...'):
         responses = asyncio.get_event_loop().run_until_complete(
             dendrite(axons=validator_axons, synapse=synapse, deserialize=False, timeout=timeout)

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -243,7 +243,7 @@ def broadcast_reserve_with_retry(
             )
 
         console.print(f'  Broadcasting to {len(validator_axons)} validators...')
-        responses = broadcast_synapse(ephemeral_wallet, validator_axons, synapse, timeout=30.0)
+        responses = broadcast_synapse(ephemeral_wallet, validator_axons, synapse, timeout=60.0)
 
         accepted = sum(1 for r in responses if getattr(r, 'accepted', None))
         for i, resp in enumerate(responses):

--- a/allways/commitments.py
+++ b/allways/commitments.py
@@ -117,13 +117,20 @@ def read_miner_commitment(
     block: Optional[int] = None,
     metagraph: Optional['bt.Metagraph'] = None,
 ) -> Optional[MinerPair]:
-    """Read a single miner's commitment, optionally at a specific block."""
-    if metagraph is None:
-        metagraph = subtensor.metagraph(netuid)
-    hotkey_to_uid = {metagraph.hotkeys[uid]: uid for uid in range(metagraph.n.item())}
-    uid = hotkey_to_uid.get(hotkey)
-    if uid is None:
-        return None
+    """Read a single miner's commitment, optionally at a specific block.
+
+    When ``metagraph`` is None the uid lookup is skipped (uid defaults to 0).
+    Callers that need the uid — or want to avoid returning commitments for
+    unregistered hotkeys — must pass their cached metagraph. Downloading a
+    fresh metagraph here on every call was a 30s+ RPC on testnet finney.
+    """
+    uid = 0
+    if metagraph is not None:
+        hotkey_to_uid = {metagraph.hotkeys[u]: u for u in range(metagraph.n.item())}
+        resolved = hotkey_to_uid.get(hotkey)
+        if resolved is None:
+            return None
+        uid = resolved
     commitment = get_commitment(subtensor, netuid, hotkey, block=block)
     if commitment:
         return parse_commitment_data(commitment, uid=uid, hotkey=hotkey)

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -125,11 +125,17 @@ def resolve_swap_direction(
 
 
 def load_swap_commitment(validator: 'Validator', miner_hotkey: str) -> Optional[MinerPair]:
-    """Read miner commitment and validate chains differ. Returns commitment or None."""
+    """Read miner commitment and validate chains differ. Returns commitment or None.
+
+    Passes the validator's cached metagraph so read_miner_commitment skips the
+    full subnet metagraph download — that sync takes 30s+ on testnet finney and
+    was the real source of axon handler timeouts.
+    """
     commitment = read_miner_commitment(
         subtensor=validator.axon_subtensor,
         netuid=validator.config.netuid,
         hotkey=miner_hotkey,
+        metagraph=validator.metagraph,
     )
     if commitment is None or commitment.from_chain == commitment.to_chain:
         return None
@@ -199,6 +205,7 @@ async def handle_miner_activate(
                 subtensor=validator.axon_subtensor,
                 netuid=validator.config.netuid,
                 hotkey=miner_hotkey,
+                metagraph=validator.metagraph,
             )
             if commitment is None:
                 reject_synapse(synapse, 'No commitment found', ctx)
@@ -330,7 +337,11 @@ async def handle_swap_reserve(
             if has_swap:
                 reject_synapse(synapse, 'Miner has an active swap', ctx)
                 return synapse
-            if reserved_until >= validator.block:
+            # Read the current block via axon_subtensor — validator.block goes
+            # through self.subtensor, which the forward loop already uses;
+            # concurrent reads collide on the same websocket.
+            cur_block = validator.axon_subtensor.get_current_block()
+            if reserved_until >= cur_block:
                 reject_synapse(synapse, 'Miner already reserved', ctx)
                 return synapse
             if synapse.tao_amount > collateral:
@@ -354,7 +365,7 @@ async def handle_swap_reserve(
             strike_count, last_expired = contract.get_cooldown(synapse.from_address)
             if strike_count > 0 and last_expired > 0:
                 cooldown = RESERVATION_COOLDOWN_BLOCKS * (2 ** (strike_count - 1))
-                if validator.block < last_expired + cooldown:
+                if cur_block < last_expired + cooldown:
                     reject_synapse(synapse, f'Address on cooldown ({cooldown} blocks remaining)', ctx)
                     return synapse
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -120,7 +120,14 @@ class Validator(BaseValidatorNeuron):
         self.axon_subtensor = bt.Subtensor(config=self.config)
         self.axon_contract_client = AllwaysContractClient(subtensor=self.axon_subtensor)
         self.axon_chain_providers = create_chain_providers(subtensor=self.axon_subtensor)
-        self.bounds_cache = BoundsCache(self.axon_contract_client, lambda: self.block)
+        # Must read the current block via axon_subtensor — the block getter on
+        # self (self.block) goes through self.subtensor, which the forward loop
+        # is already using; concurrent axon + forward reads collide on the same
+        # websocket and raise ConcurrencyError.
+        self.bounds_cache = BoundsCache(
+            self.axon_contract_client,
+            self.axon_subtensor.get_current_block,
+        )
 
         # Attach synapse handlers to axon
         self.attach_axon_handlers()


### PR DESCRIPTION
## Summary

- **Validator fix**: axon handlers were reading the current block through `self.block` (and `BoundsCache` through `lambda: self.block`), which goes through `self.subtensor` — the same websocket the forward loop is using. Under testnet load the two callers collided and raised `cannot call recv while another thread is already running recv or recv_streaming`. Route both through `axon_subtensor.get_current_block` so they stay on separate connections. Also pass `validator.metagraph` into `read_miner_commitment` so handlers skip the 30s+ full-subnet metagraph download per request.
- **CLI UX**: `read_miner_commitment` now skips the metagraph download when one isn't supplied (uid defaults to 0) — fixes `alw miner status` feeling hung. Dendrite default timeouts for `alw miner activate` and `alw swap now` bumped from 30s → 60s so the CLI doesn't report "no response" while the validator is still voting on testnet. `ALW_DENDRITE_TIMEOUT` still overrides.

Diagnosed live on the test validator with temporary per-RPC tracing; root cause was a single `validator.block` call on the shared subtensor. Fix was verified end-to-end on testnet sn19 (miner activate + commit read both succeed cleanly now).

## Test plan

- [x] `alw miner activate` succeeds on testnet without "no response" timeout
- [x] `alw miner status` committed-pair read returns quickly (no metagraph download)
- [x] Validator handler trace: `is_hotkey_registered` → `read_miner_commitment` → `get_miner_snapshot` → `bounds_cache.min_collateral` → `vote_activate` with no `ConcurrencyError`
- [ ] `alw swap now` TAO→BTC happy-path reserve + confirm