### PR TITLE
fix: clear request on quorum failure, not just success

### DIFF
--- a/smart-contracts/ink/lib.rs
+++ b/smart-contracts/ink/lib.rs
@@ -229,8 +229,13 @@ mod allways_swap_manager {
             };
             let votes = self.record_vote(id, caller)?;
             if votes >= self.get_required_votes() {
-                on_quorum(self)?;
+                // Clear the request whether on_quorum succeeds or fails.
+                // Without this, a closure that returns Err leaves the vote
+                // persisted on a request that won't be cleared until expiry,
+                // blocking the validator from re-voting (AlreadyVoted).
+                let result = on_quorum(self);
                 self.clear_request(miner, req_type);
+                result?;
             }
             Ok(())
         }
@@ -280,9 +285,13 @@ mod allways_swap_manager {
             });
 
             if votes >= self.get_required_votes() {
-                on_quorum(self)?;
+                // Clear on success or failure so a failed quorum doesn't
+                // strand the vote (AlreadyVoted blocks the validator from
+                // retrying until the request expires).
+                let result = on_quorum(self);
                 self.clear_request_data(id);
                 self.pending_swap_votes.remove((swap_id, req_type));
+                result?;
             }
             Ok(())
         }


### PR DESCRIPTION
## Summary

Closes #185. `consensus_vote` and `consensus_swap_vote` ran `on_quorum` first and only called `clear_request` on success. If the closure returned `Err` (e.g. a post-quorum invariant fails), the vote stayed persisted on a request that wouldn't be cleared until expiry, and the validator who cast the quorum-reaching vote could no longer re-vote (`AlreadyVoted`).

Run `on_quorum` and clear unconditionally; propagate the error after cleanup so storage stays consistent regardless of the closure's outcome.

## Test plan

- [ ] Existing consensus tests pass
- [ ] Unit test: `on_quorum` returning `Err` still clears `request_voters` / `request_hash` / `pending_swap_votes`
- [ ] Unit test: validator can re-vote on a fresh request after a failed quorum closure
- [ ] Unit test: original error from `on_quorum` is still surfaced to the caller
