### PR TITLE
CLI: validate netuid before int() in get_cli_context

### DIFF
--- a/allways/cli/main.py
+++ b/allways/cli/main.py
@@ -47,7 +47,13 @@ from rich.table import Table  # noqa: E402
 load_dotenv()
 
 from allways.cli.help import StyledAliasGroup, StyledGroup  # noqa: E402
-from allways.cli.swap_commands.helpers import ALLWAYS_DIR, CONFIG_FILE, apply_global_flags, console  # noqa: E402
+from allways.cli.swap_commands.helpers import (  # noqa: E402
+    ALLWAYS_DIR,
+    CONFIG_FILE,
+    apply_global_flags,
+    console,
+    parse_netuid,
+)
 
 # Restore original argv now that bittensor has been imported
 _sys.argv = _saved_argv
@@ -152,6 +158,11 @@ def config_set(key: str, value: str):
             if value == endpoint:
                 value = name
                 break
+
+    # Validate netuid here so a bad value never lands in the file (issue #236).
+    # Stored as int so later reads don't need to re-parse.
+    if key == 'netuid':
+        value = parse_netuid(value, source='netuid')
 
     old_value = config.get(key)
     config[key] = value

--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -114,6 +114,29 @@ def sign_or_prompt_external(
     return pasted
 
 
+def parse_netuid(value, source: str = 'netuid') -> int:
+    """Parse a netuid into a non-negative int, raising a clean Click error.
+
+    Without this guard, ``int('notanumber')`` deep inside ``get_cli_context``
+    surfaces as a Python traceback to the user (issue #236). ``isdigit()``
+    rejects empty strings, negatives (``-1``), and fractions (``1.5``) in one
+    check; bool is filtered up front because ``isinstance(True, int)`` is
+    ``True``. ``source`` names where the value came from for the error.
+    """
+    if isinstance(value, bool):
+        raise click.UsageError(f'{source} must be a non-negative integer (got {value!r})')
+    if isinstance(value, int):
+        if value < 0:
+            raise click.UsageError(f'{source} must be a non-negative integer (got {value})')
+        return value
+    if not isinstance(value, str):
+        raise click.UsageError(f'{source} must be a non-negative integer (got {value!r})')
+    stripped = value.strip()
+    if not stripped.isdigit():
+        raise click.UsageError(f'{source} must be a non-negative integer (got {value!r})')
+    return int(stripped)
+
+
 def is_valid_ss58(address: str) -> bool:
     """Check if a string is a syntactically valid SS58 address.
 
@@ -238,11 +261,14 @@ def get_cli_context(
             )
         contract_addr = config.get('contract-address') or config.get('contract_address') or DEFAULT_CONTRACT_ADDRESS
         client = AllwaysContractClient(contract_address=contract_addr, subtensor=subtensor) if need_client else None
-    # Ensure netuid is resolved for callers
+    # Ensure netuid is resolved for callers. Validate before int() so a
+    # bad value from --netuid or ~/.allways/config.json fails with a
+    # one-line UsageError instead of a Python traceback (issue #236).
     if 'netuid' not in config:
         config['netuid'] = NETUID_FINNEY
     else:
-        config['netuid'] = int(config['netuid'])
+        source = '--netuid' if 'netuid' in _CLI_OVERRIDES else 'netuid (from ~/.allways/config.json)'
+        config['netuid'] = parse_netuid(config['netuid'], source=source)
     return config, wallet, subtensor, client
 
 

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -1,0 +1,56 @@
+"""Tests for allways.cli.swap_commands.helpers."""
+
+import click
+import pytest
+
+from allways.cli.swap_commands.helpers import parse_netuid
+
+
+class TestParseNetuid:
+    def test_int_passthrough(self):
+        assert parse_netuid(7) == 7
+        assert parse_netuid(0) == 0
+
+    def test_str_digits(self):
+        assert parse_netuid('7') == 7
+        assert parse_netuid('0') == 0
+        assert parse_netuid('  42  ') == 42
+
+    def test_rejects_non_numeric_string(self):
+        with pytest.raises(click.UsageError, match='non-negative integer'):
+            parse_netuid('notanumber')
+
+    def test_rejects_empty_string(self):
+        with pytest.raises(click.UsageError, match='non-negative integer'):
+            parse_netuid('')
+        with pytest.raises(click.UsageError, match='non-negative integer'):
+            parse_netuid('   ')
+
+    def test_rejects_fractional_string(self):
+        with pytest.raises(click.UsageError, match='non-negative integer'):
+            parse_netuid('1.5')
+
+    def test_rejects_negative_string(self):
+        with pytest.raises(click.UsageError, match='non-negative integer'):
+            parse_netuid('-1')
+
+    def test_rejects_negative_int(self):
+        with pytest.raises(click.UsageError, match='non-negative integer'):
+            parse_netuid(-1)
+
+    def test_rejects_bool(self):
+        # bool is an int subclass — we don't want True/False quietly becoming 1/0.
+        with pytest.raises(click.UsageError, match='non-negative integer'):
+            parse_netuid(True)
+        with pytest.raises(click.UsageError, match='non-negative integer'):
+            parse_netuid(False)
+
+    def test_rejects_other_types(self):
+        with pytest.raises(click.UsageError, match='non-negative integer'):
+            parse_netuid(None)
+        with pytest.raises(click.UsageError, match='non-negative integer'):
+            parse_netuid(1.0)
+
+    def test_source_appears_in_error(self):
+        with pytest.raises(click.UsageError, match='--netuid'):
+            parse_netuid('bad', source='--netuid')


### PR DESCRIPTION
## Summary

`get_cli_context` ([helpers.py:241-245](https://github.com/entrius/allways/blob/test/allways/cli/swap_commands/helpers.py#L241-L245)) calls `int(config['netuid'])` on whatever string lands in the merged config. Any non-integer value — `--netuid notanumber`, a hand-edited `~/.allways/config.json`, or an `alw config set netuid x` typo — raises an uncaught `ValueError` and dumps a Python traceback to the user.

Adds a `parse_netuid()` helper that raises `click.UsageError` (Click renders a one-line `Error: ...` and exits non-zero) and wires it into both call sites:

- **`get_cli_context`** — validates before coercion. The error names the source so users know whether to fix `--netuid` or the config file.
- **`alw config set netuid`** — validates up front, so a bad value never lands in `~/.allways/config.json` in the first place. Stored as `int` so subsequent reads don't re-parse.

`isdigit()` collapses the four reject cases (empty, fractional, negative, non-numeric) into one check; `bool` is filtered up front because `isinstance(True, int)` is `True`.

### Before
```
$ alw view rates --netuid notanumber
Traceback (most recent call last):
  File ".../allways/cli/swap_commands/helpers.py", line 245, in get_cli_context
    config['netuid'] = int(config['netuid'])
ValueError: invalid literal for int() with base 10: 'notanumber'
```

### After
```
$ alw view rates --netuid notanumber
Usage: alw view rates [OPTIONS]
Error: --netuid must be a non-negative integer (got 'notanumber')

$ alw config set netuid 1.5
Usage: alw config set [OPTIONS] KEY VALUE
Error: netuid must be a non-negative integer (got '1.5')
```

Fixes #236. Orthogonal to #203 (the same layering for `network`).

## Test plan

- [x] `pytest tests/test_cli_helpers.py` — new file covers int passthrough, digit-string accept, and rejections for `notanumber` / empty / whitespace / `1.5` / `-1` / negative int / `bool` / `None` / `float`, plus that the `source` string surfaces in the error
- [ ] `pytest tests/` — full suite green
- [ ] `ruff check` + `ruff format` clean
- [ ] Smoke: `alw view rates --netuid notanumber` exits 2 with the one-line error, no traceback
- [ ] Smoke: `alw config set netuid 1.5` is rejected; the file is unchanged
- [ ] Smoke: `alw status` with a valid `--netuid 7` still works as before