### PR TITLE
CLI: clarify alw swap now reservation expiry messaging

### DIFF
--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -326,7 +326,16 @@ def broadcast_reserve_with_retry(
             return None
         if reserved:
             ttl_remaining = reserved_until - subtensor.get_current_block()
-            console.print(f'[green]Miner reserved! ~{ttl_remaining * 12 // 60} min to send funds.[/green]')
+            minutes_remaining = ttl_remaining * 12 // 60
+            console.print(
+                f'[green]Miner reserved! You have ~{minutes_remaining} minutes to send your funds '
+                f'before the reservation expires.[/green]'
+            )
+            console.print(
+                '[yellow]Please account for network latency — give your tx a couple of minutes '
+                'to land in a block. Do NOT send near or after the reservation window closes, '
+                'or your transaction may not confirm in time and the reservation will expire.[/yellow]'
+            )
 
         if reserved:
             break


### PR DESCRIPTION
## Summary
- `alw swap now` previously printed `Miner reserved! ~6 min to send funds.` — terse, didn't explain what happens at expiry or that network confirmation time eats into the window.
- New message keeps the green headline (with the actual remaining minutes) and adds a yellow safety note about accounting for network latency and not cutting the deadline close.

## Rationale
Swap UX feedback during testing — users asked for clearer guidance on the reservation window so they don't broadcast a tx that confirms after expiry.

## Test plan
- [x] `ruff check` clean
- [ ] Manual: run `alw swap now` against dev environment and verify both lines render with correct color and the minute count matches reservation TTL