### PR TITLE
collateral deposit: shrink gas buffer to 0.02 TAO

### DIFF
--- a/allways/cli/swap_commands/collateral.py
+++ b/allways/cli/swap_commands/collateral.py
@@ -71,7 +71,9 @@ def collateral_deposit(amount: float | None, yes: bool):
         if free_balance < required:
             console.print(
                 f'[red]Insufficient hotkey balance. Free: {from_rao(free_balance):.4f} TAO, '
-                f'need: {from_rao(required):.4f} TAO (amount + tx fees).[/red]'
+                f'need: {from_rao(required):.4f} TAO '
+                f'(amount + {from_rao(MIN_BALANCE_FOR_TX_RAO):.2f} TAO gas buffer, pre-checked so the tx does not '
+                'fail on chain and waste fees).[/red]'
             )
             console.print('[dim]Collateral is posted from the hotkey, not the coldkey.[/dim]')
             console.print(

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -22,7 +22,9 @@ BTC_TO_SAT = 100_000_000
 RATE_PRECISION = 10**18
 
 # ─── Transaction Fees ────────────────────────────────────
-MIN_BALANCE_FOR_TX_RAO = 250_000_000  # 0.25 TAO minimum for extrinsic fees
+# Small headroom kept aside for extrinsic fees so a deposit doesn't burn gas
+# and revert. Real fees are sub-millitao; 0.02 TAO is conservative.
+MIN_BALANCE_FOR_TX_RAO = 20_000_000  # 0.02 TAO buffer for extrinsic fees
 # BTC fee floor (sat/vB). Catches the case where the upstream estimator
 # returns nonsense low. 5 is cheap enough to barely register on mainnet
 # and still clears testnet quickly, so a single floor covers both.


### PR DESCRIPTION
## Summary
- Drops `MIN_BALANCE_FOR_TX_RAO` from 0.25 TAO → 0.02 TAO. Real extrinsic fees are sub-millitao; the old buffer was rejecting deposits that would have comfortably gone through.
- Reworded the insufficient-balance error in `alw collateral deposit` so it explains we pre-check the gas buffer to avoid burning fees on a reverted tx.

## Test plan
- [ ] `alw collateral deposit --amount X` where `free = X + 0.02 TAO` succeeds (previously would have required `X + 0.25 TAO`).
- [ ] Error path: `free < amount + 0.02 TAO` prints the new wording.