### PR TITLE
CLI: actionable validator rejection messages + loading indicators

### DIFF
--- a/allways/cli/swap_commands/miner_commands.py
+++ b/allways/cli/swap_commands/miner_commands.py
@@ -20,6 +20,7 @@ from allways.cli.swap_commands.helpers import (
     print_contract_error,
     read_miner_commitment,
 )
+from allways.cli.validator_rejections import render_and_aggregate
 from allways.constants import FEE_DIVISOR
 from allways.contract_client import ContractError
 
@@ -138,24 +139,6 @@ def miner_status(hotkey: str):
     console.print(f'\n[dim]Total: {len(swaps)} active swaps[/dim]\n')
 
 
-def friendly_rejection(reason: str) -> str:
-    """Convert raw validator rejection reasons into human-readable messages."""
-    if not reason:
-        return ''
-    r = reason.lower()
-    if 'already active' in r:
-        return 'miner is already active'
-    if 'ContractReverted' in reason or 'contractreverted' in r:
-        return 'contract reverted (collateral/validator issue)'
-    if 'insufficient collateral' in r:
-        return reason
-    if 'no commitment found' in r:
-        return 'no pair commitment found — run: alw pair set'
-    if 'not registered' in r:
-        return 'hotkey not registered on subnet'
-    return reason
-
-
 @miner_group.command('activate')
 def miner_activate():
     """Activate miner via dendrite broadcast to all validators.
@@ -203,26 +186,16 @@ def miner_activate():
 
     # Broadcast
     timeout = resolve_dendrite_timeout(60.0)
-    with loading(f'Broadcasting to {len(validator_axons)} validators...'):
+    with loading(f'Broadcasting activation to {len(validator_axons)} validators...'):
         responses = asyncio.get_event_loop().run_until_complete(
             dendrite(axons=validator_axons, synapse=synapse, deserialize=False, timeout=timeout)
         )
 
-    # Show per-validator results
-    accepted = 0
-    no_response = 0
-    for i, resp in enumerate(responses):
-        if getattr(resp, 'accepted', None):
-            console.print(f'  Validator {i + 1}: [green]accepted[/green]')
-            accepted += 1
-            continue
-        raw_reason = getattr(resp, 'rejection_reason', '') or ''
-        if not raw_reason:
-            console.print(f'  Validator {i + 1}: [yellow]no response — timeout or validator down[/yellow]')
-            no_response += 1
-        else:
-            console.print(f'  Validator {i + 1}: [red]rejected[/red] — {friendly_rejection(raw_reason)}')
-
+    info = render_and_aggregate(console, responses, label='V', context={'miner_hotkey': hotkey})
+    accepted = info.accepted
+    no_response = info.no_response
+    if accepted == 0 and info.headline:
+        console.print(f'\n[red]{info.headline}[/red]')
     console.print(f'\n{accepted}/{len(validator_axons)} validators accepted')
 
     # Poll chain — the on-chain flag is authoritative. A validator can
@@ -244,18 +217,17 @@ def miner_activate():
         return
 
     if accepted == 0 and no_response == len(validator_axons):
-        console.print('[yellow]No validators responded within the dendrite timeout.[/yellow]')
         console.print('[dim]The chain may be slow — the vote could still land after this check.[/dim]')
         console.print('[dim]Retry with a longer timeout: ALW_DENDRITE_TIMEOUT=90 alw miner activate[/dim]')
         console.print('[dim]Or re-run `alw miner status` in a minute to see if activation completed.[/dim]\n')
-    elif accepted == 0:
-        console.print('[red]Activation failed — no validators accepted the request.[/red]')
-        console.print('[dim]Prerequisites:[/dim]')
+    elif accepted == 0 and info.category in ('', 'mixed', 'unmatched'):
+        # Translator couldn't pin down a single cause — fall back to the prerequisites checklist.
+        console.print('[dim]Prerequisites for activation:[/dim]')
         console.print('[dim]  - Hotkey registered on this subnet (btcli subnets register)[/dim]')
         console.print('[dim]  - Trading pair posted (alw miner post)[/dim]')
         console.print('[dim]  - Collateral deposited >= 0.1 TAO (alw collateral deposit)[/dim]')
         console.print('[dim]Run `alw miner status` to see which are missing.[/dim]\n')
-    else:
+    elif accepted > 0:
         console.print(
             '[yellow]Votes submitted but quorum not yet reached. Check status with: alw miner status[/yellow]\n'
         )

--- a/allways/cli/swap_commands/post_tx.py
+++ b/allways/cli/swap_commands/post_tx.py
@@ -11,6 +11,7 @@ from allways.cli.swap_commands.helpers import (
     console,
     get_cli_context,
     load_pending_swap,
+    loading,
     print_contract_error,
     resolve_source_tx_block,
 )
@@ -56,8 +57,9 @@ def post_tx_command(tx_hash: str, tx_block: int):
 
     # Validate reservation is still active on-chain
     try:
-        reserved_until = client.get_miner_reserved_until(state.miner_hotkey)
-        current_block = subtensor.get_current_block()
+        with loading('Reading reservation status...'):
+            reserved_until = client.get_miner_reserved_until(state.miner_hotkey)
+            current_block = subtensor.get_current_block()
     except ContractError as e:
         print_contract_error('Failed to read reservation status', e)
         return
@@ -115,7 +117,8 @@ def post_tx_command(tx_hash: str, tx_block: int):
         )
 
     # Discover validators
-    validator_axons = discover_validators(subtensor, netuid, contract_client=client)
+    with loading('Discovering validators...'):
+        validator_axons = discover_validators(subtensor, netuid, contract_client=client)
     if not validator_axons:
         console.print('[red]No validators found on metagraph[/red]')
         return
@@ -123,7 +126,7 @@ def post_tx_command(tx_hash: str, tx_block: int):
     ephemeral_wallet = get_ephemeral_wallet()
 
     # Sign and broadcast confirm synapse
-    accepted, queued = sign_and_broadcast_confirm(
+    accepted, queued, info = sign_and_broadcast_confirm(
         provider,
         state.user_from_address,
         from_key,
@@ -135,10 +138,14 @@ def post_tx_command(tx_hash: str, tx_block: int):
         from_chain=state.from_chain,
         to_chain=state.to_chain,
         from_tx_block=from_tx_block,
+        miner_uid=state.miner_uid,
     )
 
     if accepted == 0:
-        console.print('[yellow]No validators accepted. You can retry this command.[/yellow]')
+        # Translator already printed the headline. Suppress retry hint when the
+        # failure is deterministic — the same tx hash will reject the same way.
+        if not info.deterministic:
+            console.print('[dim]You can retry this command.[/dim]')
         return
 
     if queued > 0 and queued == accepted:

--- a/allways/cli/swap_commands/resume.py
+++ b/allways/cli/swap_commands/resume.py
@@ -17,6 +17,7 @@ from allways.cli.swap_commands.helpers import (
     console,
     get_cli_context,
     load_pending_swap,
+    loading,
     resolve_source_tx_block,
 )
 from allways.cli.swap_commands.swap import (
@@ -93,7 +94,9 @@ def resume_reservation_command(from_tx_hash_opt: Optional[str], skip_confirm: bo
 
     # Check if swap is already on-chain (cheap bool check before expensive scan)
     try:
-        if client.get_miner_has_active_swap(state.miner_hotkey):
+        with loading('Checking on-chain swap status...'):
+            has_swap = client.get_miner_has_active_swap(state.miner_hotkey)
+        if has_swap:
             for swap in client.get_miner_active_swaps(state.miner_hotkey):
                 is_ours = (
                     swap.user_from_address == state.user_from_address or swap.user_to_address == state.receive_address
@@ -115,8 +118,9 @@ def resume_reservation_command(from_tx_hash_opt: Optional[str], skip_confirm: bo
 
     # Check reservation status — if expired, there's nothing to resume
     try:
-        reserved_until = client.get_miner_reserved_until(state.miner_hotkey)
-        current_block = subtensor.get_current_block()
+        with loading('Reading reservation status...'):
+            reserved_until = client.get_miner_reserved_until(state.miner_hotkey)
+            current_block = subtensor.get_current_block()
         reservation_active = reserved_until > current_block
     except ContractError as e:
         console.print(f'[red]Failed to read reservation status: {e}[/red]')
@@ -150,7 +154,8 @@ def resume_reservation_command(from_tx_hash_opt: Optional[str], skip_confirm: bo
     from_key = wallet.coldkey if state.from_chain == 'tao' else None
 
     # Discover validators before prompting for tx hash (fail early)
-    validator_axons = discover_validators(subtensor, netuid, contract_client=client)
+    with loading('Discovering validators...'):
+        validator_axons = discover_validators(subtensor, netuid, contract_client=client)
     if not validator_axons:
         console.print('[red]No validators found on metagraph[/red]')
         return
@@ -180,7 +185,7 @@ def resume_reservation_command(from_tx_hash_opt: Optional[str], skip_confirm: bo
     )
 
     console.print('\n[dim]Confirming with validators...[/dim]')
-    accepted, queued = sign_and_broadcast_confirm(
+    accepted, queued, info = sign_and_broadcast_confirm(
         provider,
         state.user_from_address,
         from_key,
@@ -192,10 +197,14 @@ def resume_reservation_command(from_tx_hash_opt: Optional[str], skip_confirm: bo
         from_chain=state.from_chain,
         to_chain=state.to_chain,
         from_tx_block=from_tx_block,
+        miner_uid=state.miner_uid,
     )
 
     if accepted == 0:
-        console.print('[yellow]No validators accepted. You can retry: alw swap resume-reservation[/yellow]')
+        # Translator already printed the headline. Avoid suggesting retry when
+        # the rejection cannot be fixed by re-running with the same inputs.
+        if not info.deterministic:
+            console.print('[dim]Retry with: [cyan]alw swap resume-reservation[/cyan][/dim]')
         return
 
     all_queued = queued > 0 and queued == accepted

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -24,10 +24,12 @@ from allways.cli.swap_commands.helpers import (
     get_cli_context,
     is_local_network,
     load_pending_swap,
+    loading,
     resolve_source_tx_block,
     save_pending_swap,
     sign_or_prompt_external,
 )
+from allways.cli.validator_rejections import RejectionInfo, render_and_aggregate
 from allways.commitments import read_miner_commitments
 from allways.constants import FEE_DIVISOR, NETUID_FINNEY
 from allways.contract_client import ContractError
@@ -70,13 +72,16 @@ def sign_and_broadcast_confirm(
     to_chain: str = '',
     skip_confirm: bool = False,
     from_tx_block: int = 0,
+    miner_uid: Optional[int] = None,
 ) -> tuple:
     """Sign source tx proof and broadcast SwapConfirmSynapse to validators.
 
-    Returns (accepted_count, queued_count). Queued means the validator accepted
-    but is waiting for source tx confirmations before voting to initiate.
+    Returns (accepted_count, queued_count, info). ``info`` is a RejectionInfo
+    with aggregate counts and — when accepted == 0 — a translated headline +
+    deterministic flag so callers can decide whether to prompt for retry.
     """
-    console.print('[dim]Submitting swap to validators...[/dim]')
+    # Signing is fast for the internal path and may prompt interactively for
+    # the external (paste-a-signature) path — never wrap it in a spinner.
     proof_message = f'allways-swap:{from_tx_hash}'
     from_proof = sign_or_prompt_external(
         provider,
@@ -88,7 +93,7 @@ def sign_and_broadcast_confirm(
     )
     if not from_proof:
         console.print('[red]Could not obtain source tx proof signature — cannot confirm swap.[/red]')
-        return 0, 0
+        return 0, 0, RejectionInfo()
 
     confirm_synapse = SwapConfirmSynapse(
         reservation_id=miner_hotkey,
@@ -101,27 +106,28 @@ def sign_and_broadcast_confirm(
         to_chain=to_chain,
     )
 
-    console.print(f'  Broadcasting to {len(validator_axons)} validators...')
-    confirm_responses = broadcast_synapse(ephemeral_wallet, validator_axons, confirm_synapse, timeout=60.0)
+    with loading(f'Broadcasting confirmation to {len(validator_axons)} validators...'):
+        confirm_responses = broadcast_synapse(ephemeral_wallet, validator_axons, confirm_synapse, timeout=60.0)
 
-    accepted = 0
-    queued = 0
-    for i, resp in enumerate(confirm_responses):
-        raw_reason = (getattr(resp, 'rejection_reason', '') or '').strip()
-        if getattr(resp, 'accepted', None):
-            accepted += 1
-            if 'Queued' in raw_reason:
-                queued += 1
-                console.print(f'    V{i + 1}: [yellow]queued[/yellow] {raw_reason}')
-            else:
-                console.print(f'    V{i + 1}: [green]ok[/green]')
-        else:
-            # Blank = validator didn't respond; be explicit so the user can
-            # distinguish "rejected with reason" from "silently unreachable".
-            reason = raw_reason or '(no response — timeout or validator down)'
-            console.print(f'    V{i + 1}: [red]no[/red] {reason}')
+    info = render_and_aggregate(
+        console,
+        confirm_responses,
+        label='V',
+        context={
+            'from_chain': from_chain,
+            'from_chain_upper': from_chain.upper(),
+            'to_chain': to_chain,
+            'to_chain_upper': to_chain.upper(),
+            'from_address': user_from_address,
+            'miner_hotkey': miner_hotkey,
+            'miner_uid': miner_uid,
+        },
+    )
 
-    return accepted, queued
+    if info.accepted == 0 and info.headline:
+        console.print(f'\n[red]{info.headline}[/red]')
+
+    return info.accepted, info.queued, info
 
 
 def resolve_recent_swap_id(client, miner_hotkey: str) -> Optional[int]:
@@ -183,6 +189,8 @@ def broadcast_reserve_with_retry(
     """
     current_block = subtensor.get_current_block()
     reserve_proof_message = f'allways-reserve:{user_from_address}:{current_block}'
+    # Signing is fast internally and may prompt interactively for external
+    # signers — never wrap it in a spinner.
     from_address_proof = sign_or_prompt_external(
         provider,
         user_from_address,
@@ -208,10 +216,23 @@ def broadcast_reserve_with_retry(
     )
 
     ephemeral_wallet = get_ephemeral_wallet()
-    validator_axons = discover_validators(subtensor, netuid, contract_client=client)
+    with loading('Discovering validators...'):
+        validator_axons = discover_validators(subtensor, netuid, contract_client=client)
     if not validator_axons:
         console.print('[red]No validators found on metagraph[/red]')
         return None
+
+    from_amount_human = from_smallest_unit(from_amount, from_chain)
+    rejection_context = {
+        'from_chain': from_chain,
+        'from_chain_upper': from_chain.upper(),
+        'to_chain': to_chain,
+        'to_chain_upper': to_chain.upper(),
+        'from_address': user_from_address,
+        'from_amount_human': f'{from_amount_human:g}',
+        'miner_uid': selected_pair.uid,
+        'miner_hotkey': selected_pair.hotkey,
+    }
 
     reserved = False
     reserved_until = 0
@@ -242,25 +263,25 @@ def broadcast_reserve_with_retry(
                 to_chain=to_chain,
             )
 
-        console.print(f'  Broadcasting to {len(validator_axons)} validators...')
-        responses = broadcast_synapse(ephemeral_wallet, validator_axons, synapse, timeout=60.0)
+        with loading(f'Broadcasting reservation to {len(validator_axons)} validators...'):
+            responses = broadcast_synapse(ephemeral_wallet, validator_axons, synapse, timeout=60.0)
 
-        accepted = sum(1 for r in responses if getattr(r, 'accepted', None))
-        for i, resp in enumerate(responses):
-            was_accepted = bool(getattr(resp, 'accepted', None))
-            raw_reason = (getattr(resp, 'rejection_reason', '') or '').strip()
-            if was_accepted:
-                # Accepted means the validator responded. Blank reason is
-                # normal here — don't render the 'no response' fallback.
-                suffix = f' {raw_reason}' if raw_reason else ''
-                console.print(f'    V{i + 1}: [green]ok[/green]{suffix}')
-            else:
-                reason = raw_reason or '(no response — timeout or validator down)'
-                console.print(f'    V{i + 1}: [red]no[/red] {reason}')
+        info = render_and_aggregate(console, responses, label='V', context=rejection_context)
+        accepted = info.accepted
 
         if accepted == 0:
-            console.print('[red]No validators accepted the reservation.[/red]')
-            if attempt < max_retries and not skip_confirm and click.confirm('Retry?', default=True):
+            if info.headline:
+                console.print(f'\n[red]{info.headline}[/red]')
+            else:
+                console.print('\n[red]No validators accepted the reservation.[/red]')
+            # Deterministic failures (insufficient balance, invalid proof, wrong direction…)
+            # cannot succeed by retrying with the same inputs — skip the retry prompt.
+            if info.deterministic:
+                console.print(
+                    '[dim]Retrying with the same inputs will not change this — fix the underlying issue first.[/dim]'
+                )
+                return None
+            if attempt < max_retries and not skip_confirm and click.confirm('Retry?', default=False):
                 console.print('[dim]Retrying reservation...[/dim]')
                 continue
             return None
@@ -583,24 +604,25 @@ def swap_now_command(
     # Step 2: Find available miners (bilateral matching).
     # Done BEFORE any confirm prompts — if no miner can fill this swap, bail
     # out before the user wastes time answering BTC-signing questions.
-    console.print('\n[dim]Reading miner commitments...[/dim]')
-    all_pairs = read_miner_commitments(subtensor, netuid)
+    with loading('Reading miner commitments from chain...'):
+        all_pairs = read_miner_commitments(subtensor, netuid)
 
     matching_pairs = find_matching_miners(all_pairs, from_chain, to_chain)
 
     if not matching_pairs:
-        console.print(f'[yellow]No miners currently post rates for {from_chain.upper()}/{to_chain.upper()}.[/yellow]')
+        console.print(f'\n[yellow]No miners currently post rates for {from_chain.upper()}/{to_chain.upper()}.[/yellow]')
         console.print('[dim]Run [cyan]alw view rates[/cyan] to see active pairs, or try again later.[/dim]\n')
         return
 
     available_miners = []
     try:
-        for pair in matching_pairs:
-            is_active = client.get_miner_active_flag(pair.hotkey)
-            has_swap = client.get_miner_has_active_swap(pair.hotkey)
-            collateral = client.get_miner_collateral(pair.hotkey)
-            if is_active and not has_swap and collateral > 0:
-                available_miners.append((pair, collateral))
+        with loading(f'Checking eligibility for {len(matching_pairs)} miner(s)...'):
+            for pair in matching_pairs:
+                is_active = client.get_miner_active_flag(pair.hotkey)
+                has_swap = client.get_miner_has_active_swap(pair.hotkey)
+                collateral = client.get_miner_collateral(pair.hotkey)
+                if is_active and not has_swap and collateral > 0:
+                    available_miners.append((pair, collateral))
     except ContractError as e:
         console.print(f'[red]Failed to read miner data: {e}[/red]')
         return
@@ -718,8 +740,9 @@ def swap_now_command(
     # (collateral) so we fail loudly here instead of after the user has
     # reserved and sent funds.
     try:
-        min_swap = client.get_min_swap_amount()
-        max_swap = client.get_max_swap_amount()
+        with loading('Reading protocol swap bounds...'):
+            min_swap = client.get_min_swap_amount()
+            max_swap = client.get_max_swap_amount()
     except ContractError:
         console.print('[yellow]Warning: could not verify swap bounds (contract unreachable)[/yellow]')
         min_swap, max_swap = 0, 0
@@ -769,7 +792,8 @@ def swap_now_command(
 
     # Step 6b: Verify sender has enough funds
     if from_chain == 'tao':
-        tao_balance = subtensor.get_balance(wallet.coldkeypub.ss58_address)
+        with loading('Checking TAO balance...'):
+            tao_balance = subtensor.get_balance(wallet.coldkeypub.ss58_address)
         if tao_balance.rao < from_amount:
             console.print(
                 f'[red]Insufficient balance: you have {tao_balance} but need {bt.Balance.from_rao(from_amount)}[/red]'
@@ -904,13 +928,14 @@ def swap_now_command(
         from_tx_hash = None
         if from_chain == 'tao':
             try:
-                response = subtensor.transfer(
-                    wallet=wallet,
-                    destination_ss58=selected_pair.from_address,
-                    amount=bt.Balance.from_rao(from_amount),
-                    wait_for_inclusion=True,
-                    wait_for_finalization=False,
-                )
+                with loading('Submitting TAO transfer to chain...'):
+                    response = subtensor.transfer(
+                        wallet=wallet,
+                        destination_ss58=selected_pair.from_address,
+                        amount=bt.Balance.from_rao(from_amount),
+                        wait_for_inclusion=True,
+                        wait_for_finalization=False,
+                    )
                 if not response.success:
                     console.print(f'[red]TAO transfer failed: {response.message}[/red]')
                     console.print('[yellow]Resume with: alw swap post-tx <tx_hash>[/yellow]')
@@ -949,7 +974,7 @@ def swap_now_command(
     # Step 10: Post tx hash to validators
     console.print('\n[dim]Step 3/3: Confirming with validators...[/dim]')
 
-    accepted, queued = sign_and_broadcast_confirm(
+    accepted, queued, _ = sign_and_broadcast_confirm(
         provider,
         user_from_address,
         from_key,
@@ -961,10 +986,11 @@ def swap_now_command(
         from_chain=from_chain,
         to_chain=to_chain,
         from_tx_block=from_tx_block,
+        miner_uid=selected_pair.uid,
     )
 
     if accepted == 0:
-        console.print('[yellow]No validators accepted. Resume with: alw swap post-tx <tx_hash>[/yellow]')
+        console.print('[dim]Resume with: [cyan]alw swap post-tx <tx_hash>[/cyan][/dim]')
         return
 
     all_queued = queued > 0 and queued == accepted

--- a/allways/cli/validator_rejections.py
+++ b/allways/cli/validator_rejections.py
@@ -1,0 +1,391 @@
+"""Translate raw validator rejection_reason strings into actionable CLI messages.
+
+Validator-side rejection strings are stable, terse identifiers — fine for logs,
+opaque for users. This module aggregates per-validator responses, prints one
+line per validator, and (when the rejections agree) renders a single
+human-readable explanation plus a deterministic-vs-transient flag the caller
+uses to decide whether to prompt for retry.
+
+Mapping is prefix-matched on the lowercased reason so minor wording changes on
+the validator side don't silently regress the UX. Any reason that does not
+prefix-match falls through to the raw string — so adding a new validator-side
+rejection still surfaces something useful, just untranslated.
+"""
+
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+from rich.console import Console
+
+
+@dataclass
+class RejectionInfo:
+    """Aggregated outcome of a multi-validator broadcast.
+
+    Attributes:
+        accepted: validators that returned accepted=True.
+        queued: subset of accepted where the validator queued for confirmations.
+        rejected: validators that responded with a rejection_reason.
+        no_response: validators that timed out / didn't respond.
+        headline: user-facing translated message when all rejections agree;
+            empty when validators disagreed or accepted >= 1.
+        deterministic: True when retrying with identical inputs cannot succeed.
+            Only meaningful when accepted == 0.
+        category: matched rule key (e.g. 'insufficient_source_balance') or
+            'mixed' / 'unmatched' / 'no_response_only' / ''. Useful for tests.
+        raw_reasons: list of raw rejection strings (one per non-accepted
+            validator; '' for no-response).
+    """
+
+    accepted: int = 0
+    queued: int = 0
+    rejected: int = 0
+    no_response: int = 0
+    headline: str = ''
+    deterministic: bool = False
+    category: str = ''
+    raw_reasons: list[str] = field(default_factory=list)
+
+
+# Rule = (category_key, prefix, deterministic, builder)
+# Order: most specific first. Prefix match is case-insensitive.
+_Rule = tuple[str, str, bool, Callable[[dict], str]]
+
+
+def _ctx_get(ctx: dict, key: str, fallback: str = '?') -> str:
+    val = ctx.get(key)
+    return str(val) if val not in (None, '') else fallback
+
+
+_RULES: list[_Rule] = [
+    # ------ SwapReserve rejections ------
+    (
+        'insufficient_source_balance',
+        'insufficient source balance',
+        True,
+        lambda ctx: (
+            f'Source address [yellow]{_ctx_get(ctx, "from_address", "<your source address>")}[/yellow] '
+            f'does not hold enough {_ctx_get(ctx, "from_chain_upper", "funds")}. '
+            f'Fund it with at least [bold]{_ctx_get(ctx, "from_amount_human")} '
+            f'{_ctx_get(ctx, "from_chain_upper", "")}[/bold] and try again.'
+        ),
+    ),
+    (
+        'invalid_source_proof',
+        'invalid source address proof',
+        True,
+        lambda ctx: (
+            f'Signature for [yellow]{_ctx_get(ctx, "from_address", "<your source address>")}[/yellow] '
+            'did not verify. The signing key (BTC_PRIVATE_KEY/WIF or coldkey) does not match '
+            'the source address.'
+        ),
+    ),
+    (
+        'address_cooldown',
+        'address on cooldown',
+        True,
+        lambda ctx: (
+            f'Source address [yellow]{_ctx_get(ctx, "from_address", "<your source address>")}[/yellow] '
+            f'is on a reservation cooldown ({_ctx_get(ctx, "raw_reason", "")}). Wait for it to clear or '
+            'reserve from a different address.'
+        ),
+    ),
+    (
+        'wrong_direction',
+        'miner does not support this swap direction',
+        True,
+        lambda ctx: (
+            f'Miner UID {_ctx_get(ctx, "miner_uid")} does not quote a rate for '
+            f'{_ctx_get(ctx, "from_chain_upper")} → {_ctx_get(ctx, "to_chain_upper")}. '
+            'Pick a different miner.'
+        ),
+    ),
+    (
+        'no_valid_commitment',
+        'no valid commitment',
+        True,
+        lambda ctx: (
+            f'Miner UID {_ctx_get(ctx, "miner_uid")} has no valid rate commitment on-chain. Pick a different miner.'
+        ),
+    ),
+    (
+        'miner_not_active',
+        'miner not active',
+        True,
+        lambda ctx: f'Miner UID {_ctx_get(ctx, "miner_uid")} is not active on the contract. Pick a different miner.',
+    ),
+    (
+        'miner_busy',
+        'miner has an active swap',
+        False,
+        lambda ctx: (
+            f'Miner UID {_ctx_get(ctx, "miner_uid")} is currently fulfilling another swap. '
+            'Wait a few blocks or pick another miner.'
+        ),
+    ),
+    (
+        'miner_already_reserved',
+        'miner already reserved',
+        False,
+        lambda ctx: (
+            f'Miner UID {_ctx_get(ctx, "miner_uid")} is already reserved by someone else. '
+            'Wait for the reservation to clear or pick another miner.'
+        ),
+    ),
+    (
+        'insufficient_miner_collateral',
+        'insufficient miner collateral',
+        True,
+        lambda ctx: (
+            f'Miner UID {_ctx_get(ctx, "miner_uid")} does not have enough collateral for this swap '
+            'amount. Try a smaller amount or another miner.'
+        ),
+    ),
+    (
+        'miner_collateral_below_minimum',
+        'miner collateral below minimum',
+        True,
+        lambda ctx: (
+            f'Miner UID {_ctx_get(ctx, "miner_uid")} has fallen below the minimum collateral '
+            'requirement. Pick a different miner.'
+        ),
+    ),
+    (
+        'swap_below_min',
+        'swap amount below minimum',
+        True,
+        lambda ctx: (
+            f'Swap amount is below the protocol minimum ({_ctx_get(ctx, "raw_reason", "")}). Try a larger amount.'
+        ),
+    ),
+    (
+        'swap_above_max',
+        'swap amount above maximum',
+        True,
+        lambda ctx: (
+            f'Swap amount is above the protocol maximum ({_ctx_get(ctx, "raw_reason", "")}). Try a smaller amount.'
+        ),
+    ),
+    (
+        'same_chain',
+        'source and destination chains must be different',
+        True,
+        lambda ctx: 'Source and destination chains must differ.',
+    ),
+    # ------ SwapConfirm rejections ------
+    (
+        'no_active_reservation',
+        'no active reservation for this miner',
+        True,
+        lambda ctx: (
+            f'Miner UID {_ctx_get(ctx, "miner_uid")} no longer has an active reservation — it likely '
+            'expired before your tx was confirmed. Start a new swap with: alw swap now'
+        ),
+    ),
+    (
+        'reservation_data_missing',
+        'reservation data not found',
+        True,
+        lambda ctx: 'The reservation has already been initiated or cleared. Check status: alw view reservation',
+    ),
+    (
+        'invalid_tx_proof',
+        'invalid source tx proof',
+        True,
+        lambda ctx: (
+            'Signature over the source tx hash did not verify. The signing key does not match '
+            f'[yellow]{_ctx_get(ctx, "from_address", "<your source address>")}[/yellow].'
+        ),
+    ),
+    (
+        'invalid_dest_address',
+        'invalid destination address format',
+        True,
+        lambda ctx: (
+            f'Destination address is not a valid {_ctx_get(ctx, "to_chain_upper", "destination chain")} '
+            'address. Re-run the swap with the correct receive address.'
+        ),
+    ),
+    (
+        'unsupported_dest_chain',
+        'unsupported destination chain',
+        True,
+        lambda ctx: f'Validator does not support this destination chain ({_ctx_get(ctx, "raw_reason", "")}).',
+    ),
+    (
+        'tx_not_found',
+        'source transaction not found',
+        False,
+        lambda ctx: (
+            'Validators could not find your source transaction (or sender/amount mismatched). '
+            'It may need more time to propagate, or the hash/sender may be off. Retry in a few blocks; '
+            'if you have it, pass [cyan]--block <N>[/cyan].'
+        ),
+    ),
+    (
+        'missing_dest_address',
+        'missing destination address',
+        True,
+        lambda ctx: 'Internal: missing destination address in the request.',
+    ),
+    # ------ MinerActivate rejections ------
+    (
+        'miner_not_registered',
+        'hotkey not registered on subnet',
+        True,
+        lambda ctx: 'Your hotkey is not registered on this subnet. Register first: btcli subnets register',
+    ),
+    (
+        'miner_no_commitment',
+        'no commitment found',
+        True,
+        lambda ctx: 'No trading-pair commitment found for your miner. Run: alw pair set',
+    ),
+    (
+        'already_active',
+        'miner is already active',
+        True,
+        lambda ctx: 'Your miner is already active.',
+    ),
+    (
+        'insufficient_collateral',
+        'insufficient collateral',
+        True,
+        lambda ctx: f'Insufficient collateral ({_ctx_get(ctx, "raw_reason", "")}). Top up with: alw collateral deposit',
+    ),
+    # ------ Generic / shared ------
+    (
+        'unsupported_chain',
+        'unsupported chain',
+        True,
+        lambda ctx: f'Validator does not support this chain ({_ctx_get(ctx, "raw_reason", "")}).',
+    ),
+    (
+        'missing_src_proof',
+        'missing source address or proof',
+        True,
+        lambda ctx: 'Internal: missing source address or proof in the request.',
+    ),
+    (
+        'missing_chain_fields',
+        'missing from_chain or to_chain',
+        True,
+        lambda ctx: 'Internal: missing chain fields in the request.',
+    ),
+    (
+        'contract_rejected',
+        'contract rejected',
+        False,
+        lambda ctx: 'Contract rejected the request on-chain — usually transient. Retrying may help.',
+    ),
+]
+
+
+def _match_rule(reason: str) -> Optional[_Rule]:
+    if not reason:
+        return None
+    needle = reason.lower()
+    for rule in _RULES:
+        _, prefix, _, _ = rule
+        if needle.startswith(prefix):
+            return rule
+    return None
+
+
+def render_and_aggregate(
+    console: Console,
+    responses,
+    *,
+    label: str = 'V',
+    context: Optional[dict] = None,
+) -> RejectionInfo:
+    """Print per-validator status lines and return aggregate counts + headline.
+
+    Each response is rendered as one line:
+      ``{label}{i}: ok``
+      ``{label}{i}: queued <reason>``       (accepted but waiting for confirmations)
+      ``{label}{i}: no <raw reason>``       (rejected)
+      ``{label}{i}: no response — timeout`` (no rejection_reason returned)
+
+    When ``accepted == 0`` and every rejection prefix-matches the same rule,
+    a translated headline is set on the returned info. Mixed-reason failures
+    fall back to ``headline=''`` so the caller can render a generic line.
+    """
+    ctx = dict(context or {})
+    info = RejectionInfo()
+
+    for i, resp in enumerate(responses, 1):
+        accepted = bool(getattr(resp, 'accepted', None))
+        raw = (getattr(resp, 'rejection_reason', '') or '').strip()
+        if accepted:
+            info.accepted += 1
+            if raw and 'queued' in raw.lower():
+                info.queued += 1
+                console.print(f'  {label}{i}: [yellow]queued[/yellow] {raw}')
+            else:
+                # Blank reason on accept is normal — don't print the no-response fallback.
+                console.print(f'  {label}{i}: [green]ok[/green]')
+            continue
+
+        info.raw_reasons.append(raw)
+        if not raw:
+            info.no_response += 1
+            console.print(f'  {label}{i}: [yellow]no response[/yellow] [dim]— timeout or validator down[/dim]')
+        else:
+            info.rejected += 1
+            console.print(f'  {label}{i}: [red]no[/red] [dim]{raw}[/dim]')
+
+    if info.accepted > 0 or (info.rejected == 0 and info.no_response == 0):
+        return info
+
+    # No-response-only: deterministic=False (transient by nature).
+    if info.rejected == 0 and info.no_response > 0:
+        info.category = 'no_response_only'
+        info.headline = 'No validators responded within the timeout — the chain may be slow or validators may be down.'
+        info.deterministic = False
+        return info
+
+    # Match every rejected reason to a rule. If they all map to the same
+    # rule, render the translated headline; otherwise call it mixed.
+    matched_categories: set[str] = set()
+    last_match: Optional[_Rule] = None
+    last_raw = ''
+    unmatched = False
+    for raw in info.raw_reasons:
+        if not raw:
+            continue
+        rule = _match_rule(raw)
+        if rule is None:
+            unmatched = True
+            last_raw = raw
+            continue
+        matched_categories.add(rule[0])
+        last_match = rule
+        last_raw = raw
+
+    if last_match is None:
+        # No rejection prefix-matched any rule — surface the raw reason as the headline
+        # so the user still gets *something* actionable. Treat as transient by default
+        # so the user can choose to retry.
+        info.category = 'unmatched'
+        info.headline = last_raw or 'Validators rejected the request.'
+        info.deterministic = False
+        return info
+
+    if len(matched_categories) > 1 or unmatched:
+        info.category = 'mixed'
+        info.headline = ''
+        # Mixed deterministic flags → call it transient so the user can retry.
+        info.deterministic = False
+        return info
+
+    category, _, det, builder = last_match
+    ctx.setdefault('raw_reason', last_raw)
+    info.category = category
+    info.deterministic = det
+    try:
+        info.headline = builder(ctx)
+    except Exception:
+        # A formatting error in the builder must not crash the CLI — fall back to the raw reason.
+        info.headline = last_raw
+    return info

--- a/tests/test_validator_rejections.py
+++ b/tests/test_validator_rejections.py
@@ -1,0 +1,138 @@
+"""Tests for the centralized validator rejection translator.
+
+Locks down the prefix→message mapping and the aggregation behavior so that
+adding a new rejection cause on the validator side is caught here as a
+diff to the rules table rather than as a regression in CLI UX.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from rich.console import Console
+
+from allways.cli.validator_rejections import RejectionInfo, render_and_aggregate
+
+
+@dataclass
+class FakeResp:
+    accepted: Optional[bool] = None
+    rejection_reason: Optional[str] = None
+
+
+def _silent_console() -> Console:
+    # record=True + file=open(os.devnull) would also work, but Rich's default
+    # constructor is fine — we just don't assert against printed output here.
+    return Console(quiet=True)
+
+
+def test_all_accepted_no_headline():
+    info = render_and_aggregate(_silent_console(), [FakeResp(accepted=True), FakeResp(accepted=True)])
+    assert info.accepted == 2
+    assert info.rejected == 0
+    assert info.headline == ''
+    assert info.deterministic is False
+
+
+def test_all_queued_counted_separately():
+    responses = [
+        FakeResp(accepted=True, rejection_reason='Queued — 1/6 confirmations.'),
+        FakeResp(accepted=True, rejection_reason='Queued — 2/6 confirmations.'),
+    ]
+    info = render_and_aggregate(_silent_console(), responses)
+    assert info.accepted == 2
+    assert info.queued == 2
+
+
+def test_insufficient_source_balance_translates():
+    responses = [FakeResp(accepted=False, rejection_reason='Insufficient source balance')]
+    info = render_and_aggregate(
+        _silent_console(),
+        responses,
+        context={
+            'from_chain_upper': 'BTC',
+            'from_address': 'tb1qabc',
+            'from_amount_human': '0.0008',
+        },
+    )
+    assert info.category == 'insufficient_source_balance'
+    assert info.deterministic is True
+    assert 'tb1qabc' in info.headline
+    assert 'BTC' in info.headline
+    assert '0.0008' in info.headline
+
+
+def test_address_cooldown_includes_raw_reason():
+    raw = 'Address on cooldown (50 blocks remaining)'
+    info = render_and_aggregate(
+        _silent_console(),
+        [FakeResp(accepted=False, rejection_reason=raw)],
+        context={'from_address': 'tb1qabc'},
+    )
+    assert info.category == 'address_cooldown'
+    assert info.deterministic is True
+    assert '50 blocks remaining' in info.headline
+
+
+def test_miner_busy_is_not_deterministic():
+    info = render_and_aggregate(
+        _silent_console(),
+        [FakeResp(accepted=False, rejection_reason='Miner has an active swap')],
+        context={'miner_uid': 4},
+    )
+    assert info.category == 'miner_busy'
+    assert info.deterministic is False
+    assert 'UID 4' in info.headline
+
+
+def test_mixed_reasons_no_headline():
+    responses = [
+        FakeResp(accepted=False, rejection_reason='Insufficient source balance'),
+        FakeResp(accepted=False, rejection_reason='Miner already reserved'),
+    ]
+    info = render_and_aggregate(_silent_console(), responses, context={'miner_uid': 1})
+    assert info.category == 'mixed'
+    assert info.headline == ''
+    assert info.deterministic is False  # mixed → let the user retry if they want
+
+
+def test_no_response_only():
+    responses = [FakeResp(accepted=False, rejection_reason=''), FakeResp(accepted=False, rejection_reason=None)]
+    info = render_and_aggregate(_silent_console(), responses)
+    assert info.category == 'no_response_only'
+    assert info.no_response == 2
+    assert info.deterministic is False
+    assert 'no validators responded' in info.headline.lower()
+
+
+def test_unmatched_falls_back_to_raw():
+    info = render_and_aggregate(
+        _silent_console(),
+        [FakeResp(accepted=False, rejection_reason='Some brand-new validator error')],
+    )
+    assert info.category == 'unmatched'
+    assert info.headline == 'Some brand-new validator error'
+    assert info.deterministic is False  # unknown → safer to allow retry
+
+
+def test_swap_confirm_tx_not_found_is_transient():
+    info = render_and_aggregate(
+        _silent_console(),
+        [FakeResp(accepted=False, rejection_reason='Source transaction not found, amount or sender mismatch')],
+    )
+    assert info.category == 'tx_not_found'
+    assert info.deterministic is False
+
+
+def test_miner_activate_unregistered():
+    info = render_and_aggregate(
+        _silent_console(),
+        [FakeResp(accepted=False, rejection_reason='Hotkey not registered on subnet')],
+    )
+    assert info.category == 'miner_not_registered'
+    assert info.deterministic is True
+    assert 'btcli subnets register' in info.headline
+
+
+def test_returns_rejectioninfo_dataclass():
+    info = render_and_aggregate(_silent_console(), [])
+    assert isinstance(info, RejectionInfo)


### PR DESCRIPTION
## Summary
- Centralizes per-validator broadcast result rendering in `allways/cli/validator_rejections.py` — a prefix-matched rules table maps every `reject_synapse(...)` reason from `axon_handlers.py` to an actionable, user-facing explanation, plus a deterministic-vs-transient classification.
- Wires the translator into the four CLI sites that broadcast to validators: `alw swap now` (reserve + confirm), `alw swap post-tx`, `alw swap resume-reservation`, `alw miner activate`. Replaces the ad-hoc `friendly_rejection` helper in `miner_commands.py`.
- Suppresses the `Retry?` prompt for deterministic failures (insufficient source balance, invalid proof, wrong direction, swap amount out of range, miner not active, etc.) — retrying with the same inputs can't fix them, so don't ask.
- Adds spinners around the remaining intermittent steps in `alw swap now` / `post-tx` / `resume`: reading miner commitments, eligibility check, protocol bounds query, balance check, validator discovery, broadcast, TAO transfer. Never wraps an interactive signing prompt.

### Before
```
    V1: no Insufficient source balance
No validators accepted the reservation.
Retry? [Y/n]:
```

### After
```
  V1: no Insufficient source balance

Source address tb1qg6da0krxahqyjhtdmnrrf8qfeqzyfc6ge9kp6j does not hold enough BTC.
Fund it with at least 0.0008 BTC and try again.
Retrying with the same inputs will not change this — fix the underlying issue first.
```

## Test plan
- [ ] `pytest tests/` — 311 passed (added 11 translator tests)
- [ ] `ruff format && ruff check` — clean
- [ ] Trigger insufficient-balance reject in dev environment, confirm new message
- [ ] Trigger miner-busy reject (transient), confirm `Retry?` still appears
- [ ] Trigger no-validator-response, confirm new copy
- [ ] BTC external-signing flow — confirm no spinner above the paste prompt
- [ ] `alw miner activate` with unregistered hotkey, confirm translator headline replaces the prereqs list