### PR TITLE
CLI: detect stale pending_swap.json when miner is re-reserved

### DIFF
--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -11,7 +11,7 @@ import click
 from rich.console import Console
 
 from allways.chain_providers.base import ProviderUnreachableError
-from allways.classes import MinerPair, SwapStatus
+from allways.classes import MinerPair, Swap, SwapStatus
 from allways.commitments import parse_commitment_data, read_miner_commitment, read_miner_commitments  # noqa: F401
 from allways.constants import CONTRACT_ADDRESS as DEFAULT_CONTRACT_ADDRESS
 from allways.constants import NETUID_FINNEY, TAO_TO_RAO
@@ -329,6 +329,89 @@ def mark_pending_swap_tx_sent(tx_hash: str) -> None:
 # contract default (see ``reservation_ttl`` init in
 # allways/smart-contracts/ink/lib.rs); update both together.
 _DEFAULT_RESERVATION_TTL_BLOCKS = 4032
+
+
+@dataclass
+class ReservationStatus:
+    """Result of reconciling pending_swap.json against on-chain state.
+
+    ``kind`` is one of:
+      - ``ours_active``: reservation still on chain and matches our local row
+      - ``our_swap``: reservation already advanced into a swap on the same
+        miner that matches our user addresses; ``swap`` is set
+      - ``replaced``: a different reservation now occupies the miner — ours
+        is gone (expired or consumed-and-completed)
+      - ``expired``: no reservation on chain and no matching active swap
+      - ``rpc_error``: contract reads failed; caller should not act on result
+    """
+
+    kind: str
+    swap: Optional[Swap] = None
+    reserved_until: int = 0
+
+
+def probe_pending_reservation(client, state: PendingSwapState) -> ReservationStatus:
+    """Reconcile a saved pending_swap.json against on-chain state.
+
+    The naive ``reserved_until > current_block`` check (the old logic) breaks
+    in two ways:
+
+      1. ``vote_extend_reservation`` advances ``reserved_until`` in-place when
+         a validator sees the source tx, so the saved value can legitimately
+         lag the on-chain value. Equality with the saved block is wrong.
+      2. After our reservation is consumed (vote_initiate) and the resulting
+         swap completes, the swap is pruned but the miner can be re-reserved
+         by another user. The miner's new ``reserved_until`` is in the future
+         — the old check then mis-reports our stale local row as "ACTIVE".
+
+    Resolution order (strongest signal first):
+
+      Step 1 — probe ``get_miner_active_swaps`` and match by user addresses.
+        Survives extension and into FULFILLED. If hit, our reservation has
+        already advanced into a swap.
+
+      Step 2 — read on-chain reservation. No row + no swap match means our
+        reservation is gone (expired or consumed-and-pruned) — ``expired``.
+
+      Step 3 — if a row exists but the amounts differ from our saved state,
+        it's someone else's reservation — ``replaced``.
+
+      Step 4 — amounts match but ``reserved_until`` is more than ``ttl``
+        blocks past our saved value: a single extension can't push the value
+        beyond ``current_block + ttl``, and we'd have caught chained
+        extensions in step 1 once ``vote_initiate`` ran. So this is a
+        replacement that happens to share our amounts — ``replaced``.
+
+      Step 5 — within tolerance: ``ours_active``.
+    """
+    try:
+        for swap in client.get_miner_active_swaps(state.miner_hotkey):
+            if swap.user_from_address == state.user_from_address and swap.user_to_address == state.receive_address:
+                return ReservationStatus(kind='our_swap', swap=swap)
+    except ContractError:
+        return ReservationStatus(kind='rpc_error')
+
+    try:
+        reserved_until = client.get_miner_reserved_until(state.miner_hotkey)
+        on_chain = client.get_reservation_data(state.miner_hotkey)
+    except ContractError:
+        return ReservationStatus(kind='rpc_error')
+
+    if reserved_until == 0 or on_chain is None:
+        return ReservationStatus(kind='expired')
+
+    chain_tao, chain_from, chain_to = on_chain
+    if chain_tao != state.tao_amount or chain_from != state.from_amount or chain_to != state.to_amount:
+        return ReservationStatus(kind='replaced')
+
+    try:
+        ttl = int(client.get_reservation_ttl())
+    except ContractError:
+        ttl = _DEFAULT_RESERVATION_TTL_BLOCKS
+    if reserved_until - state.reserved_until_block > ttl:
+        return ReservationStatus(kind='replaced')
+
+    return ReservationStatus(kind='ours_active', reserved_until=reserved_until)
 
 
 def resolve_source_tx_block(

--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -384,10 +384,13 @@ def probe_pending_reservation(client, state: PendingSwapState) -> ReservationSta
 
       Step 5 — within tolerance: ``ours_active``.
     """
+    # Cheap-bool short-circuit: skip the swap-range scan when the miner has
+    # no active swap, which is the common case for the status/swap-now path.
     try:
-        for swap in client.get_miner_active_swaps(state.miner_hotkey):
-            if swap.user_from_address == state.user_from_address and swap.user_to_address == state.receive_address:
-                return ReservationStatus(kind='our_swap', swap=swap)
+        if client.get_miner_has_active_swap(state.miner_hotkey):
+            for swap in client.get_miner_active_swaps(state.miner_hotkey):
+                if swap.user_from_address == state.user_from_address and swap.user_to_address == state.receive_address:
+                    return ReservationStatus(kind='our_swap', swap=swap)
     except ContractError:
         return ReservationStatus(kind='rpc_error')
 

--- a/allways/cli/swap_commands/status.py
+++ b/allways/cli/swap_commands/status.py
@@ -11,6 +11,7 @@ from allways.cli.swap_commands.helpers import (
     get_cli_context,
     load_pending_swap,
     loading,
+    probe_pending_reservation,
     read_miner_commitments,
 )
 from allways.constants import NETUID_FINNEY
@@ -79,20 +80,24 @@ def status_command():
         # Pending reservation
         pending = load_pending_swap()
         if pending:
-            try:
-                reserved_until = client.get_miner_reserved_until(pending.miner_hotkey)
-                if reserved_until > subtensor.get_current_block():
-                    remaining = reserved_until - subtensor.get_current_block()
-                    remaining_min = remaining * SECONDS_PER_BLOCK / 60
-                    table.add_row(
-                        'Pending Reservation',
-                        f'send {pending.from_chain.upper()} → receive {pending.to_chain.upper()} '
-                        f'(~{remaining_min:.0f} min left)',
-                    )
-                else:
-                    table.add_row('Pending Reservation', '[dim]Expired[/dim]')
-            except ContractError:
+            res_status = probe_pending_reservation(client, pending)
+            if res_status.kind == 'ours_active':
+                remaining = max(0, res_status.reserved_until - subtensor.get_current_block())
+                remaining_min = remaining * SECONDS_PER_BLOCK / 60
+                table.add_row(
+                    'Pending Reservation',
+                    f'send {pending.from_chain.upper()} → receive {pending.to_chain.upper()} '
+                    f'(~{remaining_min:.0f} min left)',
+                )
+            elif res_status.kind == 'our_swap':
+                table.add_row(
+                    'Pending Reservation',
+                    f'[dim]became swap #{res_status.swap.id} ({res_status.swap.status.name})[/dim]',
+                )
+            elif res_status.kind == 'rpc_error':
                 table.add_row('Pending Reservation', '[dim]unable to verify[/dim]')
+            else:  # 'replaced' or 'expired'
+                table.add_row('Pending Reservation', '[dim]Expired[/dim]')
         else:
             table.add_row('Pending Reservation', 'None')
 

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -27,6 +27,7 @@ from allways.cli.swap_commands.helpers import (
     load_pending_swap,
     loading,
     mark_pending_swap_tx_sent,
+    probe_pending_reservation,
     resolve_source_tx_block,
     save_pending_swap,
     sign_or_prompt_external,
@@ -589,22 +590,31 @@ def swap_now_command(
     # Check for pending reservation
     existing = load_pending_swap()
     if existing:
-        try:
-            reserved_until = client.get_miner_reserved_until(existing.miner_hotkey)
-            current_block = subtensor.get_current_block()
-            if reserved_until > current_block:
-                remaining = reserved_until - current_block
-                remaining_min = remaining * SECONDS_PER_BLOCK / 60
-                console.print(
-                    f'[yellow]You have a pending reservation (~{remaining} blocks, ~{remaining_min:.0f} min left).[/yellow]'
-                )
-                console.print('  Complete it with: [cyan]alw swap post-tx <tx_hash>[/cyan]\n')
-                if not skip_confirm and not click.confirm('Start a new swap instead?'):
-                    return
-            else:
-                clear_pending_swap()
-        except ContractError:
+        status = probe_pending_reservation(client, existing)
+        if status.kind == 'rpc_error':
             console.print('[yellow]Could not verify existing reservation (contract unreachable)[/yellow]')
+        elif status.kind == 'ours_active':
+            try:
+                current_block = subtensor.get_current_block()
+                remaining = max(0, status.reserved_until - current_block)
+            except Exception:
+                remaining = 0
+            remaining_min = remaining * SECONDS_PER_BLOCK / 60
+            console.print(
+                f'[yellow]You have a pending reservation (~{remaining} blocks, ~{remaining_min:.0f} min left).[/yellow]'
+            )
+            console.print('  Complete it with: [cyan]alw swap post-tx <tx_hash>[/cyan]\n')
+            if not skip_confirm and not click.confirm('Start a new swap instead?'):
+                return
+        elif status.kind == 'our_swap':
+            console.print(
+                f'[dim]Previous reservation is now swap #{status.swap.id} ({status.swap.status.name}) — '
+                f'cleared local state. Watch with: alw view swap {status.swap.id} --watch[/dim]\n'
+            )
+            clear_pending_swap()
+        else:  # 'replaced' or 'expired'
+            console.print('[dim]Previous reservation is no longer active — cleared local state.[/dim]\n')
+            clear_pending_swap()
 
     # Interactive mode: force lightweight BTC (no local Bitcoin node needed).
     # Non-interactive mode: respect environment config (local dev uses node mode for RPC signing).

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -594,11 +594,7 @@ def swap_now_command(
         if status.kind == 'rpc_error':
             console.print('[yellow]Could not verify existing reservation (contract unreachable)[/yellow]')
         elif status.kind == 'ours_active':
-            try:
-                current_block = subtensor.get_current_block()
-                remaining = max(0, status.reserved_until - current_block)
-            except Exception:
-                remaining = 0
+            remaining = max(0, status.reserved_until - subtensor.get_current_block())
             remaining_min = remaining * SECONDS_PER_BLOCK / 60
             console.print(
                 f'[yellow]You have a pending reservation (~{remaining} blocks, ~{remaining_min:.0f} min left).[/yellow]'

--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -972,14 +972,12 @@ def view_reservation():
 
     with loading('Reading reservation...'):
         status = probe_pending_reservation(client, state)
-        try:
-            current_block = subtensor.get_current_block()
-        except Exception:
-            current_block = 0
 
     if status.kind == 'rpc_error':
         console.print('[red]Failed to read reservation status from contract.[/red]')
         return
+
+    current_block = subtensor.get_current_block()
 
     console.print('\n[bold]Swap Reservation[/bold]\n')
 

--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -22,6 +22,7 @@ from allways.cli.swap_commands.helpers import (
     get_cli_context,
     load_pending_swap,
     loading,
+    probe_pending_reservation,
     read_miner_commitments,
 )
 from allways.constants import FEE_DIVISOR
@@ -969,29 +970,16 @@ def view_reservation():
         console.print('[dim]Run `alw swap now` to initiate a swap.[/dim]\n')
         return
 
-    # Validate against on-chain state. When the reservation struct is gone,
-    # disambiguate expired-by-TTL from consumed-by-vote_initiate by probing
-    # the miner for an active swap we can match back to this reservation.
-    consumed_swap = None
-    try:
-        with loading('Reading reservation...'):
-            reserved_until = client.get_miner_reserved_until(state.miner_hotkey)
+    with loading('Reading reservation...'):
+        status = probe_pending_reservation(client, state)
+        try:
             current_block = subtensor.get_current_block()
-            on_chain_reservation = client.get_reservation_data(state.miner_hotkey)
-            if reserved_until == 0 and on_chain_reservation is None:
-                if client.get_miner_has_active_swap(state.miner_hotkey):
-                    for swap in client.get_miner_active_swaps(state.miner_hotkey):
-                        if (
-                            swap.user_from_address == state.user_from_address
-                            or swap.user_to_address == state.receive_address
-                        ):
-                            consumed_swap = swap
-                            break
-    except ContractError as e:
-        console.print(f'[red]Failed to read reservation status: {e}[/red]')
-        return
+        except Exception:
+            current_block = 0
 
-    is_active = reserved_until > current_block
+    if status.kind == 'rpc_error':
+        console.print('[red]Failed to read reservation status from contract.[/red]')
+        return
 
     console.print('\n[bold]Swap Reservation[/bold]\n')
 
@@ -1014,34 +1002,29 @@ def view_reservation():
     table.add_row(f'  to (your {dst_up})', state.receive_address)
     table.add_row('Miner', f'UID {state.miner_uid} ({state.miner_hotkey[:16]}...)')
 
-    if on_chain_reservation:
-        chain_tao, chain_from, chain_to = on_chain_reservation
-        mismatch = chain_tao != state.tao_amount or chain_from != state.from_amount or chain_to != state.to_amount
-        if mismatch:
-            table.add_row('Chain Amounts', '[red]mismatch with local state[/red]')
-        else:
-            table.add_row('Chain Amounts', f'[green]✓ locked {from_rao(chain_tao):.4f} TAO[/green]')
+    if status.kind == 'ours_active':
+        table.add_row('Chain Amounts', f'[green]✓ locked {from_rao(state.tao_amount):.4f} TAO[/green]')
 
     sent_tx_hash = (state.from_tx_hash or '').strip()
 
-    if is_active:
-        remaining = reserved_until - current_block
+    if status.kind == 'ours_active':
+        remaining = max(0, status.reserved_until - current_block)
         remaining_min = remaining * SECONDS_PER_BLOCK / 60
         table.add_row('Status', '[green]ACTIVE[/green]')
         table.add_row('Time Remaining', f'~{remaining} blocks (~{remaining_min:.0f} min)')
         if sent_tx_hash:
             tx_display = sent_tx_hash if len(sent_tx_hash) <= 24 else sent_tx_hash[:24] + '...'
             table.add_row(f'Source TX ({src_up})', tx_display)
-    elif consumed_swap is not None:
-        table.add_row('Status', f'[green]INITIATED (swap #{consumed_swap.id})[/green]')
-        table.add_row('Swap Status', consumed_swap.status.name)
-    else:
+    elif status.kind == 'our_swap':
+        table.add_row('Status', f'[green]INITIATED (swap #{status.swap.id})[/green]')
+        table.add_row('Swap Status', status.swap.status.name)
+    else:  # 'replaced' or 'expired'
         table.add_row('Status', '[yellow]NO LONGER ACTIVE[/yellow]')
         table.add_row('Time Remaining', '—')
 
     console.print(table)
 
-    if is_active:
+    if status.kind == 'ours_active':
         if sent_tx_hash:
             console.print(f'\n[green]Source tx already broadcast:[/green] [cyan]{sent_tx_hash}[/cyan]')
             console.print(
@@ -1057,14 +1040,14 @@ def view_reservation():
                 f'from [yellow]{state.user_from_address}[/yellow] to [yellow]{state.miner_from_address}[/yellow], then run:'
             )
             console.print('  [bold cyan]alw swap post-tx <your_transaction_hash>[/bold cyan]\n')
-    elif consumed_swap is not None:
+    elif status.kind == 'our_swap':
         console.print(
-            f'\n[green]Reservation was consumed into swap #{consumed_swap.id} — it is in progress on-chain.[/green]'
+            f'\n[green]Reservation was consumed into swap #{status.swap.id} — it is in progress on-chain.[/green]'
         )
-        console.print(f'[dim]Watch with: alw view swap {consumed_swap.id} --watch[/dim]')
+        console.print(f'[dim]Watch with: alw view swap {status.swap.id} --watch[/dim]')
         clear_pending_swap()
         console.print('[dim]Local reservation state cleared.[/dim]\n')
-    else:
+    else:  # 'replaced' or 'expired'
         console.print(
             '\n[yellow]Reservation is no longer active on-chain.[/yellow]\n'
             '[dim]Either the reservation expired before you sent funds, or your swap already '

--- a/tests/test_probe_pending_reservation.py
+++ b/tests/test_probe_pending_reservation.py
@@ -62,6 +62,9 @@ def make_swap(**overrides) -> Swap:
 def make_client(*, active_swaps=(), reserved_until=0, reservation_data=None, ttl=4032):
     """Build a contract-client double whose only behavior is what the probe touches."""
     client = MagicMock()
+    # has_active_swap mirrors whether the test set up any active swaps so the
+    # probe's cheap-bool short-circuit behaves like real chain state.
+    client.get_miner_has_active_swap.return_value = bool(active_swaps)
     client.get_miner_active_swaps.return_value = list(active_swaps)
     client.get_miner_reserved_until.return_value = reserved_until
     client.get_reservation_data.return_value = reservation_data
@@ -153,9 +156,21 @@ def test_ours_active_when_unchanged():
     assert result.kind == 'ours_active'
 
 
+def test_skips_active_swap_scan_when_miner_has_no_active_swap():
+    """The cheap-bool short-circuit avoids the swap-range scan in the common case."""
+    state = make_state()
+    client = make_client()
+    client.get_miner_has_active_swap.return_value = False
+
+    probe_pending_reservation(client, state)
+
+    client.get_miner_active_swaps.assert_not_called()
+
+
 def test_rpc_error_short_circuits_when_active_swaps_call_fails():
     state = make_state()
     client = MagicMock()
+    client.get_miner_has_active_swap.return_value = True
     client.get_miner_active_swaps.side_effect = ContractError('rpc down')
 
     result = probe_pending_reservation(client, state)

--- a/tests/test_probe_pending_reservation.py
+++ b/tests/test_probe_pending_reservation.py
@@ -1,0 +1,173 @@
+"""probe_pending_reservation: reconcile pending_swap.json with on-chain state.
+
+Pins the five-branch decision the helper makes so the UX bug it fixes
+(stale local file shown as ACTIVE because miner was re-reserved by another
+user) doesn't regress.
+"""
+
+from unittest.mock import MagicMock
+
+from allways.classes import Swap, SwapStatus
+from allways.cli.swap_commands.helpers import (
+    PendingSwapState,
+    ReservationStatus,
+    probe_pending_reservation,
+)
+from allways.contract_client import ContractError
+
+
+def make_state(**overrides) -> PendingSwapState:
+    base = dict(
+        miner_hotkey='5MinerHk',
+        miner_uid=4,
+        from_chain='btc',
+        to_chain='tao',
+        from_amount=100_000,
+        to_amount=300_000_000,
+        tao_amount=300_000_000,
+        user_receives=297_000_000,
+        rate_str='3000',
+        miner_from_address='tb1qminer',
+        user_from_address='tb1quser',
+        receive_address='5UserHk',
+        reserved_until_block=1_000_100,
+        netuid=2,
+        wallet_name='default',
+        hotkey_name='default',
+        created_at=0.0,
+        from_tx_hash='',
+    )
+    base.update(overrides)
+    return PendingSwapState(**base)
+
+
+def make_swap(**overrides) -> Swap:
+    base = dict(
+        id=3,
+        user_hotkey='5UserHk',
+        miner_hotkey='5MinerHk',
+        from_chain='btc',
+        to_chain='tao',
+        from_amount=100_000,
+        to_amount=300_000_000,
+        tao_amount=300_000_000,
+        user_from_address='tb1quser',
+        user_to_address='5UserHk',
+        status=SwapStatus.FULFILLED,
+    )
+    base.update(overrides)
+    return Swap(**base)
+
+
+def make_client(*, active_swaps=(), reserved_until=0, reservation_data=None, ttl=4032):
+    """Build a contract-client double whose only behavior is what the probe touches."""
+    client = MagicMock()
+    client.get_miner_active_swaps.return_value = list(active_swaps)
+    client.get_miner_reserved_until.return_value = reserved_until
+    client.get_reservation_data.return_value = reservation_data
+    client.get_reservation_ttl.return_value = ttl
+    return client
+
+
+def test_our_swap_when_active_swaps_match_user_addresses():
+    state = make_state()
+    swap = make_swap(user_from_address=state.user_from_address, user_to_address=state.receive_address)
+    client = make_client(active_swaps=[swap])
+
+    result = probe_pending_reservation(client, state)
+
+    assert result.kind == 'our_swap'
+    assert result.swap is swap
+
+
+def test_active_swap_for_different_user_does_not_match():
+    """Same miner can carry someone else's swap — addresses must match ours."""
+    state = make_state()
+    other = make_swap(user_from_address='tb1qsomeoneelse', user_to_address='5OtherHk')
+    client = make_client(active_swaps=[other])
+
+    result = probe_pending_reservation(client, state)
+
+    assert result.kind == 'expired'
+
+
+def test_expired_when_no_swap_and_no_reservation():
+    state = make_state()
+    client = make_client()
+
+    result = probe_pending_reservation(client, state)
+
+    assert result.kind == 'expired'
+
+
+def test_replaced_when_reservation_amounts_differ():
+    state = make_state()
+    client = make_client(
+        reserved_until=1_000_050,
+        reservation_data=(state.tao_amount + 1, state.from_amount, state.to_amount),
+    )
+
+    result = probe_pending_reservation(client, state)
+
+    assert result.kind == 'replaced'
+
+
+def test_replaced_when_reserved_until_is_more_than_ttl_past_saved():
+    """The user's bug: same miner re-reserved with same params after our swap completed."""
+    state = make_state(reserved_until_block=1_000_100)
+    client = make_client(
+        reserved_until=1_000_100 + 4033,
+        reservation_data=(state.tao_amount, state.from_amount, state.to_amount),
+        ttl=4032,
+    )
+
+    result = probe_pending_reservation(client, state)
+
+    assert result.kind == 'replaced'
+
+
+def test_ours_active_when_amounts_match_and_within_ttl():
+    """Single extension: reserved_until advanced but stays within ttl of saved."""
+    state = make_state(reserved_until_block=1_000_100)
+    client = make_client(
+        reserved_until=1_000_100 + 4031,
+        reservation_data=(state.tao_amount, state.from_amount, state.to_amount),
+        ttl=4032,
+    )
+
+    result = probe_pending_reservation(client, state)
+
+    assert result.kind == 'ours_active'
+    assert result.reserved_until == 1_000_100 + 4031
+
+
+def test_ours_active_when_unchanged():
+    state = make_state(reserved_until_block=1_000_100)
+    client = make_client(
+        reserved_until=1_000_100,
+        reservation_data=(state.tao_amount, state.from_amount, state.to_amount),
+    )
+
+    result = probe_pending_reservation(client, state)
+
+    assert result.kind == 'ours_active'
+
+
+def test_rpc_error_short_circuits_when_active_swaps_call_fails():
+    state = make_state()
+    client = MagicMock()
+    client.get_miner_active_swaps.side_effect = ContractError('rpc down')
+
+    result = probe_pending_reservation(client, state)
+
+    assert result == ReservationStatus(kind='rpc_error')
+
+
+def test_rpc_error_when_reservation_read_fails():
+    state = make_state()
+    client = make_client()
+    client.get_miner_reserved_until.side_effect = ContractError('rpc down')
+
+    result = probe_pending_reservation(client, state)
+
+    assert result.kind == 'rpc_error'


### PR DESCRIPTION
## Summary

`alw swap now` and `alw view reservation` were treating any local `pending_swap.json` as live whenever the saved miner had an on-chain `reserved_until > now`. That conflates "this miner is reserved by anyone" with "our reservation is still live" — so when a swap completed and another user (or another process) re-reserved the same miner, the stale local row was reported as ACTIVE.

Reported case: user completed swap #3, came back later, `alw swap now` warned about a pending reservation, `alw view reservation` showed it ACTIVE with `~16 blocks` remaining and the old BTC tx attached, but `alw view swap 3 --watch` correctly said the swap was already resolved.

## Approach

New `probe_pending_reservation` helper in `swap_commands/helpers.py` decides among five outcomes:

1. **`our_swap`** — `get_miner_active_swaps` has a swap on this miner whose `(user_from_address, receive_address)` match ours. Strongest signal; survives `vote_extend_reservation` and into `FULFILLED`.
2. **`expired`** — no swap match and no reservation row.
3. **`replaced`** — reservation amounts differ from saved.
4. **`replaced`** — amounts match but `reserved_until` is more than `reservation_ttl` past our saved value (a single extension can't push it that far, and chained extensions would have shown up as a swap in step 1).
5. **`ours_active`** — within tolerance.

Three call sites consume it: `swap.py` (start-new prompt), `view.py` (full table), `status.py` (dashboard row). Each clears `pending_swap.json` and prints a one-line resolution when the saved state is no longer ours.

## Tradeoffs

The amount-tuple match in step 4 is *almost* unique-per-reservation but technically could collide if a different user re-reserves the same miner with the same exact amounts. The contract doesn't expose `Reservation.from_addr`, so the amount tuple plus the ttl-bounded drift check is the best disambiguator without a contract change. In practice, step 1 catches every "stale local file" case once a tx is broadcast (the reservation transitions into a swap and the swap match wins). A contract getter for `from_addr` would close the residual hole — deferring until the collision actually surfaces.

## Test plan

- [x] `pytest tests/test_probe_pending_reservation.py` — 9 cases covering all 5 branches, including the exact stale-after-completed-swap case
- [x] Full unit suite (`pytest tests/`) green — 330 passed
- [x] `ruff format .` + `ruff check .` clean
- [ ] Manual reproduction: complete a swap on dev environment, leave `pending_swap.json` behind, re-reserve same miner with another wallet, verify `alw swap now` / `alw view reservation` / `alw status` all auto-clear instead of showing ACTIVE