### PR TITLE
validator: anchor extension target on deadline + retry BTC fee estimate

### DIFF
--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -1,4 +1,5 @@
 import os
+import time
 from typing import Any, Optional, Tuple
 
 import base58
@@ -616,23 +617,30 @@ class BitcoinProvider(ChainProvider):
         without overpaying for next-block urgency. ``override`` (sat/vB) skips
         estimation, floor, and multiplier — caller is taking explicit
         responsibility for the rate (e.g. CPFP / manual bump).
+
+        One retry with a 3s sleep on API failure — Blockstream's testnet
+        endpoint occasionally returns 5xx; silent fallback to the floor has
+        stranded at least one dest tx at 5 sat/vB.
         """
         if override is not None:
             return max(1, override)
 
         from allways.constants import BTC_FEE_RATE_SAFETY_MULTIPLIER, BTC_MIN_FEE_RATE
 
-        try:
-            url = f'{self.blockstream_api_url()}/fee-estimates'
-            resp = self.http.get(url, timeout=10)
-            resp.raise_for_status()
-            estimates = resp.json()
-            for target in ('2', '3'):
-                if target in estimates:
-                    padded = int(round(float(estimates[target]) * BTC_FEE_RATE_SAFETY_MULTIPLIER))
-                    return max(BTC_MIN_FEE_RATE, padded)
-        except Exception:
-            pass
+        url = f'{self.blockstream_api_url()}/fee-estimates'
+        for attempt in range(2):
+            try:
+                resp = self.http.get(url, timeout=10)
+                resp.raise_for_status()
+                estimates = resp.json()
+                for target in ('2', '3'):
+                    if target in estimates:
+                        padded = int(round(float(estimates[target]) * BTC_FEE_RATE_SAFETY_MULTIPLIER))
+                        return max(BTC_MIN_FEE_RATE, padded)
+            except Exception as e:
+                bt.logging.debug(f'estimate_fee_rate: attempt {attempt + 1} failed: {e}')
+            if attempt == 0:
+                time.sleep(3)
         return BTC_MIN_FEE_RATE
 
     def send_amount(

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -80,22 +80,28 @@ def compute_extension_target(
     from_chain_id: str,
     remaining_blocks: int,
     current_subnet_block: int,
+    deadline_block: int = 0,
 ) -> int:
     """Subtensor block to extend a reservation/timeout to.
 
     Covers ``remaining_blocks`` source-chain blocks plus a padding buffer,
-    rounded up to EXTENSION_BUCKET_BLOCKS so validators with slightly different
-    views converge on the same target. Capped at MAX_EXTENSION_BLOCKS — the
-    contract enforces the same cap, this is just a pre-check to avoid wasting
-    a tx on a doomed proposal.
+    bucket-rounded so validators converge, capped at MAX_EXTENSION_BLOCKS.
+
+    Anchored on ``max(current_subnet_block, deadline_block)`` so runway is
+    measured past the existing deadline. Propose fires inside
+    EXTEND_THRESHOLD_BLOCKS of the deadline, so a current-block anchor
+    silently shortens tier-0 BTC's nominal +90 to ~+71 past the old
+    deadline — barely one BTC block. ``deadline_block`` defaults to 0 to
+    keep callers that don't have one yet on the old behaviour.
 
     Callers pick ``remaining_blocks`` per tier:
-    - Tier-1 (tx visibility, no confirmations yet): pass 1 — buys one block.
-    - Tier-2 (≥1 confirmation): pass max(0, min_confirmations - observed).
+    - Tier-0 (tx visibility, no confirmations yet): pass 1.
+    - Tier-1+ (≥1 confirmation): pass max(0, min_confirmations - observed).
     """
     chain = get_chain(from_chain_id)
     seconds_needed = remaining_blocks * chain.seconds_per_block + EXTENSION_PADDING_SECONDS
     blocks_needed = math.ceil(seconds_needed / SUBTENSOR_BLOCK_SECONDS)
     blocks_needed = math.ceil(blocks_needed / EXTENSION_BUCKET_BLOCKS) * EXTENSION_BUCKET_BLOCKS
     blocks_needed = min(blocks_needed, MAX_EXTENSION_BLOCKS)
-    return current_subnet_block + blocks_needed
+    anchor = max(current_subnet_block, deadline_block)
+    return anchor + blocks_needed

--- a/allways/validator/optimistic_extensions.py
+++ b/allways/validator/optimistic_extensions.py
@@ -16,11 +16,9 @@ import bittensor as bt
 from allways.chains import compute_extension_target, get_chain
 from allways.classes import PendingExtension
 from allways.constants import (
-    CHALLENGE_WINDOW_BLOCKS,
     EXTENSION_BUCKET_BLOCKS,
     MAX_EXTENSIONS_PER_RESERVATION,
     MAX_EXTENSIONS_PER_SWAP,
-    VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE,
 )
 from allways.contract_client import (
     AllwaysContractClient,
@@ -98,28 +96,7 @@ class OptimisticExtensionWatcher:
                 return False
             chain = get_chain(from_chain_id)
             remaining = max(0, chain.min_confirmations - observed_confirmations)
-        target_block = compute_extension_target(from_chain_id, remaining, current_block)
-
-        if target_block <= reserved_until:
-            # Bucketed target landed at or before the existing deadline — the
-            # extension is unnecessary, don't waste a tx.
-            return False
-
-        # Defensive floor (applied only after we've decided the propose is
-        # worth doing): the new deadline must clear the *existing*
-        # reserved_until by at least one challenge window plus one
-        # forward-step worth of jitter. Anchoring on reserved_until (not
-        # current_block) is what makes every successful extension land a
-        # meaningful chunk of runway past the old deadline — anchoring on
-        # current_block would let a propose that fires with 25 blocks
-        # remaining land a target only 3-5 blocks past the old deadline,
-        # immediately re-arming the next extension cycle. Round up to an
-        # EXTENSION_BUCKET_BLOCKS boundary so validators converge.
-        min_safe_target = reserved_until + CHALLENGE_WINDOW_BLOCKS + VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE
-        if target_block < min_safe_target:
-            target_block = (
-                min_safe_target - current_block + EXTENSION_BUCKET_BLOCKS - 1
-            ) // EXTENSION_BUCKET_BLOCKS * EXTENSION_BUCKET_BLOCKS + current_block
+        target_block = compute_extension_target(from_chain_id, remaining, current_block, deadline_block=reserved_until)
 
         return self._try_call(
             'propose_extend_reservation',
@@ -224,24 +201,7 @@ class OptimisticExtensionWatcher:
                 return False
             chain = get_chain(dest_chain_id)
             remaining = max(0, chain.min_confirmations - observed_confirmations)
-        target_block = compute_extension_target(dest_chain_id, remaining, current_block)
-
-        if target_block <= timeout_block:
-            return False
-
-        # Mirror of the floor in maybe_propose_reservation: a propose whose
-        # natural target lands only a few blocks past the existing
-        # timeout_block immediately re-arms the next extension cycle, since
-        # finalize itself eats CHALLENGE_WINDOW_BLOCKS and one forward step
-        # of jitter before the new deadline starts paying. Anchor on
-        # timeout_block (not current_block) so each successful extension
-        # buys a meaningful chunk of runway, then bucket-round so validators
-        # converge on the same target.
-        min_safe_target = timeout_block + CHALLENGE_WINDOW_BLOCKS + VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE
-        if target_block < min_safe_target:
-            target_block = (
-                min_safe_target - current_block + EXTENSION_BUCKET_BLOCKS - 1
-            ) // EXTENSION_BUCKET_BLOCKS * EXTENSION_BUCKET_BLOCKS + current_block
+        target_block = compute_extension_target(dest_chain_id, remaining, current_block, deadline_block=timeout_block)
 
         return self._try_call(
             'propose_extend_timeout',

--- a/tests/test_optimistic_extensions.py
+++ b/tests/test_optimistic_extensions.py
@@ -48,9 +48,8 @@ def make_watcher(pending_reservation=None, pending_timeout=None, propose_raises=
 
 class TestMaybeProposeReservation:
     def test_tier0_proposes_on_visibility_with_short_target(self):
-        # Tier 0 (extension_count=0): caller has already verified tx visibility;
-        # target = current + tier1_blocks. For BTC: (600+300)/12 = 75 → bucket(90).
-        # current=1000, reserved_until=1050 (< 1090) → propose fires with target=1090.
+        # Tier 0: BTC blocks_needed=90, anchor=max(current=1000, reserved=1050)=1050,
+        # target=1140.
         w = make_watcher(pending_reservation=None)
         result = w.maybe_propose_reservation(
             miner_hotkey=MINER,
@@ -65,11 +64,11 @@ class TestMaybeProposeReservation:
         assert result is True
         call_kwargs = w.contract_client.propose_extend_reservation.call_args.kwargs
         assert call_kwargs['miner_hotkey'] == MINER
-        assert call_kwargs['target_block'] == 1090
+        assert call_kwargs['target_block'] == 1140
 
     def test_tier1_proposes_with_chain_aware_target(self):
-        # Tier 1 (extension_count=1): require ≥1 conf; target = chain-aware.
-        # BTC at 1/3 confs → remaining=2, seconds=1500, blocks=125 → bucket(150).
+        # Tier 1: BTC remaining=2 → blocks_needed=150, anchor=max(1000,1100)=1100,
+        # target=1250.
         w = make_watcher(pending_reservation=None)
         result = w.maybe_propose_reservation(
             miner_hotkey=MINER,
@@ -82,7 +81,7 @@ class TestMaybeProposeReservation:
             pending=w.fetch_pending_reservation(MINER),
         )
         assert result is True
-        assert w.contract_client.propose_extend_reservation.call_args.kwargs['target_block'] == 1150
+        assert w.contract_client.propose_extend_reservation.call_args.kwargs['target_block'] == 1250
 
     def test_tier1_skips_when_below_one_confirmation(self):
         # Tier 1 demands ≥1 confirmation — mempool-only tx is not enough.
@@ -130,45 +129,6 @@ class TestMaybeProposeReservation:
         )
         assert result is False
         w.contract_client.propose_extend_reservation.assert_not_called()
-
-    def test_tier0_skips_when_target_does_not_advance(self):
-        # Tier 0 target = current + 90 = 1090. If reserved_until is already
-        # past 1090, no need to propose.
-        w = make_watcher(pending_reservation=None)
-        result = w.maybe_propose_reservation(
-            miner_hotkey=MINER,
-            from_chain_id='btc',
-            from_tx_hash=bytes(32),
-            current_block=1000,
-            reserved_until=1100,
-            observed_confirmations=0,
-            extension_count=0,
-            pending=w.fetch_pending_reservation(MINER),
-        )
-        assert result is False
-        w.contract_client.propose_extend_reservation.assert_not_called()
-
-    def test_floor_widens_target_when_natural_target_too_close_to_reserved_until(self):
-        # If the natural chain-aware target advances past reserved_until but
-        # only by a few blocks, the floor must push it out so a successful
-        # finalize lands meaningful runway past the old deadline (≥ challenge
-        # window + 1 forward step). With reserved_until=1085 and BTC tier-0
-        # natural=1090 (only +5 past old deadline), the floor anchors at
-        # reserved_until + 8 + 20 = 1113 and bucket-rounds to 1120.
-        w = make_watcher(pending_reservation=None)
-        result = w.maybe_propose_reservation(
-            miner_hotkey=MINER,
-            from_chain_id='btc',
-            from_tx_hash=bytes(32),
-            current_block=1000,
-            reserved_until=1085,
-            observed_confirmations=0,
-            extension_count=0,
-            pending=w.fetch_pending_reservation(MINER),
-        )
-        assert result is True
-        target = w.contract_client.propose_extend_reservation.call_args.kwargs['target_block']
-        assert target == 1120
 
     def test_swallows_contract_rejection(self):
         w = make_watcher(
@@ -332,6 +292,8 @@ class TestFetchPendingReservation:
 
 class TestMaybeProposeTimeout:
     def test_tier0_proposes_on_visibility(self):
+        # BTC tier-0: blocks_needed=90, anchor=max(current=1000, timeout=1050)=1050,
+        # target=1140.
         w = make_watcher(pending_timeout=None)
         result = w.maybe_propose_timeout(
             swap_id=42,
@@ -345,7 +307,7 @@ class TestMaybeProposeTimeout:
         assert result is True
         kwargs = w.contract_client.propose_extend_timeout.call_args.kwargs
         assert kwargs['swap_id'] == 42
-        assert kwargs['target_block'] == 1090
+        assert kwargs['target_block'] == 1140
 
     def test_tier1_requires_confirmations(self):
         w = make_watcher(pending_timeout=None)
@@ -385,25 +347,6 @@ class TestMaybeProposeTimeout:
             pending=w.fetch_pending_timeout(42),
         )
         assert result is False
-
-    def test_floor_widens_target_when_natural_target_too_close_to_timeout_block(self):
-        # Mirror of the reservation-side floor: BTC tier-0 natural target = 1090,
-        # but timeout_block=1085 means a successful finalize would land only +5
-        # past the old deadline before re-arming. Floor anchors at
-        # timeout_block + 8 + 20 = 1113 and bucket-rounds (current=1000) to 1120.
-        w = make_watcher(pending_timeout=None)
-        result = w.maybe_propose_timeout(
-            swap_id=42,
-            dest_chain_id='btc',
-            current_block=1000,
-            timeout_block=1085,
-            observed_confirmations=0,
-            extension_count=0,
-            pending=w.fetch_pending_timeout(42),
-        )
-        assert result is True
-        target = w.contract_client.propose_extend_timeout.call_args.kwargs['target_block']
-        assert target == 1120
 
 
 class TestMaybeChallengeTimeout:


### PR DESCRIPTION
## Why

Two related fixes for the same testnet timeout failure mode (swap fulfilled, miner sent BTC, extension fired and finalized — but the swap still timed out before the BTC tx got even one confirmation).

### A — extension target anchored on `current_block`, not the deadline

`compute_extension_target` returned `current_block + blocks_needed`. Propose fires inside `EXTEND_THRESHOLD_BLOCKS = 20` of the existing deadline, so the +90 a tier-0 BTC propose nominally buys collapsed to **+71** past the old deadline. Combined with the challenge window (8) plus a forward-step worth of jitter (~16-20) eaten by the propose→finalize round trip, the new deadline kicked in with only ~50 sub blocks of runway — barely one BTC block on average, with heavy variance.

Concretely, the testnet swap that died:

| Quantity | Value |
|---|---|
| `current_block` at propose | 7029580 |
| Old `timeout_block` | 7029599 |
| Tier-0 target (`current + 90`) | 7029670 |
| Runway past old deadline | **71** sub blocks ≈ 14 min |

After the propose→finalize cycle finished, ~58 of those 71 sub blocks remained. BTC produced no blocks in that window; the validator timed out the swap and the miner ate the slash even though they had broadcast a valid dest tx within seconds of fulfillment.

### B — BTC fee estimator silently falls back to the floor on testnet flakes

`BitcoinProvider.estimate_fee_rate` does one Blockstream call. On testnet that endpoint sporadically returns 5xx / times out; the bare `except` swallowed the failure and returned `BTC_MIN_FEE_RATE = 5`. That's the rate the miner used on the dead swap (`fee = 705 sat / vsize = 141 vB = exactly 5 sat/vB`), and the tx is still unconfirmed in the mempool hours later.

## Change

### A
- `chains.compute_extension_target` gains `deadline_block: int = 0` and now anchors on `max(current_subnet_block, deadline_block)`. Default of 0 keeps any caller without a deadline on the old semantics.
- `maybe_propose_reservation` passes `reserved_until`; `maybe_propose_timeout` passes `timeout_block`.
- With the new anchor, two defensive branches in `maybe_propose_*` are provably unreachable on every chain (`blocks_needed` is bucket-rounded to `≥30`, so `target ≥ deadline + 30 > deadline + 28 = floor`, and `> deadline` always). Both branches plus the three tests covering them are removed:
  - `if target_block <= reserved_until: return False` (and timeout sibling)
  - the `min_safe_target` floor block (and timeout sibling)
- `CHALLENGE_WINDOW_BLOCKS` and `VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE` imports drop from `optimistic_extensions.py` since nothing uses them after the floor removal.

### B
- `estimate_fee_rate` runs the request, sleeps 3 s, and retries once before falling back to `BTC_MIN_FEE_RATE`.

## Per-tier impact (BTC tier-0)

| Quantity | Before | After |
|---|---|---|
| Anchor | `current_block` | `max(current, deadline)` |
| New runway past old deadline | ~71 sub blocks (~14 min) | ~90 sub blocks (~18 min, ≈1.8 BTC blocks) |

Tier-1 sees the same +`blocks_needed` past the old deadline, which is the whole point — runway should not depend on whether propose fires 1 block or 20 blocks before the deadline.

## Removal proof (for the deletions)

For every supported chain `c` and any `remaining_blocks ≥ 0`:
- `seconds_needed = remaining × c.seconds_per_block + 300 ≥ 300`
- `ceil(300 / 12) = 25` → bucket-rounded to `≥30`
- `min(blocks_needed, MAX_EXTENSION_BLOCKS=250) ≥ 30`
- ⇒ `target ≥ deadline + 30`, which clears both the `≤ deadline` skip and the `deadline + 28` floor unconditionally.

If a future chain wants to opt into a tighter cushion the right place is `compute_extension_target` (one anchor, one bucket constant) rather than scattered branch guards.

## Test plan

- [x] `pytest tests/` — 384 passed (3 dead tests removed; remaining propose-target asserts updated)
- [x] `ruff format` + `ruff check` — clean
- [ ] Manual on testnet: trigger a fresh BTC swap, observe propose target lands `current + ≥90` past the deadline, and BTC tx confirms within the extended window.