### PR TITLE
validator: disable HTTP keepalive in BitcoinProvider

### DIFF
--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -96,6 +96,12 @@ class BitcoinProvider(ChainProvider):
             if not self.network:
                 self.network = 'mainnet'
 
+        # Disable HTTP keepalive: validators are long-running and the default
+        # global session pools idle TLS sockets that Blockstream's CDN silently
+        # drops, wedging subsequent reads until our timeout fires.
+        self.http = requests.Session()
+        self.http.headers['Connection'] = 'close'
+
     def get_chain(self) -> ChainDefinition:
         return CHAIN_BTC
 
@@ -108,7 +114,7 @@ class BitcoinProvider(ChainProvider):
             except ImportError as e:
                 raise ConnectionError('BTC_MODE=lightweight requires embit (pip install embit)') from e
             try:
-                resp = requests.get(f'{self.blockstream_api_url()}/blocks/tip/height', timeout=10)
+                resp = self.http.get(f'{self.blockstream_api_url()}/blocks/tip/height', timeout=10)
                 resp.raise_for_status()
                 tip = int(resp.text.strip())
                 bt.logging.success(f'BTC lightweight mode: network={self.network}, Blockstream tip={tip}')
@@ -133,7 +139,7 @@ class BitcoinProvider(ChainProvider):
         }
         try:
             auth = (self.rpc_user, self.rpc_pass) if self.rpc_user else None
-            response = requests.post(self.rpc_url, json=payload, auth=auth, timeout=30)
+            response = self.http.post(self.rpc_url, json=payload, auth=auth, timeout=30)
             response.raise_for_status()
             result = response.json()
             if result.get('error'):
@@ -225,7 +231,7 @@ class BitcoinProvider(ChainProvider):
     def blockstream_calc_confirmations(self, block_number: int) -> int:
         """Fetch the chain tip from Blockstream and calculate confirmations for a block."""
         try:
-            tip_resp = requests.get(f'{self.blockstream_api_url()}/blocks/tip/height', timeout=10)
+            tip_resp = self.http.get(f'{self.blockstream_api_url()}/blocks/tip/height', timeout=10)
             if tip_resp.ok:
                 tip_height = int(tip_resp.text.strip())
                 return tip_height - block_number + 1
@@ -239,7 +245,7 @@ class BitcoinProvider(ChainProvider):
         """Verify via Blockstream API; raises ProviderUnreachableError if unreachable."""
         try:
             url = f'{self.blockstream_api_url()}/tx/{tx_hash}'
-            resp = requests.get(url, timeout=15)
+            resp = self.http.get(url, timeout=15)
             if resp.status_code == 404:
                 return None
             resp.raise_for_status()
@@ -300,7 +306,7 @@ class BitcoinProvider(ChainProvider):
         """Get balance via Blockstream API. Returns satoshis."""
         try:
             url = f'{self.blockstream_api_url()}/address/{address}'
-            resp = requests.get(url, timeout=15)
+            resp = self.http.get(url, timeout=15)
             resp.raise_for_status()
             data = resp.json()
             funded = data.get('chain_stats', {}).get('funded_txo_sum', 0)
@@ -472,7 +478,7 @@ class BitcoinProvider(ChainProvider):
                 # Legacy P2PKH: need full previous transaction for signing
                 for i, utxo in enumerate(selected):
                     tx_url = f'{self.blockstream_api_url()}/tx/{utxo["txid"]}/hex'
-                    tx_resp = requests.get(tx_url, timeout=15)
+                    tx_resp = self.http.get(tx_url, timeout=15)
                     tx_resp.raise_for_status()
                     prev_tx = Transaction.from_string(tx_resp.text.strip())
                     psbt.inputs[i].non_witness_utxo = prev_tx
@@ -523,7 +529,7 @@ class BitcoinProvider(ChainProvider):
                 bt.logging.error(f'WIF key derives {addr} but committed address is {from_address} — key mismatch')
                 return None
             utxo_url = f'{self.blockstream_api_url()}/address/{addr}/utxo'
-            resp = requests.get(utxo_url, timeout=15)
+            resp = self.http.get(utxo_url, timeout=15)
             resp.raise_for_status()
             utxos = resp.json()
             if not utxos:
@@ -538,7 +544,7 @@ class BitcoinProvider(ChainProvider):
                 if idx > 0:
                     _time.sleep(1)
                 utxo_url = f'{self.blockstream_api_url()}/address/{addr}/utxo'
-                resp = requests.get(utxo_url, timeout=15)
+                resp = self.http.get(utxo_url, timeout=15)
                 resp.raise_for_status()
                 candidate_utxos = resp.json()
                 if candidate_utxos:
@@ -574,7 +580,7 @@ class BitcoinProvider(ChainProvider):
     def broadcast_tx(self, raw_hex: str) -> Optional[str]:
         """Broadcast a raw transaction via Blockstream. Returns tx_hash or None."""
         url = f'{self.blockstream_api_url()}/tx'
-        resp = requests.post(url, data=raw_hex, timeout=15)
+        resp = self.http.post(url, data=raw_hex, timeout=15)
         if resp.status_code != 200:
             bt.logging.error(f'Broadcast rejected ({resp.status_code}): {resp.text.strip()}')
             return None
@@ -591,7 +597,7 @@ class BitcoinProvider(ChainProvider):
         min_fee_rate = BTC_MIN_FEE_RATE
         try:
             url = f'{self.blockstream_api_url()}/fee-estimates'
-            resp = requests.get(url, timeout=10)
+            resp = self.http.get(url, timeout=10)
             resp.raise_for_status()
             estimates = resp.json()
             # Target 2-3 blocks (~20-30 min confirmation)


### PR DESCRIPTION
## Summary

- Fix validator wedging against Blockstream when verifying BTC source tx during a `PendingConfirm`.
- Symptom (test, BTC->TAO): `Blockstream API unreachable: ... Read timed out (read timeout=15)` repeating each forward step while the same URL responds in ~85 ms via `curl` from inside the same container, and ~95 ms in a fresh `python3 requests.get` in the same container. Validator keeps voting `extend_reservation` (correct) but never confirms.

## Why

`allways/chain_providers/bitcoin.py` made every HTTP call through module-level `requests.get/post(...)`. Those use the global default `Session`, which pools TLS connections. Blockstream sits behind a CDN that silently drops idle sockets — the next reuse from the long-running validator process hangs until our read timeout fires, and stays wedged.

## Fix

One `Session` per `BitcoinProvider` with `Connection: close`. Every request opens a fresh socket and the server closes it; pooling can't accumulate stale connections. Applies to both modes:

- **lightweight (Blockstream):** primary pain point — verified the server echoes `Connection: close` on the response.
- **node (local Bitcoin Core RPC):** symmetry/safety; localhost RPC has no CDN in the path so it's a no-op for performance and a strict reliability win.

Cost is one TCP+TLS RTT per call, negligible vs the 10–15 s timeouts already in place.

## Test plan

- [x] `ruff format` + `ruff check allways/ neurons/` — clean
- [x] `pytest tests/test_bitcoin_signing.py` — 30/30 pass
- [x] Smoke test: `BitcoinProvider()` constructs in both modes; live `self.http.get(...)` against `blockstream.info/testnet/api/blocks/tip/height` returns 200 with `Connection: close` echoed back
- [ ] Restart `aw-vali` in the affected env; confirm next forward step emits `confirmed! voted initiate (...)` for the stuck `PendingConfirm`
- [ ] Run dev-environment suite 02 (`./tests/run.sh --chains btc --suite 02`) once dev env is healthy