### PR TITLE
miner: always cache coldkey password env var to stop mid-swap prompts

### DIFF
--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -70,22 +70,25 @@ class Miner(BaseMinerNeuron):
         bt.logging.info(f'Miner initialized: hotkey={self.wallet.hotkey.ss58_address} | addresses={self.my_addresses}')
 
     def unlock_coldkey(self) -> None:
-        """Cache the coldkey password into bittensor's per-keyfile env var so
-        every later ``unlock_coldkey()`` call is non-interactive. As of
-        bittensor 10.3.0, ``subtensor.transfer`` re-runs ``unlock_coldkey()``
-        on every extrinsic; without the env var, each transfer re-prompts and
-        a detached miner reads garbage from stdin, producing spurious
+        """Cache the coldkey password through bittensor's keyfile so every
+        later ``unlock_coldkey()`` call is non-interactive. As of bittensor
+        10.3.0, ``subtensor.transfer`` re-runs ``unlock_coldkey()`` on every
+        extrinsic; without a cached password, each transfer re-prompts and a
+        detached miner reads garbage from stdin, producing spurious
         "password invalid" errors mid-swap.
 
         Reads ``MINER_BITTENSOR_COLDKEY_PASSWORD`` if set, otherwise prompts
-        once at startup.
+        once at startup. Uses ``save_password_to_env`` (not direct
+        ``os.environ`` assignment) because bittensor-wallet 4.0.1 stores the
+        password via its own encoding — a plaintext value in the
+        ``BT_PW__...`` env var is rejected as malformed base64.
         """
         from getpass import getpass
 
         password = os.environ.get('MINER_BITTENSOR_COLDKEY_PASSWORD')
         if not password:
             password = getpass(f'Enter password to unlock coldkey ({self.wallet.name}): ')
-        os.environ[self.wallet.coldkey_file.env_var_name()] = password
+        self.wallet.coldkey_file.save_password_to_env(password)
         self.wallet.unlock_coldkey()
         bt.logging.info('Bittensor coldkey unlocked')
 

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -70,20 +70,22 @@ class Miner(BaseMinerNeuron):
         bt.logging.info(f'Miner initialized: hotkey={self.wallet.hotkey.ss58_address} | addresses={self.my_addresses}')
 
     def unlock_coldkey(self) -> None:
-        """Decrypt and cache the bittensor coldkey at startup so per-swap TAO
-        transfers don't re-prompt for a password each time. Without this, every
-        ``send_amount`` call hits ``wallet.coldkey`` which re-reads the keyfile;
-        when the miner runs detached from a TTY, ``getpass`` returns garbage
-        and every fulfillment fails with "password invalid".
+        """Cache the coldkey password into bittensor's per-keyfile env var so
+        every later ``unlock_coldkey()`` call is non-interactive. As of
+        bittensor 10.3.0, ``subtensor.transfer`` re-runs ``unlock_coldkey()``
+        on every extrinsic; without the env var, each transfer re-prompts and
+        a detached miner reads garbage from stdin, producing spurious
+        "password invalid" errors mid-swap.
 
-        If ``MINER_BITTENSOR_COLDKEY_PASSWORD`` is set in the environment, it
-        is forwarded into bittensor's per-keyfile env var so unlocking is
-        non-interactive. Otherwise this prompts once at startup (when the
-        operator is present).
+        Reads ``MINER_BITTENSOR_COLDKEY_PASSWORD`` if set, otherwise prompts
+        once at startup.
         """
+        from getpass import getpass
+
         password = os.environ.get('MINER_BITTENSOR_COLDKEY_PASSWORD')
-        if password:
-            os.environ[self.wallet.coldkey_file.env_var_name()] = password
+        if not password:
+            password = getpass(f'Enter password to unlock coldkey ({self.wallet.name}): ')
+        os.environ[self.wallet.coldkey_file.env_var_name()] = password
         self.wallet.unlock_coldkey()
         bt.logging.info('Bittensor coldkey unlocked')
 


### PR DESCRIPTION
## Summary

Bittensor 10.3.0 (#232) reroutes `subtensor.transfer` through `transfer_extrinsic` → `ExtrinsicResponse.unlock_wallet` → `unlock_key`, which calls `wallet.unlock_coldkey()` on every transfer. The startup unlock added in #227 only populated `BT_PW__...` when `MINER_BITTENSOR_COLDKEY_PASSWORD` was already in the env, so operators who entered the password interactively at launch hit a fresh `getpass` prompt mid-swap. On a detached miner, that prompt reads garbage from stdin and bittensor reports the password as invalid — even though the original was correct.

This commit always populates the per-keyfile env var after capturing the password (whether from `MINER_BITTENSOR_COLDKEY_PASSWORD` or interactive prompt), so every subsequent `unlock_coldkey()` call inside the transfer extrinsic decrypts non-interactively.

## Test plan

- [ ] Start miner without `MINER_BITTENSOR_COLDKEY_PASSWORD`, enter password at startup prompt, run a swap end-to-end — verify no mid-swap prompt and no "password invalid" error.
- [ ] Start miner with `MINER_BITTENSOR_COLDKEY_PASSWORD` set — verify no startup prompt and a swap completes.