### PR TITLE
fix(swap): give user a path to surface an already-sent tx before retrying

### DIFF
--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -451,6 +451,27 @@ def send_btc(chain_providers, config, to_address: str, amount_sat: int, from_add
         # Retry or fall through to manual
         if attempt < max_retries:
             console.print('[yellow]BTC send failed.[/yellow]')
+            console.print(
+                '[dim]If the first broadcast actually landed but the RPC response was lost,[/dim]\n'
+                '[dim]retrying may either fail with insufficient funds (UTXOs locked) or pick a[/dim]\n'
+                '[dim]different UTXO set and produce a second send. Check your wallet before retrying.[/dim]'
+            )
+            existing = click.prompt(
+                'Already-sent tx hash (paste if found in wallet/mempool), or blank to retry',
+                default='',
+                show_default=False,
+            ).strip()
+            if existing:
+                tx_info = provider.verify_transaction(
+                    tx_hash=existing,
+                    expected_recipient=to_address,
+                    expected_amount=amount_sat,
+                )
+                if tx_info is None:
+                    console.print('[red]No matching tx found for that hash — not using it.[/red]')
+                else:
+                    console.print(f'[green]Using existing tx: {existing[:16]}...[/green]')
+                    return (existing, tx_info.block_number or 0)
             if not click.confirm('Retry?', default=True):
                 break
             console.print('[dim]Retrying...[/dim]')


### PR DESCRIPTION

If the first sendtoaddress broadcast actually propagated but the RPC response was lost, Core's wallet locks the UTXOs so a retry either fails with insufficient funds or picks a different UTXO set producing a second tx. Lightweight mode has no wallet-level UTXO locking and is even more exposed.

Before retrying, warn the user about the locked-UTXO / second-send risk and prompt for an already-sent tx hash from their wallet/mempool. If they paste one that verifies, use it; otherwise fall through to retry. Keeps the existing flow for the common case (real RPC failure).

Closes #204