### PR TITLE
CLI: route view active-swaps --status completed|timed_out to dashboard

### DIFF
--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -531,7 +531,7 @@ def view_rates(
     '--status',
     default=None,
     type=click.Choice(['active', 'fulfilled', 'completed', 'timed_out'], case_sensitive=False),
-    help='Filter by status (active, fulfilled, completed, timed_out)',
+    help='Filter by status (active, fulfilled, completed, timed_out — last two link to dashboard)',
 )
 def view_active_swaps(status: str):
     """View active swaps on the contract.
@@ -540,9 +540,23 @@ def view_active_swaps(status: str):
         $ alw view active-swaps
         $ alw view active-swaps --status active[/dim]
     """
-    _, _, _, client = get_cli_context(need_wallet=False)
-
     console.print('\n[bold]Active Swaps[/bold]\n')
+
+    # COMPLETED and TIMED_OUT swaps are pruned from on-chain storage on
+    # finalization (lib.rs:804, 861). Filtering get_active_swaps() by
+    # those statuses is mathematically guaranteed to return [], so the
+    # old code printed a misleading "No swaps found" no matter how many
+    # resolved swaps actually exist. Short-circuit with the same dashboard
+    # fallback view_swap uses (issue #246).
+    if status and status.lower() in ('completed', 'timed_out'):
+        dashboard_url = os.environ.get('ALLWAYS_DASHBOARD_URL', DEFAULT_DASHBOARD_URL).rstrip('/')
+        console.print(
+            '[green]Resolved swaps are pruned from on-chain storage.[/green]\n'
+            f'[dim]View history at:[/dim] {dashboard_url}'
+        )
+        return
+
+    _, _, _, client = get_cli_context(need_wallet=False)
 
     try:
         with loading('Reading swaps...'):

--- a/tests/test_view_active_swaps_resolved_hint.py
+++ b/tests/test_view_active_swaps_resolved_hint.py
@@ -1,0 +1,144 @@
+"""Tests for `alw view active-swaps --status completed|timed_out` (issue #246).
+
+Verifies the dashboard hint short-circuits before touching the contract,
+and that the queryable filters (active/fulfilled) still go through the
+normal get_active_swaps() path."""
+
+import pytest
+from click.testing import CliRunner
+
+from allways.cli.swap_commands.view import DEFAULT_DASHBOARD_URL, view_active_swaps
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def isolate_dashboard_env(monkeypatch):
+    monkeypatch.delenv('ALLWAYS_DASHBOARD_URL', raising=False)
+
+
+class TestResolvedHintShortCircuit:
+    def test_status_completed_prints_dashboard_hint_no_contract_call(self, runner, monkeypatch):
+        """The bug: get_active_swaps was called only to filter to []. The
+        fix: short-circuit to the dashboard hint before any RPC."""
+        called = {'get_cli_context': False}
+
+        def fail_if_called(*a, **kw):
+            called['get_cli_context'] = True
+            raise AssertionError('get_cli_context must NOT be called for completed/timed_out')
+
+        monkeypatch.setattr('allways.cli.swap_commands.view.get_cli_context', fail_if_called)
+
+        result = runner.invoke(view_active_swaps, ['--status', 'completed'])
+        assert result.exit_code == 0, result.output
+        assert called['get_cli_context'] is False
+        assert 'pruned from on-chain storage' in result.output
+        assert DEFAULT_DASHBOARD_URL in result.output
+        # The misleading "No swaps found" must NOT appear.
+        assert 'No swaps found' not in result.output
+
+    def test_status_timed_out_prints_dashboard_hint(self, runner, monkeypatch):
+        def fail_if_called(*a, **kw):
+            raise AssertionError('get_cli_context must NOT be called')
+
+        monkeypatch.setattr('allways.cli.swap_commands.view.get_cli_context', fail_if_called)
+
+        result = runner.invoke(view_active_swaps, ['--status', 'timed_out'])
+        assert result.exit_code == 0
+        assert 'pruned from on-chain storage' in result.output
+        assert 'No swaps found' not in result.output
+
+    def test_uppercase_status_still_routes_to_dashboard(self, runner, monkeypatch):
+        """case_sensitive=False on the Click choice — uppercase still hits."""
+
+        def fail_if_called(*a, **kw):
+            raise AssertionError('contract call leaked')
+
+        monkeypatch.setattr('allways.cli.swap_commands.view.get_cli_context', fail_if_called)
+
+        result = runner.invoke(view_active_swaps, ['--status', 'COMPLETED'])
+        assert result.exit_code == 0
+        assert 'pruned from on-chain storage' in result.output
+
+    def test_dashboard_url_env_override_honored(self, runner, monkeypatch):
+        monkeypatch.setattr('allways.cli.swap_commands.view.get_cli_context', lambda *a, **kw: None)
+        monkeypatch.setenv('ALLWAYS_DASHBOARD_URL', 'https://my.custom.dash/')
+
+        result = runner.invoke(view_active_swaps, ['--status', 'completed'])
+        assert 'https://my.custom.dash' in result.output
+        # Trailing slash should be stripped (matches view_swap behavior).
+        assert 'https://my.custom.dash/' not in result.output.replace(
+            'https://my.custom.dash/\n', 'https://my.custom.dash\n'
+        )
+
+
+class TestQueryableStatusesUnchanged:
+    """The active/fulfilled paths must still hit the contract. Only the
+    misleading completed/timed_out filters short-circuit."""
+
+    def test_status_active_still_calls_contract(self, runner, monkeypatch):
+        called = {'get_cli_context': False}
+
+        class FakeClient:
+            def get_active_swaps(self):
+                called['get_cli_context'] = True
+                return []  # empty is fine for this test
+
+        def fake_ctx(*a, **kw):
+            return None, None, None, FakeClient()
+
+        monkeypatch.setattr('allways.cli.swap_commands.view.get_cli_context', fake_ctx)
+
+        result = runner.invoke(view_active_swaps, ['--status', 'active'])
+        assert result.exit_code == 0
+        assert called['get_cli_context'] is True
+        # No dashboard hint for queryable statuses — that text is reserved
+        # for the resolved branch.
+        assert 'pruned from on-chain storage' not in result.output
+
+    def test_no_status_still_calls_contract(self, runner, monkeypatch):
+        called = {'get_cli_context': False}
+
+        class FakeClient:
+            def get_active_swaps(self):
+                called['get_cli_context'] = True
+                return []
+
+        def fake_ctx(*a, **kw):
+            return None, None, None, FakeClient()
+
+        monkeypatch.setattr('allways.cli.swap_commands.view.get_cli_context', fake_ctx)
+
+        result = runner.invoke(view_active_swaps, [])
+        assert result.exit_code == 0
+        assert called['get_cli_context'] is True
+        assert 'pruned from on-chain storage' not in result.output
+
+
+class TestChoiceListPreserved:
+    """The fix routes completed/timed_out via dashboard rather than dropping
+    them — keeps the user-facing surface area, just makes it honest."""
+
+    def test_invalid_status_rejected_by_click(self, runner):
+        result = runner.invoke(view_active_swaps, ['--status', 'bogus'])
+        assert result.exit_code != 0
+        assert 'Invalid value' in result.output or 'bogus' in result.output
+
+    def test_all_four_statuses_accepted_by_click(self, runner, monkeypatch):
+        """Click should accept all four; behavior diverges inside the function."""
+
+        class FakeClient:
+            def get_active_swaps(self):
+                return []
+
+        monkeypatch.setattr(
+            'allways.cli.swap_commands.view.get_cli_context',
+            lambda *a, **kw: (None, None, None, FakeClient()),
+        )
+
+        for status in ('active', 'fulfilled', 'completed', 'timed_out'):
+            result = runner.invoke(view_active_swaps, ['--status', status])
+            assert result.exit_code == 0, f'{status}: {result.output}'


### PR DESCRIPTION
## Summary

`view_active_swaps` ([view.py:529-565](https://github.com/entrius/allways/blob/test/allways/cli/swap_commands/view.py#L529-L565)) accepted `--status` values `[active, fulfilled, completed, timed_out]` via `click.Choice` and then filtered `get_active_swaps()` by them. But the contract removes `COMPLETED` / `TIMED_OUT` swaps from storage on finalization ([lib.rs:804](https://github.com/entrius/allways/blob/test/smart-contracts/ink/lib.rs#L804), [861](https://github.com/entrius/allways/blob/test/smart-contracts/ink/lib.rs#L861)), so filtering by either is mathematically guaranteed to return `[]`. The old code fetched anyway, printed a misleading `[yellow]No swaps found[/yellow]`, and exited — regardless of how many resolved swaps actually exist. False signal in a credibility-sensitive context (operators checking "did anything complete?").

`view_swap` (single-id path) already handles this correctly via [#66](https://github.com/entrius/allways/issues/66) — it falls back to a dashboard URL when `swap_id < next_id` but storage is empty ([view.py:704-710](https://github.com/entrius/allways/blob/test/allways/cli/swap_commands/view.py#L704-L710)). Apply the same fallback to the bulk-listing path: when `--status` is `completed` or `timed_out`, short-circuit to the dashboard hint without touching the contract.

The two queryable statuses (`active`, `fulfilled`) still go through `get_active_swaps()` unchanged.

### Before
```
$ alw view active-swaps --status completed

Active Swaps

No swaps found
```

### After
```
$ alw view active-swaps --status completed

Active Swaps

Resolved swaps are pruned from on-chain storage.
View history at: https://test.all-ways.io
```

`ALLWAYS_DASHBOARD_URL` env override is honored, matching `view_swap`.

## Test plan

- [x] `pytest tests/test_view_active_swaps_resolved_hint.py` — 8 tests covering: `--status completed` short-circuits without calling `get_cli_context`; same for `timed_out`; uppercase still routes to dashboard (Click `case_sensitive=False`); `ALLWAYS_DASHBOARD_URL` env override honored with trailing-slash strip; `--status active` and bare invocation still hit the contract; all four choices still accepted by Click; bogus status still rejected
- [ ] `pytest tests/` — full suite green
- [ ] `ruff check` + `ruff format` clean
- [ ] Smoke: `alw view active-swaps --status completed` prints the dashboard URL, no contract call
- [ ] Smoke: `alw view active-swaps --status active` still queries the contract as before

Fixes #246.