### PR TITLE
CLI: stop telling users to re-send funds in alw view reservation

### DIFF
--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -270,6 +270,10 @@ class PendingSwapState:
     wallet_name: str
     hotkey_name: str
     created_at: float
+    # Empty until the user has broadcast the source-chain tx — once set, the
+    # swap is waiting on validator confirm/initiate, not on the user. Lets
+    # `alw view reservation` stop instructing the user to send funds again.
+    from_tx_hash: str = ''
 
 
 def save_pending_swap(state: PendingSwapState) -> None:
@@ -301,6 +305,24 @@ def load_pending_swap() -> Optional[PendingSwapState]:
 def clear_pending_swap() -> None:
     """Remove the pending swap state file."""
     PENDING_SWAP_FILE.unlink(missing_ok=True)
+
+
+def mark_pending_swap_tx_sent(tx_hash: str) -> None:
+    """Record that the source-chain tx has been broadcast for the pending swap.
+
+    Best-effort — silently no-ops when the pending file is missing or the hash
+    is empty. Without this, `alw view reservation` keeps instructing the user
+    to send funds even after they already have, and the wizard's polling /
+    Ctrl+C exit paths leave that state behind.
+    """
+    tx_hash = (tx_hash or '').strip()
+    if not tx_hash:
+        return
+    state = load_pending_swap()
+    if not state:
+        return
+    state.from_tx_hash = tx_hash
+    save_pending_swap(state)
 
 
 # Fallback when the contract's reservation TTL can't be read. Mirrors the

--- a/allways/cli/swap_commands/post_tx.py
+++ b/allways/cli/swap_commands/post_tx.py
@@ -12,6 +12,7 @@ from allways.cli.swap_commands.helpers import (
     get_cli_context,
     load_pending_swap,
     loading,
+    mark_pending_swap_tx_sent,
     print_contract_error,
     resolve_source_tx_block,
 )
@@ -90,6 +91,9 @@ def post_tx_command(tx_hash: str, tx_block: int):
         return
 
     tx_hash = tx_hash.strip()
+    # The user is asserting they've sent funds — record it so that even if
+    # validators reject the confirm, `alw view reservation` reflects reality.
+    mark_pending_swap_tx_sent(tx_hash)
 
     # Set up chain provider and signing key
     chain_providers = create_chain_providers(subtensor=subtensor)

--- a/allways/cli/swap_commands/resume.py
+++ b/allways/cli/swap_commands/resume.py
@@ -18,6 +18,7 @@ from allways.cli.swap_commands.helpers import (
     get_cli_context,
     load_pending_swap,
     loading,
+    mark_pending_swap_tx_sent,
     resolve_source_tx_block,
 )
 from allways.cli.swap_commands.swap import (
@@ -171,6 +172,9 @@ def resume_reservation_command(from_tx_hash_opt: Optional[str], skip_confirm: bo
             return
 
     from_tx_hash = from_tx_hash_opt.strip()
+    # The user has asserted they've sent funds — persist the tx hash so
+    # `alw view reservation` reflects that, even if validators reject below.
+    mark_pending_swap_tx_sent(from_tx_hash)
 
     # Reservation-wide block lookup so a resumed tx still ±3-hints the
     # validator. 0 = miss (falls back to validator-side scan).

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -25,6 +25,7 @@ from allways.cli.swap_commands.helpers import (
     is_local_network,
     load_pending_swap,
     loading,
+    mark_pending_swap_tx_sent,
     resolve_source_tx_block,
     save_pending_swap,
     sign_or_prompt_external,
@@ -905,6 +906,7 @@ def swap_now_command(
         # Funds already sent externally — use provided tx hash
         from_tx_hash = from_tx_hash_opt
         console.print(f'[dim]Using provided source tx: {from_tx_hash[:16]}...[/dim]')
+        mark_pending_swap_tx_sent(from_tx_hash)
         from_tx_block = resolve_source_tx_block(
             provider=provider,
             tx_hash=from_tx_hash,
@@ -950,6 +952,7 @@ def swap_now_command(
                         getattr(getattr(response, 'extrinsic_receipt', None), 'extrinsic_hash', '') or 'tao_transfer'
                     )
                 console.print(f'[green]TAO sent (tx: {from_tx_hash[:16]}...)[/green]')
+                mark_pending_swap_tx_sent(from_tx_hash)
             except Exception as e:
                 console.print(f'[red]Transfer error ({type(e).__name__}): {e}[/red]')
                 console.print('[yellow]Resume with: alw swap post-tx <tx_hash>[/yellow]')
@@ -965,6 +968,7 @@ def swap_now_command(
             if send_result is None:
                 return
             from_tx_hash = send_result[0]
+            mark_pending_swap_tx_sent(from_tx_hash)
             # send_btc returns (tx_hash, block_number). 0 means unknown
             # (e.g. lightweight broadcaster); that's fine — validator falls
             # back to the scan path.

--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -1022,11 +1022,16 @@ def view_reservation():
         else:
             table.add_row('Chain Amounts', f'[green]✓ locked {from_rao(chain_tao):.4f} TAO[/green]')
 
+    sent_tx_hash = (state.from_tx_hash or '').strip()
+
     if is_active:
         remaining = reserved_until - current_block
         remaining_min = remaining * SECONDS_PER_BLOCK / 60
         table.add_row('Status', '[green]ACTIVE[/green]')
         table.add_row('Time Remaining', f'~{remaining} blocks (~{remaining_min:.0f} min)')
+        if sent_tx_hash:
+            tx_display = sent_tx_hash if len(sent_tx_hash) <= 24 else sent_tx_hash[:24] + '...'
+            table.add_row(f'Source TX ({src_up})', tx_display)
     elif consumed_swap is not None:
         table.add_row('Status', f'[green]INITIATED (swap #{consumed_swap.id})[/green]')
         table.add_row('Swap Status', consumed_swap.status.name)
@@ -1037,11 +1042,21 @@ def view_reservation():
     console.print(table)
 
     if is_active:
-        console.print(
-            f'\n[bold]Next step:[/bold] Send {human_send} {state.from_chain.upper()} '
-            f'from [yellow]{state.user_from_address}[/yellow] to [yellow]{state.miner_from_address}[/yellow], then run:'
-        )
-        console.print('  [bold cyan]alw swap post-tx <your_transaction_hash>[/bold cyan]\n')
+        if sent_tx_hash:
+            console.print(f'\n[green]Source tx already broadcast:[/green] [cyan]{sent_tx_hash}[/cyan]')
+            console.print(
+                '[dim]Validators are waiting on source-chain confirmations before initiating the swap '
+                'on-chain. Nothing more to do — leave this reservation alone until it either initiates '
+                'or expires.[/dim]'
+            )
+            console.print('\n[dim]If validators never picked up your confirm, re-broadcast it with:[/dim]')
+            console.print(f'  [bold cyan]alw swap post-tx {sent_tx_hash}[/bold cyan]\n')
+        else:
+            console.print(
+                f'\n[bold]Next step:[/bold] Send {human_send} {state.from_chain.upper()} '
+                f'from [yellow]{state.user_from_address}[/yellow] to [yellow]{state.miner_from_address}[/yellow], then run:'
+            )
+            console.print('  [bold cyan]alw swap post-tx <your_transaction_hash>[/bold cyan]\n')
     elif consumed_swap is not None:
         console.print(
             f'\n[green]Reservation was consumed into swap #{consumed_swap.id} — it is in progress on-chain.[/green]'


### PR DESCRIPTION
## Summary
- `alw view reservation` was instructing users to send the source-chain tx even when `alw swap now` had already broadcast it — `pending_swap.json` carried no record of what the user sent, so the wizard's Ctrl+C / confirm-timeout exits left a misleading "Next step: send X to Y" message behind.
- `PendingSwapState` now tracks `from_tx_hash`. The wizard saves it after a successful BTC/TAO transfer (or when `--from-tx-hash` is supplied), and `alw swap post-tx` / `alw swap resume-reservation` save it before broadcasting the confirm — so the truth survives a validator-side rejection too.
- When the reservation is still ACTIVE and a tx hash is on file, `view reservation` now shows the recorded tx and tells the user to wait for validator confirm/initiate (with a re-broadcast hint via `alw swap post-tx <hash>`).

Backward compatible: the new field defaults to `''`, so old `pending_swap.json` files load unchanged.

## Test plan
- [x] `ruff format` + `ruff check` clean across `allways/cli/swap_commands/`
- [x] Round-trip persistence smoke test: default empty, mark-then-load returns the trimmed hash, empty-input no-op, missing-file no-op, old JSON without the field still loads.
- [ ] Manual: run `alw swap now` against the local dev environment, Ctrl+C after the BTC broadcast, verify `alw view reservation` shows the tx and the new "already broadcast" copy instead of the old "Send X to Y" instructions.
- [ ] Manual: with no tx persisted (fresh `alw swap now` interrupted before send), verify the original "Next step: send funds" copy still renders.