### PR TITLE
fix(event-watcher): don't double-count in-flight swaps after restart

### DIFF
--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -215,6 +215,9 @@ class ContractEventWatcher:
         self.active_miners: Set[str] = set()
         self.open_swap_count: Dict[str, int] = {}
         self.busy_events: List[BusyEvent] = []
+        # Swap IDs already counted as +1 by bootstrap. SwapInitiated events
+        # for these IDs replayed by sync_to are skipped so we don't double-count.
+        self._bootstrap_initiated_ids: Set[int] = set()
         self.active_events: List[ActiveEvent] = []
         self.active_events_by_hotkey: Dict[str, List[ActiveEvent]] = {}
 
@@ -295,6 +298,9 @@ class ContractEventWatcher:
                     seen_hotkeys.add(hk)
                     self.open_swap_count[hk] = self.open_swap_count.get(hk, 0) + 1
                     self.busy_events.append(BusyEvent(hotkey=hk, delta=+1, block=init_block))
+                    swap_id = getattr(swap, 'id', None)
+                    if isinstance(swap_id, int):
+                        self._bootstrap_initiated_ids.add(swap_id)
                 if seen_hotkeys:
                     self.busy_events.sort(key=lambda ev: ev.block)
                     bt.logging.info(f'EventWatcher bootstrap: seeded {len(seen_hotkeys)} miners as busy from contract')
@@ -387,6 +393,11 @@ class ContractEventWatcher:
             self.record_active_transition(block_num, hotkey, active)
         elif name == 'SwapInitiated':
             miner = values.get('miner', '')
+            swap_id = values.get('swap_id')
+            if isinstance(swap_id, int) and swap_id in self._bootstrap_initiated_ids:
+                # Already +1'd by bootstrap from contract state; skip replay.
+                self._bootstrap_initiated_ids.discard(swap_id)
+                return
             if miner:
                 self.apply_busy_delta(block_num, miner, +1)
         elif name == 'SwapCompleted':


### PR DESCRIPTION
## Summary

Closes #202. Bootstrap seeded `+1 BusyEvent` for each in-flight swap at its `initiated_block`, then rewound cursor to `current_block - SCORING_WINDOW_BLOCKS`. `sync_to` then replayed the same `SwapInitiated` event, applying a second `+1`. The matching `-1` from terminal events fires only once, so the miner stayed stuck at `open_swap_count=1` forever — permanently excluded from crown-time credit.

Track the swap IDs seeded during bootstrap in `_bootstrap_initiated_ids`; in `apply_event`, skip the `SwapInitiated` replay for any ID in that set (and discard it from the set so a future legitimate event for the same ID would still count, though IDs are unique so this is defensive).

## Test plan

- [ ] Existing event-watcher tests pass
- [ ] Unit test: restart with in-flight swap → `open_swap_count` is 1 after bootstrap + sync (not 2)
- [ ] Unit test: terminal event resolves the count to 0
- [ ] Unit test: swap initiated *after* bootstrap still increments normally
- [ ] Unit test: a swap not in bootstrap set still increments via replay
