### PR TITLE
validator: anchor challenge target on deadline (mirror of #258)

### DIFF
--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -287,6 +287,7 @@ def try_extend_reservation(
         from_chain_id=item.from_chain,
         observed_confirmations=tx_info.confirmations,
         current_block=current_block,
+        reserved_until=reserved_until,
         pending=pending,
     )
 
@@ -476,6 +477,7 @@ def extend_fulfilled_near_timeout(self: Validator) -> None:
             dest_chain_id=swap.to_chain,
             observed_confirmations=tx_info.confirmations,
             current_block=current_block,
+            timeout_block=swap.timeout_block,
             pending=pending,
         )
         proposed = self.optimistic_extensions.maybe_propose_timeout(

--- a/allways/validator/optimistic_extensions.py
+++ b/allways/validator/optimistic_extensions.py
@@ -114,14 +114,20 @@ class OptimisticExtensionWatcher:
         from_chain_id: str,
         observed_confirmations: int,
         current_block: int,
+        reserved_until: int,
         pending: Optional[PendingExtension],
     ) -> bool:
         """Challenge the pending reservation extension if its target is too far.
 
+        Mirrors the deadline-anchored math used by ``maybe_propose_reservation``
+        so challenger and proposer compute the same expected target. Without
+        this the two sides could drift by up to EXTEND_THRESHOLD_BLOCKS,
+        which the EXTENSION_BUCKET_BLOCKS tolerance currently absorbs but
+        shouldn't have to.
+
         Tolerance is one bucket — proposals within EXTENSION_BUCKET_BLOCKS of
         the locally-computed target are accepted as benign rounding drift.
-        Skips proposals submitted by this validator's own wallet. ``pending``
-        is the caller-supplied snapshot — see ``maybe_propose_reservation``.
+        Skips proposals submitted by this validator's own wallet.
         """
         if pending is None:
             return False
@@ -130,7 +136,7 @@ class OptimisticExtensionWatcher:
 
         chain = get_chain(from_chain_id)
         remaining = max(0, chain.min_confirmations - observed_confirmations)
-        expected = compute_extension_target(from_chain_id, remaining, current_block)
+        expected = compute_extension_target(from_chain_id, remaining, current_block, deadline_block=reserved_until)
         if pending.target_block <= expected + EXTENSION_BUCKET_BLOCKS:
             return False
 
@@ -218,8 +224,11 @@ class OptimisticExtensionWatcher:
         dest_chain_id: str,
         observed_confirmations: int,
         current_block: int,
+        timeout_block: int,
         pending: Optional[PendingExtension],
     ) -> bool:
+        """Mirror of ``maybe_challenge_reservation``: deadline-anchored expected
+        target so challenger and proposer stay aligned."""
         if pending is None:
             return False
         if self._is_own_proposal(pending):
@@ -227,7 +236,7 @@ class OptimisticExtensionWatcher:
 
         chain = get_chain(dest_chain_id)
         remaining = max(0, chain.min_confirmations - observed_confirmations)
-        expected = compute_extension_target(dest_chain_id, remaining, current_block)
+        expected = compute_extension_target(dest_chain_id, remaining, current_block, deadline_block=timeout_block)
         if pending.target_block <= expected + EXTENSION_BUCKET_BLOCKS:
             return False
 

--- a/tests/test_optimistic_extensions.py
+++ b/tests/test_optimistic_extensions.py
@@ -150,8 +150,8 @@ class TestMaybeProposeReservation:
 
 class TestMaybeChallengeReservation:
     def test_challenges_when_target_too_far(self):
-        # Local expected target for BTC at 1/3 confs, current=1000 = 1150.
-        # Pending target=2000 is way beyond expected + bucket(30) = 1180.
+        # BTC at 1/3 confs → blocks_needed=150. Anchor=max(1000,1100)=1100,
+        # expected=1250. Pending=2000 is past expected + bucket(30)=1280.
         w = make_watcher(
             pending_reservation=PendingExtension(OTHER_HOTKEY, target_block=2000, proposed_at=995),
         )
@@ -160,22 +160,23 @@ class TestMaybeChallengeReservation:
             from_chain_id='btc',
             observed_confirmations=1,
             current_block=1000,
+            reserved_until=1100,
             pending=w.fetch_pending_reservation(MINER),
         )
         assert result is True
         w.contract_client.challenge_extend_reservation.assert_called_once()
 
     def test_skips_when_target_within_one_bucket_tolerance(self):
-        # Expected target = 1150. Bucket = 30. Pending = 1180 (= expected + bucket)
-        # is the boundary — should be accepted (within tolerance).
+        # expected=1250 (see above), pending=1280 is the boundary.
         w = make_watcher(
-            pending_reservation=PendingExtension(OTHER_HOTKEY, target_block=1180, proposed_at=995),
+            pending_reservation=PendingExtension(OTHER_HOTKEY, target_block=1280, proposed_at=995),
         )
         result = w.maybe_challenge_reservation(
             miner_hotkey=MINER,
             from_chain_id='btc',
             observed_confirmations=1,
             current_block=1000,
+            reserved_until=1100,
             pending=w.fetch_pending_reservation(MINER),
         )
         assert result is False
@@ -188,6 +189,7 @@ class TestMaybeChallengeReservation:
             from_chain_id='btc',
             observed_confirmations=1,
             current_block=1000,
+            reserved_until=1100,
             pending=w.fetch_pending_reservation(MINER),
         )
         assert result is False
@@ -203,6 +205,7 @@ class TestMaybeChallengeReservation:
             from_chain_id='btc',
             observed_confirmations=1,
             current_block=1000,
+            reserved_until=1100,
             pending=w.fetch_pending_reservation(MINER),
         )
         assert result is False
@@ -351,6 +354,8 @@ class TestMaybeProposeTimeout:
 
 class TestMaybeChallengeTimeout:
     def test_challenges_when_target_too_far(self):
+        # Anchor=max(1000,1100)=1100, expected=1250, pending=2000 past
+        # expected + bucket(30)=1280.
         w = make_watcher(
             pending_timeout=PendingExtension(OTHER_HOTKEY, target_block=2000, proposed_at=995),
         )
@@ -359,6 +364,7 @@ class TestMaybeChallengeTimeout:
             dest_chain_id='btc',
             observed_confirmations=1,
             current_block=1000,
+            timeout_block=1100,
             pending=w.fetch_pending_timeout(42),
         )
         assert result is True
@@ -372,6 +378,7 @@ class TestMaybeChallengeTimeout:
             dest_chain_id='btc',
             observed_confirmations=1,
             current_block=1000,
+            timeout_block=1100,
             pending=w.fetch_pending_timeout(42),
         )
         assert result is False


### PR DESCRIPTION
## Why

#258 made `maybe_propose_reservation` / `maybe_propose_timeout` compute their target against `max(current_block, deadline_block)`. The matching `maybe_challenge_reservation` / `maybe_challenge_timeout` still anchored on `current_block` alone, so the challenger's locally-computed expected target diverged from the proposer's by up to `EXTEND_THRESHOLD_BLOCKS` (20 sub blocks).

In numbers: a proposer firing 19 blocks before the deadline now lands at `deadline + blocks_needed`, while a challenger one block later computes `current + blocks_needed = deadline - 18 + blocks_needed`. Difference: 18 sub blocks. `EXTENSION_BUCKET_BLOCKS = 30` absorbs that drift today, so we don't see false challenges in practice — but the two sides should compute against the same anchor or a future threshold/bucket tweak silently re-introduces a false-challenge window.

## Coverage check (all 6 paths)

| Method | Anchors target? | Status |
|---|---|---|
| `maybe_propose_reservation` | yes — `deadline_block=reserved_until` | ✓ in #258 |
| `maybe_challenge_reservation` | yes — `deadline_block=reserved_until` | ✓ this PR |
| `maybe_finalize_reservation` | **no** — commits `pending.target_block` from contract; no math to anchor | n/a |
| `maybe_propose_timeout` | yes — `deadline_block=timeout_block` | ✓ in #258 |
| `maybe_challenge_timeout` | yes — `deadline_block=timeout_block` | ✓ this PR |
| `maybe_finalize_timeout` | **no** — commits `pending.target_block` from contract; no math to anchor | n/a |

## Change

- `maybe_challenge_reservation` gains `reserved_until: int`; passes it as `deadline_block` to `compute_extension_target`.
- `maybe_challenge_timeout` gains `timeout_block: int`; same pattern.
- `forward.py` already has both values in scope at the call sites — wired through with no other changes.
- Tests updated: challenge tests now pass `reserved_until` / `timeout_block`, and the tolerance / too-far asserts use the new deadline-anchored expected target (anchor=1100, BTC tier-1 → expected=1250, tolerance boundary=1280).

## Test plan

- [x] `pytest tests/` — 384 passed
- [x] `ruff format` + `ruff check` — clean
- [ ] Manual on testnet: with two validators racing, confirm neither incorrectly challenges the other's deadline-anchored proposal.