### PR TITLE
validator: forward-loop redundancies (epoch-gate registration, throttle prune, in-memory busy, cache source verify)

### DIFF
--- a/allways/validator/chain_verification.py
+++ b/allways/validator/chain_verification.py
@@ -1,7 +1,7 @@
 """Verifies both sides of a swap using chain providers and on-chain swap data."""
 
 import asyncio
-from typing import Dict
+from typing import Dict, Set
 
 import bittensor as bt
 
@@ -25,6 +25,7 @@ class SwapVerifier:
         self.providers = chain_providers
         self.fee_divisor = fee_divisor
         self.last_logged_confs: Dict[str, int] = {}  # swap_id:chain -> confs
+        self.source_verified_ids: Set[int] = set()  # source tx is final once confirmed
 
     def verify_tx(
         self,
@@ -117,17 +118,22 @@ class SwapVerifier:
             )
             return False
 
-        # Verify sequentially — parallel threads cause WebSocket contention
-        # with the API server thread sharing the same substrate connection
-        source_ok = await asyncio.to_thread(
-            self.verify_tx,
-            swap,
-            swap.from_chain,
-            swap.from_tx_hash,
-            swap.miner_from_address,
-            swap.from_amount,
-            swap.from_tx_block,
-        )
+        # Sequential — parallel threads contend on the shared substrate WS.
+        if swap.id in self.source_verified_ids:
+            source_ok = True
+        else:
+            source_ok = await asyncio.to_thread(
+                self.verify_tx,
+                swap,
+                swap.from_chain,
+                swap.from_tx_hash,
+                swap.miner_from_address,
+                swap.from_amount,
+                swap.from_tx_block,
+            )
+            if source_ok:
+                self.source_verified_ids.add(swap.id)
+
         dest_ok = await asyncio.to_thread(
             self.verify_tx,
             swap,

--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -195,6 +195,7 @@ class ActiveEvent:
 
 
 MAX_BLOCKS_PER_SYNC = 50
+EVENT_PRUNE_INTERVAL_BLOCKS = 100  # O(events) sweep; window much wider than per-step delta.
 
 
 class ContractEventWatcher:
@@ -217,6 +218,7 @@ class ContractEventWatcher:
         self.swap_tracker = swap_tracker
         self.registry = load_event_registry(metadata_path)
         self.cursor: int = 0
+        self.last_prune_block: int = 0
 
         self.active_miners: Set[str] = set()
         self.open_swap_count: Dict[str, int] = {}
@@ -325,7 +327,9 @@ class ContractEventWatcher:
         for block_num in range(self.cursor + 1, end + 1):
             self.process_block(block_num)
         self.cursor = end
-        self.prune_old_events(current_block)
+        if current_block - self.last_prune_block >= EVENT_PRUNE_INTERVAL_BLOCKS:
+            self.prune_old_events(current_block)
+            self.last_prune_block = current_block
 
     def process_block(self, block_num: int) -> None:
         try:

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -109,13 +109,15 @@ def initialize_pending_user_reservations(self: Validator) -> None:
         provider = self.chain_providers.get(item.from_chain)
         min_confs = provider.get_chain().min_confirmations if provider else '?'
 
-        try:
-            if self.contract_client.get_miner_has_active_swap(item.miner_hotkey):
-                self.state_store.remove(item.miner_hotkey)
-                bt.logging.info(f'PendingConfirm [{swap_label} {miner_short}]: already has active swap, dropping')
-                continue
-        except Exception as e:
-            bt.logging.warning(f'PendingConfirm [{swap_label} {miner_short}]: active swap check failed: {e}')
+        # In-memory fast path; only verify with contract before dropping (watcher could be stale).
+        if self.event_watcher.open_swap_count.get(item.miner_hotkey, 0) > 0:
+            try:
+                if self.contract_client.get_miner_has_active_swap(item.miner_hotkey):
+                    self.state_store.remove(item.miner_hotkey)
+                    bt.logging.info(f'PendingConfirm [{swap_label} {miner_short}]: already has active swap, dropping')
+                    continue
+            except Exception as e:
+                bt.logging.warning(f'PendingConfirm [{swap_label} {miner_short}]: active swap check failed: {e}')
 
         if provider is None:
             self.state_store.remove(item.miner_hotkey)

--- a/neurons/base/neuron.py
+++ b/neurons/base/neuron.py
@@ -86,9 +86,9 @@ class BaseNeuron(ABC):
 
     def sync(self):
         """Wrapper for synchronizing the state of the network for the given miner or validator."""
-        self.check_registered()
-
+        # Registration only changes at epoch boundaries; cold-start covered by __init__.
         if self.should_sync_metagraph():
+            self.check_registered()
             self.resync_metagraph()
 
         if self.should_set_weights():


### PR DESCRIPTION
## What

Four independent forward-loop optimizations, each a single commit. Built on top of #255.

```
7217738 validator: gate check_registered behind should_sync_metagraph
8d77fe1 validator: throttle event_watcher.prune_old_events to every 100 blocks
02304d0 validator: gate has-active-swap RPC behind in-memory busy counter
7363690 validator: cache source-tx verification per swap_id
```

## Per-step impact

| Hot-path call | Before | After |
|---|---|---|
| `is_hotkey_registered` | 1/step | 1/epoch |
| `prune_old_events` walk | 1/step | 1/100 blocks |
| `get_miner_has_active_swap` per pending row | 1 | 0 in steady state, 1 only when watcher reports busy |
| Source-tx verify per FULFILLED swap | 1+/step | 1 lifetime, then cached |

## Correctness notes

**Commit 3** uses the in-memory `event_watcher.open_swap_count` as a fast path but still verifies with the contract before dropping a pending row. The watcher can lag the chain after a `sync_to` failure; dropping a `pending_confirms` row on a stale "busy" report would burn the user's reserved TAO. The contract verify is only paid when the watcher reports busy (rare in steady state).

**Commit 4**'s `source_verified_ids` set grows by one entry per FULFILLED swap. No eviction — the source tx is final once confirmed, so the cache is correct for the lifetime of the validator process. Memory is bounded by total swap count (negligible at any realistic scale).

## Held back from this PR

- **Tier 2 #4** (parallelize `event_watcher.sync_to`) — biggest single latency win for high-block-lag steps; deferred per "don't want to break anything."
- **Tier 2 #6** (`refresh_miner_rates` throttle) — needs measurement against scoring accuracy.

## Test plan

- [x] `pytest tests/` — 387 passed
- [x] `ruff check` + `ruff format --check` — clean
- [ ] Manual: testnet step-duration before/after under multi-row load.