### PR TITLE
CLI: surface hotkey-funded note in collateral deposit summary

### DIFF
--- a/allways/cli/swap_commands/collateral.py
+++ b/allways/cli/swap_commands/collateral.py
@@ -49,7 +49,8 @@ def collateral_deposit(amount: float | None, yes: bool):
     console.print('\n[bold]Depositing Collateral[/bold]\n')
     console.print(f'  Amount:  [green]{amount} TAO[/green] ({amount_rao} rao)')
     console.print(f'  Wallet:  {wallet.name}')
-    console.print(f'  Hotkey:  {wallet.hotkey.ss58_address}\n')
+    console.print(f'  Hotkey:  {wallet.hotkey.ss58_address}')
+    console.print('  [dim]Funds are debited from the hotkey balance (not the coldkey).[/dim]\n')
 
     try:
         max_collateral_rao = client.get_max_collateral()


### PR DESCRIPTION
## Summary
- The hotkey-vs-coldkey clarification only appeared on the insufficient-balance error path. On the happy path, miners had no signal that the deposit pulls from their **hotkey** balance.
- Adds one dim line to the deposit summary so the source of funds is clear before the confirm prompt.

### Before
```
Depositing Collateral

  Amount:  1.0 TAO (1000000000 rao)
  Wallet:  bowser
  Hotkey:  5H4...

Confirm depositing collateral? [y/N]:
```

### After
```
Depositing Collateral

  Amount:  1.0 TAO (1000000000 rao)
  Wallet:  bowser
  Hotkey:  5H4...
  Funds are debited from the hotkey balance (not the coldkey).

Confirm depositing collateral? [y/N]:
```

## Test plan
- [ ] `alw collateral deposit --amount 1` shows the new hint above the confirm prompt
- [ ] Insufficient-balance path still works (existing detailed message unchanged)