### PR TITLE
cli: pick lowest TAO/BTC rate when sending TAO

### DIFF
--- a/allways/cli/swap_commands/pair.py
+++ b/allways/cli/swap_commands/pair.py
@@ -6,6 +6,7 @@ from allways.chains import SUPPORTED_CHAINS, canonical_pair
 from allways.cli.help import StyledCommand
 from allways.cli.swap_commands.helpers import console, get_cli_context, loading
 from allways.constants import COMMITMENT_VERSION
+from allways.utils.rate import normalize_rate
 
 
 def prompt_chain(label: str, exclude: str | None = None) -> str:
@@ -150,8 +151,8 @@ def post_pair(
     config, wallet, subtensor, _ = get_cli_context(need_client=False)
     netuid = config['netuid']
 
-    rate_str = f'{rate:g}'
-    counter_rate_str = f'{counter_rate:g}'
+    rate_str = normalize_rate(rate)
+    counter_rate_str = normalize_rate(counter_rate)
     commitment_data = (
         f'v{COMMITMENT_VERSION}:{src_chain}:{src_addr}:{dst_chain}:{dst_addr}:{rate_str}:{counter_rate_str}'
     )

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -729,7 +729,10 @@ def swap_now_command(
                     console.print('[yellow]Cancelled[/yellow]')
                     return
 
-    available_miners.sort(key=lambda x: x[0].rate, reverse=True)
+    # Rate is TAO/BTC: highest is best when receiving TAO, lowest when sending TAO.
+    canon_from, canon_to = canonical_pair(from_chain, to_chain)
+    canon_is_reverse = from_chain != canon_from
+    available_miners.sort(key=lambda x: x[0].rate, reverse=not canon_is_reverse)
 
     # Show miners table
     table = Table(title='Available Miners', show_header=True)
@@ -744,9 +747,7 @@ def swap_now_command(
     console.print(table)
 
     # Step 3: Select miner (default to best rate)
-    canon_from, canon_to = canonical_pair(from_chain, to_chain)
     best_pair = available_miners[0][0]
-    canon_is_reverse = from_chain != canon_from
     if canon_is_reverse:
         best_rate_line = (
             f'send {best_pair.rate:g} {from_chain.upper()} to get 1 {to_chain.upper()} (Miner UID {best_pair.uid})'

--- a/allways/commitments.py
+++ b/allways/commitments.py
@@ -1,5 +1,6 @@
 """Shared commitment parsing logic — used by validator, miner, and CLI."""
 
+import math
 from typing import List, Optional
 
 import bittensor as bt
@@ -37,14 +38,17 @@ def parse_commitment_data(raw: str, uid: int = 0, hotkey: str = '') -> Optional[
         src_addr = parts[2]
         dst_chain = parts[3]
         dst_addr = parts[4]
-        # Normalize on ingest so a miner posting more precision than RATE_SIG_FIGS
-        # is treated identically by every validator. Rebuild the float from the
-        # normalized string so scoring (uses .rate) and consensus hash (uses
-        # .rate_str) cannot diverge.
+        # Normalize on ingest. Float rebuilt from the normalized string so
+        # scoring (uses .rate) and consensus hash (uses .rate_str) cannot diverge.
         rate_str = normalize_rate(float(parts[5]))
         rate = float(rate_str)
         counter_rate_str = normalize_rate(float(parts[6]))
         counter_rate = float(counter_rate_str)
+        # Reject NaN/Inf (parse cleanly via float() but break every downstream
+        # comparison) and negatives (existing rate <= 0 filters mask 0 as
+        # "opted out", but a negative would slip through some paths).
+        if not (math.isfinite(rate) and math.isfinite(counter_rate)) or rate < 0 or counter_rate < 0:
+            return None
 
         if src_chain not in SUPPORTED_CHAINS or dst_chain not in SUPPORTED_CHAINS:
             return None

--- a/allways/commitments.py
+++ b/allways/commitments.py
@@ -8,6 +8,7 @@ from bittensor.utils import ss58_encode
 from allways.chains import SUPPORTED_CHAINS, canonical_pair
 from allways.classes import MinerPair
 from allways.constants import COMMITMENT_VERSION
+from allways.utils.rate import normalize_rate
 
 SS58_PREFIX = 42
 
@@ -36,9 +37,13 @@ def parse_commitment_data(raw: str, uid: int = 0, hotkey: str = '') -> Optional[
         src_addr = parts[2]
         dst_chain = parts[3]
         dst_addr = parts[4]
-        rate_str = parts[5]
+        # Normalize on ingest so a miner posting more precision than RATE_SIG_FIGS
+        # is treated identically by every validator. Rebuild the float from the
+        # normalized string so scoring (uses .rate) and consensus hash (uses
+        # .rate_str) cannot diverge.
+        rate_str = normalize_rate(float(parts[5]))
         rate = float(rate_str)
-        counter_rate_str = parts[6]
+        counter_rate_str = normalize_rate(float(parts[6]))
         counter_rate = float(counter_rate_str)
 
         if src_chain not in SUPPORTED_CHAINS or dst_chain not in SUPPORTED_CHAINS:

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -20,6 +20,10 @@ BTC_TO_SAT = 100_000_000
 
 # ─── Rate Encoding ───────────────────────────────────────
 RATE_PRECISION = 10**18
+# Significant digits enforced on every committed rate. Normalized at the CLI
+# (post) and again at the validator (parse) so scoring buckets, consensus
+# hashes, and contract storage all agree on the same canonical string.
+RATE_SIG_FIGS = 6
 
 # ─── Transaction Fees ────────────────────────────────────
 # Small headroom kept aside for extrinsic fees so a deposit doesn't burn gas

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -23,7 +23,7 @@ RATE_PRECISION = 10**18
 # Significant digits enforced on every committed rate. Normalized at the CLI
 # (post) and again at the validator (parse) so scoring buckets, consensus
 # hashes, and contract storage all agree on the same canonical string.
-RATE_SIG_FIGS = 6
+RATE_SIG_FIGS = 4
 
 # ─── Transaction Fees ────────────────────────────────────
 # Small headroom kept aside for extrinsic fees so a deposit doesn't burn gas

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -23,7 +23,7 @@ RATE_PRECISION = 10**18
 # Significant digits enforced on every committed rate. Normalized at the CLI
 # (post) and again at the validator (parse) so scoring buckets, consensus
 # hashes, and contract storage all agree on the same canonical string.
-RATE_SIG_FIGS = 4
+RATE_SIG_FIGS = 5
 
 # ─── Transaction Fees ────────────────────────────────────
 # Small headroom kept aside for extrinsic fees so a deposit doesn't burn gas

--- a/allways/utils/rate.py
+++ b/allways/utils/rate.py
@@ -5,7 +5,12 @@ from typing import Tuple
 
 from allways.chains import canonical_pair, get_chain
 from allways.classes import Swap
-from allways.constants import RATE_PRECISION
+from allways.constants import RATE_PRECISION, RATE_SIG_FIGS
+
+
+def normalize_rate(rate: float) -> str:
+    """Canonical RATE_SIG_FIGS-precision string for any committed rate."""
+    return f'{rate:.{RATE_SIG_FIGS}g}'
 
 
 def calculate_to_amount(

--- a/neurons/base/validator.py
+++ b/neurons/base/validator.py
@@ -8,7 +8,7 @@ from typing import List, Set, Union
 import bittensor as bt
 import numpy as np
 
-from allways.constants import VALIDATOR_POLL_INTERVAL_SECONDS
+from allways.constants import RECYCLE_UID, VALIDATOR_POLL_INTERVAL_SECONDS
 from allways.utils.config import add_validator_args
 from neurons.base.neuron import BaseNeuron
 from neurons.base.utils.weight_utils import (
@@ -172,9 +172,17 @@ class BaseValidatorNeuron(BaseNeuron):
         norm = np.linalg.norm(self.scores, ord=1, axis=0, keepdims=True)
 
         if np.any(norm == 0) or np.isnan(norm).any():
-            norm = np.ones_like(norm)
-
-        raw_weights = self.scores / norm
+            # Empty/NaN scores (cold start, RPC failure, all miners deregistered).
+            # Hand the full pool to RECYCLE_UID — without this, bittensor's
+            # process_weights_for_netuid falls back to uniform 1/n across every
+            # UID and emissions split evenly instead of fully recycling.
+            n_uids = self.metagraph.n.item()
+            recycle_uid = RECYCLE_UID if RECYCLE_UID < n_uids else 0
+            raw_weights = np.zeros_like(self.scores)
+            raw_weights[recycle_uid] = 1.0
+            bt.logging.warning(f'set_weights: scores empty, routing full pool to recycle UID {recycle_uid}')
+        else:
+            raw_weights = self.scores / norm
 
         bt.logging.debug('raw_weights', raw_weights)
         bt.logging.debug('raw_weight_uids', str(self.metagraph.uids.tolist()))

--- a/tests/test_commitments.py
+++ b/tests/test_commitments.py
@@ -111,6 +111,46 @@ class TestParseCommitmentData:
         assert pair.rate == 0.0
         assert pair.counter_rate == 0.0
 
+    def test_high_precision_rate_normalized_to_six_sig_figs(self):
+        raw = 'v1:btc:bc1qaddr:tao:5Caddr:0.0001234567:340.987654'
+        pair = parse_commitment_data(raw)
+        assert pair is not None
+        assert pair.rate_str == '0.000123457'
+        assert pair.counter_rate_str == '340.988'
+
+    def test_normalized_rate_str_round_trips_to_float(self):
+        """Scoring uses .rate (float), consensus hash uses .rate_str — they must agree."""
+        raw = 'v1:btc:bc1qaddr:tao:5Caddr:0.0001234567:340.987654'
+        pair = parse_commitment_data(raw)
+        assert float(pair.rate_str) == pair.rate
+        assert float(pair.counter_rate_str) == pair.counter_rate
+
+    def test_already_canonical_rate_is_unchanged(self):
+        raw = 'v1:btc:bc1qaddr:tao:5Caddr:345:0.5'
+        pair = parse_commitment_data(raw)
+        assert pair is not None
+        assert pair.rate_str == '345'
+        assert pair.counter_rate_str == '0.5'
+
+    def test_normalization_strips_trailing_zeros(self):
+        raw = 'v1:btc:bc1qaddr:tao:5Caddr:345.000000:0.500000'
+        pair = parse_commitment_data(raw)
+        assert pair.rate_str == '345'
+        assert pair.counter_rate_str == '0.5'
+
+    def test_negative_rate_rejected(self):
+        assert parse_commitment_data('v1:btc:addr:tao:addr:-1:340') is None
+
+    def test_negative_counter_rate_rejected(self):
+        assert parse_commitment_data('v1:btc:addr:tao:addr:340:-1') is None
+
+    def test_nan_rate_rejected(self):
+        assert parse_commitment_data('v1:btc:addr:tao:addr:nan:340') is None
+
+    def test_inf_rate_rejected(self):
+        assert parse_commitment_data('v1:btc:addr:tao:addr:inf:340') is None
+        assert parse_commitment_data('v1:btc:addr:tao:addr:340:-inf') is None
+
     def test_disabled_direction_produces_zero_dest_amount(self):
         """Full guard chain: disabled direction → rate=0 → to_amount=0 → contract rejects."""
         from allways.utils.rate import calculate_to_amount

--- a/tests/test_commitments.py
+++ b/tests/test_commitments.py
@@ -45,14 +45,13 @@ class TestParseCommitmentData:
         assert pair.counter_rate_str == '340'
 
     def test_fractional_rates(self):
-        # Posted rates exceed RATE_SIG_FIGS; parser normalizes both on read.
         raw = 'v1:btc:bc1qaddr:tao:5Caddr:345.12:350.45'
         pair = parse_commitment_data(raw)
         assert pair is not None
-        assert pair.rate_str == '345.1'
-        assert pair.counter_rate_str == '350.4'
-        assert pair.rate == float(pair.rate_str)
-        assert pair.counter_rate == float(pair.counter_rate_str)
+        assert pair.rate == 345.12
+        assert pair.rate_str == '345.12'
+        assert pair.counter_rate == 350.45
+        assert pair.counter_rate_str == '350.45'
 
     def test_get_rate_for_direction(self):
         raw = 'v1:btc:bc1qaddr:tao:5Caddr:340:350'
@@ -116,8 +115,8 @@ class TestParseCommitmentData:
         raw = 'v1:btc:bc1qaddr:tao:5Caddr:0.0001234567:340.987654'
         pair = parse_commitment_data(raw)
         assert pair is not None
-        assert pair.rate_str == '0.0001235'
-        assert pair.counter_rate_str == '341'
+        assert pair.rate_str == '0.00012346'
+        assert pair.counter_rate_str == '340.99'
 
     def test_normalized_rate_str_round_trips_to_float(self):
         """Scoring uses .rate (float), consensus hash uses .rate_str — they must agree."""

--- a/tests/test_commitments.py
+++ b/tests/test_commitments.py
@@ -45,13 +45,14 @@ class TestParseCommitmentData:
         assert pair.counter_rate_str == '340'
 
     def test_fractional_rates(self):
+        # Posted rates exceed RATE_SIG_FIGS; parser normalizes both on read.
         raw = 'v1:btc:bc1qaddr:tao:5Caddr:345.12:350.45'
         pair = parse_commitment_data(raw)
         assert pair is not None
-        assert pair.rate == 345.12
-        assert pair.rate_str == '345.12'
-        assert pair.counter_rate == 350.45
-        assert pair.counter_rate_str == '350.45'
+        assert pair.rate_str == '345.1'
+        assert pair.counter_rate_str == '350.4'
+        assert pair.rate == float(pair.rate_str)
+        assert pair.counter_rate == float(pair.counter_rate_str)
 
     def test_get_rate_for_direction(self):
         raw = 'v1:btc:bc1qaddr:tao:5Caddr:340:350'
@@ -111,12 +112,12 @@ class TestParseCommitmentData:
         assert pair.rate == 0.0
         assert pair.counter_rate == 0.0
 
-    def test_high_precision_rate_normalized_to_six_sig_figs(self):
+    def test_high_precision_rate_normalized_to_sig_figs(self):
         raw = 'v1:btc:bc1qaddr:tao:5Caddr:0.0001234567:340.987654'
         pair = parse_commitment_data(raw)
         assert pair is not None
-        assert pair.rate_str == '0.000123457'
-        assert pair.counter_rate_str == '340.988'
+        assert pair.rate_str == '0.0001235'
+        assert pair.counter_rate_str == '341'
 
     def test_normalized_rate_str_round_trips_to_float(self):
         """Scoring uses .rate (float), consensus hash uses .rate_str — they must agree."""

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -237,12 +237,12 @@ class TestNormalizeRate:
         assert normalize_rate(345) == '345'
 
     def test_already_within_precision(self):
-        assert normalize_rate(345.12) == '345.12'
+        assert normalize_rate(345.1) == '345.1'
         assert normalize_rate(0.5) == '0.5'
 
     def test_truncates_excess_precision(self):
-        assert normalize_rate(250.123456789) == '250.123'
-        assert normalize_rate(0.0001234567) == '0.000123457'
+        assert normalize_rate(250.123456789) == '250.1'
+        assert normalize_rate(0.0001234567) == '0.0001235'
 
     def test_strips_trailing_zeros(self):
         assert normalize_rate(345.000000) == '345'

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -3,7 +3,7 @@
 from decimal import Decimal
 
 from allways.constants import BTC_TO_SAT, RATE_PRECISION, TAO_TO_RAO
-from allways.utils.rate import apply_fee_deduction, calculate_to_amount
+from allways.utils.rate import apply_fee_deduction, calculate_to_amount, normalize_rate
 
 # Chain decimals
 TAO_DEC = 9
@@ -228,3 +228,46 @@ class TestFeeDeduction:
 
     def test_apply_fee_deduction_zero_amount(self):
         assert apply_fee_deduction(0, 100) == 0
+
+
+class TestNormalizeRate:
+    """6-sig-fig canonicalization applied at every commitment ingest gate."""
+
+    def test_integer_rate(self):
+        assert normalize_rate(345) == '345'
+
+    def test_already_within_precision(self):
+        assert normalize_rate(345.12) == '345.12'
+        assert normalize_rate(0.5) == '0.5'
+
+    def test_truncates_excess_precision(self):
+        assert normalize_rate(250.123456789) == '250.123'
+        assert normalize_rate(0.0001234567) == '0.000123457'
+
+    def test_strips_trailing_zeros(self):
+        assert normalize_rate(345.000000) == '345'
+        assert normalize_rate(0.500000) == '0.5'
+
+    def test_zero(self):
+        assert normalize_rate(0) == '0'
+        assert normalize_rate(0.0) == '0'
+
+    def test_idempotent(self):
+        """Round-tripping a normalized rate through float→normalize is a no-op."""
+        for raw in (345.12, 0.0001234567, 250.123456789, 1e-6):
+            once = normalize_rate(raw)
+            twice = normalize_rate(float(once))
+            assert once == twice
+
+    def test_round_trip_preserves_float_equality(self):
+        """float(normalize_rate(x)) must equal float(normalize_rate(x)) re-parsed
+        for IEEE-754 stability — scoring (.rate) and consensus hash (.rate_str)
+        share a MinerPair, so any drift would split validators."""
+        for raw in (345.12, 0.0001234567, 250.123, 0.5):
+            s = normalize_rate(raw)
+            assert float(s) == float(normalize_rate(float(s)))
+
+    def test_small_rate_uses_scientific_notation(self):
+        """Pre-existing :g behavior — sub-1e-4 values switch to scientific.
+        Documented so a future change to fixed-point doesn't silently break."""
+        assert normalize_rate(1e-6) == '1e-06'

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -237,12 +237,12 @@ class TestNormalizeRate:
         assert normalize_rate(345) == '345'
 
     def test_already_within_precision(self):
-        assert normalize_rate(345.1) == '345.1'
+        assert normalize_rate(345.12) == '345.12'
         assert normalize_rate(0.5) == '0.5'
 
     def test_truncates_excess_precision(self):
-        assert normalize_rate(250.123456789) == '250.1'
-        assert normalize_rate(0.0001234567) == '0.0001235'
+        assert normalize_rate(250.123456789) == '250.12'
+        assert normalize_rate(0.0001234567) == '0.00012346'
 
     def test_strips_trailing_zeros(self):
         assert normalize_rate(345.000000) == '345'


### PR DESCRIPTION
## Summary
- `alw swap now` always sorted miners by rate descending, which is correct only when receiving TAO. For TAO→BTC the user wants the **lowest** TAO/BTC rate (less TAO in for the same 1 BTC out), but the table, the "Best rate" hint, and the default `[1]` selection all picked the highest.
- Sort direction is now flipped on `canon_is_reverse`, so the same code path orders miners best-first in either direction.

## Repro
```
$ alw swap now
... pick Bittensor → Bitcoin ...
  1  UID 2  Rate 251  Collateral 0.5
  2  UID 4  Rate 250  Collateral 0.9
  Best rate: send 251 TAO to get 1 BTC (Miner UID 2)   # wrong — UID 4 at 250 is cheaper
```

## Test plan
- [x] `ruff check allways/cli/swap_commands/swap.py` — clean
- [ ] Manual: `alw swap now` against testnet with ≥2 miners on the TAO→BTC pair, confirm lowest-rate miner is row 1 / default / "Best rate" hint
- [ ] Manual: same against BTC→TAO, confirm highest-rate miner stays row 1 (no regression)