### PR TITLE
fix(ink): clean up used_from_tx on confirm and timeout

### DIFF
--- a/smart-contracts/ink/lib.rs
+++ b/smart-contracts/ink/lib.rs
@@ -801,6 +801,7 @@ mod allways_swap_manager {
                     fee_amount: actual_fee,
                 });
 
+                this.used_from_tx.remove(&swap.from_tx_hash);
                 this.swaps.remove(swap_id);
                 this.clear_pending_swap_votes(swap_id);
                 Ok(())
@@ -858,6 +859,7 @@ mod allways_swap_manager {
                     slash_amount: actual_slash,
                 });
 
+                this.used_from_tx.remove(&swap.from_tx_hash);
                 this.swaps.remove(swap_id);
                 this.clear_pending_swap_votes(swap_id);
                 Ok(())


### PR DESCRIPTION
## Summary

Closes #174. `used_from_tx` was inserted on `vote_initiate` but never removed on `confirm_swap` or `timeout_swap`, so every initiated swap left a permanent `String` entry in contract storage.

Adds `used_from_tx.remove(&swap.from_tx_hash)` alongside the existing `swaps.remove(swap_id)` in both terminal paths. Replay protection still holds via the consumed source UTXO (BTC) or nonce (TAO); the entry isn't needed after the swap resolves.

Same shape as the `request_votes` leak fix (PR #149).

## Test plan

- [ ] Existing contract tests pass
- [ ] Add unit test: confirm_swap removes the from_tx_hash entry
- [ ] Add unit test: timeout_swap removes the from_tx_hash entry
- [ ] Verify replay attempt with same `from_tx_hash` after confirm still fails (UTXO/nonce already spent on the source chain)
