### PR TITLE
CLI: sanitize ALW_DENDRITE_TIMEOUT (reject nan/inf/zero/negative)

### DIFF
--- a/allways/cli/dendrite_lite.py
+++ b/allways/cli/dendrite_lite.py
@@ -93,13 +93,28 @@ def broadcast_synapse(
 
 
 def resolve_dendrite_timeout(default: float) -> float:
-    """Honor ALW_DENDRITE_TIMEOUT as an override for slow chains (e.g. testnet)."""
+    """Honor ALW_DENDRITE_TIMEOUT as an override for slow chains (e.g. testnet).
+
+    Rejects ``nan``, ``inf``, and non-positive values so a typo in the env
+    var doesn't silently break dendrite calls (issue #240). ``float()`` alone
+    accepts all three, and the dendrite call would either hang on ``nan``,
+    bypass the override on ``inf``, or fail every send instantly on ``0``/
+    negative — none of which are useful, so we fall back to ``default``.
+    """
+    import math
     import os
 
     override = os.environ.get('ALW_DENDRITE_TIMEOUT')
     if not override:
         return default
     try:
-        return float(override)
+        value = float(override)
     except ValueError:
+        bt.logging.warning(f'ALW_DENDRITE_TIMEOUT={override!r} is not a number, using default {default}')
         return default
+    if not math.isfinite(value) or value <= 0:
+        bt.logging.warning(
+            f'ALW_DENDRITE_TIMEOUT={override!r} must be a finite positive float, using default {default}'
+        )
+        return default
+    return value

--- a/tests/test_dendrite_lite.py
+++ b/tests/test_dendrite_lite.py
@@ -1,0 +1,66 @@
+"""Tests for resolve_dendrite_timeout — env var sanitization (issue #240)."""
+
+import os
+
+import pytest
+
+from allways.cli.dendrite_lite import resolve_dendrite_timeout
+
+ENV_VAR = 'ALW_DENDRITE_TIMEOUT'
+
+
+@pytest.fixture(autouse=True)
+def isolate_env(monkeypatch):
+    monkeypatch.delenv(ENV_VAR, raising=False)
+
+
+class TestResolveDendriteTimeout:
+    def test_unset_returns_default(self):
+        assert resolve_dendrite_timeout(30.0) == 30.0
+
+    def test_empty_returns_default(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, '')
+        assert resolve_dendrite_timeout(30.0) == 30.0
+
+    def test_valid_float_overrides(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, '60')
+        assert resolve_dendrite_timeout(30.0) == 60.0
+
+    def test_valid_fractional_float_overrides(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, '12.5')
+        assert resolve_dendrite_timeout(30.0) == 12.5
+
+    def test_nan_falls_back_to_default(self, monkeypatch):
+        """The reproducer from issue #240."""
+        monkeypatch.setenv(ENV_VAR, 'nan')
+        assert resolve_dendrite_timeout(30.0) == 30.0
+
+    def test_inf_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, 'inf')
+        assert resolve_dendrite_timeout(30.0) == 30.0
+
+    def test_negative_inf_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, '-inf')
+        assert resolve_dendrite_timeout(30.0) == 30.0
+
+    def test_zero_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, '0')
+        assert resolve_dendrite_timeout(30.0) == 30.0
+
+    def test_negative_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, '-1')
+        assert resolve_dendrite_timeout(30.0) == 30.0
+
+    def test_non_numeric_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, 'foo')
+        assert resolve_dendrite_timeout(30.0) == 30.0
+
+    def test_whitespace_around_valid_value(self, monkeypatch):
+        """float() strips whitespace — make sure that path still works."""
+        monkeypatch.setenv(ENV_VAR, '  45  ')
+        assert resolve_dendrite_timeout(30.0) == 45.0
+
+    def test_default_propagates_on_fallback(self, monkeypatch):
+        """When falling back, the *caller's* default must be honored, not 30."""
+        monkeypatch.setenv(ENV_VAR, 'nan')
+        assert resolve_dendrite_timeout(7.5) == 7.5

--- a/tests/test_dendrite_lite.py
+++ b/tests/test_dendrite_lite.py
@@ -1,7 +1,5 @@
 """Tests for resolve_dendrite_timeout — env var sanitization (issue #240)."""
 
-import os
-
 import pytest
 
 from allways.cli.dendrite_lite import resolve_dendrite_timeout


### PR DESCRIPTION
## Summary

`resolve_dendrite_timeout` ([dendrite_lite.py:95-105](https://github.com/entrius/allways/blob/test/allways/cli/dendrite_lite.py#L95-L105)) returned `float(override)` directly, so `'nan'`, `'inf'`, `'0'`, and negative values slipped through to the dendrite call. None of those are useful overrides and each breaks differently:

- `nan` — `asyncio.wait_for` rejects `nan` deep inside the coroutine, surfacing as confusing "Operation cancelled" or hangs.
- `inf` / `-inf` — defeats the override's purpose; the CLI sits indefinitely on a dead validator.
- `0` / negative — every dendrite send times out instantly.

Add a `math.isfinite() and value > 0` guard, fall back to the caller's default, and emit `bt.logging.warning` so the operator knows their override was ignored. The existing `ValueError` fallback was silent — same warning treatment now, so a typo'd `ALW_DENDRITE_TIMEOUT=Inifity` is debuggable instead of mysteriously inert.

### Reproducer (from the issue)
```bash
$ uv run python -c "import os; os.environ['ALW_DENDRITE_TIMEOUT']='nan'; \
    from allways.cli.dendrite_lite import resolve_dendrite_timeout; \
    print(repr(resolve_dendrite_timeout(30)))"

# Before:  nan
# After:   30.0   (and a warning logged about the rejected value)
```

## Test plan

- [x] `pytest tests/test_dendrite_lite.py` — 12 tests covering: unset/empty env → default; integer / fractional / whitespace-padded values pass through; six bad-value cases (`nan`, `inf`, `-inf`, `0`, `-1`, `foo`) fall back; the *caller's* `default` is honored on fallback (not a hardcoded 30)
- [ ] `pytest tests/` — full suite green
- [ ] `ruff check` + `ruff format` clean
- [ ] Smoke: `ALW_DENDRITE_TIMEOUT=nan alw status` runs normally; warning in logs identifies the rejected value
- [ ] Smoke: `ALW_DENDRITE_TIMEOUT=60 alw swap quote ...` uses the 60s override (no warning)
- [ ] Smoke: `ALW_DENDRITE_TIMEOUT=0 alw status` does **not** instantly time out

Fixes #240.