### PR TITLE
validator: recover orphaned swaps after WS death + cold restart

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -67,3 +67,10 @@ DEFAULT_FULFILLMENT_TIMEOUT_BLOCKS = 30  # ~5 min
 DEFAULT_MIN_SWAP_AMOUNT_RAO = 100_000_000  # 0.1 TAO
 DEFAULT_MAX_SWAP_AMOUNT_RAO = 500_000_000  # 0.5 TAO
 RESERVATION_TTL_BLOCKS = 30  # ~5 min
+
+# ─── Validator Init ───────────────────────────────────────
+# Floor for the SwapTracker cold-start scan. Without it the cutoff equals
+# fulfillment_timeout_blocks (~5 min), so a validator restart >5 min after
+# a swap was initiated drops the swap from the active set and no one ever
+# votes timeout — the swap stays ACTIVE on chain forever.
+VALIDATOR_INIT_BACKFILL_BLOCKS = 300  # ~1h at 12s/block

--- a/allways/contract_client.py
+++ b/allways/contract_client.py
@@ -43,11 +43,12 @@ Layout
 
 import os
 import struct
-from typing import List, Optional, Tuple
+from typing import Any, Callable, List, Optional, Tuple, TypeVar
 
 import bittensor as bt
 from substrateinterface import Keypair
 from substrateinterface.exceptions import ExtrinsicNotFound
+from websockets.exceptions import ConnectionClosed
 
 try:
     from async_substrate_interface.errors import ExtrinsicNotFound as AsyncExtrinsicNotFound
@@ -72,6 +73,8 @@ from allways.utils.scale import (
     encode_u128,
     strip_hex_prefix,
 )
+
+T = TypeVar('T')
 
 # =========================================================================
 # Contract selectors (from metadata — deterministic per contract build)
@@ -302,6 +305,15 @@ def get_contract_address() -> Optional[str]:
     return os.environ.get('CONTRACT_ADDRESS') or CONTRACT_ADDRESS
 
 
+# Errors that signal a wedged substrate WebSocket — caller can swap the
+# connection and retry once. Anything else propagates as-is.
+RECONNECT_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    ConnectionClosed,
+    ConnectionError,
+    TimeoutError,
+)
+
+
 class AllwaysContractClient:
     """Client for the Allways Swap Manager contract using raw RPC calls."""
 
@@ -309,14 +321,46 @@ class AllwaysContractClient:
         self,
         contract_address: Optional[str] = None,
         subtensor: Optional[bt.Subtensor] = None,
+        reconnect_subtensor: Optional[Callable[[], None]] = None,
     ):
         self.contract_address = contract_address or get_contract_address() or ''
         self.subtensor = subtensor
+        # Owner-supplied callback that rebuilds substrate state and updates
+        # ``self.subtensor`` to a fresh ``bt.Subtensor``. Invoked at most once
+        # per RPC call when a connection-class error fires; on success the
+        # call is retried, on failure the original error is re-raised.
+        self.reconnect_subtensor = reconnect_subtensor
         self.readonly_keypair = Keypair.create_from_uri('//Alice')
         self.initialized = False
 
         if not self.contract_address:
             bt.logging.warning('Allways contract address not set')
+
+    def substrate_call(self, fn: Callable[[Any], T]) -> T:
+        """Run ``fn(substrate)``; on a connection-class error, invoke the
+        reconnect callback once and retry. Caller's callback is responsible
+        for replacing ``self.subtensor`` with a fresh handle.
+
+        Retry is safe for reads and for writes that the contract guards
+        against duplicates (e.g. vote_*, mark_fulfilled — already-voted /
+        status checks reject the second submission). Do NOT use this path
+        for value-bearing or otherwise non-idempotent extrinsics: if the
+        WS dies after the node accepted the first extrinsic but before the
+        receipt returned, the retry composes a fresh nonce and submits a
+        second extrinsic that can also land.
+        """
+        try:
+            return fn(self.subtensor.substrate)
+        except RECONNECT_EXCEPTIONS as e:
+            if self.reconnect_subtensor is None:
+                raise
+            bt.logging.warning(f'Substrate WS error ({e!s}); reconnecting and retrying once')
+            try:
+                self.reconnect_subtensor()
+            except Exception as reconnect_err:
+                bt.logging.error(f'Substrate reconnect callback failed: {reconnect_err}')
+                raise e from reconnect_err
+            return fn(self.subtensor.substrate)
 
     def ensure_initialized(self):
         if not self.contract_address:
@@ -362,7 +406,9 @@ class AllwaysContractClient:
 
             prefix = origin + dest + value + gas_limit + storage_limit
             call_params = prefix + compact_encode_len(len(input_data)) + input_data
-            result = substrate.rpc_request('state_call', ['ContractsApi_call', '0x' + call_params.hex()])
+            result = self.substrate_call(
+                lambda s: s.rpc_request('state_call', ['ContractsApi_call', '0x' + call_params.hex()])
+            )
 
             if not result.get('result'):
                 return None
@@ -449,11 +495,9 @@ class AllwaysContractClient:
         encoded_args = self.encode_args(method, args or {})
         call_data = selector + encoded_args
 
-        substrate = self.subtensor.substrate
-
         signer_address = keypair.ss58_address
         try:
-            account_info = substrate.query('System', 'Account', [signer_address])
+            account_info = self.substrate_call(lambda s: s.query('System', 'Account', [signer_address]))
         except Exception as e:
             raise ContractError(f'{method}: balance query failed: {e}') from e
 
@@ -462,8 +506,8 @@ class AllwaysContractClient:
         if free_balance < MIN_BALANCE_FOR_TX_RAO:
             raise ContractError(f'{method}: free={free_balance}')
 
-        try:
-            call = substrate.compose_call(
+        def submit_extrinsic(s):
+            call = s.compose_call(
                 call_module='Contracts',
                 call_function='call',
                 call_params={
@@ -474,8 +518,11 @@ class AllwaysContractClient:
                     'data': '0x' + call_data.hex(),
                 },
             )
-            extrinsic = substrate.create_signed_extrinsic(call=call, keypair=keypair)
-            receipt = substrate.submit_extrinsic(extrinsic, wait_for_inclusion=True, wait_for_finalization=False)
+            extrinsic = s.create_signed_extrinsic(call=call, keypair=keypair)
+            return s.submit_extrinsic(extrinsic, wait_for_inclusion=True, wait_for_finalization=False)
+
+        try:
+            receipt = self.substrate_call(submit_extrinsic)
         except Exception as e:
             raise ContractError(f'{method}: exec failed: {e}') from e
 

--- a/allways/validator/swap_tracker.py
+++ b/allways/validator/swap_tracker.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Set
 import bittensor as bt
 
 from allways.classes import Swap, SwapStatus
-from allways.constants import EXTEND_THRESHOLD_BLOCKS
+from allways.constants import EXTEND_THRESHOLD_BLOCKS, VALIDATOR_INIT_BACKFILL_BLOCKS
 from allways.contract_client import AllwaysContractClient
 
 ACTIVE_STATUSES = (SwapStatus.ACTIVE, SwapStatus.FULFILLED)
@@ -46,7 +46,7 @@ class SwapTracker:
             bt.logging.info('SwapTracker initialized: no swaps exist')
             return
 
-        cutoff_block = current_block - self.fulfillment_timeout_blocks
+        cutoff_block = current_block - max(self.fulfillment_timeout_blocks, VALIDATOR_INIT_BACKFILL_BLOCKS)
         latest_id = next_id - 1
 
         for swap_id in reversed(range(1, next_id)):

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -35,7 +35,10 @@ class Miner(BaseMinerNeuron):
     def __init__(self, config=None):
         super().__init__(config=config)
 
-        self.contract_client = AllwaysContractClient(subtensor=self.subtensor)
+        self.contract_client = AllwaysContractClient(
+            subtensor=self.subtensor,
+            reconnect_subtensor=self.reconnect_and_propagate,
+        )
         self.chain_providers = create_chain_providers(check=True, subtensor=self.subtensor, wallet=self.wallet)
 
         self.swap_poller = SwapPoller(

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -56,7 +56,10 @@ class Validator(BaseValidatorNeuron):
     def __init__(self, config=None):
         super().__init__(config=config)
 
-        self.contract_client = AllwaysContractClient(subtensor=self.subtensor)
+        self.contract_client = AllwaysContractClient(
+            subtensor=self.subtensor,
+            reconnect_subtensor=self.reconnect_and_propagate,
+        )
         self.chain_providers = create_chain_providers(check=True, require_send=False, subtensor=self.subtensor)
 
         timeout_blocks = self.contract_client.get_fulfillment_timeout() or DEFAULT_FULFILLMENT_TIMEOUT_BLOCKS
@@ -118,7 +121,10 @@ class Validator(BaseValidatorNeuron):
         # to prevent "cannot call recv while another coroutine is already running recv" errors.
         self.axon_lock = threading.Lock()
         self.axon_subtensor = bt.Subtensor(config=self.config)
-        self.axon_contract_client = AllwaysContractClient(subtensor=self.axon_subtensor)
+        self.axon_contract_client = AllwaysContractClient(
+            subtensor=self.axon_subtensor,
+            reconnect_subtensor=self.reconnect_axon_subtensor,
+        )
         self.axon_chain_providers = create_chain_providers(subtensor=self.axon_subtensor)
         # Must read the current block via axon_subtensor — the block getter on
         # self (self.block) goes through self.subtensor, which the forward loop
@@ -150,6 +156,25 @@ class Validator(BaseValidatorNeuron):
             priority_fn=partial(priority_swap_confirm, self),
         )
         bt.logging.info('Axon handlers attached: MinerActivate, SwapReserve, SwapConfirm')
+
+    def reconnect_and_propagate(self):
+        """Rebuild the main subtensor and update components that hold it."""
+        self.reconnect_subtensor()
+        self.contract_client.subtensor = self.subtensor
+        tao_provider = self.chain_providers.get('tao')
+        if tao_provider and hasattr(tao_provider, 'subtensor'):
+            tao_provider.subtensor = self.subtensor
+
+    def reconnect_axon_subtensor(self):
+        """Rebuild the axon-side subtensor used by handler threads."""
+        bt.logging.info('Reconnecting axon subtensor...')
+        old = self.axon_subtensor
+        self.axon_subtensor = bt.Subtensor(config=self.config)
+        self.axon_contract_client.subtensor = self.axon_subtensor
+        try:
+            old.close()
+        except Exception:
+            pass
 
     async def forward(self):
         """Validator forward pass - delegates to allways.validator.forward."""

--- a/tests/test_contract_client.py
+++ b/tests/test_contract_client.py
@@ -1,0 +1,116 @@
+"""AllwaysContractClient.substrate_call: reconnect-on-WS-error retry logic.
+
+The wrapper handles transient substrate WebSocket deaths transparently:
+on a connection-class exception it invokes the owner-supplied reconnect
+callback (which must replace ``client.subtensor`` with a fresh handle)
+and retries the call once. Anything else propagates as-is.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from websockets.exceptions import ConnectionClosed
+
+from allways.contract_client import AllwaysContractClient
+
+
+def make_subtensor() -> MagicMock:
+    sub = MagicMock()
+    sub.substrate = MagicMock()
+    return sub
+
+
+class TestSubstrateCall:
+    def test_returns_value_when_call_succeeds(self):
+        client = AllwaysContractClient(contract_address='5xx', subtensor=make_subtensor())
+        result = client.substrate_call(lambda s: 'ok')
+        assert result == 'ok'
+
+    def test_no_reconnect_callback_re_raises(self):
+        client = AllwaysContractClient(contract_address='5xx', subtensor=make_subtensor())
+
+        def fn(s):
+            raise ConnectionClosed(None, None)
+
+        with pytest.raises(ConnectionClosed):
+            client.substrate_call(fn)
+
+    def test_reconnects_and_retries_on_connection_closed(self):
+        first = make_subtensor()
+        second = make_subtensor()
+
+        calls = []
+
+        def fn(s):
+            calls.append(s)
+            if s is first.substrate:
+                raise ConnectionClosed(None, None)
+            return 'recovered'
+
+        client = AllwaysContractClient(contract_address='5xx', subtensor=first)
+        client.reconnect_subtensor = lambda: setattr(client, 'subtensor', second)
+
+        result = client.substrate_call(fn)
+
+        assert result == 'recovered'
+        assert calls == [first.substrate, second.substrate]
+
+    def test_retries_on_timeout_and_connection_error(self):
+        for exc in (TimeoutError(), ConnectionError()):
+            first = make_subtensor()
+            second = make_subtensor()
+            attempts = [0]
+
+            def fn(s, exc=exc):
+                attempts[0] += 1
+                if attempts[0] == 1:
+                    raise exc
+                return 'ok'
+
+            client = AllwaysContractClient(contract_address='5xx', subtensor=first)
+            client.reconnect_subtensor = lambda: setattr(client, 'subtensor', second)
+
+            assert client.substrate_call(fn) == 'ok'
+            assert attempts[0] == 2
+
+    def test_reconnect_callback_failure_re_raises_original(self):
+        client = AllwaysContractClient(contract_address='5xx', subtensor=make_subtensor())
+
+        original = ConnectionClosed(None, None)
+
+        def fn(s):
+            raise original
+
+        def failing_reconnect():
+            raise RuntimeError('cannot rebuild')
+
+        client.reconnect_subtensor = failing_reconnect
+
+        with pytest.raises(ConnectionClosed) as ei:
+            client.substrate_call(fn)
+        assert ei.value is original
+
+    def test_does_not_retry_on_non_connection_error(self):
+        client = AllwaysContractClient(contract_address='5xx', subtensor=make_subtensor())
+        reconnect = MagicMock()
+        client.reconnect_subtensor = reconnect
+
+        def fn(s):
+            raise ValueError('bad payload')
+
+        with pytest.raises(ValueError):
+            client.substrate_call(fn)
+        reconnect.assert_not_called()
+
+    def test_second_attempt_failure_propagates(self):
+        first = make_subtensor()
+        second = make_subtensor()
+
+        def fn(s):
+            raise ConnectionClosed(None, None)
+
+        client = AllwaysContractClient(contract_address='5xx', subtensor=first)
+        client.reconnect_subtensor = lambda: setattr(client, 'subtensor', second)
+
+        with pytest.raises(ConnectionClosed):
+            client.substrate_call(fn)

--- a/tests/test_swap_tracker.py
+++ b/tests/test_swap_tracker.py
@@ -93,12 +93,17 @@ class TestInitialize:
         assert tracker.last_scanned_id == 11
 
     def test_initialize_stops_at_cutoff_block(self):
-        """Backward scan halts when it reaches a swap older than the cutoff."""
+        """Backward scan halts when it reaches a swap older than the cutoff.
+
+        The cutoff is ``max(fulfillment_timeout, VALIDATOR_INIT_BACKFILL_BLOCKS)``
+        so a fresh validator can recover ACTIVE swaps orphaned during outages
+        longer than the fulfillment timeout window.
+        """
         tracker = make_tracker()
         stale = make_swap(swap_id=5)
-        stale.initiated_block = 900  # below 1000 - 30 = 970 cutoff
+        stale.initiated_block = 600  # below 1000 - 300 = 700 cutoff
         active = make_swap(swap_id=6)
-        active.initiated_block = 980
+        active.initiated_block = 800
 
         tracker.client.get_next_swap_id.return_value = 7
         tracker.client.get_swap.side_effect = lambda sid: {5: stale, 6: active}.get(sid)


### PR DESCRIPTION
## Summary

Two fixes for an incident where a swap stayed `ACTIVE` on chain forever — miner never saw it, validator never voted to time it out.

### 1. `contract: reconnect substrate WS on connection-class errors`
The miner's substrate WebSocket died from a keepalive timeout. The handle stayed attached, every subsequent RPC raised, and nothing rebuilt it in-process. `AllwaysContractClient` now accepts a `reconnect_subtensor` callback; on `ConnectionClosed` / `ConnectionError` / `TimeoutError` the wrapper invokes it once and retries against the fresh substrate. Miner reuses its existing `reconnect_and_propagate`; validator gains matching helpers for the main and axon-side clients.

Retry is bounded to one attempt and documented as safe only for reads and contract-guarded writes (`vote_*`, `mark_fulfilled`). Value-bearing extrinsics must not flow through this path — a retry after a node-side accept would re-submit with a fresh nonce.

### 2. `validator: floor SwapTracker init backfill at ~1h of blocks`
`SwapTracker.initialize` cut off the cold-start scan at `current_block - fulfillment_timeout` (~5 min). The contract has no auto-resolve on timeout — if no validator was online during the window, the swap stays `ACTIVE` on chain. Any restart >5 min after initiation orphaned the swap forever. Floor the cutoff at `VALIDATOR_INIT_BACKFILL_BLOCKS = 300` (~1h) so a fresh validator can still discover and time out swaps that landed during a prior outage.

## Test plan

- [x] `pytest tests/` — 320 passed (7 new tests for `substrate_call`, 1 updated for new cutoff).
- [x] `ruff check` clean across all touched files.
- [ ] Restart `aw-vali` against testnet; confirm `SwapTracker initialized` picks up swap #2 and the next forward step votes timeout.
- [ ] Kill the miner's substrate WS mid-poll (e.g. `iptables -j DROP` on the WS port for 30s); confirm `Substrate WS error (...); reconnecting and retrying once` log + recovery.
- [ ] Run an E2E suite (`./tests/run.sh --chains btc --suite 02`) to confirm no regression in the happy path.