### PR TITLE
CLI: improve swap send error UX (BTC reason + TAO retry)

### DIFF
--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -102,6 +102,14 @@ class BitcoinProvider(ChainProvider):
         self.http = requests.Session()
         self.http.headers['Connection'] = 'close'
 
+        # Last failure reason from send_amount / send_amount_lightweight, so
+        # callers can surface a useful message without scraping logs.
+        self.last_send_error: Optional[str] = None
+
+    def _send_error(self, msg: str) -> None:
+        self.last_send_error = msg
+        bt.logging.error(msg)
+
     def get_chain(self) -> ChainDefinition:
         return CHAIN_BTC
 
@@ -415,6 +423,7 @@ class BitcoinProvider(ChainProvider):
 
         Does NOT work on regtest (no public APIs). Returns (tx_hash, 0) or None.
         """
+        self.last_send_error = None
         try:
             from embit.ec import PrivateKey as EmbitPrivateKey
             from embit.networks import NETWORKS
@@ -422,12 +431,12 @@ class BitcoinProvider(ChainProvider):
             from embit.script import Witness, address_to_scriptpubkey, p2pkh, p2sh, p2wpkh
             from embit.transaction import Transaction, TransactionInput, TransactionOutput
         except ImportError:
-            bt.logging.error('embit not installed (pip install embit)')
+            self._send_error('embit not installed (pip install embit)')
             return None
 
         wif = os.environ.get('BTC_PRIVATE_KEY')
         if not wif:
-            bt.logging.error('BTC_PRIVATE_KEY not set')
+            self._send_error('BTC_PRIVATE_KEY not set')
             return None
 
         try:
@@ -485,7 +494,7 @@ class BitcoinProvider(ChainProvider):
 
             num_sigs = psbt.sign_with(privkey)
             if num_sigs != len(selected):
-                bt.logging.error(f'Expected {len(selected)} sigs, got {num_sigs}')
+                self._send_error(f'Expected {len(selected)} sigs, got {num_sigs}')
                 return None
 
             # Finalize: extract tx (psbt.tx returns a copy each time) and attach signatures
@@ -514,7 +523,7 @@ class BitcoinProvider(ChainProvider):
             bt.logging.info(f'Sent {amount} sat to {to_address} via embit (tx: {tx_hash}, fee: {fee})')
             return (tx_hash, 0)
         except Exception as e:
-            bt.logging.error(f'embit send failed: {e}')
+            self._send_error(f'embit send failed: {e}')
             return None
 
     def resolve_sender_utxos(self, from_address, type_to_script):
@@ -522,18 +531,18 @@ class BitcoinProvider(ChainProvider):
         if from_address:
             detected = detect_address_type(from_address)
             if detected not in type_to_script:
-                bt.logging.error(f'Unsupported address type for {from_address}: {detected}')
+                self._send_error(f'Unsupported address type for {from_address}: {detected}')
                 return None
             atype, script, addr = type_to_script[detected]
             if addr != from_address:
-                bt.logging.error(f'WIF key derives {addr} but committed address is {from_address} — key mismatch')
+                self._send_error(f'WIF key derives {addr} but committed address is {from_address} — key mismatch')
                 return None
             utxo_url = f'{self.blockstream_api_url()}/address/{addr}/utxo'
             resp = self.http.get(utxo_url, timeout=15)
             resp.raise_for_status()
             utxos = resp.json()
             if not utxos:
-                bt.logging.error(f'No UTXOs found for {from_address}')
+                self._send_error(f'No UTXOs found for {from_address}')
                 return None
             return script, addr, utxos, atype
 
@@ -553,7 +562,7 @@ class BitcoinProvider(ChainProvider):
             except Exception:
                 continue
 
-        bt.logging.error('No UTXOs found for any address type')
+        self._send_error('No UTXOs found for any address type')
         return None
 
     def select_utxos(self, utxos, amount: int, is_segwit: bool):
@@ -573,7 +582,7 @@ class BitcoinProvider(ChainProvider):
         est_vsize = 11 + len(selected) * input_vsize + 2 * 31
         fee = est_vsize * fee_rate
         if total_in < amount + fee:
-            bt.logging.error(f'Insufficient funds: have {total_in} sat, need {amount} + {fee} fee')
+            self._send_error(f'Insufficient funds: have {total_in} sat, need {amount} + {fee} fee')
             return None
         return selected, total_in, fee
 
@@ -582,7 +591,7 @@ class BitcoinProvider(ChainProvider):
         url = f'{self.blockstream_api_url()}/tx'
         resp = self.http.post(url, data=raw_hex, timeout=15)
         if resp.status_code != 200:
-            bt.logging.error(f'Broadcast rejected ({resp.status_code}): {resp.text.strip()}')
+            self._send_error(f'Broadcast rejected ({resp.status_code}): {resp.text.strip()}')
             return None
         return resp.text.strip()
 
@@ -625,13 +634,14 @@ class BitcoinProvider(ChainProvider):
         if self.mode == 'lightweight':
             return self.send_amount_lightweight(to_address, amount, from_address=from_address)
 
+        self.last_send_error = None
         btc_amount = amount / BTC_TO_SAT
         if from_address:
             tx_hash = self.rpc_send_from_address(from_address, to_address, btc_amount)
         else:
             tx_hash = self.rpc_call('sendtoaddress', [to_address, btc_amount])
         if not tx_hash or not isinstance(tx_hash, str):
-            bt.logging.error(f'BTC send failed for {amount} sat to {to_address}')
+            self._send_error(f'BTC send failed for {amount} sat to {to_address}')
             return None
 
         block_count = self.rpc_call('getblockcount', [])

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -955,34 +955,46 @@ def swap_now_command(
 
         from_tx_hash = None
         if from_chain == 'tao':
-            try:
-                with loading('Submitting TAO transfer to chain...'):
-                    response = subtensor.transfer(
-                        wallet=wallet,
-                        destination_ss58=selected_pair.from_address,
-                        amount=bt.Balance.from_rao(from_amount),
-                        wait_for_inclusion=True,
-                        wait_for_finalization=False,
-                    )
-                if not response.success:
-                    console.print(f'[red]TAO transfer failed: {response.message}[/red]')
-                    console.print('[yellow]Resume with: alw swap post-tx <tx_hash>[/yellow]')
-                    return
+            for attempt in range(2):
                 try:
-                    receipt = response.extrinsic_receipt
-                    from_tx_hash = receipt.extrinsic_hash
-                    if getattr(receipt, 'block_hash', None):
-                        from_tx_block = subtensor.substrate.get_block_number(receipt.block_hash) or 0
-                except Exception:
-                    from_tx_hash = (
-                        getattr(getattr(response, 'extrinsic_receipt', None), 'extrinsic_hash', '') or 'tao_transfer'
-                    )
-                console.print(f'[green]TAO sent (tx: {from_tx_hash[:16]}...)[/green]')
-                mark_pending_swap_tx_sent(from_tx_hash)
-            except Exception as e:
-                console.print(f'[red]Transfer error ({type(e).__name__}): {e}[/red]')
-                console.print('[yellow]Resume with: alw swap post-tx <tx_hash>[/yellow]')
-                return
+                    with loading('Submitting TAO transfer to chain...'):
+                        response = subtensor.transfer(
+                            wallet=wallet,
+                            destination_ss58=selected_pair.from_address,
+                            amount=bt.Balance.from_rao(from_amount),
+                            wait_for_inclusion=True,
+                            wait_for_finalization=False,
+                        )
+                    if not response.success:
+                        # Extrinsic may have been submitted but rejected on-chain;
+                        # post-tx is a valid recovery if the user has the hash.
+                        console.print(f'[red]TAO transfer failed: {response.message}[/red]')
+                        console.print(
+                            '[yellow]If the tx did broadcast, resume with: alw swap post-tx <tx_hash>[/yellow]'
+                        )
+                        return
+                    try:
+                        receipt = response.extrinsic_receipt
+                        from_tx_hash = receipt.extrinsic_hash
+                        if getattr(receipt, 'block_hash', None):
+                            from_tx_block = subtensor.substrate.get_block_number(receipt.block_hash) or 0
+                    except Exception:
+                        from_tx_hash = (
+                            getattr(getattr(response, 'extrinsic_receipt', None), 'extrinsic_hash', '')
+                            or 'tao_transfer'
+                        )
+                    console.print(f'[green]TAO sent (tx: {from_tx_hash[:16]}...)[/green]')
+                    mark_pending_swap_tx_sent(from_tx_hash)
+                    break
+                except Exception as e:
+                    console.print(f'[red]Transfer error ({type(e).__name__}): {e}[/red]')
+                    if attempt == 0 and click.confirm('Retry?', default=True):
+                        time.sleep(1)
+                        continue
+                    # Pre-broadcast failure: no tx hash exists, so post-tx
+                    # recovery isn't applicable. Just let the reservation lapse.
+                    console.print('[yellow]Reservation will expire on its own — start a new swap when ready.[/yellow]')
+                    return
         else:
             send_result = send_btc(
                 chain_providers,

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -1,6 +1,7 @@
 """alw swap - Guided interactive swap with automatic fund sending."""
 
 import os
+import sys
 import time
 from typing import Optional
 
@@ -454,41 +455,57 @@ def poll_for_swap_with_progress(client, miner_hotkey: str, from_chain: str, max_
 
 
 def send_btc(chain_providers, config, to_address: str, amount_sat: int, from_address: str = None):
-    """Send BTC with fallback: embit lightweight -> RPC -> manual (with retry).
+    """Send BTC, retry on failure, fall back to manual tx-hash entry.
 
+    In lightweight mode there is no Bitcoin Core fallback — both paths route
+    through the same Blockstream API — so we don't pretend otherwise.
     Returns (tx_hash, block_number) or None (manual fallback failed/skipped).
     """
     provider = chain_providers.get('btc')
     is_local = is_local_network(config.get('network', 'finney'))
     human_amount = amount_sat / 100_000_000
+    is_lightweight = getattr(provider, 'mode', None) == 'lightweight'
 
-    max_retries = 2
-    for attempt in range(max_retries + 1):
-        # 1. Try embit lightweight wallet (mainnet/testnet only — no public APIs on regtest)
+    def attempt_send():
         if not is_local and hasattr(provider, 'send_amount_lightweight'):
             console.print('[dim]Sending BTC via lightweight wallet...[/dim]')
             result = provider.send_amount_lightweight(to_address, amount_sat, from_address=from_address)
             if result:
-                console.print(f'[green]BTC sent (tx: {result[0][:16]}...)[/green]')
                 return result
-
-        # 2. Try Bitcoin Core RPC
+            if is_lightweight:
+                return None
         console.print('[dim]Sending BTC via Bitcoin Core RPC...[/dim]')
-        result = provider.send_amount(to_address, amount_sat)
+        return provider.send_amount(to_address, amount_sat)
+
+    max_retries = 2
+    for attempt in range(max_retries + 1):
+        result = attempt_send()
         if result:
-            console.print(f'[green]BTC sent via RPC (tx: {result[0][:16]}...)[/green]')
+            console.print(f'[green]BTC sent (tx: {result[0][:16]}...)[/green]')
             return result
 
-        # Retry or fall through to manual
-        if attempt < max_retries:
-            console.print('[yellow]BTC send failed.[/yellow]')
-            if not click.confirm('Retry?', default=True):
-                break
-            console.print('[dim]Retrying...[/dim]')
-        else:
-            console.print('[yellow]BTC send failed after retries.[/yellow]')
+        # Drain async log output so the reason lands above the Retry prompt
+        # rather than after it.
+        sys.stderr.flush()
+        time.sleep(0.2)
 
-    # 3. Manual fallback
+        reason = getattr(provider, 'last_send_error', None)
+        if reason:
+            console.print(f'[yellow]BTC send failed:[/yellow] {reason}')
+        else:
+            console.print('[yellow]BTC send failed.[/yellow]')
+
+        if attempt >= max_retries:
+            console.print('[yellow]Giving up after retries.[/yellow]')
+            break
+        if not click.confirm('Retry?', default=True):
+            break
+        # Brief backoff so a flaky upstream (Blockstream/Core) has a moment to
+        # recover before we hammer it again.
+        time.sleep(1)
+        console.print('[dim]Retrying...[/dim]')
+
+    # Manual fallback
     console.print(f'\n  Send [green]{human_amount} BTC[/green] to: [cyan]{to_address}[/cyan]\n')
     tx_hash = click.prompt('Enter transaction hash after sending (or "skip" to exit)', default='')
     if not tx_hash or tx_hash.lower() == 'skip':


### PR DESCRIPTION
## Summary
- Surface the actual failure reason (e.g. `Connection aborted`, `Insufficient funds`, `Broadcast rejected`) above the `Retry?` prompt in `alw swap now`, instead of just `BTC send failed.` followed by a stray loguru line landing on the next render.
- Skip the misleading `Sending BTC via Bitcoin Core RPC...` step in `BTC_MODE=lightweight` — `BitcoinProvider.send_amount` already short-circuits to the lightweight path in that mode, so the second attempt was a no-op pretending to be a fallback.
- Add a 1s backoff before retrying so a flaky upstream (Blockstream/Core) gets a moment to recover, plus a brief `stderr.flush` + 0.2s wait so the captured error reason renders above the prompt rather than racing it.

Internally, `BitcoinProvider` now stashes its last failure reason in `self.last_send_error` (set via a small `_send_error` helper alongside the existing `bt.logging.error` call) so the CLI can read it without scraping logs.

## Test plan
- [ ] Run `alw swap now` against testnet with the network temporarily blocked and confirm the prompt now reads `BTC send failed: <reason>` before `Retry?`.
- [ ] Confirm in lightweight mode there is no longer a `Sending BTC via Bitcoin Core RPC...` line after the lightweight attempt fails.
- [ ] In node mode (`BTC_MODE=node`), confirm both attempts still fire as before and surface the RPC reason on failure.
- [ ] `ruff check allways/` and full E2E suite (`./tests/run.sh --chains btc --suite 02`) before merge.