### PR TITLE
validator: stop stranded extension proposals near deadline

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -100,7 +100,7 @@ FEE_DIVISOR = 100
 # Fallbacks/defaults for CLI display. Live values are written by `alw admin`
 # and read from the contract at runtime.
 MIN_COLLATERAL_TAO = 0.1
-DEFAULT_FULFILLMENT_TIMEOUT_BLOCKS = 30  # ~5 min
+DEFAULT_FULFILLMENT_TIMEOUT_BLOCKS = 50  # ~10 min
 DEFAULT_MIN_SWAP_AMOUNT_RAO = 100_000_000  # 0.1 TAO
 DEFAULT_MAX_SWAP_AMOUNT_RAO = 500_000_000  # 0.5 TAO
-RESERVATION_TTL_BLOCKS = 30  # ~5 min
+RESERVATION_TTL_BLOCKS = 50  # ~10 min

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -58,7 +58,6 @@ RECYCLE_UID = 53  # Subnet owner UID
 RESERVATION_COOLDOWN_BLOCKS = 150  # ~30 min base cooldown on failed reservation
 RESERVATION_COOLDOWN_MULTIPLIER = 2  # 150 → 300 → 600 ...
 MAX_RESERVATIONS_PER_ADDRESS = 1
-EXTEND_THRESHOLD_BLOCKS = 20  # ~4 min — vote to extend when this many blocks remain
 # A user's tx is often invisible to a validator's RPC for the first few seconds
 # after submission (mempool propagation lag, regional RPC differences). Treat
 # "not found" as transient until the same entry has polled null this many times.
@@ -80,6 +79,11 @@ CHALLENGE_WINDOW_BLOCKS = 8
 # sizing extension targets so a single delayed step doesn't strand a propose
 # whose finalize window opens past the original reservation deadline.
 VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE = 20
+# Vote to extend when this many blocks remain. Sized for one full forward
+# step to land the propose tx, the challenge window to elapse, and a second
+# forward step to land the finalize — without that runway, the propose is
+# orphaned and the reservation expires anyway.
+EXTEND_THRESHOLD_BLOCKS = 2 * VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE + CHALLENGE_WINDOW_BLOCKS
 
 # Tiered escalation. First extension fires on tx visibility alone (mempool
 # OK) and buys time for one block; second extension requires ≥1 confirmation

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -79,11 +79,10 @@ CHALLENGE_WINDOW_BLOCKS = 8
 # sizing extension targets so a single delayed step doesn't strand a propose
 # whose finalize window opens past the original reservation deadline.
 VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE = 20
-# Vote to extend when this many blocks remain. Sized for one full forward
-# step to land the propose tx, the challenge window to elapse, and a second
-# forward step to land the finalize — without that runway, the propose is
-# orphaned and the reservation expires anyway.
-EXTEND_THRESHOLD_BLOCKS = 2 * VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE + CHALLENGE_WINDOW_BLOCKS
+# Vote to extend when this many blocks remain. Sized for one forward step
+# to land the propose tx and the challenge window to elapse — without that
+# runway the propose is orphaned and the reservation expires anyway.
+EXTEND_THRESHOLD_BLOCKS = VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE + CHALLENGE_WINDOW_BLOCKS
 
 # Tiered escalation. First extension fires on tx visibility alone (mempool
 # OK) and buys time for one block; second extension requires ≥1 confirmation

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -283,6 +283,13 @@ async def handle_swap_reserve(
             reject_synapse(synapse, 'Invalid source address proof', ctx)
             return synapse
 
+        # Source-chain RPC — separate connection from substrate, so it doesn't
+        # need axon_lock and shouldn't block the substrate websocket.
+        balance = provider.get_balance(synapse.from_address)
+        if balance < synapse.from_amount:
+            reject_synapse(synapse, 'Insufficient source balance', ctx)
+            return synapse
+
         # Pure-local crypto — compute the request hash outside the lock as a cheap pre-check.
         from_addr_bytes = synapse.from_address.encode('utf-8')
         miner_bytes = bytes.fromhex(Keypair(ss58_address=miner).public_key.hex())
@@ -315,11 +322,6 @@ async def handle_swap_reserve(
             reserve_rate, _ = commitment.get_rate_for_direction(synapse.from_chain)
             if reserve_rate <= 0:
                 reject_synapse(synapse, 'Miner does not support this swap direction', ctx)
-                return synapse
-
-            balance = provider.get_balance(synapse.from_address)
-            if balance < synapse.from_amount:
-                reject_synapse(synapse, 'Insufficient source balance', ctx)
                 return synapse
 
             collateral, active, has_swap, reserved_until, _ = contract.get_miner_snapshot(miner)

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -369,6 +369,7 @@ async def handle_swap_reserve(
                     )
                     return synapse
 
+            bt.logging.info(f'{ctx} preflight ok, voting')
             contract.vote_reserve(
                 wallet=validator.wallet,
                 request_hash=request_hash,

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -248,6 +248,15 @@ def try_extend_reservation(
     itself enforces the per-tier evidence rule (tier 0: visibility OK; tier 1:
     confirmations >= 1; tier 2+: refused).
     """
+    # ``current_block`` from the caller was captured at step start; verifying
+    # each pending confirm before this one can burn many blocks. Refresh so
+    # the EXTEND_THRESHOLD_BLOCKS gate matches the height the propose tx will
+    # actually land at, not where the step began.
+    try:
+        current_block = self.subtensor.get_current_block()
+    except Exception as e:
+        bt.logging.debug(f'PendingConfirm [{swap_label} {miner_short}]: refresh current_block failed: {e}')
+
     try:
         reserved_until = self.contract_client.get_miner_reserved_until(item.miner_hotkey)
     except Exception as e:

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -46,6 +46,7 @@ async def forward(self: Validator) -> None:
     # reads them.
     try:
         self.event_watcher.sync_to(self.block)
+        bt.logging.info('forward: events synced')
     except Exception as e:
         bt.logging.warning(f'Event watcher sync failed: {e}')
 
@@ -64,17 +65,20 @@ async def forward(self: Validator) -> None:
 
     # Pull newly-initiated and resolved swaps off the contract.
     await tracker.poll()
+    bt.logging.info('forward: tracker polled')
 
     # Verify FULFILLED swaps end-to-end and vote confirm_swap. The returned
     # set is swap IDs where the provider was unreachable this cycle, so the
     # timeout phase knows to skip them (transient outage shouldn't slash).
     uncertain_swaps = await confirm_miner_fulfillments(self, tracker, verifier, self.block)
+    bt.logging.info('forward: fulfillments verified')
 
     extend_fulfilled_near_timeout(self)
     enforce_swap_timeouts(self, tracker, uncertain_swaps)
 
     if self.step % SCORING_WINDOW_BLOCKS == 0:
         score_and_reward_miners(self)
+        bt.logging.info('forward: scoring done')
 
 
 def clear_provider_caches(self: Validator) -> None:

--- a/allways/validator/optimistic_extensions.py
+++ b/allways/validator/optimistic_extensions.py
@@ -16,6 +16,7 @@ import bittensor as bt
 from allways.chains import compute_extension_target, get_chain
 from allways.classes import PendingExtension
 from allways.constants import (
+    CHALLENGE_WINDOW_BLOCKS,
     EXTENSION_BUCKET_BLOCKS,
     MAX_EXTENSIONS_PER_RESERVATION,
     MAX_EXTENSIONS_PER_SWAP,
@@ -87,6 +88,14 @@ class OptimisticExtensionWatcher:
             return False
 
         if pending is not None:
+            return False
+
+        # Refuse a doomed propose: if the challenge window can't close before
+        # the existing deadline, finalize will only become eligible after
+        # expiry. Anchoring the target on ``reserved_until`` sizes the *new*
+        # deadline safely past the old one, but it can't rescue a propose
+        # whose challenge window outlives the original reservation.
+        if current_block + CHALLENGE_WINDOW_BLOCKS >= reserved_until:
             return False
 
         if extension_count == 0:

--- a/tests/test_optimistic_extensions.py
+++ b/tests/test_optimistic_extensions.py
@@ -147,6 +147,24 @@ class TestMaybeProposeReservation:
         )
         assert result is False  # rejection means we didn't successfully propose
 
+    def test_skips_when_challenge_window_cannot_close_before_deadline(self):
+        # current=1000, reserved_until=1005 → only 5 blocks runway, less than
+        # CHALLENGE_WINDOW_BLOCKS(=8). Finalize would be eligible at block
+        # 1008 but reservation expires at 1005 — propose is doomed, refuse it.
+        w = make_watcher(pending_reservation=None)
+        result = w.maybe_propose_reservation(
+            miner_hotkey=MINER,
+            from_chain_id='btc',
+            from_tx_hash=bytes(32),
+            current_block=1000,
+            reserved_until=1005,
+            observed_confirmations=0,
+            extension_count=0,
+            pending=w.fetch_pending_reservation(MINER),
+        )
+        assert result is False
+        w.contract_client.propose_extend_reservation.assert_not_called()
+
 
 class TestMaybeChallengeReservation:
     def test_challenges_when_target_too_far(self):


### PR DESCRIPTION
## Summary
- Stop \`maybe_propose_reservation\` from firing when the challenge window can't close before the existing deadline — finalize would only become eligible post-expiry, leaving the proposal orphaned and the reservation expired anyway.
- Refresh \`current_block\` at the top of \`try_extend_reservation\` so the \`EXTEND_THRESHOLD_BLOCKS\` gate matches the height the propose tx will land at, not where the step began.
- Derive \`EXTEND_THRESHOLD_BLOCKS\` from \`VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE + CHALLENGE_WINDOW_BLOCKS\` (= 28) instead of the magic 20.
- Bump \`RESERVATION_TTL_BLOCKS\` and \`DEFAULT_FULFILLMENT_TIMEOUT_BLOCKS\` defaults from 30 → 50 so reservations have clearance above the new threshold and don't auto-propose immediately on creation.
- Also includes earlier touch-ups: split swap-reserve balance check out of \`axon_lock\`, log progress markers in forward + swap-reserve.

## Repro
On testnet a propose was submitted at block N with target N+92, but the reservation deadline was N+2. Finalize was eligible at N+8 (≥ proposed_at + CHALLENGE_WINDOW_BLOCKS), past expiry, so the proposal was orphaned and the reservation expired at the original deadline despite a valid pending tx in the validator's \`pending_confirms\` queue.

## Test plan
- [x] \`pytest tests/\` — 385 passed
- [x] \`ruff check allways/ tests/\` — clean
- [x] New regression test \`test_skips_when_challenge_window_cannot_close_before_deadline\` covers the hard gate
- [ ] Manual: restart testnet validator with this branch + 50-block reservation TTL on the contract; confirm an extension fires at ≥28 blocks remaining instead of stranding at <8