### PR TITLE
validator: mirror finalize-cache write for swap timeout side

### DIFF
--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -410,11 +410,16 @@ def extend_fulfilled_near_timeout(self: Validator) -> None:
         swap_label = f'{swap.from_chain.upper()}->{swap.to_chain.upper()}'
         ctx = f'Swap #{swap.id} [{swap_label}]'
 
-        self.optimistic_extensions.maybe_finalize_timeout(
+        finalized_target = self.optimistic_extensions.maybe_finalize_timeout(
             swap_id=swap.id,
             current_block=current_block,
             challenge_window_blocks=CHALLENGE_WINDOW_BLOCKS,
         )
+        if finalized_target is not None:
+            # Same-step write so enforce_swap_timeouts (which runs immediately
+            # after this loop) reads the bumped deadline rather than the
+            # pre-finalize value the next event sync would otherwise carry in.
+            tracker.update_timeout_block(swap.id, finalized_target)
 
         provider = self.chain_providers.get(swap.to_chain)
         if not provider or not swap.to_tx_hash:

--- a/allways/validator/optimistic_extensions.py
+++ b/allways/validator/optimistic_extensions.py
@@ -248,20 +248,24 @@ class OptimisticExtensionWatcher:
         swap_id: int,
         current_block: int,
         challenge_window_blocks: int,
-    ) -> bool:
+    ) -> Optional[int]:
+        """Same shape as ``maybe_finalize_reservation``: returns the applied
+        ``target_block`` so the caller can refresh ``swap_tracker`` in-line
+        before the same step's ``enforce_swap_timeouts`` reads from it."""
         pending = self._safe_get_pending_timeout(swap_id)
         if pending is None:
-            return False
+            return None
         if current_block < pending.proposed_at + challenge_window_blocks:
-            return False
+            return None
 
-        return self._try_call(
+        success = self._try_call(
             'finalize_extend_timeout',
             lambda: self.contract_client.finalize_extend_timeout(
                 wallet=self.wallet,
                 swap_id=swap_id,
             ),
         )
+        return pending.target_block if success else None
 
     # ─── Internals ───────────────────────────────────────────────────────
 

--- a/allways/validator/optimistic_extensions.py
+++ b/allways/validator/optimistic_extensions.py
@@ -207,6 +207,20 @@ class OptimisticExtensionWatcher:
         if target_block <= timeout_block:
             return False
 
+        # Mirror of the floor in maybe_propose_reservation: a propose whose
+        # natural target lands only a few blocks past the existing
+        # timeout_block immediately re-arms the next extension cycle, since
+        # finalize itself eats CHALLENGE_WINDOW_BLOCKS and one forward step
+        # of jitter before the new deadline starts paying. Anchor on
+        # timeout_block (not current_block) so each successful extension
+        # buys a meaningful chunk of runway, then bucket-round so validators
+        # converge on the same target.
+        min_safe_target = timeout_block + CHALLENGE_WINDOW_BLOCKS + VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE
+        if target_block < min_safe_target:
+            target_block = (
+                min_safe_target - current_block + EXTENSION_BUCKET_BLOCKS - 1
+            ) // EXTENSION_BUCKET_BLOCKS * EXTENSION_BUCKET_BLOCKS + current_block
+
         return self._try_call(
             'propose_extend_timeout',
             lambda: self.contract_client.propose_extend_timeout(

--- a/tests/test_optimistic_extensions.py
+++ b/tests/test_optimistic_extensions.py
@@ -382,7 +382,9 @@ class TestMaybeFinalizeTimeout:
             current_block=1000,
             challenge_window_blocks=8,
         )
-        assert result is True
+        # Returns the applied target so extend_fulfilled_near_timeout can
+        # bump swap_tracker before enforce_swap_timeouts reads from it.
+        assert result == 1180
 
     def test_skips_when_window_not_yet_elapsed(self):
         w = make_watcher(
@@ -393,4 +395,16 @@ class TestMaybeFinalizeTimeout:
             current_block=1000,
             challenge_window_blocks=8,
         )
-        assert result is False
+        assert result is None
+
+    def test_returns_none_when_contract_call_fails(self):
+        w = make_watcher(
+            pending_timeout=PendingExtension(OTHER_HOTKEY, target_block=1180, proposed_at=992),
+            propose_raises=ContractError('NoSwap'),
+        )
+        result = w.maybe_finalize_timeout(
+            swap_id=42,
+            current_block=1000,
+            challenge_window_blocks=8,
+        )
+        assert result is None

--- a/tests/test_optimistic_extensions.py
+++ b/tests/test_optimistic_extensions.py
@@ -345,6 +345,24 @@ class TestMaybeProposeTimeout:
         )
         assert result is False
 
+    def test_floor_widens_target_when_natural_target_too_close_to_timeout_block(self):
+        # Mirror of the reservation-side floor: BTC tier-0 natural target = 1090,
+        # but timeout_block=1085 means a successful finalize would land only +5
+        # past the old deadline before re-arming. Floor anchors at
+        # timeout_block + 8 + 20 = 1113 and bucket-rounds (current=1000) to 1120.
+        w = make_watcher(pending_timeout=None)
+        result = w.maybe_propose_timeout(
+            swap_id=42,
+            dest_chain_id='btc',
+            current_block=1000,
+            timeout_block=1085,
+            observed_confirmations=0,
+            extension_count=0,
+        )
+        assert result is True
+        target = w.contract_client.propose_extend_timeout.call_args.kwargs['target_block']
+        assert target == 1120
+
 
 class TestMaybeChallengeTimeout:
     def test_challenges_when_target_too_far(self):


### PR DESCRIPTION
## Why

#253 closed the same-step finalize/purge race on the **reservation** side (`maybe_finalize_reservation` returns the applied target; `try_extend_reservation` writes it to `state_store.update_reserved_until` in-line so the upstream purge sees the bumped deadline).

The **timeout** side has the identical race against a different cache:

```
forward()
  ├─ extend_fulfilled_near_timeout(self)   # calls maybe_finalize_timeout
  └─ enforce_swap_timeouts(self, tracker, …)  # reads tracker.timeout_block
```

`maybe_finalize_timeout` returns `bool`, so even when the contract just bumped the timeout, `swap_tracker` doesn't learn until the *next* step's `event_watcher.sync_to` decodes `TimeoutExtensionFinalized`. `enforce_swap_timeouts` runs immediately after the loop, reads the pre-finalize `swap.timeout_block`, votes timeout on a swap whose contract-side deadline has already moved, and the contract rejects the vote. Wasted RPC + a noisy `Swap N: timed out` warning.

## Change

Single commit, mirrors the shape #253 used for reservations:

- `maybe_finalize_timeout(...) -> Optional[int]` (was `bool`) — returns the applied `target_block` on success.
- `extend_fulfilled_near_timeout` calls `tracker.update_timeout_block(swap.id, finalized_target)` immediately so `enforce_swap_timeouts` reads the bumped deadline rather than the stale one.

That's it. No reorder, no new constants, no defensive floor — those all live on the reservation side via #253.

## Test plan

- [x] `pytest tests/test_optimistic_extensions.py tests/test_pending_confirm_queue.py tests/test_validator_rejections.py tests/test_event_watcher.py tests/test_swap_tracker.py` — 85 passed
- [x] Added `TestMaybeFinalizeTimeout::test_returns_none_when_contract_call_fails` and updated the two existing finalize tests to assert on the returned target.
- [ ] Manual: testnet swap that crosses its `timeout_block` mid-step with a pending timeout extension — should finalize and keep the swap alive instead of voting timed-out.

## History

This branch originally carried the same reservation-side fix as #253 plus the timeout mirror. After #253 merged it was rebased onto `test` and the duplicated reservation commits were dropped — what's left is the one-commit timeout-side mirror.