### PR TITLE
fix: higher confirmation threshold for destination leg

### DIFF
--- a/allways/chains.py
+++ b/allways/chains.py
@@ -14,7 +14,8 @@ class ChainDefinition:
     decimals: int  # Precision (e.g. 8 for BTC, 9 for TAO)
     env_prefix: str  # .env variable prefix (e.g. 'BTC' -> BTC_RPC_URL)
     seconds_per_block: int = 12  # Average block time on this chain
-    min_confirmations: int = 1  # Minimum confirmations before accepting a transaction
+    min_confirmations: int = 1  # Default — source leg (user→miner): miner bears reorg risk
+    destination_min_confirmations: int = 0  # 0 = use min_confirmations; user→miner direction
 
 
 # ─── Supported Chains ────────────────────────────────────
@@ -26,6 +27,7 @@ CHAIN_BTC = ChainDefinition(
     env_prefix='BTC',
     seconds_per_block=600,
     min_confirmations=3,
+    destination_min_confirmations=6,
 )
 CHAIN_TAO = ChainDefinition(
     id='tao',
@@ -68,3 +70,14 @@ def confirmations_to_subtensor_blocks(chain_id: str) -> int:
     """How many subtensor blocks a chain's min_confirmations take."""
     chain = get_chain(chain_id)
     return math.ceil(chain.min_confirmations * chain.seconds_per_block / SUBTENSOR_BLOCK_SECONDS)
+
+
+def get_destination_min_confirmations(chain_id: str) -> int:
+    """Confirmations required for the miner→user fulfillment leg.
+
+    The user has already given up their funds when this leg runs, so a
+    reorg dropping the miner's send falls on the user. Use a higher
+    threshold than the source leg, where the miner bears reorg risk.
+    """
+    chain = get_chain(chain_id)
+    return chain.destination_min_confirmations or chain.min_confirmations

--- a/allways/validator/chain_verification.py
+++ b/allways/validator/chain_verification.py
@@ -6,6 +6,7 @@ from typing import Dict
 import bittensor as bt
 
 from allways.chain_providers.base import ChainProvider, ProviderUnreachableError, TransactionInfo
+from allways.chains import get_destination_min_confirmations
 from allways.classes import Swap
 from allways.utils.rate import expected_swap_amounts
 
@@ -35,6 +36,7 @@ class SwapVerifier:
         expected_amount: int,
         block_hint: int = 0,
         expected_sender: str = '',
+        is_destination: bool = False,
     ) -> bool:
         """Verify a confirmed transaction on a specific chain.
 
@@ -66,7 +68,15 @@ class SwapVerifier:
                     f'(tx={tx_hash[:16]}... block_hint={block_hint})'
                 )
                 return False
-            if not tx_info.confirmed:
+            if is_destination:
+                # User has already given up source funds; reorg risk falls on them.
+                # Require the higher destination_min_confirmations regardless of
+                # the provider's source-leg `confirmed` flag.
+                required = get_destination_min_confirmations(chain)
+                if tx_info.confirmations < required:
+                    self.log_confs_progress(swap.id, chain, tx_hash, tx_info, expected_recipient, expected_amount)
+                    return False
+            elif not tx_info.confirmed:
                 self.log_confs_progress(swap.id, chain, tx_hash, tx_info, expected_recipient, expected_amount)
                 return False
             return True
@@ -137,6 +147,7 @@ class SwapVerifier:
             expected_user_receives,
             swap.to_tx_block,
             swap.miner_to_address,
+            True,
         )
 
         return source_ok and dest_ok


### PR DESCRIPTION
## Summary

Closes #187. `chains.py` hardcoded a single `min_confirmations` for both legs of a swap, but the two directions have asymmetric reorg risk:

- **User → miner** (source leg): miner bears reorg risk → 3 confs is fine
- **Miner → user** (destination leg): user has already given up source funds → reorg falls on them, 6 confs is the de-facto BTC standard

Adds `destination_min_confirmations` to `ChainDefinition` (defaults to 0, meaning "use `min_confirmations`"); set to 6 for BTC. `SwapVerifier.verify_tx` now takes `is_destination` and applies the higher threshold on the miner→user leg via `get_destination_min_confirmations(chain)`. Source-leg verification, CLI, and axon UX still use the original `min_confirmations`, so behavior is unchanged for those paths.

## Test plan

- [ ] Existing chain-verification tests pass
- [ ] Unit test: source leg accepts at 3 BTC confirmations (unchanged)
- [ ] Unit test: destination leg rejects at 3 confirmations, accepts at 6
- [ ] Unit test: TAO swaps unaffected (no `destination_min_confirmations` set → falls back to `min_confirmations`)
- [ ] Verify `verify_miner_fulfillment` passes `is_destination=True` only on the dest leg
