### PR TITLE
fix: reject NaN/inf rates in commitment parser

### DIFF
--- a/allways/commitments.py
+++ b/allways/commitments.py
@@ -1,5 +1,6 @@
 """Shared commitment parsing logic — used by validator, miner, and CLI."""
 
+import math
 from typing import List, Optional
 
 import bittensor as bt
@@ -40,6 +41,11 @@ def parse_commitment_data(raw: str, uid: int = 0, hotkey: str = '') -> Optional[
         rate = float(rate_str)
         counter_rate_str = parts[6]
         counter_rate = float(counter_rate_str)
+
+        if not (math.isfinite(rate) and rate > 0):
+            return None
+        if not (math.isfinite(counter_rate) and counter_rate > 0):
+            return None
 
         if src_chain not in SUPPORTED_CHAINS or dst_chain not in SUPPORTED_CHAINS:
             return None


### PR DESCRIPTION
## Summary

Closes #184. `float('nan')` and `float('inf')` don't raise, and the surrounding `except` only catches `ValueError` / `IndexError`, so neither was rejected by the commitment parser. An `inf` rate sorted to the top of crown-holder ranking; a `NaN` rate dropped silently out of comparisons (`NaN == NaN` is False).

After parsing both `rate` and `counter_rate`, reject any value that isn't `math.isfinite` and `> 0`.

## Test plan

- [ ] Existing commitment parser tests pass
- [ ] Unit test: `'inf'` / `'-inf'` / `'nan'` rate strings return `None`
- [ ] Unit test: `0` and negative rates still rejected
- [ ] Unit test: legitimate finite positive rates still parse
