### PR TITLE
validator: gap-based SwapTracker init scan to recover old orphans

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -67,10 +67,3 @@ DEFAULT_FULFILLMENT_TIMEOUT_BLOCKS = 30  # ~5 min
 DEFAULT_MIN_SWAP_AMOUNT_RAO = 100_000_000  # 0.1 TAO
 DEFAULT_MAX_SWAP_AMOUNT_RAO = 500_000_000  # 0.5 TAO
 RESERVATION_TTL_BLOCKS = 30  # ~5 min
-
-# ─── Validator Init ───────────────────────────────────────
-# Floor for the SwapTracker cold-start scan. Without it the cutoff equals
-# fulfillment_timeout_blocks (~5 min), so a validator restart >5 min after
-# a swap was initiated drops the swap from the active set and no one ever
-# votes timeout — the swap stays ACTIVE on chain forever.
-VALIDATOR_INIT_BACKFILL_BLOCKS = 300  # ~1h at 12s/block

--- a/allways/validator/swap_tracker.py
+++ b/allways/validator/swap_tracker.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Set
 import bittensor as bt
 
 from allways.classes import Swap, SwapStatus
-from allways.constants import EXTEND_THRESHOLD_BLOCKS, VALIDATOR_INIT_BACKFILL_BLOCKS
+from allways.constants import EXTEND_THRESHOLD_BLOCKS
 from allways.contract_client import AllwaysContractClient
 
 ACTIVE_STATUSES = (SwapStatus.ACTIVE, SwapStatus.FULFILLED)
@@ -17,16 +17,19 @@ ACTIVE_STATUSES = (SwapStatus.ACTIVE, SwapStatus.FULFILLED)
 # RPC flakes without the fragile timeout-block inference the V1 tracker used.
 NULL_SWAP_RETRY_LIMIT = 3
 
+# Cold-start backward scan halts after this many consecutive None lookups.
+# Resolved swaps are pruned from contract storage (`swaps.remove`), so a long
+# run of Nones means we've passed the live-swap region. Block-age cutoffs
+# silently dropped long-stuck ACTIVE swaps; this does not. Tuned low for
+# current volume — bump if the gap between contiguous active swap IDs grows.
+MAX_INIT_GAP = 20
+
 
 class SwapTracker:
     """Discovery scans new swap IDs since the last poll; monitoring re-fetches
     all tracked ACTIVE/FULFILLED swaps each poll."""
 
-    def __init__(
-        self,
-        client: AllwaysContractClient,
-        fulfillment_timeout_blocks: int,
-    ):
+    def __init__(self, client: AllwaysContractClient):
         self.client = client
         self.last_scanned_id = 0
         self.active: Dict[int, Swap] = {}
@@ -36,35 +39,37 @@ class SwapTracker:
         # the voted value so the next extension round can vote again.
         self.extend_timeout_voted_at: Dict[int, int] = {}
         self.null_retry_count: Dict[int, int] = {}
-        self.fulfillment_timeout_blocks = fulfillment_timeout_blocks
 
-    def initialize(self, current_block: int):
-        """Cold start: scan backward from latest swap to seed active set."""
+    def initialize(self):
+        """Cold start: scan backward from latest swap to seed active set.
+
+        Halts on consecutive Nones (resolved/pruned region) rather than on
+        block age — an ACTIVE swap orphaned by a prior validator outage can be
+        arbitrarily old, and a block-based cutoff would let it fall through.
+        """
         next_id = self.client.get_next_swap_id()
         if next_id <= 1:
             self.last_scanned_id = 0
             bt.logging.info('SwapTracker initialized: no swaps exist')
             return
 
-        cutoff_block = current_block - max(self.fulfillment_timeout_blocks, VALIDATOR_INIT_BACKFILL_BLOCKS)
-        latest_id = next_id - 1
-
-        for swap_id in reversed(range(1, next_id)):
+        consecutive_none = 0
+        for swap_id in range(next_id - 1, 0, -1):
             swap = self.client.get_swap(swap_id)
             if swap is None:
+                consecutive_none += 1
+                if consecutive_none >= MAX_INIT_GAP:
+                    bt.logging.debug(
+                        f'SwapTracker init: stopping at swap {swap_id} '
+                        f'after {consecutive_none} consecutive resolved/pruned swaps'
+                    )
+                    break
                 continue
-
-            if swap.initiated_block < cutoff_block:
-                bt.logging.debug(
-                    f'SwapTracker init: stopping at swap {swap_id} '
-                    f'(initiated_block={swap.initiated_block} < cutoff={cutoff_block})'
-                )
-                break
-
+            consecutive_none = 0
             if swap.status in ACTIVE_STATUSES:
                 self.active[swap.id] = swap
 
-        self.last_scanned_id = latest_id
+        self.last_scanned_id = next_id - 1
 
         bt.logging.info(f'SwapTracker initialized: active={len(self.active)}, last_scanned_id={self.last_scanned_id}')
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -104,11 +104,8 @@ class Validator(BaseValidatorNeuron):
             contract_client=self.contract_client,
         )
 
-        self.swap_tracker = SwapTracker(
-            client=self.contract_client,
-            fulfillment_timeout_blocks=timeout_blocks,
-        )
-        self.swap_tracker.initialize(self.block)
+        self.swap_tracker = SwapTracker(client=self.contract_client)
+        self.swap_tracker.initialize()
         bt.logging.debug(f'Validator components: fee_divisor={self.fee_divisor}, timeout={timeout_blocks}')
 
         self.swap_verifier = SwapVerifier(

--- a/tests/test_swap_tracker.py
+++ b/tests/test_swap_tracker.py
@@ -11,7 +11,7 @@ import asyncio
 from unittest.mock import MagicMock
 
 from allways.classes import Swap, SwapStatus
-from allways.validator.swap_tracker import NULL_SWAP_RETRY_LIMIT, SwapTracker
+from allways.validator.swap_tracker import MAX_INIT_GAP, NULL_SWAP_RETRY_LIMIT, SwapTracker
 
 
 def make_swap(swap_id: int, miner_hotkey: str = 'hk_a', timeout_block: int = 500) -> Swap:
@@ -34,7 +34,7 @@ def make_swap(swap_id: int, miner_hotkey: str = 'hk_a', timeout_block: int = 500
 
 def make_tracker() -> SwapTracker:
     client = MagicMock()
-    return SwapTracker(client=client, fulfillment_timeout_blocks=30)
+    return SwapTracker(client=client)
 
 
 class TestResolve:
@@ -70,7 +70,7 @@ class TestInitialize:
         tracker = make_tracker()
         tracker.client.get_next_swap_id.return_value = 1  # next_id=1 means no swaps exist
 
-        tracker.initialize(current_block=1000)
+        tracker.initialize()
 
         assert tracker.last_scanned_id == 0
         assert tracker.active == {}
@@ -78,51 +78,61 @@ class TestInitialize:
     def test_initialize_picks_up_active_swaps_from_backward_scan(self):
         tracker = make_tracker()
         swap_active = make_swap(swap_id=10)
-        swap_active.initiated_block = 990
         swap_fulfilled = make_swap(swap_id=11)
         swap_fulfilled.status = SwapStatus.FULFILLED
-        swap_fulfilled.initiated_block = 995
 
         tracker.client.get_next_swap_id.return_value = 12
         tracker.client.get_swap.side_effect = lambda sid: {10: swap_active, 11: swap_fulfilled}.get(sid)
 
-        tracker.initialize(current_block=1000)
+        tracker.initialize()
 
         assert 10 in tracker.active
         assert 11 in tracker.active
         assert tracker.last_scanned_id == 11
 
-    def test_initialize_stops_at_cutoff_block(self):
-        """Backward scan halts when it reaches a swap older than the cutoff.
-
-        The cutoff is ``max(fulfillment_timeout, VALIDATOR_INIT_BACKFILL_BLOCKS)``
-        so a fresh validator can recover ACTIVE swaps orphaned during outages
-        longer than the fulfillment timeout window.
+    def test_initialize_recovers_old_orphaned_active_swap(self):
+        """An ACTIVE swap older than any cold-start time window must be picked
+        up — it is the exact case (validator outage long enough that no one
+        voted timeout) the recovery scan exists for.
         """
         tracker = make_tracker()
-        stale = make_swap(swap_id=5)
-        stale.initiated_block = 600  # below 1000 - 300 = 700 cutoff
-        active = make_swap(swap_id=6)
-        active.initiated_block = 800
+        ancient = make_swap(swap_id=1)
+        ancient.initiated_block = 100  # arbitrarily old vs current_block
 
-        tracker.client.get_next_swap_id.return_value = 7
-        tracker.client.get_swap.side_effect = lambda sid: {5: stale, 6: active}.get(sid)
+        tracker.client.get_next_swap_id.return_value = 2
+        tracker.client.get_swap.side_effect = lambda sid: {1: ancient}.get(sid)
 
-        tracker.initialize(current_block=1000)
+        tracker.initialize()
 
-        assert 5 not in tracker.active
-        assert 6 in tracker.active
+        assert 1 in tracker.active
+        assert tracker.last_scanned_id == 1
+
+    def test_initialize_halts_after_consecutive_pruned_swaps(self):
+        """A long run of pruned (None) swap IDs short-circuits the scan so
+        cold start stays bounded on contracts with millions of resolved swaps.
+        """
+        tracker = make_tracker()
+        recent = make_swap(swap_id=1000)
+        # swaps 1..999 all return None (pruned). The active swap at 1000 is
+        # found, then the scan walks 999..(1000 - MAX_INIT_GAP) Nones and stops.
+        tracker.client.get_next_swap_id.return_value = 1001
+        tracker.client.get_swap.side_effect = lambda sid: recent if sid == 1000 else None
+
+        tracker.initialize()
+
+        assert 1000 in tracker.active
+        # call_count == the active swap + MAX_INIT_GAP Nones before halting
+        assert tracker.client.get_swap.call_count == 1 + MAX_INIT_GAP
 
     def test_initialize_skips_terminal_swaps(self):
         tracker = make_tracker()
         completed = make_swap(swap_id=20)
         completed.status = SwapStatus.COMPLETED
-        completed.initiated_block = 990
 
         tracker.client.get_next_swap_id.return_value = 21
         tracker.client.get_swap.return_value = completed
 
-        tracker.initialize(current_block=1000)
+        tracker.initialize()
 
         assert 20 not in tracker.active
 


### PR DESCRIPTION
## Summary
- Replace `SwapTracker.initialize`'s block-age cutoff with a gap-based stop (halt after `MAX_INIT_GAP=20` consecutive `None` lookups). The contract `swaps.remove`s on terminal status, so `None` is the canonical "no live swap" signal — block age was a false proxy that silently dropped long-stuck ACTIVE swaps.
- Drop now-dead `VALIDATOR_INIT_BACKFILL_BLOCKS` constant and `fulfillment_timeout_blocks` constructor arg.

## Why
On the test-vali, swap 2 was orphaned by a now-fixed validator bug. After restart, init bailed out at swap 2 (`initiated_block=6993688 < cutoff=6999634`) and set `last_scanned_id=2`, so runtime poll's discovery range `(3, next_id=3)` was empty. The swap stayed invisible forever — miner kept logging `inside cushion window` warnings every poll because no validator ever voted timeout. Gap-based scan picks it up regardless of age.

## Test plan
- [x] `pytest tests/test_swap_tracker.py` — 26 passed (new `test_initialize_recovers_old_orphaned_active_swap` and `test_initialize_halts_after_consecutive_pruned_swaps`)
- [x] `pytest tests/` — 321 passed
- [x] `ruff format` + `ruff check` clean
- [ ] Restart test-vali → confirm init scan picks up swap 2 → timeout vote fires → miner stops spamming