### PR TITLE
validator: stop stranded timeout-extension proposals near deadline

### DIFF
--- a/allways/validator/optimistic_extensions.py
+++ b/allways/validator/optimistic_extensions.py
@@ -209,9 +209,6 @@ class OptimisticExtensionWatcher:
         if pending is not None:
             return False
 
-        # Mirror of the reservation-side guard: refuse a doomed propose. If the
-        # challenge window can't close before the existing timeout, finalize
-        # only becomes eligible after the swap has already timed out.
         if current_block + CHALLENGE_WINDOW_BLOCKS >= timeout_block:
             return False
 

--- a/allways/validator/optimistic_extensions.py
+++ b/allways/validator/optimistic_extensions.py
@@ -209,6 +209,12 @@ class OptimisticExtensionWatcher:
         if pending is not None:
             return False
 
+        # Mirror of the reservation-side guard: refuse a doomed propose. If the
+        # challenge window can't close before the existing timeout, finalize
+        # only becomes eligible after the swap has already timed out.
+        if current_block + CHALLENGE_WINDOW_BLOCKS >= timeout_block:
+            return False
+
         if extension_count == 0:
             remaining = 1
         else:

--- a/tests/test_optimistic_extensions.py
+++ b/tests/test_optimistic_extensions.py
@@ -369,6 +369,23 @@ class TestMaybeProposeTimeout:
         )
         assert result is False
 
+    def test_skips_when_challenge_window_cannot_close_before_deadline(self):
+        # current=1000, timeout_block=1005 → only 5 blocks runway, less than
+        # CHALLENGE_WINDOW_BLOCKS(=8). Finalize would be eligible at block
+        # 1008 but the swap times out at 1005 — propose is doomed, refuse it.
+        w = make_watcher(pending_timeout=None)
+        result = w.maybe_propose_timeout(
+            swap_id=42,
+            dest_chain_id='btc',
+            current_block=1000,
+            timeout_block=1005,
+            observed_confirmations=0,
+            extension_count=0,
+            pending=w.fetch_pending_timeout(42),
+        )
+        assert result is False
+        w.contract_client.propose_extend_timeout.assert_not_called()
+
 
 class TestMaybeChallengeTimeout:
     def test_challenges_when_target_too_far(self):


### PR DESCRIPTION
## Summary
- Mirrors #260's reservation-side near-deadline guard onto the swap-timeout side of `OptimisticExtensionWatcher`.
- `maybe_propose_timeout` now refuses to submit when `current_block + CHALLENGE_WINDOW_BLOCKS >= timeout_block` — finalize couldn't become eligible before the swap times out, so the propose is doomed at submission.
- Adds the matching unit test (analog of `test_skips_when_challenge_window_cannot_close_before_deadline` on the reservation side).

## Why
Observed in a quick test: `TimeoutExtensionProposed` at block N, `SwapCompleted` at N+9 — within the 8-block challenge window, so the propose was guaranteed never to finalize. Contract-side cleanup wipes the stranded entry safely, so this isn't a correctness issue, but the doomed extrinsic is wasted gas and the asymmetry vs. the reservation path is exactly what #258/#259/#260 have been closing.

## Test plan
- [x] `pytest tests/test_optimistic_extensions.py` — 31/31 pass
- [x] `ruff format` + `ruff check` clean