### PR TITLE
fix(contract-client): reject unknown SwapData status bytes

### DIFF
--- a/allways/contract_client.py
+++ b/allways/contract_client.py
@@ -581,7 +581,11 @@ class AllwaysContractClient:
             to_tx_block, o = decode_u32(data, o)
             status_byte = data[o]
             o += 1
-            status = SwapStatus(status_byte) if status_byte <= 3 else SwapStatus.ACTIVE
+            try:
+                status = SwapStatus(status_byte)
+            except ValueError:
+                bt.logging.error(f'SwapData decode: unknown status byte {status_byte}')
+                return None
             initiated_block, o = decode_u32(data, o)
             timeout_block, o = decode_u32(data, o)
             fulfilled_block, o = decode_u32(data, o)


### PR DESCRIPTION
## Summary

Closes #205. `decode_swap_data` silently coerced any unknown `status_byte` to `SwapStatus.ACTIVE`, so a future contract enum addition (e.g. `Expired`) would read as a live swap and the validator could try to confirm/timeout it.

Use a `try/except ValueError` around `SwapStatus(status_byte)` and return `None` on unknown bytes (with an `error` log), so callers treat the record as undecodable rather than acting on a fabricated state.

## Test plan

- [ ] Existing decoder tests pass
- [ ] Unit test: known status bytes (0–3) decode to the matching `SwapStatus`
- [ ] Unit test: unknown status byte returns `None` and logs an error
- [ ] Verify callers handle `None` return path (don't try to confirm/timeout)
