### PR TITLE
CLI: validate BTC_PRIVATE_KEY WIF prefix; clean up .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,26 +2,44 @@
 NETUID=7
 WALLET_NAME=default
 HOTKEY_NAME=default
-# Validators should point at a local subtensor lite node for cheap
+WALLET_PATH=~/.bittensor/wallets
+
+# Subtensor endpoint. Validators should point at a local lite node for cheap
 # commitment polling. Examples:
 #   SUBTENSOR_NETWORK=local             # ws://127.0.0.1:9944 (lite node or dev env)
 #   SUBTENSOR_NETWORK=finney            # public mainnet entrypoint
 #   SUBTENSOR_NETWORK=ws://host:9944    # custom remote node
 SUBTENSOR_NETWORK=finney
+
 PORT=8091
-WALLET_PATH=~/.bittensor/wallets
 LOG_LEVEL=info
 
+# ─── Contract ──────────────────────────────────────────────
+# Override the default Allways Swap Manager contract address. Leave unset to
+# use the bundled mainnet default. Set this when running against testnet,
+# the dev environment, or a forked deployment.
+CONTRACT_ADDRESS=
+
 # ─── Chain: Bitcoin (env_prefix=BTC) ───────────────────────
-BTC_MODE=lightweight           # node = local Bitcoin node | lightweight = Blockstream API (no node required)
-BTC_NETWORK=mainnet            # mainnet | testnet (auto-detected from RPC URL in node mode)
-BTC_RPC_URL=                   # Required for BTC_MODE=node only
+# node = local Bitcoin node | lightweight = Blockstream API (no node required)
+BTC_MODE=lightweight
+# mainnet | testnet (auto-detected from RPC URL in node mode)
+BTC_NETWORK=mainnet
+# Required for BTC_MODE=node only
+BTC_RPC_URL=
 BTC_RPC_USER=
 BTC_RPC_PASS=
 
+# ─── Bitcoin signing (users + miners) ──────────────────────
+# WIF private key. Required for miners in lightweight mode. Optional for
+# users running `alw swap`: when set, the CLI signs and broadcasts BTC
+# sends locally; when unset, the CLI falls back to a bring-your-own-signature
+# flow and you broadcast via your own wallet.
+BTC_PRIVATE_KEY=
+
 # ─── Miner-only ───────────────────────────────────────────
 MINER_BTC_ADDRESS=
-BTC_PRIVATE_KEY=               # WIF private key — required for miners in lightweight mode
+
 # Skip fulfilling a swap when fewer than this many blocks remain before its
 # timeout. Guards against slow dest-chain inclusion turning a send into a
 # slash. Default: 5 blocks (~1 min at 12s). Set to 0 to disable.

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -622,7 +622,9 @@ def swap_now_command(
         if from_chain == 'tao':
             console.print('\n  [green]TAO will be sent automatically from your wallet.[/green]')
         else:
-            has_private_key = bool(os.environ.get('BTC_PRIVATE_KEY'))
+            # Prefix-check the value (not just truthy): dotenv can leak an inline comment as the var.
+            wif_raw = (os.environ.get('BTC_PRIVATE_KEY') or '').strip()
+            has_private_key = bool(wif_raw) and wif_raw[0] in '5KLc9'
             btc_mode = os.environ.get('BTC_MODE', 'lightweight')
             is_local = is_local_network(config.get('network', 'finney'))
 


### PR DESCRIPTION
## Summary
- `alw swap` showed the green *\"BTC_PRIVATE_KEY set — will sign and attempt BTC sends locally\"* message even when the key was unset, then forced auto-sign and failed at broadcast. Root cause: dotenv parses `BTC_PRIVATE_KEY=               # WIF private key …` as the literal comment string (non-empty), so `bool(os.environ.get(...))` was `True`. Repro: `python3 -c "from dotenv import load_dotenv; import os; load_dotenv(); print(repr(os.environ['BTC_PRIVATE_KEY']))"` against the shipped `.env.example`.
- Tightened the gate in `swap.py:625` to mirror `chain_providers/bitcoin.py:get_wif` — only trust the var if its first char is `5/K/L` (mainnet) or `9/c` (test/regtest). Comment-bleed, empty, and whitespace-only values now correctly fall back to the BYO-signature flow.
- Reorganized `.env.example`: every comment now sits on its own line above its variable (so future inline-comment footguns can't sneak in), `BTC_PRIVATE_KEY` was pulled out of the *Miner-only* block into a dedicated **Bitcoin signing (users + miners)** section since CLI users also set it for local auto-sign, and a new **Contract** section documents `CONTRACT_ADDRESS` for testnet / dev-env / forked deployments.

## Test plan
- [ ] `ruff format . && ruff check .` clean
- [ ] With `BTC_PRIVATE_KEY=  # comment` in `.env`, `alw swap now` shows the yellow external-signing path (not the green auto-sign one)
- [ ] With a real mainnet WIF (`K…` / `L…` / `5…`), `alw swap now` shows the green auto-sign path
- [ ] With a real testnet WIF (`c…` / `9…`), `alw swap now` shows the green auto-sign path
- [ ] With `BTC_PRIVATE_KEY` unset, `alw swap now` shows the yellow external-signing path
- [ ] Dev environment + suite 02 still passes