### PR TITLE
fix: SS58 checksum-validate receive addresses

### DIFF
--- a/allways/chain_providers/subtensor.py
+++ b/allways/chain_providers/subtensor.py
@@ -274,11 +274,14 @@ class SubtensorProvider(ChainProvider):
             return 0
 
     def is_valid_address(self, address: str) -> bool:
-        """Validate an SS58 address."""
+        """Validate an SS58 address (length, charset, and checksum)."""
+        if not address:
+            return False
         try:
-            if not address or len(address) != 48:
-                return False
-            return bool(re.match(r'^[1-9A-HJ-NP-Za-km-z]{48}$', address))
+            from scalecodec.utils.ss58 import ss58_decode
+
+            ss58_decode(address)
+            return True
         except Exception:
             return False
 


### PR DESCRIPTION
## Summary

Closes #200. `SubtensorProvider.is_valid_address` only checked 48-char Base58 charset via regex — no SS58 checksum. A typo like `'xxxx...xxxx'` passed the only validation gate at [swap.py:751](allways/cli/swap_commands/swap.py#L751); the miner then sent TAO to that literal address and funds were unrecoverable.

Replace the regex with `scalecodec.utils.ss58.ss58_decode`, which verifies the checksum. Same approach already used for BTC (`bech32` / `base58check`) and for SS58 in admin commands ([helpers.py:117-130](allways/cli/swap_commands/helpers.py#L117-L130)). Zero behavior change for legitimate addresses; catches all typos at the CLI gate.

## Test plan

- [ ] Existing subtensor-provider tests pass
- [ ] Unit test: real SS58 address (e.g. `5GrwvaEF...`) returns `True`
- [ ] Unit test: 48-char Base58-charset string with bad checksum (`'x' * 48`) returns `False`
- [ ] Unit test: empty / wrong-length / non-Base58 input returns `False`
- [ ] Manual: `alw swap` rejects a typo'd TAO destination before signing
