### PR TITLE
validator: refresh cached reserved_until after extend vote

### DIFF
--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -248,6 +248,11 @@ def try_extend_reservation(
             from_tx_hash=item.from_tx_hash,
         )
         self.extend_reservation_voted_at[vote_key] = reserved_until
+        # Refresh the local cache from the contract: if quorum landed this vote
+        # the on-chain reserved_until has advanced, and the up-front purge would
+        # otherwise delete this row at the original TTL while the reservation
+        # is still alive on-chain.
+        refresh_cached_reserved_until(self, item)
         bt.logging.info(
             f'PendingConfirm [{swap_label} {miner_short}]: '
             f'voted to extend reservation ({reserved_until - current_block} blocks remaining)'
@@ -257,10 +262,22 @@ def try_extend_reservation(
             self.extend_reservation_voted_at[(item.miner_hotkey, item.from_tx_hash)] = (
                 self.contract_client.get_miner_reserved_until(item.miner_hotkey)
             )
+            refresh_cached_reserved_until(self, item)
         else:
             bt.logging.debug(f'PendingConfirm [{swap_label} {miner_short}]: extend vote: {e}')
     except Exception as e:
         bt.logging.debug(f'PendingConfirm [{swap_label} {miner_short}]: extend check failed: {e}')
+
+
+def refresh_cached_reserved_until(self: Validator, item: PendingConfirm) -> None:
+    try:
+        latest = self.contract_client.get_miner_reserved_until(item.miner_hotkey)
+    except Exception as e:
+        bt.logging.debug(f'PendingConfirm [{item.miner_hotkey[:8]}]: reserved_until refresh failed: {e}')
+        return
+    if latest > item.reserved_until:
+        self.state_store.update_reserved_until(item.miner_hotkey, latest)
+        item.reserved_until = latest
 
 
 def poll_commitments(self: Validator) -> None:

--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -114,6 +114,21 @@ class ValidatorStateStore:
             conn.commit()
         return self.row_to_pending(row)
 
+    def update_reserved_until(self, miner_hotkey: str, reserved_until: int) -> None:
+        """Refresh the cached reserved_until on an existing pending_confirms row.
+
+        Called after the contract's reservation has been extended on-chain — without
+        this, the row's stale value causes ``purge_expired_pending_confirms`` to
+        delete a still-live entry the moment the original TTL elapses.
+        """
+        with self.lock:
+            conn = self.require_connection()
+            conn.execute(
+                'UPDATE pending_confirms SET reserved_until = ? WHERE miner_hotkey = ?',
+                (reserved_until, miner_hotkey),
+            )
+            conn.commit()
+
     def has(self, miner_hotkey: str) -> bool:
         with self.lock:
             conn = self.require_connection()

--- a/tests/test_pending_confirm_queue.py
+++ b/tests/test_pending_confirm_queue.py
@@ -107,6 +107,30 @@ class TestPendingConfirmQueue:
         assert queue.has('miner-2')
         assert queue.pending_size() == 1
 
+    def test_update_reserved_until_prevents_stale_purge(self, tmp_path: Path):
+        """Regression: after the contract extends a reservation, refreshing the
+        cached reserved_until must keep the row alive past its original TTL."""
+        db_path = tmp_path / 'state.db'
+        current_block = 105
+        queue = ValidatorStateStore(db_path=db_path, current_block_fn=lambda: current_block)
+
+        queue.enqueue(PENDING_CONFIRM_SAMPLE1)  # reserved_until=100
+        queue.update_reserved_until('miner-1', 130)
+
+        items = queue.get_all()
+        assert len(items) == 1
+        assert items[0].reserved_until == 130
+
+        removed = queue.purge_expired_pending_confirms()
+        assert removed == 0
+        assert queue.has('miner-1')
+
+    def test_update_reserved_until_unknown_hotkey_is_noop(self, tmp_path: Path):
+        db_path = tmp_path / 'state.db'
+        queue = ValidatorStateStore(db_path=db_path)
+        queue.update_reserved_until('miner-unknown', 999)
+        assert queue.pending_size() == 0
+
     def test_enqueue_and_remove_are_safe_across_threads(self, tmp_path: Path):
         db_path = tmp_path / 'state.db'
         queue = ValidatorStateStore(db_path=db_path)


### PR DESCRIPTION
## Summary

Fixes a bug where a user's BTC→TAO swap could lose its miner reservation mid-flight while the user's source tx was still confirming. Symptom: dashboard shows `ReservationExtended` events but the miner returns to "available", and the validator stops logging the `PendingConfirm` it had been tracking.

## Root cause

`handle_swap_confirm` enqueues a `PendingConfirm` with the contract's current `reserved_until` (axon_handlers.py:533). That value is **never refreshed** for the lifetime of the row.

Every forward step starts with `state_store.purge_expired_pending_confirms()` (forward.py:44), which deletes rows where `reserved_until < current_block`. When `try_extend_reservation` votes to extend, the contract's `reserved_until` advances on quorum, but the local row's cached value stays put. Once `current_block` passes the original TTL the row is purged — even though the on-chain reservation is still alive.

After that, `state_store.get_all()` returns nothing for the miner: no further verification, no further extends, the source tx confirms into the void, and the on-chain reservation eventually drifts past its (un-extended) limit too.

## Fix

After every successful extend vote (and on `AlreadyVoted`), re-read `get_miner_reserved_until` from the contract and write it back to the local row via a new `state_store.update_reserved_until` helper. The refresh is idempotent and only writes when the on-chain value moved forward.

## Test plan

- [x] `pytest tests/` — 313 passed locally, including two new tests:
  - `test_update_reserved_until_prevents_stale_purge` — repro for the bug: extending the cached value keeps the row past its original TTL.
  - `test_update_reserved_until_unknown_hotkey_is_noop` — guard for the no-row case.
- [x] `ruff format` / `ruff check` — clean.
- [ ] Verify against a live BTC→TAO swap on the dev environment: extend logs should fire as before, `purge_expired_pending_confirms` should not delete the row, and vote_initiate should land once min confirmations are reached.