### PR TITLE
validator: route swap_confirm block read through axon_subtensor

### DIFF
--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -439,7 +439,8 @@ async def handle_swap_confirm(
 
         with validator.axon_lock:
             reserved_until = contract.get_miner_reserved_until(miner)
-            if reserved_until < validator.block:
+            # Read the current block via axon_subtensor — see handle_swap_reserve.
+            if reserved_until < validator.axon_subtensor.get_current_block():
                 reject_synapse(synapse, 'No active reservation for this miner', ctx)
                 return synapse
 

--- a/tests/test_axon_handlers.py
+++ b/tests/test_axon_handlers.py
@@ -90,6 +90,7 @@ def make_validator(
     """
     validator = MagicMock()
     validator.block = block
+    validator.axon_subtensor.get_current_block.return_value = block
     validator.config.netuid = 2
     validator.axon_lock = threading.Lock()
 


### PR DESCRIPTION
## Summary

Follow-up to #198. `handle_swap_confirm` still reads `validator.block`, which goes through `self.subtensor` and collides with the forward loop on the shared websocket — exactly the case #198 fixed for `handle_swap_reserve` and `BoundsCache`. Reserve only worked because the 12s `ttl_get_block` cache happened to be fresh; the confirm vote a few minutes later got an expired cache and crossed websockets, throwing `ConcurrencyError: cannot call recv while another thread is already running recv`.

One-line change: read through `axon_subtensor.get_current_block()` instead.

## Test plan

- [ ] `alw swap now` TAO→BTC: reserve → send → confirm completes without `ConcurrencyError`