### PR TITLE
miner: unlock coldkey at startup to stop per-swap password prompts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,9 +45,9 @@ MINER_BTC_ADDRESS=
 # slash. Default: 5 blocks (~1 min at 12s). Set to 0 to disable.
 MINER_TIMEOUT_CUSHION_BLOCKS=5
 
-# Coldkey password for headless miners. The miner unlocks the coldkey once at
-# startup so per-swap TAO transfers don't re-prompt; when the process runs
-# detached from a TTY (pm2/systemd) the prompt would otherwise fail and every
-# fulfillment would error with "password invalid". Leave unset to be prompted
-# interactively at launch.
-MINER_COLDKEY_PASSWORD=
+# Bittensor coldkey password for headless miners. The miner unlocks the
+# coldkey once at startup so per-swap TAO transfers don't re-prompt; when the
+# process runs detached from a TTY (pm2/systemd) the prompt would otherwise
+# fail and every fulfillment would error with "password invalid". Leave unset
+# to be prompted interactively at launch.
+MINER_BITTENSOR_COLDKEY_PASSWORD=

--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,10 @@ MINER_BTC_ADDRESS=
 # timeout. Guards against slow dest-chain inclusion turning a send into a
 # slash. Default: 5 blocks (~1 min at 12s). Set to 0 to disable.
 MINER_TIMEOUT_CUSHION_BLOCKS=5
+
+# Coldkey password for headless miners. The miner unlocks the coldkey once at
+# startup so per-swap TAO transfers don't re-prompt; when the process runs
+# detached from a TTY (pm2/systemd) the prompt would otherwise fail and every
+# fulfillment would error with "password invalid". Leave unset to be prompted
+# interactively at launch.
+MINER_COLDKEY_PASSWORD=

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -6,6 +6,7 @@ Usage:
     python neurons/miner.py --netuid 7 --wallet.name default --wallet.hotkey default
 """
 
+import os
 import time
 from pathlib import Path
 from typing import Dict
@@ -34,6 +35,8 @@ class Miner(BaseMinerNeuron):
 
     def __init__(self, config=None):
         super().__init__(config=config)
+
+        self.unlock_coldkey()
 
         self.contract_client = AllwaysContractClient(
             subtensor=self.subtensor,
@@ -65,6 +68,23 @@ class Miner(BaseMinerNeuron):
         self.consecutive_poll_failures = 0
 
         bt.logging.info(f'Miner initialized: hotkey={self.wallet.hotkey.ss58_address} | addresses={self.my_addresses}')
+
+    def unlock_coldkey(self) -> None:
+        """Decrypt and cache the coldkey at startup so per-swap TAO transfers
+        don't re-prompt for a password each time. Without this, every
+        ``send_amount`` call hits ``wallet.coldkey`` which re-reads the keyfile;
+        when the miner runs detached from a TTY, ``getpass`` returns garbage
+        and every fulfillment fails with "password invalid".
+
+        If ``MINER_COLDKEY_PASSWORD`` is set in the environment, it is forwarded
+        into bittensor's per-keyfile env var so unlocking is non-interactive.
+        Otherwise this prompts once at startup (when the operator is present).
+        """
+        password = os.environ.get('MINER_COLDKEY_PASSWORD')
+        if password:
+            os.environ[self.wallet.coldkey_file.env_var_name()] = password
+        self.wallet.unlock_coldkey()
+        bt.logging.info('Coldkey unlocked')
 
     def load_my_addresses(self) -> Dict[str, str]:
         """Read this miner's committed pair once and map chain → address.

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -70,21 +70,22 @@ class Miner(BaseMinerNeuron):
         bt.logging.info(f'Miner initialized: hotkey={self.wallet.hotkey.ss58_address} | addresses={self.my_addresses}')
 
     def unlock_coldkey(self) -> None:
-        """Decrypt and cache the coldkey at startup so per-swap TAO transfers
-        don't re-prompt for a password each time. Without this, every
+        """Decrypt and cache the bittensor coldkey at startup so per-swap TAO
+        transfers don't re-prompt for a password each time. Without this, every
         ``send_amount`` call hits ``wallet.coldkey`` which re-reads the keyfile;
         when the miner runs detached from a TTY, ``getpass`` returns garbage
         and every fulfillment fails with "password invalid".
 
-        If ``MINER_COLDKEY_PASSWORD`` is set in the environment, it is forwarded
-        into bittensor's per-keyfile env var so unlocking is non-interactive.
-        Otherwise this prompts once at startup (when the operator is present).
+        If ``MINER_BITTENSOR_COLDKEY_PASSWORD`` is set in the environment, it
+        is forwarded into bittensor's per-keyfile env var so unlocking is
+        non-interactive. Otherwise this prompts once at startup (when the
+        operator is present).
         """
-        password = os.environ.get('MINER_COLDKEY_PASSWORD')
+        password = os.environ.get('MINER_BITTENSOR_COLDKEY_PASSWORD')
         if password:
             os.environ[self.wallet.coldkey_file.env_var_name()] = password
         self.wallet.unlock_coldkey()
-        bt.logging.info('Coldkey unlocked')
+        bt.logging.info('Bittensor coldkey unlocked')
 
     def load_my_addresses(self) -> Dict[str, str]:
         """Read this miner's committed pair once and map chain → address.


### PR DESCRIPTION
## Summary

- `subtensor.transfer` accesses `wallet.coldkey` on every TAO fulfillment, which re-decrypts the keyfile each time. When the miner runs detached from a TTY (pm2/systemd), `getpass` returns garbage and every send fails with "password invalid", looping until the swap times out and the miner is slashed.
- Unlock the coldkey once in `Miner.__init__` so the decrypted keypair is cached for the lifetime of the process.
- Add a new `MINER_COLDKEY_PASSWORD` env var (forwarded to bittensor's per-keyfile `BT_PW_<path>` variable) so headless miners can launch non-interactively.

## Test plan

- [ ] Start miner without `MINER_COLDKEY_PASSWORD`, attached to a TTY → prompts once, "Coldkey unlocked" logs, fulfillment runs without re-prompting
- [ ] Start miner with `MINER_COLDKEY_PASSWORD` set in `.env` → no prompt, "Coldkey unlocked" logs immediately
- [ ] Start miner detached with wrong password → fails fast at startup, not silently every swap
- [ ] Run a btc → tao swap end-to-end and confirm the TAO transfer succeeds the first time