### PR TITLE
CLI: traceback on embit send failure + view-reservation hint on pause

### DIFF
--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -471,7 +471,11 @@ class BitcoinProvider(ChainProvider):
                 txid_bytes = bytes.fromhex(utxo['txid'])
                 tx.vin.append(TransactionInput(txid_bytes, utxo['vout']))
 
-            tx.vout.append(TransactionOutput(amount, address_to_scriptpubkey(to_address)))
+            to_script = address_to_scriptpubkey(to_address)
+            if to_script is None:
+                self._send_error(f'Could not derive scriptPubKey for destination {to_address}')
+                return None
+            tx.vout.append(TransactionOutput(amount, to_script))
             if change > 546:  # dust threshold
                 tx.vout.append(TransactionOutput(change, my_script))
 
@@ -523,7 +527,10 @@ class BitcoinProvider(ChainProvider):
             bt.logging.info(f'Sent {amount} sat to {to_address} via embit (tx: {tx_hash}, fee: {fee})')
             return (tx_hash, 0)
         except Exception as e:
-            self._send_error(f'embit send failed: {e}')
+            import traceback
+
+            bt.logging.debug(f'embit send traceback:\n{traceback.format_exc()}')
+            self._send_error(f'embit send failed: {type(e).__name__}: {e}')
             return None
 
     def resolve_sender_utxos(self, from_address, type_to_script):

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -509,7 +509,10 @@ def send_btc(chain_providers, config, to_address: str, amount_sat: int, from_add
     console.print(f'\n  Send [green]{human_amount} BTC[/green] to: [cyan]{to_address}[/cyan]\n')
     tx_hash = click.prompt('Enter transaction hash after sending (or "skip" to exit)', default='')
     if not tx_hash or tx_hash.lower() == 'skip':
-        console.print('[yellow]Swap paused. Resume with: alw swap post-tx <tx_hash>[/yellow]')
+        console.print(
+            '[yellow]Swap paused. Run [cyan]alw view reservation[/cyan] to see your '
+            'reservation status and the resume command once you have a tx hash.[/yellow]'
+        )
         return None
     return (tx_hash.strip(), 0)
 

--- a/allways/cli/validator_rejections.py
+++ b/allways/cli/validator_rejections.py
@@ -86,8 +86,9 @@ _RULES: list[_Rule] = [
         True,
         lambda ctx: (
             f'Source address [yellow]{_ctx_get(ctx, "from_address", "<your source address>")}[/yellow] '
-            f'is on a reservation cooldown ({_ctx_get(ctx, "raw_reason", "")}). Wait for it to clear or '
-            'reserve from a different address.'
+            f'is cooling down — {_ctx_get(ctx, "raw_reason", "").removeprefix("Address on cooldown: ")}. '
+            f'Each failed reservation doubles the next cooldown; wait it out or reserve from a different '
+            'address.'
         ),
     ),
     (

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -366,7 +366,13 @@ async def handle_swap_reserve(
             if strike_count > 0 and last_expired > 0:
                 cooldown = RESERVATION_COOLDOWN_BLOCKS * (2 ** (strike_count - 1))
                 if cur_block < last_expired + cooldown:
-                    reject_synapse(synapse, f'Address on cooldown ({cooldown} blocks remaining)', ctx)
+                    remaining = (last_expired + cooldown) - cur_block
+                    reject_synapse(
+                        synapse,
+                        f'Address on cooldown: ~{remaining} blocks remaining '
+                        f'(strike {strike_count}, {cooldown}-block window)',
+                        ctx,
+                    )
                     return synapse
 
             contract.vote_reserve(

--- a/tests/test_validator_rejections.py
+++ b/tests/test_validator_rejections.py
@@ -62,7 +62,7 @@ def test_insufficient_source_balance_translates():
 
 
 def test_address_cooldown_includes_raw_reason():
-    raw = 'Address on cooldown (50 blocks remaining)'
+    raw = 'Address on cooldown: ~50 blocks remaining (strike 2, 300-block window)'
     info = render_and_aggregate(
         _silent_console(),
         [FakeResp(accepted=False, rejection_reason=raw)],
@@ -71,6 +71,10 @@ def test_address_cooldown_includes_raw_reason():
     assert info.category == 'address_cooldown'
     assert info.deterministic is True
     assert '50 blocks remaining' in info.headline
+    assert 'strike 2' in info.headline
+    assert 'doubles' in info.headline
+    # No double-wrapped 'Address on cooldown: Address on cooldown'
+    assert info.headline.lower().count('address on cooldown') == 0
 
 
 def test_miner_busy_is_not_deterministic():


### PR DESCRIPTION
## Summary

Follow-up to #224. While retry/resume UX is now correct, the underlying `embit send failed: 'NoneType' object has no attribute 'script_pubkey'` is still hitting users on flaky Blockstream connections, and we couldn't pin the exact crash site without a traceback. Two changes:

1. **Capture the traceback.** `send_amount_lightweight`'s outer except now logs `bt.logging.debug(traceback.format_exc())` and surfaces `embit send failed: <ExcType>: <msg>`. With debug-level logging on (`bt.logging.set_debug()`), we'll get the full stack so we can finally root-cause the `script_pubkey` AttributeError instead of guessing.
2. **Defensive guard on `address_to_scriptpubkey`.** Embit's `address_to_scriptpubkey` can fall through and return `None` for a base58-decodable address whose prefix doesn't match any known network — surfacing as `'NoneType' object has no attribute 'script_pubkey'` deep inside `psbt.sign_with`. We now check for `None` immediately and emit `Could not derive scriptPubKey for destination <addr>` instead.

3. **Manual-fallback hint points at `alw view reservation`.** When the user hits `skip` at the manual `Enter transaction hash` prompt (because they haven't actually broadcast yet), the old hint `Resume with: alw swap post-tx <tx_hash>` is misleading — they don't have a hash. New hint:

   `Swap paused. Run alw view reservation to see your reservation status and the resume command once you have a tx hash.`

## Test plan
- [ ] Reproduce the connection blip and confirm the new message is `embit send failed: <ExcType>: ...`.
- [ ] With `bt.logging.set_debug()` enabled, confirm the traceback is logged.
- [ ] Confirm hitting `skip` at the manual fallback now prints the `alw view reservation` hint, and that running `alw view reservation` afterward shows the active reservation + `alw swap post-tx <tx_hash>` line.
- [ ] `ruff check allways/`.