### PR TITLE
CLI: stale-reservation expiry + swap-confirm UX cleanup

### DIFF
--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -350,7 +350,7 @@ class ReservationStatus:
     reserved_until: int = 0
 
 
-def probe_pending_reservation(client, state: PendingSwapState) -> ReservationStatus:
+def probe_pending_reservation(client, state: PendingSwapState, current_block: int) -> ReservationStatus:
     """Reconcile a saved pending_swap.json against on-chain state.
 
     The naive ``reserved_until > current_block`` check (the old logic) breaks
@@ -373,16 +373,22 @@ def probe_pending_reservation(client, state: PendingSwapState) -> ReservationSta
       Step 2 — read on-chain reservation. No row + no swap match means our
         reservation is gone (expired or consumed-and-pruned) — ``expired``.
 
-      Step 3 — if a row exists but the amounts differ from our saved state,
+      Step 3 — ``reserved_until`` is in the past. The contract leaves expired
+        rows in the map until the miner is re-reserved (lazy clear in
+        ``vote_reserve``), so a non-zero stale row is still expired — ours
+        if amounts match, someone else's if not, but either way the local
+        file is dead. ``expired``.
+
+      Step 4 — if a row exists but the amounts differ from our saved state,
         it's someone else's reservation — ``replaced``.
 
-      Step 4 — amounts match but ``reserved_until`` is more than ``ttl``
+      Step 5 — amounts match but ``reserved_until`` is more than ``ttl``
         blocks past our saved value: a single extension can't push the value
         beyond ``current_block + ttl``, and we'd have caught chained
         extensions in step 1 once ``vote_initiate`` ran. So this is a
         replacement that happens to share our amounts — ``replaced``.
 
-      Step 5 — within tolerance: ``ours_active``.
+      Step 6 — within tolerance: ``ours_active``.
     """
     # Cheap-bool short-circuit: skip the swap-range scan when the miner has
     # no active swap, which is the common case for the status/swap-now path.
@@ -400,7 +406,7 @@ def probe_pending_reservation(client, state: PendingSwapState) -> ReservationSta
     except ContractError:
         return ReservationStatus(kind='rpc_error')
 
-    if reserved_until == 0 or on_chain is None:
+    if reserved_until == 0 or on_chain is None or reserved_until < current_block:
         return ReservationStatus(kind='expired')
 
     chain_tao, chain_from, chain_to = on_chain

--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -473,7 +473,12 @@ def resolve_source_tx_block(
         console.print(f'[green]  ✓ found at block {tx_info.block_number}[/green]')
         return int(tx_info.block_number)
 
-    console.print(f'[yellow]  ✗ tx not found in last {max_scan_blocks} blocks on your local node.[/yellow]')
+    # In lightweight mode there is no local node — the lookup goes through a
+    # remote API (e.g. Blockstream for BTC), so don't claim "your local node".
+    source = (
+        'via lightweight wallet lookup' if getattr(provider, 'mode', None) == 'lightweight' else 'on your local node'
+    )
+    console.print(f'[yellow]  ✗ tx not found in last {max_scan_blocks} blocks {source}.[/yellow]')
     console.print(
         '[dim]  Validators will scan too; if they reject, retry with: '
         '[cyan]alw swap post-tx <hash> --block <N>[/cyan][/dim]'

--- a/allways/cli/swap_commands/status.py
+++ b/allways/cli/swap_commands/status.py
@@ -80,9 +80,10 @@ def status_command():
         # Pending reservation
         pending = load_pending_swap()
         if pending:
-            res_status = probe_pending_reservation(client, pending)
+            current_block = subtensor.get_current_block()
+            res_status = probe_pending_reservation(client, pending, current_block)
             if res_status.kind == 'ours_active':
-                remaining = max(0, res_status.reserved_until - subtensor.get_current_block())
+                remaining = max(0, res_status.reserved_until - current_block)
                 remaining_min = remaining * SECONDS_PER_BLOCK / 60
                 table.add_row(
                     'Pending Reservation',

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -128,7 +128,10 @@ def sign_and_broadcast_confirm(
     )
 
     if info.accepted == 0 and info.headline:
-        console.print(f'\n[red]{info.headline}[/red]')
+        # tx_not_found is almost always propagation lag, not a real failure —
+        # render it in yellow so it doesn't scan as "your swap broke".
+        color = 'yellow' if info.category == 'tx_not_found' else 'red'
+        console.print(f'\n[{color}]{info.headline}[/{color}]')
 
     return info.accepted, info.queued, info
 

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -590,11 +590,12 @@ def swap_now_command(
     # Check for pending reservation
     existing = load_pending_swap()
     if existing:
-        status = probe_pending_reservation(client, existing)
+        current_block = subtensor.get_current_block()
+        status = probe_pending_reservation(client, existing, current_block)
         if status.kind == 'rpc_error':
             console.print('[yellow]Could not verify existing reservation (contract unreachable)[/yellow]')
         elif status.kind == 'ours_active':
-            remaining = max(0, status.reserved_until - subtensor.get_current_block())
+            remaining = max(0, status.reserved_until - current_block)
             remaining_min = remaining * SECONDS_PER_BLOCK / 60
             console.print(
                 f'[yellow]You have a pending reservation (~{remaining} blocks, ~{remaining_min:.0f} min left).[/yellow]'

--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -970,14 +970,13 @@ def view_reservation():
         console.print('[dim]Run `alw swap now` to initiate a swap.[/dim]\n')
         return
 
+    current_block = subtensor.get_current_block()
     with loading('Reading reservation...'):
-        status = probe_pending_reservation(client, state)
+        status = probe_pending_reservation(client, state, current_block)
 
     if status.kind == 'rpc_error':
         console.print('[red]Failed to read reservation status from contract.[/red]')
         return
-
-    current_block = subtensor.get_current_block()
 
     console.print('\n[bold]Swap Reservation[/bold]\n')
 

--- a/allways/cli/validator_rejections.py
+++ b/allways/cli/validator_rejections.py
@@ -217,10 +217,17 @@ _RULES: list[_Rule] = [
         'tx_not_found',
         'source transaction not found',
         False,
+        # The same validator path that rejects here will queue the tx with
+        # `0/N confirmations` once it propagates, so this is almost always
+        # just a freshly broadcast tx that hasn't reached validator nodes
+        # yet. Frame it as a wait, not a hard error — a stern "could not
+        # find" message has scared users into thinking the swap failed.
         lambda ctx: (
-            'Validators could not find your source transaction (or sender/amount mismatched). '
-            'It may need more time to propagate, or the hash/sender may be off. Retry in a few blocks; '
-            'if you have it, pass [cyan]--block <N>[/cyan].'
+            'Source tx not yet visible to validators — usually just propagation lag. '
+            'Retry in a few seconds with the resume hint below; validators will queue and '
+            'auto-initiate once the tx lands.\n'
+            '[dim]If it keeps rejecting, the hash or sender may be off — '
+            'pass [cyan]--block <N>[/cyan] if you have it.[/dim]'
         ),
     ),
     (

--- a/tests/test_probe_pending_reservation.py
+++ b/tests/test_probe_pending_reservation.py
@@ -1,8 +1,9 @@
 """probe_pending_reservation: reconcile pending_swap.json with on-chain state.
 
-Pins the five-branch decision the helper makes so the UX bug it fixes
-(stale local file shown as ACTIVE because miner was re-reserved by another
-user) doesn't regress.
+Pins the six-branch decision the helper makes so the UX bugs it fixes don't
+regress: stale local file shown as ACTIVE because the miner was re-reserved
+by another user, and stale local file shown as ACTIVE because the contract
+leaves expired rows in the reservation map until lazy clear.
 """
 
 from unittest.mock import MagicMock
@@ -59,6 +60,11 @@ def make_swap(**overrides) -> Swap:
     return Swap(**base)
 
 
+# Default current block sits below every ``reserved_until`` value used here,
+# so the past-block check stays inert in tests that aren't exercising it.
+CURRENT_BLOCK = 1_000_000
+
+
 def make_client(*, active_swaps=(), reserved_until=0, reservation_data=None, ttl=4032):
     """Build a contract-client double whose only behavior is what the probe touches."""
     client = MagicMock()
@@ -77,7 +83,7 @@ def test_our_swap_when_active_swaps_match_user_addresses():
     swap = make_swap(user_from_address=state.user_from_address, user_to_address=state.receive_address)
     client = make_client(active_swaps=[swap])
 
-    result = probe_pending_reservation(client, state)
+    result = probe_pending_reservation(client, state, CURRENT_BLOCK)
 
     assert result.kind == 'our_swap'
     assert result.swap is swap
@@ -89,7 +95,7 @@ def test_active_swap_for_different_user_does_not_match():
     other = make_swap(user_from_address='tb1qsomeoneelse', user_to_address='5OtherHk')
     client = make_client(active_swaps=[other])
 
-    result = probe_pending_reservation(client, state)
+    result = probe_pending_reservation(client, state, CURRENT_BLOCK)
 
     assert result.kind == 'expired'
 
@@ -98,7 +104,22 @@ def test_expired_when_no_swap_and_no_reservation():
     state = make_state()
     client = make_client()
 
-    result = probe_pending_reservation(client, state)
+    result = probe_pending_reservation(client, state, CURRENT_BLOCK)
+
+    assert result.kind == 'expired'
+
+
+def test_expired_when_reserved_until_is_in_the_past():
+    """Contract leaves expired rows in the map (lazy clear). A non-zero stale
+    row whose reserved_until is below current_block must read as ``expired``,
+    not ``ours_active`` with ~0 blocks left."""
+    state = make_state(reserved_until_block=1_000_100)
+    client = make_client(
+        reserved_until=1_000_100,
+        reservation_data=(state.tao_amount, state.from_amount, state.to_amount),
+    )
+
+    result = probe_pending_reservation(client, state, current_block=1_000_101)
 
     assert result.kind == 'expired'
 
@@ -110,7 +131,7 @@ def test_replaced_when_reservation_amounts_differ():
         reservation_data=(state.tao_amount + 1, state.from_amount, state.to_amount),
     )
 
-    result = probe_pending_reservation(client, state)
+    result = probe_pending_reservation(client, state, CURRENT_BLOCK)
 
     assert result.kind == 'replaced'
 
@@ -124,7 +145,7 @@ def test_replaced_when_reserved_until_is_more_than_ttl_past_saved():
         ttl=4032,
     )
 
-    result = probe_pending_reservation(client, state)
+    result = probe_pending_reservation(client, state, CURRENT_BLOCK)
 
     assert result.kind == 'replaced'
 
@@ -138,7 +159,7 @@ def test_ours_active_when_amounts_match_and_within_ttl():
         ttl=4032,
     )
 
-    result = probe_pending_reservation(client, state)
+    result = probe_pending_reservation(client, state, CURRENT_BLOCK)
 
     assert result.kind == 'ours_active'
     assert result.reserved_until == 1_000_100 + 4031
@@ -151,7 +172,7 @@ def test_ours_active_when_unchanged():
         reservation_data=(state.tao_amount, state.from_amount, state.to_amount),
     )
 
-    result = probe_pending_reservation(client, state)
+    result = probe_pending_reservation(client, state, CURRENT_BLOCK)
 
     assert result.kind == 'ours_active'
 
@@ -162,7 +183,7 @@ def test_skips_active_swap_scan_when_miner_has_no_active_swap():
     client = make_client()
     client.get_miner_has_active_swap.return_value = False
 
-    probe_pending_reservation(client, state)
+    probe_pending_reservation(client, state, CURRENT_BLOCK)
 
     client.get_miner_active_swaps.assert_not_called()
 
@@ -173,7 +194,7 @@ def test_rpc_error_short_circuits_when_active_swaps_call_fails():
     client.get_miner_has_active_swap.return_value = True
     client.get_miner_active_swaps.side_effect = ContractError('rpc down')
 
-    result = probe_pending_reservation(client, state)
+    result = probe_pending_reservation(client, state, CURRENT_BLOCK)
 
     assert result == ReservationStatus(kind='rpc_error')
 
@@ -183,6 +204,6 @@ def test_rpc_error_when_reservation_read_fails():
     client = make_client()
     client.get_miner_reserved_until.side_effect = ContractError('rpc down')
 
-    result = probe_pending_reservation(client, state)
+    result = probe_pending_reservation(client, state, CURRENT_BLOCK)
 
     assert result.kind == 'rpc_error'


### PR DESCRIPTION
## Summary

Three small CLI fixes around the swap-now / post-tx flow.

### 1. Stale `pending_swap.json` shown as ACTIVE with ~0 blocks left
`probe_pending_reservation` only short-circuited on `reserved_until == 0`, but the contract leaves expired reservation rows in its map until the miner is re-reserved (lazy clear in `vote_reserve` at `lib.rs:507-513`). A stale local file therefore read as `ours_active` and `alw swap now` kept prompting "complete it with: alw swap post-tx".

Thread `current_block` into the helper and treat `reserved_until < current_block` as `expired`. Same fix flows through `alw view reservation` and `alw status`. `post_tx.py:68` and `resume.py:125` already compared directly against `current_block`, so behavior is now consistent across all CLI consumers of `pending_swap.json`.

### 2. `tx_not_found` confirm rejection reads as a hard failure
A freshly-broadcast source tx often hits the validator confirm path before validators' nodes have indexed it. The validator's `verify_transaction` returns `None`, the synapse rejects with "Source transaction not found, amount or sender mismatch", and the CLI rendered the headline in red — even though the exact same retry seconds later returns `queued — 0/N confirmations` and the swap proceeds normally.

Soften the headline to lead with propagation as the most likely cause, point at the resume hint already printed below, and render in yellow when category is `tx_not_found` so it stops scanning as "your swap broke".

### 3. "your local node" wording in lightweight BTC mode
`resolve_source_tx_block` printed `tx not found in last N blocks on your local node` regardless of provider mode. In lightweight mode the lookup is a remote Blockstream API call — there is no local node. Branch on `provider.mode` so the message reads `via lightweight wallet lookup` when appropriate.

## Test plan
- [x] `pytest tests/` — 332 passed (incl. new `test_expired_when_reserved_until_is_in_the_past` regression test)
- [x] `ruff format` + `ruff check` clean
- [ ] Smoke: stale `pending_swap.json` → `alw swap now` clears local state instead of offering "complete it"
- [ ] Smoke: BTC swap immediately after broadcast → headline reads "Source tx not yet visible — usually just propagation lag" in yellow, retrying the resume hint queues normally
- [ ] Smoke: BTC swap with `BTC_MODE=lightweight` and a tx not yet at the API → message reads "via lightweight wallet lookup", not "on your local node"