### PR TITLE
validator: cut per-row pending-extension RPCs from 3→1 per forward step

### DIFF
--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -98,16 +98,16 @@ def initialize_pending_user_reservations(self: Validator) -> None:
         return
 
     current_block = self.block
+    # One {hotkey: uid} pass replaces an O(N) list scan per row when sizing
+    # up the per-row log prefix.
+    hotkey_to_uid = {hk: uid for uid, hk in enumerate(self.metagraph.hotkeys)}
 
     for item in items:
         swap_label = f'{item.from_chain.upper()}->{item.to_chain.upper()}'
-        try:
-            uid = self.metagraph.hotkeys.index(item.miner_hotkey)
-        except ValueError:
-            uid = '?'
+        uid = hotkey_to_uid.get(item.miner_hotkey, '?')
         miner_short = f'UID {uid} ({item.miner_hotkey[:8]})'
-        chain_def = self.chain_providers.get(item.from_chain)
-        min_confs = chain_def.get_chain().min_confirmations if chain_def else '?'
+        provider = self.chain_providers.get(item.from_chain)
+        min_confs = provider.get_chain().min_confirmations if provider else '?'
 
         try:
             if self.contract_client.get_miner_has_active_swap(item.miner_hotkey):
@@ -117,7 +117,6 @@ def initialize_pending_user_reservations(self: Validator) -> None:
         except Exception as e:
             bt.logging.warning(f'PendingConfirm [{swap_label} {miner_short}]: active swap check failed: {e}')
 
-        provider = self.chain_providers.get(item.from_chain)
         if provider is None:
             self.state_store.remove(item.miner_hotkey)
             bt.logging.warning(
@@ -249,10 +248,15 @@ def try_extend_reservation(
         bt.logging.debug(f'PendingConfirm [{swap_label} {miner_short}]: reserved_until read failed: {e}')
         reserved_until = item.reserved_until
 
+    # One pending-extension fetch shared across finalize/challenge/propose;
+    # used to be three separate RPCs per row per step.
+    pending = self.optimistic_extensions.fetch_pending_reservation(item.miner_hotkey)
+
     finalized_target = self.optimistic_extensions.maybe_finalize_reservation(
         miner_hotkey=item.miner_hotkey,
         current_block=current_block,
         challenge_window_blocks=CHALLENGE_WINDOW_BLOCKS,
+        pending=pending,
     )
     if finalized_target is not None:
         # Same-step write so the upstream purge sweep sees the bumped deadline.
@@ -260,6 +264,10 @@ def try_extend_reservation(
         # until the next forward step's event_watcher.sync_to.
         self.state_store.update_reserved_until(item.miner_hotkey, finalized_target)
         reserved_until = finalized_target
+        # The just-finalized proposal is gone from contract storage; refresh
+        # so downstream challenge/propose see the post-finalize state instead
+        # of a stale "still pending" snapshot.
+        pending = None
 
     if tx_info is None:
         return
@@ -277,6 +285,7 @@ def try_extend_reservation(
         from_chain_id=item.from_chain,
         observed_confirmations=tx_info.confirmations,
         current_block=current_block,
+        pending=pending,
     )
 
     try:
@@ -302,6 +311,7 @@ def try_extend_reservation(
         reserved_until=reserved_until,
         observed_confirmations=tx_info.confirmations,
         extension_count=extension_count,
+        pending=pending,
     )
     if proposed:
         bt.logging.info(
@@ -410,16 +420,22 @@ def extend_fulfilled_near_timeout(self: Validator) -> None:
         swap_label = f'{swap.from_chain.upper()}->{swap.to_chain.upper()}'
         ctx = f'Swap #{swap.id} [{swap_label}]'
 
+        # One pending-extension fetch shared across finalize/challenge/propose.
+        pending = self.optimistic_extensions.fetch_pending_timeout(swap.id)
+
         finalized_target = self.optimistic_extensions.maybe_finalize_timeout(
             swap_id=swap.id,
             current_block=current_block,
             challenge_window_blocks=CHALLENGE_WINDOW_BLOCKS,
+            pending=pending,
         )
         if finalized_target is not None:
             # Same-step write so enforce_swap_timeouts (which runs immediately
             # after this loop) reads the bumped deadline rather than the
             # pre-finalize value the next event sync would otherwise carry in.
             tracker.update_timeout_block(swap.id, finalized_target)
+            # Just-finalized proposal is gone from contract storage.
+            pending = None
 
         provider = self.chain_providers.get(swap.to_chain)
         if not provider or not swap.to_tx_hash:
@@ -458,6 +474,7 @@ def extend_fulfilled_near_timeout(self: Validator) -> None:
             dest_chain_id=swap.to_chain,
             observed_confirmations=tx_info.confirmations,
             current_block=current_block,
+            pending=pending,
         )
         proposed = self.optimistic_extensions.maybe_propose_timeout(
             swap_id=swap.id,
@@ -466,6 +483,7 @@ def extend_fulfilled_near_timeout(self: Validator) -> None:
             timeout_block=swap.timeout_block,
             observed_confirmations=tx_info.confirmations,
             extension_count=extension_count,
+            pending=pending,
         )
         if proposed:
             bt.logging.info(

--- a/allways/validator/optimistic_extensions.py
+++ b/allways/validator/optimistic_extensions.py
@@ -43,6 +43,19 @@ class OptimisticExtensionWatcher:
         self.contract_client = contract_client
         self.wallet = wallet
 
+    # ─── Pending-extension fetch helpers ─────────────────────────────────
+    #
+    # Callers (forward.py) fetch once per row and pass the result into the
+    # propose/challenge/finalize methods. Used to be three separate fetches
+    # per row from inside each method — that turned into N pending rows × 3
+    # RPCs per forward step, which dominated step latency on busy validators.
+
+    def fetch_pending_reservation(self, miner_hotkey: str) -> Optional[PendingExtension]:
+        return self._safe_get_pending_reservation(miner_hotkey)
+
+    def fetch_pending_timeout(self, swap_id: int) -> Optional[PendingExtension]:
+        return self._safe_get_pending_timeout(swap_id)
+
     # ─── Reservation side ────────────────────────────────────────────────
 
     def maybe_propose_reservation(
@@ -54,9 +67,15 @@ class OptimisticExtensionWatcher:
         reserved_until: int,
         observed_confirmations: int,
         extension_count: int,
+        pending: Optional[PendingExtension],
     ) -> bool:
         """Submit a propose_extend_reservation if no proposal is pending,
         tiered on ``extension_count``.
+
+        ``pending`` is the contract's current pending entry for this miner
+        (``None`` if no proposal is in-flight). Caller fetches once via
+        ``fetch_pending_reservation`` and passes the same value into all
+        three propose/challenge/finalize methods to avoid redundant RPCs.
 
         - Tier 0 (first extension): caller is responsible for ensuring the tx
           is visible (``tx_info != None``); target sized for one chain block.
@@ -69,8 +88,7 @@ class OptimisticExtensionWatcher:
         if extension_count >= MAX_EXTENSIONS_PER_RESERVATION:
             return False
 
-        existing = self._safe_get_pending_reservation(miner_hotkey)
-        if existing is not None:
+        if pending is not None:
             return False
 
         if extension_count == 0:
@@ -119,14 +137,15 @@ class OptimisticExtensionWatcher:
         from_chain_id: str,
         observed_confirmations: int,
         current_block: int,
+        pending: Optional[PendingExtension],
     ) -> bool:
         """Challenge the pending reservation extension if its target is too far.
 
         Tolerance is one bucket — proposals within EXTENSION_BUCKET_BLOCKS of
         the locally-computed target are accepted as benign rounding drift.
-        Skips proposals submitted by this validator's own wallet.
+        Skips proposals submitted by this validator's own wallet. ``pending``
+        is the caller-supplied snapshot — see ``maybe_propose_reservation``.
         """
-        pending = self._safe_get_pending_reservation(miner_hotkey)
         if pending is None:
             return False
         if self._is_own_proposal(pending):
@@ -151,17 +170,19 @@ class OptimisticExtensionWatcher:
         miner_hotkey: str,
         current_block: int,
         challenge_window_blocks: int,
+        pending: Optional[PendingExtension],
     ) -> Optional[int]:
         """Finalize the pending reservation extension if its window has elapsed.
 
         Returns the applied ``target_block`` on success, ``None`` otherwise.
         Callers use the returned target to refresh local caches (e.g.
         state_store.update_reserved_until) without waiting for the next event
-        sync. The contract's own check is authoritative — we just gate on the
-        local view to avoid known-doomed txs. ``challenge_window_blocks`` is
-        passed in (rather than imported) so tests can vary it cheaply.
+        sync. ``pending`` is the caller-supplied snapshot — see
+        ``maybe_propose_reservation``. The contract's own check is
+        authoritative; the local pending read just lets us avoid a
+        known-doomed tx. ``challenge_window_blocks`` is passed in (rather
+        than imported) so tests can vary it cheaply.
         """
-        pending = self._safe_get_pending_reservation(miner_hotkey)
         if pending is None:
             return None
         if current_block < pending.proposed_at + challenge_window_blocks:
@@ -186,13 +207,14 @@ class OptimisticExtensionWatcher:
         timeout_block: int,
         observed_confirmations: int,
         extension_count: int,
+        pending: Optional[PendingExtension],
     ) -> bool:
-        """Tiered timeout-extension propose. See ``maybe_propose_reservation``."""
+        """Tiered timeout-extension propose. See ``maybe_propose_reservation``
+        for the ``pending`` contract."""
         if extension_count >= MAX_EXTENSIONS_PER_SWAP:
             return False
 
-        existing = self._safe_get_pending_timeout(swap_id)
-        if existing is not None:
+        if pending is not None:
             return False
 
         if extension_count == 0:
@@ -236,8 +258,8 @@ class OptimisticExtensionWatcher:
         dest_chain_id: str,
         observed_confirmations: int,
         current_block: int,
+        pending: Optional[PendingExtension],
     ) -> bool:
-        pending = self._safe_get_pending_timeout(swap_id)
         if pending is None:
             return False
         if self._is_own_proposal(pending):
@@ -262,11 +284,13 @@ class OptimisticExtensionWatcher:
         swap_id: int,
         current_block: int,
         challenge_window_blocks: int,
+        pending: Optional[PendingExtension],
     ) -> Optional[int]:
         """Same shape as ``maybe_finalize_reservation``: returns the applied
         ``target_block`` so the caller can refresh ``swap_tracker`` in-line
-        before the same step's ``enforce_swap_timeouts`` reads from it."""
-        pending = self._safe_get_pending_timeout(swap_id)
+        before the same step's ``enforce_swap_timeouts`` reads from it.
+        ``pending`` is the caller-supplied snapshot — see
+        ``maybe_propose_reservation``."""
         if pending is None:
             return None
         if current_block < pending.proposed_at + challenge_window_blocks:

--- a/tests/test_optimistic_extensions.py
+++ b/tests/test_optimistic_extensions.py
@@ -2,7 +2,10 @@
 
 Mocks the contract_client + wallet — no chain, no on-chain state. Each test
 asserts on whether the wrapper called the right contract write (or stayed
-silent) given a specific input.
+silent) given a specific input. ``pending`` is now a caller-supplied
+parameter (forward.py fetches once per row instead of three times); each
+test resolves it via ``w.fetch_pending_reservation`` / ``fetch_pending_timeout``
+so the existing ``make_watcher(pending_*)`` mocks still drive the value.
 """
 
 from unittest.mock import MagicMock
@@ -57,6 +60,7 @@ class TestMaybeProposeReservation:
             reserved_until=1050,
             observed_confirmations=0,
             extension_count=0,
+            pending=w.fetch_pending_reservation(MINER),
         )
         assert result is True
         call_kwargs = w.contract_client.propose_extend_reservation.call_args.kwargs
@@ -75,6 +79,7 @@ class TestMaybeProposeReservation:
             reserved_until=1100,
             observed_confirmations=1,
             extension_count=1,
+            pending=w.fetch_pending_reservation(MINER),
         )
         assert result is True
         assert w.contract_client.propose_extend_reservation.call_args.kwargs['target_block'] == 1150
@@ -90,6 +95,7 @@ class TestMaybeProposeReservation:
             reserved_until=1100,
             observed_confirmations=0,
             extension_count=1,
+            pending=w.fetch_pending_reservation(MINER),
         )
         assert result is False
         w.contract_client.propose_extend_reservation.assert_not_called()
@@ -105,6 +111,7 @@ class TestMaybeProposeReservation:
             reserved_until=1100,
             observed_confirmations=1,
             extension_count=2,
+            pending=w.fetch_pending_reservation(MINER),
         )
         assert result is False
         w.contract_client.propose_extend_reservation.assert_not_called()
@@ -119,6 +126,7 @@ class TestMaybeProposeReservation:
             reserved_until=1100,
             observed_confirmations=0,
             extension_count=0,
+            pending=w.fetch_pending_reservation(MINER),
         )
         assert result is False
         w.contract_client.propose_extend_reservation.assert_not_called()
@@ -135,6 +143,7 @@ class TestMaybeProposeReservation:
             reserved_until=1100,
             observed_confirmations=0,
             extension_count=0,
+            pending=w.fetch_pending_reservation(MINER),
         )
         assert result is False
         w.contract_client.propose_extend_reservation.assert_not_called()
@@ -155,6 +164,7 @@ class TestMaybeProposeReservation:
             reserved_until=1085,
             observed_confirmations=0,
             extension_count=0,
+            pending=w.fetch_pending_reservation(MINER),
         )
         assert result is True
         target = w.contract_client.propose_extend_reservation.call_args.kwargs['target_block']
@@ -173,6 +183,7 @@ class TestMaybeProposeReservation:
             reserved_until=1050,
             observed_confirmations=0,
             extension_count=0,
+            pending=w.fetch_pending_reservation(MINER),
         )
         assert result is False  # rejection means we didn't successfully propose
 
@@ -189,6 +200,7 @@ class TestMaybeChallengeReservation:
             from_chain_id='btc',
             observed_confirmations=1,
             current_block=1000,
+            pending=w.fetch_pending_reservation(MINER),
         )
         assert result is True
         w.contract_client.challenge_extend_reservation.assert_called_once()
@@ -204,6 +216,7 @@ class TestMaybeChallengeReservation:
             from_chain_id='btc',
             observed_confirmations=1,
             current_block=1000,
+            pending=w.fetch_pending_reservation(MINER),
         )
         assert result is False
         w.contract_client.challenge_extend_reservation.assert_not_called()
@@ -215,6 +228,7 @@ class TestMaybeChallengeReservation:
             from_chain_id='btc',
             observed_confirmations=1,
             current_block=1000,
+            pending=w.fetch_pending_reservation(MINER),
         )
         assert result is False
         w.contract_client.challenge_extend_reservation.assert_not_called()
@@ -229,6 +243,7 @@ class TestMaybeChallengeReservation:
             from_chain_id='btc',
             observed_confirmations=1,
             current_block=1000,
+            pending=w.fetch_pending_reservation(MINER),
         )
         assert result is False
         w.contract_client.challenge_extend_reservation.assert_not_called()
@@ -244,6 +259,7 @@ class TestMaybeFinalizeReservation:
             miner_hotkey=MINER,
             current_block=1000,
             challenge_window_blocks=8,
+            pending=w.fetch_pending_reservation(MINER),
         )
         # Returns the applied target so the caller can refresh local caches
         # (e.g. state_store.update_reserved_until) without waiting for the
@@ -260,6 +276,7 @@ class TestMaybeFinalizeReservation:
             miner_hotkey=MINER,
             current_block=1000,
             challenge_window_blocks=8,
+            pending=w.fetch_pending_reservation(MINER),
         )
         assert result is None
         w.contract_client.finalize_extend_reservation.assert_not_called()
@@ -270,6 +287,7 @@ class TestMaybeFinalizeReservation:
             miner_hotkey=MINER,
             current_block=1000,
             challenge_window_blocks=8,
+            pending=w.fetch_pending_reservation(MINER),
         )
         assert result is None
         w.contract_client.finalize_extend_reservation.assert_not_called()
@@ -284,8 +302,27 @@ class TestMaybeFinalizeReservation:
             miner_hotkey=MINER,
             current_block=1000,
             challenge_window_blocks=8,
+            pending=w.fetch_pending_reservation(MINER),
         )
         assert result is None
+
+
+class TestFetchPendingReservation:
+    def test_returns_pending_when_cc_has_one(self):
+        pending = PendingExtension(OTHER_HOTKEY, 1180, 990)
+        w = make_watcher(pending_reservation=pending)
+        assert w.fetch_pending_reservation(MINER) is pending
+
+    def test_returns_none_when_cc_has_none(self):
+        w = make_watcher(pending_reservation=None)
+        assert w.fetch_pending_reservation(MINER) is None
+
+    def test_swallows_cc_exception(self):
+        # Forward loop should never see an exception bubble up — a transient
+        # RPC failure means "no pending I can act on this step", same as None.
+        w = make_watcher(pending_reservation=None)
+        w.contract_client.get_pending_reservation_extension.side_effect = RuntimeError('rpc flake')
+        assert w.fetch_pending_reservation(MINER) is None
 
 
 # =============================================================================
@@ -303,6 +340,7 @@ class TestMaybeProposeTimeout:
             timeout_block=1050,
             observed_confirmations=0,
             extension_count=0,
+            pending=w.fetch_pending_timeout(42),
         )
         assert result is True
         kwargs = w.contract_client.propose_extend_timeout.call_args.kwargs
@@ -318,6 +356,7 @@ class TestMaybeProposeTimeout:
             timeout_block=1100,
             observed_confirmations=0,
             extension_count=1,
+            pending=w.fetch_pending_timeout(42),
         )
         assert result is False
 
@@ -330,6 +369,7 @@ class TestMaybeProposeTimeout:
             timeout_block=1100,
             observed_confirmations=1,
             extension_count=2,
+            pending=w.fetch_pending_timeout(42),
         )
         assert result is False
 
@@ -342,6 +382,7 @@ class TestMaybeProposeTimeout:
             timeout_block=1050,
             observed_confirmations=0,
             extension_count=0,
+            pending=w.fetch_pending_timeout(42),
         )
         assert result is False
 
@@ -358,6 +399,7 @@ class TestMaybeProposeTimeout:
             timeout_block=1085,
             observed_confirmations=0,
             extension_count=0,
+            pending=w.fetch_pending_timeout(42),
         )
         assert result is True
         target = w.contract_client.propose_extend_timeout.call_args.kwargs['target_block']
@@ -374,6 +416,7 @@ class TestMaybeChallengeTimeout:
             dest_chain_id='btc',
             observed_confirmations=1,
             current_block=1000,
+            pending=w.fetch_pending_timeout(42),
         )
         assert result is True
 
@@ -386,6 +429,7 @@ class TestMaybeChallengeTimeout:
             dest_chain_id='btc',
             observed_confirmations=1,
             current_block=1000,
+            pending=w.fetch_pending_timeout(42),
         )
         assert result is False
 
@@ -399,6 +443,7 @@ class TestMaybeFinalizeTimeout:
             swap_id=42,
             current_block=1000,
             challenge_window_blocks=8,
+            pending=w.fetch_pending_timeout(42),
         )
         # Returns the applied target so extend_fulfilled_near_timeout can
         # bump swap_tracker before enforce_swap_timeouts reads from it.
@@ -412,6 +457,7 @@ class TestMaybeFinalizeTimeout:
             swap_id=42,
             current_block=1000,
             challenge_window_blocks=8,
+            pending=w.fetch_pending_timeout(42),
         )
         assert result is None
 
@@ -424,5 +470,22 @@ class TestMaybeFinalizeTimeout:
             swap_id=42,
             current_block=1000,
             challenge_window_blocks=8,
+            pending=w.fetch_pending_timeout(42),
         )
         assert result is None
+
+
+class TestFetchPendingTimeout:
+    def test_returns_pending_when_cc_has_one(self):
+        pending = PendingExtension(OTHER_HOTKEY, 1180, 990)
+        w = make_watcher(pending_timeout=pending)
+        assert w.fetch_pending_timeout(42) is pending
+
+    def test_returns_none_when_cc_has_none(self):
+        w = make_watcher(pending_timeout=None)
+        assert w.fetch_pending_timeout(42) is None
+
+    def test_swallows_cc_exception(self):
+        w = make_watcher(pending_timeout=None)
+        w.contract_client.get_pending_timeout_extension.side_effect = RuntimeError('rpc flake')
+        assert w.fetch_pending_timeout(42) is None


### PR DESCRIPTION
## Why

Forward-loop hot path was issuing **3 RPCs per pending row per step** for the same piece of contract state, on both the reservation side and the timeout side. That's 6 redundant RPCs per row per step at the surface; with N pending rows and M validators it scales to 2N pointless RPCs every 12s. This is the path that grows with volume — exactly the "200 blocks per forward step" failure mode you flagged.

### Reservation side, before

```
try_extend_reservation(item):
    maybe_finalize_reservation(...)    # → _safe_get_pending_reservation(miner_hotkey)  ← RPC #1
    maybe_challenge_reservation(...)   # → _safe_get_pending_reservation(miner_hotkey)  ← RPC #2
    maybe_propose_reservation(...)     # → _safe_get_pending_reservation(miner_hotkey)  ← RPC #3
```

Same shape in `extend_fulfilled_near_timeout` for `get_pending_timeout_extension`.

### Reservation side, after

```
try_extend_reservation(item):
    pending = optimistic_extensions.fetch_pending_reservation(item.miner_hotkey)   # ← only RPC
    maybe_finalize_reservation(..., pending=pending)
    # if finalize succeeded, refresh pending=None (the proposal is gone)
    maybe_challenge_reservation(..., pending=pending)
    maybe_propose_reservation(..., pending=pending)
```

Methods stay stateless. Callers own the fetch.

## Changes

- **`OptimisticExtensionWatcher`** (`allways/validator/optimistic_extensions.py`)
  - New `fetch_pending_reservation(miner_hotkey)` / `fetch_pending_timeout(swap_id)` public helpers — single source of truth for the swallow-on-error fetch.
  - `pending: Optional[PendingExtension]` is now an explicit kwarg on all 6 `maybe_propose_*` / `maybe_challenge_*` / `maybe_finalize_*` methods. Internal `_safe_get_pending_*` calls removed from those methods.
- **`forward.py`**
  - `try_extend_reservation` fetches `pending` once, passes it into all three methods, refreshes to `None` after a successful finalize (the proposal is gone from contract storage; passing the stale value would have downstream challenge/propose make wrong decisions).
  - `extend_fulfilled_near_timeout` does the same for the timeout side.
  - `initialize_pending_user_reservations`: build a `{hotkey: uid}` dict once instead of `metagraph.hotkeys.index(...)` per row, reuse the single `chain_providers.get(item.from_chain)` ref.
- **Tests** — each call now passes `pending=w.fetch_pending_reservation(MINER)` (or timeout sibling) explicitly. New `TestFetchPendingReservation` / `TestFetchPendingTimeout` cover the helpers directly, including the swallow-on-cc-exception path.

## RPC accounting

Per pending row per forward step:

|  | Before | After | Δ |
|---|---|---|---|
| `get_pending_reservation_extension` | 3 | 1 | −2 |
| `get_pending_timeout_extension` (per fulfilled swap near deadline) | 3 | 1 | −2 |
| `metagraph.hotkeys.index` | O(N) per row | O(1) per row | dict lookup |
| `chain_providers.get` | 2 | 1 | −1 |

Per-row reads that stay (different keys / different lifetimes, not dedup candidates): `get_miner_reserved_until`, `get_reservation_extension_count`, `get_miner_has_active_swap`, `provider.verify_transaction`.

## Test plan

- [x] `pytest tests/test_optimistic_extensions.py` — 31 passed (24 existing + 7 new for `fetch_pending_*`)
- [x] `pytest tests/` — 386 passed
- [x] `ruff check` + `ruff format --check` — clean
- [ ] Manual: testnet forward-step latency before/after under multi-row load.

## Stacking

Built on top of #254 (`feat/extension-finalize-cache-symmetry`) so `maybe_finalize_timeout → Optional[int]` is in scope. Order to merge: #254, then this. After both land, the only items left from the optimization rec list are the medium-impact ones (`check_registered` epoch gate, `refresh_miner_rates` throttle, `prune_old_events` throttle) — those want their own PR with cadence measurements rather than ride along here.
