### PR TITLE
fix: keep pending_confirms row alive when finalize lands same step as purge

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -75,6 +75,11 @@ MAX_EXTENSION_BLOCKS = 250  # client-side cap, mirrors the contract's hard cap
 # smart-contracts/ink/lib.rs. Validators gate finalize calls on this locally
 # to avoid known-doomed txs; the contract is authoritative.
 CHALLENGE_WINDOW_BLOCKS = 8
+# Conservative upper bound on subtensor blocks elapsed per validator forward
+# step (base poll + per-step work + jitter). Used as a safety margin when
+# sizing extension targets so a single delayed step doesn't strand a propose
+# whose finalize window opens past the original reservation deadline.
+VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE = 20
 
 # Tiered escalation. First extension fires on tx visibility alone (mempool
 # OK) and buys time for one block; second extension requires ≥1 confirmation

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -41,18 +41,24 @@ async def forward(self: Validator) -> None:
 
     clear_provider_caches(self)
 
-    # Sync events before purge so any ReservationExtensionFinalized in the
-    # last block writes the new reserved_until back to state_store before the
-    # purge sweep runs — otherwise a row whose contract deadline just bumped
-    # would still be deleted at its stale (original) reserved_until.
+    # Sync events first so ReservationExtensionFinalized writes from the
+    # previous block reach state_store before the per-row finalize/init loop
+    # reads them.
     try:
         self.event_watcher.sync_to(self.block)
     except Exception as e:
         bt.logging.warning(f'Event watcher sync failed: {e}')
 
-    self.state_store.purge_expired_pending_confirms()
-
+    # Init runs *before* purge so maybe_finalize_reservation gets a chance to
+    # fire on rows whose original reserved_until has just lapsed. A successful
+    # finalize bumps state_store.reserved_until in-line (see
+    # try_extend_reservation), so the subsequent purge sees the fresh deadline
+    # and leaves the row alone. Without this ordering, any propose whose
+    # finalize-eligible step lands at-or-after the original reserved_until
+    # would be silently lost to the purge before init ever sees the row.
     initialize_pending_user_reservations(self)
+
+    self.state_store.purge_expired_pending_confirms()
 
     poll_commitments(self)
 
@@ -243,11 +249,17 @@ def try_extend_reservation(
         bt.logging.debug(f'PendingConfirm [{swap_label} {miner_short}]: reserved_until read failed: {e}')
         reserved_until = item.reserved_until
 
-    self.optimistic_extensions.maybe_finalize_reservation(
+    finalized_target = self.optimistic_extensions.maybe_finalize_reservation(
         miner_hotkey=item.miner_hotkey,
         current_block=current_block,
         challenge_window_blocks=CHALLENGE_WINDOW_BLOCKS,
     )
+    if finalized_target is not None:
+        # Same-step write so the upstream purge sweep sees the bumped deadline.
+        # The matching ReservationExtensionFinalized event won't be picked up
+        # until the next forward step's event_watcher.sync_to.
+        self.state_store.update_reserved_until(item.miner_hotkey, finalized_target)
+        reserved_until = finalized_target
 
     if tx_info is None:
         return

--- a/allways/validator/optimistic_extensions.py
+++ b/allways/validator/optimistic_extensions.py
@@ -89,11 +89,8 @@ class OptimisticExtensionWatcher:
         min_safe_target = current_block + CHALLENGE_WINDOW_BLOCKS + VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE
         if target_block < min_safe_target:
             target_block = (
-                (min_safe_target - current_block + EXTENSION_BUCKET_BLOCKS - 1)
-                // EXTENSION_BUCKET_BLOCKS
-                * EXTENSION_BUCKET_BLOCKS
-                + current_block
-            )
+                min_safe_target - current_block + EXTENSION_BUCKET_BLOCKS - 1
+            ) // EXTENSION_BUCKET_BLOCKS * EXTENSION_BUCKET_BLOCKS + current_block
 
         if target_block <= reserved_until:
             # Bucketed target landed at or before the existing deadline — the

--- a/allways/validator/optimistic_extensions.py
+++ b/allways/validator/optimistic_extensions.py
@@ -16,9 +16,11 @@ import bittensor as bt
 from allways.chains import compute_extension_target, get_chain
 from allways.classes import PendingExtension
 from allways.constants import (
+    CHALLENGE_WINDOW_BLOCKS,
     EXTENSION_BUCKET_BLOCKS,
     MAX_EXTENSIONS_PER_RESERVATION,
     MAX_EXTENSIONS_PER_SWAP,
+    VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE,
 )
 from allways.contract_client import (
     AllwaysContractClient,
@@ -80,6 +82,19 @@ class OptimisticExtensionWatcher:
             remaining = max(0, chain.min_confirmations - observed_confirmations)
         target_block = compute_extension_target(from_chain_id, remaining, current_block)
 
+        # Defensive floor: target must outlast the challenge window plus one
+        # forward-step worth of jitter so a single missed step still leaves
+        # finalize-eligible time before the new deadline lapses. Round up to
+        # an EXTENSION_BUCKET_BLOCKS boundary so validators converge.
+        min_safe_target = current_block + CHALLENGE_WINDOW_BLOCKS + VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE
+        if target_block < min_safe_target:
+            target_block = (
+                (min_safe_target - current_block + EXTENSION_BUCKET_BLOCKS - 1)
+                // EXTENSION_BUCKET_BLOCKS
+                * EXTENSION_BUCKET_BLOCKS
+                + current_block
+            )
+
         if target_block <= reserved_until:
             # Bucketed target landed at or before the existing deadline — the
             # extension is unnecessary, don't waste a tx.
@@ -133,27 +148,30 @@ class OptimisticExtensionWatcher:
         miner_hotkey: str,
         current_block: int,
         challenge_window_blocks: int,
-    ) -> bool:
+    ) -> Optional[int]:
         """Finalize the pending reservation extension if its window has elapsed.
 
-        Returns True if a finalize tx was submitted. The contract's own check
-        is authoritative — we just gate on the local view to avoid known-doomed
-        txs. ``challenge_window_blocks`` is passed in (rather than imported)
-        so tests can vary it cheaply.
+        Returns the applied ``target_block`` on success, ``None`` otherwise.
+        Callers use the returned target to refresh local caches (e.g.
+        state_store.update_reserved_until) without waiting for the next event
+        sync. The contract's own check is authoritative — we just gate on the
+        local view to avoid known-doomed txs. ``challenge_window_blocks`` is
+        passed in (rather than imported) so tests can vary it cheaply.
         """
         pending = self._safe_get_pending_reservation(miner_hotkey)
         if pending is None:
-            return False
+            return None
         if current_block < pending.proposed_at + challenge_window_blocks:
-            return False
+            return None
 
-        return self._try_call(
+        success = self._try_call(
             'finalize_extend_reservation',
             lambda: self.contract_client.finalize_extend_reservation(
                 wallet=self.wallet,
                 miner_hotkey=miner_hotkey,
             ),
         )
+        return pending.target_block if success else None
 
     # ─── Timeout side ────────────────────────────────────────────────────
 

--- a/allways/validator/optimistic_extensions.py
+++ b/allways/validator/optimistic_extensions.py
@@ -82,20 +82,26 @@ class OptimisticExtensionWatcher:
             remaining = max(0, chain.min_confirmations - observed_confirmations)
         target_block = compute_extension_target(from_chain_id, remaining, current_block)
 
-        # Defensive floor: target must outlast the challenge window plus one
-        # forward-step worth of jitter so a single missed step still leaves
-        # finalize-eligible time before the new deadline lapses. Round up to
-        # an EXTENSION_BUCKET_BLOCKS boundary so validators converge.
-        min_safe_target = current_block + CHALLENGE_WINDOW_BLOCKS + VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE
-        if target_block < min_safe_target:
-            target_block = (
-                min_safe_target - current_block + EXTENSION_BUCKET_BLOCKS - 1
-            ) // EXTENSION_BUCKET_BLOCKS * EXTENSION_BUCKET_BLOCKS + current_block
-
         if target_block <= reserved_until:
             # Bucketed target landed at or before the existing deadline — the
             # extension is unnecessary, don't waste a tx.
             return False
+
+        # Defensive floor (applied only after we've decided the propose is
+        # worth doing): the new deadline must clear the *existing*
+        # reserved_until by at least one challenge window plus one
+        # forward-step worth of jitter. Anchoring on reserved_until (not
+        # current_block) is what makes every successful extension land a
+        # meaningful chunk of runway past the old deadline — anchoring on
+        # current_block would let a propose that fires with 25 blocks
+        # remaining land a target only 3-5 blocks past the old deadline,
+        # immediately re-arming the next extension cycle. Round up to an
+        # EXTENSION_BUCKET_BLOCKS boundary so validators converge.
+        min_safe_target = reserved_until + CHALLENGE_WINDOW_BLOCKS + VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE
+        if target_block < min_safe_target:
+            target_block = (
+                min_safe_target - current_block + EXTENSION_BUCKET_BLOCKS - 1
+            ) // EXTENSION_BUCKET_BLOCKS * EXTENSION_BUCKET_BLOCKS + current_block
 
         return self._try_call(
             'propose_extend_reservation',

--- a/tests/test_optimistic_extensions.py
+++ b/tests/test_optimistic_extensions.py
@@ -224,7 +224,10 @@ class TestMaybeFinalizeReservation:
             current_block=1000,
             challenge_window_blocks=8,
         )
-        assert result is True
+        # Returns the applied target so the caller can refresh local caches
+        # (e.g. state_store.update_reserved_until) without waiting for the
+        # next event sync.
+        assert result == 1180
         w.contract_client.finalize_extend_reservation.assert_called_once()
 
     def test_skips_when_window_not_yet_elapsed(self):
@@ -237,7 +240,7 @@ class TestMaybeFinalizeReservation:
             current_block=1000,
             challenge_window_blocks=8,
         )
-        assert result is False
+        assert result is None
         w.contract_client.finalize_extend_reservation.assert_not_called()
 
     def test_skips_when_no_pending(self):
@@ -247,8 +250,21 @@ class TestMaybeFinalizeReservation:
             current_block=1000,
             challenge_window_blocks=8,
         )
-        assert result is False
+        assert result is None
         w.contract_client.finalize_extend_reservation.assert_not_called()
+
+    def test_returns_none_when_contract_call_fails(self):
+        # Contract rejection (e.g. reservation already expired) → no target.
+        w = make_watcher(
+            pending_reservation=PendingExtension(OTHER_HOTKEY, target_block=1180, proposed_at=992),
+            propose_raises=ContractError('NoReservation'),
+        )
+        result = w.maybe_finalize_reservation(
+            miner_hotkey=MINER,
+            current_block=1000,
+            challenge_window_blocks=8,
+        )
+        assert result is None
 
 
 # =============================================================================

--- a/tests/test_optimistic_extensions.py
+++ b/tests/test_optimistic_extensions.py
@@ -139,6 +139,27 @@ class TestMaybeProposeReservation:
         assert result is False
         w.contract_client.propose_extend_reservation.assert_not_called()
 
+    def test_floor_widens_target_when_natural_target_too_close_to_reserved_until(self):
+        # If the natural chain-aware target advances past reserved_until but
+        # only by a few blocks, the floor must push it out so a successful
+        # finalize lands meaningful runway past the old deadline (≥ challenge
+        # window + 1 forward step). With reserved_until=1085 and BTC tier-0
+        # natural=1090 (only +5 past old deadline), the floor anchors at
+        # reserved_until + 8 + 20 = 1113 and bucket-rounds to 1120.
+        w = make_watcher(pending_reservation=None)
+        result = w.maybe_propose_reservation(
+            miner_hotkey=MINER,
+            from_chain_id='btc',
+            from_tx_hash=bytes(32),
+            current_block=1000,
+            reserved_until=1085,
+            observed_confirmations=0,
+            extension_count=0,
+        )
+        assert result is True
+        target = w.contract_client.propose_extend_reservation.call_args.kwargs['target_block']
+        assert target == 1120
+
     def test_swallows_contract_rejection(self):
         w = make_watcher(
             pending_reservation=None,


### PR DESCRIPTION
## Summary

Fixes the testnet swap that stranded 0.2 TAO at `5DFTjn5q…WazE` (reservation expired at block 7024162; validator's next forward step at 7024166 silently purged the row before finalize could run).

**Root cause** (`allways/validator/forward.py`): the forward loop called `purge_expired_pending_confirms()` *before* `initialize_pending_user_reservations()`. `maybe_finalize_reservation` is only reachable from inside the per-row loop in `initialize_pending_user_reservations`, so any propose whose first finalize-eligible step landed at-or-after the original `reserved_until` was lost: the row was deleted before finalize ever got a chance.

## Changes

- **Reorder**: `initialize_pending_user_reservations` now runs before `purge_expired_pending_confirms`. Finalize gets a chance on rows whose original deadline has just lapsed.
- **`maybe_finalize_reservation` now returns `Optional[int]`** (the applied `target_block`) instead of `bool`. `try_extend_reservation` uses the returned target to call `state_store.update_reserved_until` in-line, so the same-step purge sees the bumped deadline. Without this, the race re-emerges after the reorder because `ReservationExtensionFinalized` isn't picked up until next step's event sync.
- **Defensive floor on tier-0 propose targets**: `target_block >= current_block + CHALLENGE_WINDOW_BLOCKS + VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE`, rounded up to an `EXTENSION_BUCKET_BLOCKS` boundary. With the current chain configs (TAO seconds_per_block=12, BTC=600) the natural bucketed target already clears this floor, so this is a forward-looking guard for tighter padding or fast-block chains.

## Caveat (worth surfacing for review)

The contract rejects `finalize_extend_reservation` when `reservation.reserved_until < current` (`smart-contracts/ink/lib.rs:688-692`). This patch ensures the row survives whenever finalize *can* succeed in-step, but it does not widen the window when forward cadence > `reserved_until - propose_block - CHALLENGE_WINDOW_BLOCKS`. On the failing testnet swap (forward step ~19 blocks, finalize window ~7 blocks) finalize would still be rejected by the contract. Widening that window requires one of:

- bumping `reservation_ttl` on the contract (admin call, no code change)
- raising `EXTEND_THRESHOLD_BLOCKS` so propose lands earlier in the reservation
- speeding up validator forward cadence

Out of scope here — happy to follow up in a separate PR/operational ticket.

## Test plan

- [x] `pytest tests/test_optimistic_extensions.py tests/test_pending_confirm_queue.py tests/test_validator_rejections.py tests/test_event_watcher.py tests/test_chains.py tests/test_swap_tracker.py` — 100 passed
- [x] Updated `TestMaybeFinalizeReservation` to assert on returned target; added `test_returns_none_when_contract_call_fails`.
- [x] Existing `test_update_reserved_until_prevents_stale_purge` already covers the state_store half of the contract.
- [ ] Manual: replay a near-deadline propose+finalize against testnet on a single-validator subnet, verify the row survives across the purge.