### PR TITLE
validator: extend-vote reasons, swap lifecycle logs, and BTC fee UX

### DIFF
--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -617,10 +617,11 @@ class BitcoinProvider(ChainProvider):
     def estimate_fee_rate(self, override: Optional[int] = None) -> int:
         """Estimate fee rate (sat/vbyte) from Blockstream.
 
-        Default targets next-block confirmation and applies a safety multiplier
-        on top — we'd rather overpay a few sats than have a source tx stuck.
-        ``override`` (sat/vB) skips estimation, floor, and multiplier — caller
-        is taking explicit responsibility for the rate (e.g. CPFP / manual bump).
+        Targets 2-3 block confirmation (~20-30 min) with a small safety pad on
+        top, so a swap source tx reliably clears within the reservation
+        without overpaying for next-block urgency. ``override`` (sat/vB) skips
+        estimation, floor, and multiplier — caller is taking explicit
+        responsibility for the rate (e.g. CPFP / manual bump).
         """
         if override is not None:
             return max(1, override)
@@ -633,8 +634,7 @@ class BitcoinProvider(ChainProvider):
             resp = self.http.get(url, timeout=10)
             resp.raise_for_status()
             estimates = resp.json()
-            # Target next-block first; fall back to 2-block before the floor.
-            for target in ('1', '2'):
+            for target in ('2', '3'):
                 if target in estimates:
                     padded = int(round(float(estimates[target]) * BTC_FEE_RATE_SAFETY_MULTIPLIER))
                     return max(floor, padded)

--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -410,7 +410,11 @@ class BitcoinProvider(ChainProvider):
             return False
 
     def send_amount_lightweight(
-        self, to_address: str, amount: int, from_address: Optional[str] = None
+        self,
+        to_address: str,
+        amount: int,
+        from_address: Optional[str] = None,
+        fee_rate_override: Optional[int] = None,
     ) -> Optional[Tuple[str, int]]:
         """Send BTC via embit + Blockstream API (no full node required). Amount in satoshis.
 
@@ -420,6 +424,8 @@ class BitcoinProvider(ChainProvider):
         If from_address is provided (e.g. the miner's committed address), the
         matching address type is derived directly from the WIF key. Otherwise,
         all types are probed to find where UTXOs exist.
+
+        ``fee_rate_override`` (sat/vB) skips estimation and the network floor.
 
         Does NOT work on regtest (no public APIs). Returns (tx_hash, 0) or None.
         """
@@ -459,7 +465,7 @@ class BitcoinProvider(ChainProvider):
             is_segwit = addr_type in ('p2wpkh', 'p2sh-p2wpkh')
             bt.logging.info(f'Sending from {addr_type} address: {my_address}')
 
-            coin_selection = self.select_utxos(utxos, amount, is_segwit)
+            coin_selection = self.select_utxos(utxos, amount, is_segwit, fee_rate_override=fee_rate_override)
             if coin_selection is None:
                 return None
             selected, total_in, fee = coin_selection
@@ -572,9 +578,9 @@ class BitcoinProvider(ChainProvider):
         self._send_error('No UTXOs found for any address type')
         return None
 
-    def select_utxos(self, utxos, amount: int, is_segwit: bool):
+    def select_utxos(self, utxos, amount: int, is_segwit: bool, fee_rate_override: Optional[int] = None):
         """Greedy UTXO selection. Returns (selected, total_in, fee) or None."""
-        fee_rate = self.estimate_fee_rate()
+        fee_rate = self.estimate_fee_rate(override=fee_rate_override)
         input_vsize = 68 if is_segwit else 148
         selected = []
         total_in = 0
@@ -602,15 +608,23 @@ class BitcoinProvider(ChainProvider):
             return None
         return resp.text.strip()
 
-    def estimate_fee_rate(self) -> int:
-        """Estimate fee rate (sat/vbyte) from Blockstream/mempool. Falls back to 5 sat/vb.
+    def min_fee_rate(self) -> int:
+        """Network-aware fee floor (sat/vB). See constants for rationale."""
+        from allways.constants import BTC_MIN_FEE_RATE_MAINNET, BTC_MIN_FEE_RATE_TESTNET
 
-        Targets 2-3 block confirmation (~20-30 min) with a floor of 2 sat/vB
-        to avoid stuck transactions during low-fee periods.
+        return BTC_MIN_FEE_RATE_MAINNET if self.network == 'mainnet' else BTC_MIN_FEE_RATE_TESTNET
+
+    def estimate_fee_rate(self, override: Optional[int] = None) -> int:
+        """Estimate fee rate (sat/vbyte) from Blockstream/mempool.
+
+        Targets 2-3 block confirmation (~20-30 min) with a network-aware floor.
+        ``override`` (sat/vB) skips estimation and floor — caller is taking
+        explicit responsibility for the rate (e.g. CPFP / manual bump).
         """
-        from allways.constants import BTC_MIN_FEE_RATE
+        if override is not None:
+            return max(1, override)
 
-        min_fee_rate = BTC_MIN_FEE_RATE
+        floor = self.min_fee_rate()
         try:
             url = f'{self.blockstream_api_url()}/fee-estimates'
             resp = self.http.get(url, timeout=10)
@@ -619,10 +633,10 @@ class BitcoinProvider(ChainProvider):
             # Target 2-3 blocks (~20-30 min confirmation)
             for target in ('2', '3', '4'):
                 if target in estimates:
-                    return max(min_fee_rate, int(estimates[target]))
-            return max(min_fee_rate, 5)
+                    return max(floor, int(estimates[target]))
+            return max(floor, 5)
         except Exception:
-            return max(min_fee_rate, 5)
+            return max(floor, 5)
 
     def send_amount(
         self, to_address: str, amount: int, from_address: Optional[str] = None

--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -615,14 +615,17 @@ class BitcoinProvider(ChainProvider):
         return BTC_MIN_FEE_RATE_MAINNET if self.network == 'mainnet' else BTC_MIN_FEE_RATE_TESTNET
 
     def estimate_fee_rate(self, override: Optional[int] = None) -> int:
-        """Estimate fee rate (sat/vbyte) from Blockstream/mempool.
+        """Estimate fee rate (sat/vbyte) from Blockstream.
 
-        Targets 2-3 block confirmation (~20-30 min) with a network-aware floor.
-        ``override`` (sat/vB) skips estimation and floor — caller is taking
-        explicit responsibility for the rate (e.g. CPFP / manual bump).
+        Default targets next-block confirmation and applies a safety multiplier
+        on top — we'd rather overpay a few sats than have a source tx stuck.
+        ``override`` (sat/vB) skips estimation, floor, and multiplier — caller
+        is taking explicit responsibility for the rate (e.g. CPFP / manual bump).
         """
         if override is not None:
             return max(1, override)
+
+        from allways.constants import BTC_FEE_RATE_SAFETY_MULTIPLIER
 
         floor = self.min_fee_rate()
         try:
@@ -630,10 +633,11 @@ class BitcoinProvider(ChainProvider):
             resp = self.http.get(url, timeout=10)
             resp.raise_for_status()
             estimates = resp.json()
-            # Target 2-3 blocks (~20-30 min confirmation)
-            for target in ('2', '3', '4'):
+            # Target next-block first; fall back to 2-block before the floor.
+            for target in ('1', '2'):
                 if target in estimates:
-                    return max(floor, int(estimates[target]))
+                    padded = int(round(float(estimates[target]) * BTC_FEE_RATE_SAFETY_MULTIPLIER))
+                    return max(floor, padded)
             return max(floor, 5)
         except Exception:
             return max(floor, 5)

--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -608,12 +608,6 @@ class BitcoinProvider(ChainProvider):
             return None
         return resp.text.strip()
 
-    def min_fee_rate(self) -> int:
-        """Network-aware fee floor (sat/vB). See constants for rationale."""
-        from allways.constants import BTC_MIN_FEE_RATE_MAINNET, BTC_MIN_FEE_RATE_TESTNET
-
-        return BTC_MIN_FEE_RATE_MAINNET if self.network == 'mainnet' else BTC_MIN_FEE_RATE_TESTNET
-
     def estimate_fee_rate(self, override: Optional[int] = None) -> int:
         """Estimate fee rate (sat/vbyte) from Blockstream.
 
@@ -626,9 +620,8 @@ class BitcoinProvider(ChainProvider):
         if override is not None:
             return max(1, override)
 
-        from allways.constants import BTC_FEE_RATE_SAFETY_MULTIPLIER
+        from allways.constants import BTC_FEE_RATE_SAFETY_MULTIPLIER, BTC_MIN_FEE_RATE
 
-        floor = self.min_fee_rate()
         try:
             url = f'{self.blockstream_api_url()}/fee-estimates'
             resp = self.http.get(url, timeout=10)
@@ -637,10 +630,10 @@ class BitcoinProvider(ChainProvider):
             for target in ('2', '3'):
                 if target in estimates:
                     padded = int(round(float(estimates[target]) * BTC_FEE_RATE_SAFETY_MULTIPLIER))
-                    return max(floor, padded)
-            return max(floor, 5)
+                    return max(BTC_MIN_FEE_RATE, padded)
         except Exception:
-            return max(floor, 5)
+            pass
+        return BTC_MIN_FEE_RATE
 
     def send_amount(
         self, to_address: str, amount: int, from_address: Optional[str] = None

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -455,7 +455,14 @@ def poll_for_swap_with_progress(client, miner_hotkey: str, from_chain: str, max_
     return None
 
 
-def send_btc(chain_providers, config, to_address: str, amount_sat: int, from_address: str = None):
+def send_btc(
+    chain_providers,
+    config,
+    to_address: str,
+    amount_sat: int,
+    from_address: str = None,
+    fee_rate_override: Optional[int] = None,
+):
     """Send BTC, retry on failure, fall back to manual tx-hash entry.
 
     In lightweight mode there is no Bitcoin Core fallback — both paths route
@@ -470,7 +477,9 @@ def send_btc(chain_providers, config, to_address: str, amount_sat: int, from_add
     def attempt_send():
         if not is_local and hasattr(provider, 'send_amount_lightweight'):
             console.print('[dim]Sending BTC via lightweight wallet...[/dim]')
-            result = provider.send_amount_lightweight(to_address, amount_sat, from_address=from_address)
+            result = provider.send_amount_lightweight(
+                to_address, amount_sat, from_address=from_address, fee_rate_override=fee_rate_override
+            )
             if result:
                 return result
             if is_lightweight:
@@ -537,6 +546,13 @@ def swap_group():
 @click.option('--from-tx-hash', 'from_tx_hash_opt', default=None, help='Source tx hash (skip fund sending)')
 @click.option('--auto', 'auto_select', is_flag=True, help='Auto-select best rate miner')
 @click.option('--yes', 'skip_confirm', is_flag=True, help='Skip confirmation prompts')
+@click.option(
+    '--btc-fee-rate',
+    'btc_fee_rate_opt',
+    type=click.IntRange(min=1),
+    default=None,
+    help='Override BTC fee rate (sat/vB). Lightweight wallet only.',
+)
 def swap_now_command(
     from_chain_opt: Optional[str],
     to_chain_opt: Optional[str],
@@ -546,6 +562,7 @@ def swap_now_command(
     from_tx_hash_opt: Optional[str],
     auto_select: bool,
     skip_confirm: bool,
+    btc_fee_rate_opt: Optional[int],
 ):
     """Guided interactive swap - step by step.
 
@@ -856,6 +873,22 @@ def swap_now_command(
     # the miner will deliver the destination funds.
     receive_human = from_smallest_unit(user_receives, to_chain)
     fee_human = from_smallest_unit(fee_in_dest, to_chain)
+
+    btc_fee_line = ''
+    btc_provider = chain_providers.get('btc')
+    if (
+        from_chain == 'btc'
+        and btc_provider is not None
+        and getattr(btc_provider, 'mode', None) == 'lightweight'
+        and hasattr(btc_provider, 'estimate_fee_rate')
+    ):
+        try:
+            chosen_fee_rate = btc_provider.estimate_fee_rate(override=btc_fee_rate_opt)
+            origin = 'override' if btc_fee_rate_opt is not None else 'estimate'
+            btc_fee_line = f'  Network Fee:  ~{chosen_fee_rate} sat/vB ({origin})\n'
+        except Exception:
+            pass  # display-only; send path will surface real failures
+
     summary = (
         f'  You Send:     [red]{amount} {src_up}[/red]\n'
         f'    From:       [yellow]{user_from_address}[/yellow]  [dim](your {src_up} address)[/dim]\n'
@@ -864,6 +897,7 @@ def swap_now_command(
         f'    To:         [yellow]{receive_address}[/yellow]  [dim](your {dst_up} address)[/dim]\n'
         f'\n'
         f'  Protocol Fee: {fee_percent:g}% ({fee_human:.8f} {dst_up})\n'
+        f'{btc_fee_line}'
         f'  Rate:         {rate_line}\n'
         f'  Miner:        UID {selected_pair.uid}'
     )
@@ -1011,6 +1045,7 @@ def swap_now_command(
                 selected_pair.from_address,
                 from_amount,
                 from_address=user_from_address,
+                fee_rate_override=btc_fee_rate_opt,
             )
             if send_result is None:
                 return

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -551,7 +551,12 @@ def swap_group():
     'btc_fee_rate_opt',
     type=click.IntRange(min=1),
     default=None,
-    help='Override BTC fee rate (sat/vB). Lightweight wallet only.',
+    metavar='SAT_PER_VB',
+    help=(
+        'Fee rate for the BTC source tx, in satoshis per virtual byte (sat/vB). '
+        'Higher = faster confirmation. Typical mainnet values: 5-20. Default '
+        'auto-estimates from the mempool. Lightweight wallet only.'
+    ),
 )
 def swap_now_command(
     from_chain_opt: Optional[str],
@@ -884,8 +889,8 @@ def swap_now_command(
     ):
         try:
             chosen_fee_rate = btc_provider.estimate_fee_rate(override=btc_fee_rate_opt)
-            origin = 'override' if btc_fee_rate_opt is not None else 'estimate'
-            btc_fee_line = f'  Network Fee:  ~{chosen_fee_rate} sat/vB ({origin})\n'
+            origin = 'override via --btc-fee-rate' if btc_fee_rate_opt is not None else 'auto-estimated'
+            btc_fee_line = f'  BTC Fee Rate: ~{chosen_fee_rate} sat/vB  [dim]({origin})[/dim]\n'
         except Exception:
             pass  # display-only; send path will surface real failures
 

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -879,7 +879,10 @@ def swap_now_command(
     receive_human = from_smallest_unit(user_receives, to_chain)
     fee_human = from_smallest_unit(fee_in_dest, to_chain)
 
+    # Pin the fee rate at summary time so the send path uses the exact rate
+    # the user agreed to — also avoids a second Blockstream round-trip.
     btc_fee_line = ''
+    pinned_btc_fee_rate: Optional[int] = btc_fee_rate_opt
     btc_provider = chain_providers.get('btc')
     if (
         from_chain == 'btc'
@@ -888,11 +891,11 @@ def swap_now_command(
         and hasattr(btc_provider, 'estimate_fee_rate')
     ):
         try:
-            chosen_fee_rate = btc_provider.estimate_fee_rate(override=btc_fee_rate_opt)
+            pinned_btc_fee_rate = btc_provider.estimate_fee_rate(override=btc_fee_rate_opt)
             origin = 'override via --btc-fee-rate' if btc_fee_rate_opt is not None else 'auto-estimated'
-            btc_fee_line = f'  BTC Fee Rate: ~{chosen_fee_rate} sat/vB  [dim]({origin})[/dim]\n'
+            btc_fee_line = f'  BTC Fee Rate: ~{pinned_btc_fee_rate} sat/vB  [dim]({origin})[/dim]\n'
         except Exception:
-            pass  # display-only; send path will surface real failures
+            pass  # display-only; send path will fall back to estimating itself
 
     summary = (
         f'  You Send:     [red]{amount} {src_up}[/red]\n'
@@ -1050,7 +1053,7 @@ def swap_now_command(
                 selected_pair.from_address,
                 from_amount,
                 from_address=user_from_address,
-                fee_rate_override=btc_fee_rate_opt,
+                fee_rate_override=pinned_btc_fee_rate,
             )
             if send_result is None:
                 return

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -23,11 +23,15 @@ RATE_PRECISION = 10**18
 
 # ─── Transaction Fees ────────────────────────────────────
 MIN_BALANCE_FOR_TX_RAO = 250_000_000  # 0.25 TAO minimum for extrinsic fees
-# BTC fee floor (sat/vB). Mainnet floor is higher because the mempool
-# regularly evicts <5 sat/vB during congestion; testnet rarely has fee
-# pressure so 2 keeps regtest/testnet UX cheap.
+# BTC fee floor (sat/vB). Mainnet floor is high enough to survive mild
+# congestion even when the upstream estimator returns nonsense low; testnet
+# rarely has fee pressure so 2 keeps regtest/testnet UX cheap.
 BTC_MIN_FEE_RATE_TESTNET = 2
-BTC_MIN_FEE_RATE_MAINNET = 5
+BTC_MIN_FEE_RATE_MAINNET = 10
+# Multiplier applied to estimated fee rates (not to explicit user overrides).
+# Pads against mempool conditions shifting between estimate and broadcast —
+# we'd rather overpay a few sats than have a swap source tx stuck for hours.
+BTC_FEE_RATE_SAFETY_MULTIPLIER = 1.5
 
 # ─── Miner ───────────────────────────────────────────────
 # Cushion subtracted from each swap's timeout before the miner agrees to

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -23,15 +23,15 @@ RATE_PRECISION = 10**18
 
 # ─── Transaction Fees ────────────────────────────────────
 MIN_BALANCE_FOR_TX_RAO = 250_000_000  # 0.25 TAO minimum for extrinsic fees
-# BTC fee floor (sat/vB). Mainnet floor is high enough to survive mild
-# congestion even when the upstream estimator returns nonsense low; testnet
-# rarely has fee pressure so 2 keeps regtest/testnet UX cheap.
+# BTC fee floor (sat/vB). Mainnet floor catches the case where the upstream
+# estimator returns nonsense low; testnet rarely has fee pressure so 2 keeps
+# regtest/testnet UX cheap.
 BTC_MIN_FEE_RATE_TESTNET = 2
-BTC_MIN_FEE_RATE_MAINNET = 10
-# Multiplier applied to estimated fee rates (not to explicit user overrides).
-# Pads against mempool conditions shifting between estimate and broadcast —
-# we'd rather overpay a few sats than have a swap source tx stuck for hours.
-BTC_FEE_RATE_SAFETY_MULTIPLIER = 1.5
+BTC_MIN_FEE_RATE_MAINNET = 5
+# Modest pad on estimated fee rates (not on explicit user overrides) against
+# mempool conditions drifting between estimate and broadcast. Goal is
+# 'reliably confirms within ~30 min', not 'next block at any cost'.
+BTC_FEE_RATE_SAFETY_MULTIPLIER = 1.25
 
 # ─── Miner ───────────────────────────────────────────────
 # Cushion subtracted from each swap's timeout before the miner agrees to

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -23,11 +23,10 @@ RATE_PRECISION = 10**18
 
 # ─── Transaction Fees ────────────────────────────────────
 MIN_BALANCE_FOR_TX_RAO = 250_000_000  # 0.25 TAO minimum for extrinsic fees
-# BTC fee floor (sat/vB). Mainnet floor catches the case where the upstream
-# estimator returns nonsense low; testnet rarely has fee pressure so 2 keeps
-# regtest/testnet UX cheap.
-BTC_MIN_FEE_RATE_TESTNET = 2
-BTC_MIN_FEE_RATE_MAINNET = 5
+# BTC fee floor (sat/vB). Catches the case where the upstream estimator
+# returns nonsense low. 5 is cheap enough to barely register on mainnet
+# and still clears testnet quickly, so a single floor covers both.
+BTC_MIN_FEE_RATE = 5
 # Modest pad on estimated fee rates (not on explicit user overrides) against
 # mempool conditions drifting between estimate and broadcast. Goal is
 # 'reliably confirms within ~30 min', not 'next block at any cost'.

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -23,7 +23,11 @@ RATE_PRECISION = 10**18
 
 # ─── Transaction Fees ────────────────────────────────────
 MIN_BALANCE_FOR_TX_RAO = 250_000_000  # 0.25 TAO minimum for extrinsic fees
-BTC_MIN_FEE_RATE = 2  # sat/vB — floor to avoid stuck txs
+# BTC fee floor (sat/vB). Mainnet floor is higher because the mempool
+# regularly evicts <5 sat/vB during congestion; testnet rarely has fee
+# pressure so 2 keeps regtest/testnet UX cheap.
+BTC_MIN_FEE_RATE_TESTNET = 2
+BTC_MIN_FEE_RATE_MAINNET = 5
 
 # ─── Miner ───────────────────────────────────────────────
 # Cushion subtracted from each swap's timeout before the miner agrees to

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -127,7 +127,7 @@ def initialize_pending_user_reservations(self: Validator) -> None:
             )
         except ProviderUnreachableError as e:
             bt.logging.warning(f'PendingConfirm [{swap_label} {miner_short}]: provider unreachable, will retry: {e}')
-            try_extend_reservation(self, item, current_block, swap_label, miner_short)
+            try_extend_reservation(self, item, current_block, swap_label, miner_short, reason='provider unreachable')
             continue
         except Exception as e:
             bt.logging.error(f'PendingConfirm [{swap_label} {miner_short}]: verify_transaction error: {e}')
@@ -142,7 +142,14 @@ def initialize_pending_user_reservations(self: Validator) -> None:
                     f'PendingConfirm [{swap_label} {miner_short}]: tx {item.from_tx_hash[:16]}... '
                     f'not found (attempt {attempts}/{PENDING_CONFIRM_NULL_RETRY_LIMIT}), retrying'
                 )
-                try_extend_reservation(self, item, current_block, swap_label, miner_short)
+                try_extend_reservation(
+                    self,
+                    item,
+                    current_block,
+                    swap_label,
+                    miner_short,
+                    reason=f'tx_not_found {attempts}/{PENDING_CONFIRM_NULL_RETRY_LIMIT}',
+                )
                 continue
             self.state_store.remove(item.miner_hotkey)
             bt.logging.warning(
@@ -161,7 +168,14 @@ def initialize_pending_user_reservations(self: Validator) -> None:
         )
 
         if not tx_info.confirmed:
-            try_extend_reservation(self, item, current_block, swap_label, miner_short)
+            try_extend_reservation(
+                self,
+                item,
+                current_block,
+                swap_label,
+                miner_short,
+                reason=f'unconfirmed {tx_info.confirmations}/{min_confs}',
+            )
             continue
 
         # Only drop the queued entry once the vote is accepted (or the contract
@@ -225,6 +239,7 @@ def try_extend_reservation(
     current_block: int,
     swap_label: str,
     miner_short: str,
+    reason: str = '',
 ) -> None:
     """Vote to extend reservation if nearing expiry, protecting users during provider outages."""
     from substrateinterface import Keypair
@@ -253,9 +268,10 @@ def try_extend_reservation(
         # otherwise delete this row at the original TTL while the reservation
         # is still alive on-chain.
         refresh_cached_reserved_until(self, item)
+        reason_str = f' [{reason}]' if reason else ''
         bt.logging.info(
             f'PendingConfirm [{swap_label} {miner_short}]: '
-            f'voted to extend reservation ({reserved_until - current_block} blocks remaining)'
+            f'voted to extend reservation{reason_str} ({reserved_until - current_block} blocks remaining)'
         )
     except ContractError as e:
         if 'AlreadyVoted' in str(e):
@@ -361,6 +377,8 @@ async def confirm_miner_fulfillments(
             if voting.confirm_swap(self.contract_client, self.wallet, swap.id):
                 tracker.resolve(swap.id, SwapStatus.COMPLETED, current_block)
                 bt.logging.success(f'Swap {swap.id}: verified complete, confirmed')
+            else:
+                bt.logging.info(f'Swap {swap.id}: confirm vote did not land, retrying next step')
     return uncertain
 
 
@@ -431,3 +449,5 @@ def enforce_swap_timeouts(self: Validator, tracker: SwapTracker, uncertain_swaps
         if voting.timeout_swap(self.contract_client, self.wallet, swap.id):
             tracker.resolve(swap.id, SwapStatus.TIMED_OUT, self.block)
             bt.logging.warning(f'Swap {swap.id}: timed out')
+        else:
+            bt.logging.debug(f'Swap {swap.id}: timeout vote did not land, retrying next step')

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -35,8 +35,6 @@ if TYPE_CHECKING:
 async def forward(self: Validator) -> None:
     """One validator forward step. Phase order matters — each phase may depend
     on state mutated by the previous one."""
-    bt.logging.info(f'Forward step {self.step}')
-
     tracker: SwapTracker = self.swap_tracker
     verifier: SwapVerifier = self.swap_verifier
 
@@ -377,8 +375,8 @@ async def confirm_miner_fulfillments(
             if voting.confirm_swap(self.contract_client, self.wallet, swap.id):
                 tracker.resolve(swap.id, SwapStatus.COMPLETED, current_block)
                 bt.logging.success(f'Swap {swap.id}: verified complete, confirmed')
-            else:
-                bt.logging.info(f'Swap {swap.id}: confirm vote did not land, retrying next step')
+            # On vote failure, voting.confirm_swap already logs the error;
+            # the entry stays in tracker and retries next step.
     return uncertain
 
 
@@ -449,5 +447,4 @@ def enforce_swap_timeouts(self: Validator, tracker: SwapTracker, uncertain_swaps
         if voting.timeout_swap(self.contract_client, self.wallet, swap.id):
             tracker.resolve(swap.id, SwapStatus.TIMED_OUT, self.block)
             bt.logging.warning(f'Swap {swap.id}: timed out')
-        else:
-            bt.logging.debug(f'Swap {swap.id}: timeout vote did not land, retrying next step')
+        # On vote failure, voting.timeout_swap already logs the error.

--- a/allways/validator/swap_tracker.py
+++ b/allways/validator/swap_tracker.py
@@ -25,6 +25,10 @@ NULL_SWAP_RETRY_LIMIT = 3
 MAX_INIT_GAP = 20
 
 
+def _swap_label(swap: Swap) -> str:
+    return f'{swap.from_chain.upper()}->{swap.to_chain.upper()}'
+
+
 class SwapTracker:
     """Discovery scans new swap IDs since the last poll; monitoring re-fetches
     all tracked ACTIVE/FULFILLED swaps each poll."""
@@ -139,9 +143,7 @@ class SwapTracker:
                 if swap.status in ACTIVE_STATUSES:
                     self.active[swap.id] = swap
                     fresh.add(swap.id)
-
-        if new_ids:
-            bt.logging.debug(f'SwapTracker: discovered {len(fresh)} active from {len(new_ids)} new IDs')
+                    bt.logging.info(f'Swap {swap.id} [{_swap_label(swap)}]: now {swap.status.name}, monitoring')
 
         if next_id > 1:
             self.last_scanned_id = next_id - 1
@@ -170,6 +172,9 @@ class SwapTracker:
                 if self.bump_null_retry(sid):
                     resolved_ids.append(sid)
             elif result.status in ACTIVE_STATUSES:
+                prev = self.active.get(sid)
+                if prev is not None and prev.status != result.status:
+                    bt.logging.info(f'Swap {sid} [{_swap_label(result)}]: {prev.status.name} -> {result.status.name}')
                 self.active[sid] = result
                 self.null_retry_count.pop(sid, None)
             else:

--- a/allways/validator/voting.py
+++ b/allways/validator/voting.py
@@ -8,8 +8,7 @@ from allways.contract_client import AllwaysContractClient
 
 
 def confirm_swap(client: AllwaysContractClient, wallet: bt.Wallet, swap_id: int) -> bool:
-    """Vote to confirm a FULFILLED swap as COMPLETED."""
-    bt.logging.info(f'Confirming swap {swap_id}')
+    """Vote to confirm a FULFILLED swap as COMPLETED. Caller logs the outcome."""
     try:
         client.confirm_swap(wallet=wallet, swap_id=swap_id)
         return True
@@ -19,8 +18,7 @@ def confirm_swap(client: AllwaysContractClient, wallet: bt.Wallet, swap_id: int)
 
 
 def timeout_swap(client: AllwaysContractClient, wallet: bt.Wallet, swap_id: int) -> bool:
-    """Vote to time out a swap past its deadline."""
-    bt.logging.info(f'Timing out swap {swap_id}')
+    """Vote to time out a swap past its deadline. Caller logs the outcome."""
     try:
         client.timeout_swap(wallet=wallet, swap_id=swap_id)
         return True


### PR DESCRIPTION
## Summary

- **Logging:** thread an extend-reason through `try_extend_reservation` so `voted to extend reservation` lines now say *why* (`provider unreachable` / `tx_not_found N/M` / `unconfirmed N/M`); add per-swap info log when a swap appears as ACTIVE in the tracker and on ACTIVE→FULFILLED transitions; surface silent confirm/timeout vote-failures.
- **BTC fee UX:** `alw swap now --btc-fee-rate <sat/vB>` to override the lightweight wallet's fee rate; show the chosen rate in the swap summary; raise the network-aware floor to 5 sat/vB on mainnet (testnet stays at 2). Override skips estimate and floor — caller is taking explicit responsibility (e.g. CPFP / manual bump).

Context: a testnet swap stalled because Blockstream's 2/3/4-block estimate fell to 2 sat/vB and the mempool ignored it. Validator looped on extend votes with no reason in the logs, so the failure mode was invisible. Both gaps fixed here.

Extension cap (Lando is owning that follow-up) is intentionally out of scope.

## Test plan
- [x] `ruff check` clean on changed files
- [x] Full pytest suite (331 passed)
- [x] `alw swap now --help` shows the new flag
- [ ] Manual smoke: testnet swap with `--btc-fee-rate 10` confirms in 1-3 blocks
- [ ] Manual smoke: validator logs show `[unconfirmed N/M]` style reasons on extend votes during stuck-tx scenarios