### PR TITLE
validator: fire propose/challenge extension extrinsics async

### DIFF
--- a/allways/contract_client.py
+++ b/allways/contract_client.py
@@ -513,8 +513,18 @@ class AllwaysContractClient:
         keypair: Optional[Keypair] = None,
         value: int = 0,
         gas_limit: dict = None,
+        wait_for_inclusion: bool = True,
     ) -> str:
-        """Execute a contract method via raw extrinsic submission. Returns tx hash."""
+        """Execute a contract method via raw extrinsic submission. Returns tx hash.
+
+        ``wait_for_inclusion=False`` returns immediately after submission and
+        skips the receipt-success check, so contract reverts can't be detected
+        in-band. Use only for idempotent calls whose dedup is contract-side
+        (e.g. propose/challenge extension flows that the contract rejects via
+        ProposalAlreadyPending / ChallengeWindow* if our local snapshot is
+        stale). The forward step gets back a step-time worth of latency that
+        a synchronous inclusion wait would otherwise burn.
+        """
         gas_limit = gas_limit or DEFAULT_GAS_LIMIT
         selector = CONTRACT_SELECTORS.get(method)
         if not selector:
@@ -547,12 +557,18 @@ class AllwaysContractClient:
                 },
             )
             extrinsic = s.create_signed_extrinsic(call=call, keypair=keypair)
-            return s.submit_extrinsic(extrinsic, wait_for_inclusion=True, wait_for_finalization=False)
+            return s.submit_extrinsic(extrinsic, wait_for_inclusion=wait_for_inclusion, wait_for_finalization=False)
 
         try:
             receipt = self.substrate_call(submit_extrinsic)
         except Exception as e:
             raise ContractError(f'{method}: exec failed: {e}') from e
+
+        if not wait_for_inclusion:
+            # No block to inspect; trust the submission and let the next event
+            # sync surface the actual outcome. Caller relies on contract-side
+            # idempotency to absorb stale-view duplicates.
+            return receipt.extrinsic_hash
 
         try:
             if receipt.is_success:
@@ -1037,6 +1053,7 @@ class AllwaysContractClient:
             'propose_extend_reservation',
             args={'miner': miner_hotkey, 'from_tx_hash': from_tx_hash, 'target_block': target_block},
             keypair=wallet.hotkey,
+            wait_for_inclusion=False,
         )
         bt.logging.info(f'Propose extend reservation miner={miner_hotkey} target={target_block}: {tx_hash}')
         return tx_hash
@@ -1047,6 +1064,7 @@ class AllwaysContractClient:
             'challenge_extend_reservation',
             args={'miner': miner_hotkey},
             keypair=wallet.hotkey,
+            wait_for_inclusion=False,
         )
         bt.logging.info(f'Challenge extend reservation miner={miner_hotkey}: {tx_hash}')
         return tx_hash
@@ -1072,6 +1090,7 @@ class AllwaysContractClient:
             'propose_extend_timeout',
             args={'swap_id': swap_id, 'target_block': target_block},
             keypair=wallet.hotkey,
+            wait_for_inclusion=False,
         )
         bt.logging.info(f'Propose extend timeout swap={swap_id} target={target_block}: {tx_hash}')
         return tx_hash
@@ -1082,6 +1101,7 @@ class AllwaysContractClient:
             'challenge_extend_timeout',
             args={'swap_id': swap_id},
             keypair=wallet.hotkey,
+            wait_for_inclusion=False,
         )
         bt.logging.info(f'Challenge extend timeout swap={swap_id}: {tx_hash}')
         return tx_hash


### PR DESCRIPTION
## Why

Each contract write currently blocks the forward loop until inclusion (~12-24s on testnet). With one propose + one finalize landing in the same step, that's 30-50s of pure inclusion wait per active near-timeout swap. The forward loop has no useful work to do during the wait, but the WS is held and the per-step latency directly delays the next read sweep.

Quorum votes (`confirm_swap`, `timeout_swap`) need synchronous receipts — the result tells us whether we were the deciding vote, and `tracker.resolve` fires on success. Finalize also stays sync: `maybe_finalize_*` feeds the just-bumped target back into `swap_tracker` / `state_store` before `enforce_swap_timeouts` / purge reads from it (see #253, #254).

Propose and challenge are different:
- The contract already dedupes via `ProposalAlreadyPending` / `ChallengeWindowOpen` / `ChallengeWindowClosed`.
- The forward loop already gates submission on a fresh `pending` snapshot, so doomed propose/challenge submissions are rare to begin with.
- Outcomes are picked up by the next event sync regardless — we don't need an in-band receipt to act correctly.

## Change

Single-file diff:

- `exec_contract_raw` gains `wait_for_inclusion: bool = True` (default preserves existing behaviour). When `False`, the receipt has no block hash to inspect, so we return the `extrinsic_hash` straight after submission. The existing `_EXTRINSIC_NOT_FOUND` catch already absorbs the now-unreachable `is_success` path.
- `wait_for_inclusion=False` is set on:
  - `propose_extend_reservation`
  - `challenge_extend_reservation`
  - `propose_extend_timeout`
  - `challenge_extend_timeout`
- `finalize_extend_reservation` / `finalize_extend_timeout` keep `wait=True` so `maybe_finalize_*` can return the applied target on success.

## Per-step impact

| Step shape | Before | After |
|---|---|---|
| 1 propose + 1 finalize | ~30-50s blocked | ~12-25s blocked (only finalize) |
| 1 challenge | ~12-24s blocked | submission only (~1s) |
| confirm/timeout votes | unchanged | unchanged |

## Tradeoff (called out so reviewers don't have to ask)

The four async calls no longer raise `ContractError` on contract revert; `is_contract_rejection` in `optimistic_extensions._try_call` won't fire for them, so the rejected-by-contract debug log goes silent. That's fine — the `pending` snapshot already filters out the cases that would have logged (own pending proposal, stale challenge window). If revert visibility is later useful, we can re-introduce it via post-flight event observation rather than synchronous receipt inspection.

## Test plan

- [x] `pytest tests/` — 387 passed
- [x] `ruff format` + `ruff check` — clean
- [ ] Manual: testnet step-duration before/after when an extension proposal cycle fires.