### PR TITLE
fix(validator): only swallow recoverable transport errors in forward gather

### DIFF
--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Set
+from typing import TYPE_CHECKING, Set, Tuple, Type, Union
 
 import bittensor as bt
 
@@ -346,6 +346,34 @@ def purge_deregistered_hotkeys(self: Validator) -> None:
     self.last_known_rates = {k: v for k, v in self.last_known_rates.items() if k[0] not in stale}
 
 
+RECOVERABLE_VERIFY_EXCEPTIONS: Tuple[Type[BaseException], ...] = (
+    ProviderUnreachableError,
+    asyncio.TimeoutError,
+)
+
+
+async def _verify_swallowing_only_recoverable(
+    verifier: SwapVerifier,
+    swap,
+) -> Union[bool, ProviderUnreachableError, asyncio.TimeoutError]:
+    """Run ``verifier.verify_miner_fulfillment`` and convert recoverable
+    transport exceptions into return values. Programming errors
+    (``AttributeError``, ``KeyError``, ``TypeError``, …) and any other
+    unexpected exception types intentionally propagate so the forward
+    step fails loud instead of being silently logged as a generic
+    "verification error" forever (#178).
+
+    The previous shape — ``asyncio.gather(..., return_exceptions=True)``
+    paired with ``isinstance(result, Exception)`` — caught literally
+    every exception type and reduced them all to a logged warning,
+    which masked real bugs as flaky network conditions.
+    """
+    try:
+        return await verifier.verify_miner_fulfillment(swap)
+    except RECOVERABLE_VERIFY_EXCEPTIONS as exc:
+        return exc
+
+
 async def confirm_miner_fulfillments(
     self: Validator,
     tracker: SwapTracker,
@@ -359,17 +387,20 @@ async def confirm_miner_fulfillments(
     if not fulfilled:
         return uncertain
 
+    # Note: no `return_exceptions=True` — only the explicitly-recoverable
+    # exception types are caught (in the wrapper above) and returned as
+    # values; anything else propagates so it's not silently masked (#178).
     results = await asyncio.gather(
-        *[verifier.verify_miner_fulfillment(swap) for swap in fulfilled],
-        return_exceptions=True,
+        *[_verify_swallowing_only_recoverable(verifier, swap) for swap in fulfilled],
     )
     for swap, result in zip(fulfilled, results):
         if isinstance(result, ProviderUnreachableError):
             bt.logging.warning(f'Swap {swap.id}: provider unreachable, deferring verification')
             uncertain.add(swap.id)
             continue
-        if isinstance(result, Exception):
-            bt.logging.error(f'Swap {swap.id}: verification error: {result}')
+        if isinstance(result, asyncio.TimeoutError):
+            bt.logging.warning(f'Swap {swap.id}: verification timed out, deferring')
+            uncertain.add(swap.id)
             continue
         if result:
             if voting.confirm_swap(self.contract_client, self.wallet, swap.id):

--- a/tests/test_forward_verify_recoverable.py
+++ b/tests/test_forward_verify_recoverable.py
@@ -1,0 +1,119 @@
+"""Regression tests for the asyncio.gather error-handling tightening (#178).
+
+Previously ``confirm_miner_fulfillments`` used
+``asyncio.gather(..., return_exceptions=True)`` with a catch-all
+``isinstance(result, Exception)`` branch, so every exception — including
+typos, ``AttributeError``, ``KeyError`` — was reduced to a logged warning
+and the round kept going with silently-missing votes. Real bugs were
+masked as flaky network conditions for the lifetime of the deployment.
+
+These tests pin the new behavior:
+- recoverable transport exceptions (``ProviderUnreachableError``,
+  ``asyncio.TimeoutError``) are returned as values so the caller can
+  defer verification;
+- programming errors propagate out of the wrapper so the forward step
+  fails loud.
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from allways.chain_providers.base import ProviderUnreachableError
+from allways.validator.forward import (
+    RECOVERABLE_VERIFY_EXCEPTIONS,
+    _verify_swallowing_only_recoverable,
+)
+
+
+class _StubVerifier:
+    """Test double for SwapVerifier whose `verify_miner_fulfillment` is
+    parameterised by the supplied awaitable."""
+
+    def __init__(self, behavior):
+        self._behavior = behavior
+
+    async def verify_miner_fulfillment(self, swap):  # noqa: ARG002
+        return await self._behavior(swap)
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro) if False else asyncio.run(coro)
+
+
+class TestRecoverableVerifyExceptions:
+    def test_provider_unreachable_is_recoverable(self):
+        assert ProviderUnreachableError in RECOVERABLE_VERIFY_EXCEPTIONS
+
+    def test_timeout_is_recoverable(self):
+        assert asyncio.TimeoutError in RECOVERABLE_VERIFY_EXCEPTIONS
+
+    def test_programming_errors_are_not_recoverable(self):
+        # The whole point of #178: the catch-all `Exception` was the bug.
+        # Anything outside the explicit allow-list must propagate.
+        assert Exception not in RECOVERABLE_VERIFY_EXCEPTIONS
+        assert AttributeError not in RECOVERABLE_VERIFY_EXCEPTIONS
+        assert KeyError not in RECOVERABLE_VERIFY_EXCEPTIONS
+        assert TypeError not in RECOVERABLE_VERIFY_EXCEPTIONS
+        assert ValueError not in RECOVERABLE_VERIFY_EXCEPTIONS
+
+
+class TestVerifySwallowingOnlyRecoverable:
+    def test_passes_through_a_truthy_verification_result(self):
+        async def verify_returns_true(_swap):
+            return True
+
+        verifier = _StubVerifier(verify_returns_true)
+        result = _run(_verify_swallowing_only_recoverable(verifier, MagicMock()))
+        assert result is True
+
+    def test_passes_through_a_falsy_verification_result(self):
+        async def verify_returns_false(_swap):
+            return False
+
+        verifier = _StubVerifier(verify_returns_false)
+        result = _run(_verify_swallowing_only_recoverable(verifier, MagicMock()))
+        assert result is False
+
+    def test_provider_unreachable_is_returned_not_raised(self):
+        sentinel = ProviderUnreachableError('blockstream timeout')
+
+        async def verify_raises(_swap):
+            raise sentinel
+
+        verifier = _StubVerifier(verify_raises)
+        result = _run(_verify_swallowing_only_recoverable(verifier, MagicMock()))
+        assert result is sentinel
+
+    def test_asyncio_timeout_is_returned_not_raised(self):
+        async def verify_raises(_swap):
+            raise asyncio.TimeoutError()
+
+        verifier = _StubVerifier(verify_raises)
+        result = _run(_verify_swallowing_only_recoverable(verifier, MagicMock()))
+        assert isinstance(result, asyncio.TimeoutError)
+
+    def test_attribute_error_propagates_unmasked(self):
+        async def verify_raises(_swap):
+            raise AttributeError("Swap object has no attribute 'unknown_field'")
+
+        verifier = _StubVerifier(verify_raises)
+        with pytest.raises(AttributeError):
+            _run(_verify_swallowing_only_recoverable(verifier, MagicMock()))
+
+    def test_key_error_propagates_unmasked(self):
+        async def verify_raises(_swap):
+            raise KeyError('missing_key')
+
+        verifier = _StubVerifier(verify_raises)
+        with pytest.raises(KeyError):
+            _run(_verify_swallowing_only_recoverable(verifier, MagicMock()))
+
+    def test_type_error_propagates_unmasked(self):
+        async def verify_raises(_swap):
+            raise TypeError("int() argument must be str, not 'NoneType'")
+
+        verifier = _StubVerifier(verify_raises)
+        with pytest.raises(TypeError):
+            _run(_verify_swallowing_only_recoverable(verifier, MagicMock()))


### PR DESCRIPTION
```
Closes #178.

`confirm_miner_fulfillments` collected verifier results with
`asyncio.gather(..., return_exceptions=True)` and then matched
`isinstance(result, ProviderUnreachableError)` for the deferral case
and a catch-all `isinstance(result, Exception)` for everything else.
The catch-all reduced *every* exception type — including programming
errors like `AttributeError`, `KeyError`, `TypeError` and any future
typo in the verifier — to a logged "verification error" while the
forward loop kept running with silently-missing votes. Real bugs were
masked as flaky network conditions for the lifetime of the deployment.

## Fix

- Added `_verify_swallowing_only_recoverable(verifier, swap)`: an async
  wrapper that catches the explicit allow-list
  `ProviderUnreachableError` + `asyncio.TimeoutError` and converts them
  into return values, but lets every other exception propagate.
- `confirm_miner_fulfillments` now wraps each verifier call in this
  helper and uses plain `gather(...)` (no `return_exceptions=True`),
  so programming errors fail loud at the forward step boundary
  instead of being absorbed.
- Added explicit `asyncio.TimeoutError` handling in the result loop —
  previously this case was swept into the catch-all warning log; now
  it routes to the same "uncertain, defer" bucket as
  `ProviderUnreachableError`.
- Exposed `RECOVERABLE_VERIFY_EXCEPTIONS` and the helper at module
  level so the test suite can pin both the allow-list and the wrapper
  semantics directly.

## Tests

`tests/test_forward_verify_recoverable.py` adds 10 cases covering:
- the allow-list contents (`ProviderUnreachableError`,
  `asyncio.TimeoutError` are recoverable; `Exception`,
  `AttributeError`, `KeyError`, `TypeError`, `ValueError` are not);
- the wrapper passes True / False results through unchanged;
- recoverable exceptions are returned as values;
- programming errors (`AttributeError`, `KeyError`, `TypeError`)
  propagate unmasked.

`uv run pytest tests/` — 342 passed (10 new).
`uv run ruff check ...` — clean.

Closes #178
```