### PR TITLE
validator: pick lowest TAO/BTC rate for tao→btc crown

### DIFF
--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 import bittensor as bt
 import numpy as np
 
+from allways.chains import canonical_pair
 from allways.constants import (
     CREDIBILITY_WINDOW_BLOCKS,
     DIRECTION_POOLS,
@@ -249,6 +250,12 @@ def replay_crown_time_window(
     )
     replay_events = merge_replay_events(store, event_watcher, from_chain, to_chain, window_start, window_end)
 
+    # Rates are stored as canonical_dest per canonical_source (TAO per BTC).
+    # In the canonical direction (btc→tao) higher = better; in the reverse
+    # direction (tao→btc) lower = better.
+    canon_from, _ = canonical_pair(from_chain, to_chain)
+    lower_rate_wins = from_chain != canon_from
+
     crown_blocks: Dict[str, float] = {}
     prev_block = window_start
 
@@ -262,6 +269,7 @@ def replay_crown_time_window(
             rewardable_hotkeys,
             busy=busy_set,
             active=active_set,
+            lower_rate_wins=lower_rate_wins,
         )
         if not holders:
             return
@@ -298,10 +306,17 @@ def crown_holders_at_instant(
     rewardable: Set[str],
     busy: Optional[Set[str]] = None,
     active: Optional[Set[str]] = None,
+    lower_rate_wins: bool = False,
 ) -> List[str]:
     """Take the miners posting the best rate, but only if they satisfy every
     other condition (rewardable, active, not busy, rate > 0). If the best
     rate has no qualified miner, fall through to the next-best rate.
+
+    ``lower_rate_wins`` flips the sort: rates are stored as canonical_dest
+    per canonical_source (TAO per BTC), so higher-is-better only holds in
+    the canonical direction (btc→tao). In the reverse direction (tao→btc)
+    a smaller TAO/BTC quote means the miner is asking less TAO for 1 BTC —
+    a better deal for the swapper, which earns them the crown.
 
     Collateral-floor gating is trusted to the contract's active flag —
     miners who drop below the floor get auto-deactivated on-chain (fee /
@@ -323,7 +338,7 @@ def crown_holders_at_instant(
         if rate > 0:
             by_rate.setdefault(rate, []).append(hotkey)
 
-    for rate in sorted(by_rate, reverse=True):
+    for rate in sorted(by_rate, reverse=not lower_rate_wins):
         winners = [hk for hk in by_rate[rate] if qualifies(hk)]
         if winners:
             return winners

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -117,6 +117,15 @@ class TestCrownHoldersHelper:
         holders = crown_holders_at_instant(rates, {'a', 'b'}, busy={'a', 'b'})
         assert holders == []
 
+    def test_lower_rate_wins_flips_sort(self):
+        """For tao→btc the rate is TAO per BTC and lower = better. The
+        helper picks the smallest qualifying rate, falling through to the
+        next-smallest when the smallest is busy."""
+        rates = {'a': 250.0, 'b': 251.0}
+        assert crown_holders_at_instant(rates, {'a', 'b'}, lower_rate_wins=True) == ['a']
+        # Smallest miner is busy → next-smallest takes the crown.
+        assert crown_holders_at_instant(rates, {'a', 'b'}, busy={'a'}, lower_rate_wins=True) == ['b']
+
 
 class TestReplayCrownTime:
     def test_single_miner_holds_full_window(self, tmp_path: Path):
@@ -146,8 +155,8 @@ class TestReplayCrownTime:
         watcher = make_watcher(store, active={'hk_a', 'hk_b'})
         conn = store.require_connection()
         for row in (
-            ('hk_a', 'tao', 'btc', 0.00010, 0),
-            ('hk_b', 'tao', 'btc', 0.00020, 0),
+            ('hk_a', 'btc', 'tao', 100.0, 0),
+            ('hk_b', 'btc', 'tao', 200.0, 0),
         ):
             conn.execute(
                 'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
@@ -156,15 +165,15 @@ class TestReplayCrownTime:
         # Mid-window, A jumps to the top.
         conn.execute(
             'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
-            ('hk_a', 'tao', 'btc', 0.00030, 600),
+            ('hk_a', 'btc', 'tao', 300.0, 600),
         )
         conn.commit()
 
         crown = replay_crown_time_window(
             store=store,
             event_watcher=watcher,
-            from_chain='tao',
-            to_chain='btc',
+            from_chain='btc',
+            to_chain='tao',
             window_start=100,
             window_end=1100,
             rewardable_hotkeys={'hk_a', 'hk_b'},
@@ -226,8 +235,8 @@ class TestReplayCrownTime:
         watcher = make_watcher(store, active={'hk_a', 'hk_b'})
         conn = store.require_connection()
         for row in (
-            ('hk_a', 'tao', 'btc', 0.00030, 0),  # A is best
-            ('hk_b', 'tao', 'btc', 0.00020, 0),  # B is runner-up
+            ('hk_a', 'btc', 'tao', 300.0, 0),  # A is best
+            ('hk_b', 'btc', 'tao', 200.0, 0),  # B is runner-up
         ):
             conn.execute(
                 'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
@@ -242,8 +251,8 @@ class TestReplayCrownTime:
         crown = replay_crown_time_window(
             store=store,
             event_watcher=watcher,
-            from_chain='tao',
-            to_chain='btc',
+            from_chain='btc',
+            to_chain='tao',
             window_start=100,
             window_end=1100,
             rewardable_hotkeys={'hk_a', 'hk_b'},
@@ -290,8 +299,8 @@ class TestReplayCrownTime:
         watcher = make_watcher(store, active={'hk_a', 'hk_b'})
         conn = store.require_connection()
         for row in (
-            ('hk_a', 'tao', 'btc', 0.00030, 0),
-            ('hk_b', 'tao', 'btc', 0.00020, 0),
+            ('hk_a', 'btc', 'tao', 300.0, 0),
+            ('hk_b', 'btc', 'tao', 200.0, 0),
         ):
             conn.execute(
                 'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
@@ -306,8 +315,8 @@ class TestReplayCrownTime:
         crown = replay_crown_time_window(
             store=store,
             event_watcher=watcher,
-            from_chain='tao',
-            to_chain='btc',
+            from_chain='btc',
+            to_chain='tao',
             window_start=100,
             window_end=1100,
             rewardable_hotkeys={'hk_a', 'hk_b'},
@@ -377,17 +386,17 @@ class TestCalculateMinerRewards:
         # Ensure hk_a is still marked active on the watcher even if out of metagraph
         v.event_watcher.active_miners.add('hk_a')
         conn = v.state_store.require_connection()
-        for hk, rate in (('hk_a', 0.00030), ('hk_b', 0.00020)):
+        for hk, rate in (('hk_a', 300.0), ('hk_b', 200.0)):
             conn.execute(
                 'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
-                (hk, 'tao', 'btc', rate, 0),
+                (hk, 'btc', 'tao', rate, 0),
             )
         conn.commit()
 
         rewards, _ = calculate_miner_rewards(v)
 
         # hk_a isn't in metagraph so hk_b (uid 0) becomes the crown holder.
-        np.testing.assert_allclose(rewards[0], POOL_TAO_BTC, atol=1e-6)
+        np.testing.assert_allclose(rewards[0], POOL_BTC_TAO, atol=1e-6)
         v.state_store.close()
 
     def test_recycle_uid_out_of_bounds_falls_back_to_zero(self, tmp_path: Path):
@@ -557,10 +566,10 @@ class TestHistoricalActiveState:
         store = ValidatorStateStore(db_path=tmp_path / 'state.db')
         watcher = make_watcher(store, active={'hk_a', 'hk_b'})
         conn = store.require_connection()
-        for hk, rate in (('hk_a', 0.00030), ('hk_b', 0.00020)):
+        for hk, rate in (('hk_a', 300.0), ('hk_b', 200.0)):
             conn.execute(
                 'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
-                (hk, 'tao', 'btc', rate, 0),
+                (hk, 'btc', 'tao', rate, 0),
             )
         conn.commit()
         watcher.apply_event(500, 'MinerActivated', {'miner': 'hk_a', 'active': False})
@@ -568,8 +577,8 @@ class TestHistoricalActiveState:
         crown = replay_crown_time_window(
             store=store,
             event_watcher=watcher,
-            from_chain='tao',
-            to_chain='btc',
+            from_chain='btc',
+            to_chain='tao',
             window_start=100,
             window_end=1100,
             rewardable_hotkeys={'hk_a', 'hk_b'},
@@ -662,12 +671,12 @@ class TestHistoricalActiveState:
         conn = store.require_connection()
         conn.execute(
             'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
-            ('hk_b', 'tao', 'btc', 0.00020, 0),
+            ('hk_b', 'btc', 'tao', 200.0, 0),
         )
         # A's rate posted at block 500 — same block as their activation.
         conn.execute(
             'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
-            ('hk_a', 'tao', 'btc', 0.00030, 500),
+            ('hk_a', 'btc', 'tao', 300.0, 500),
         )
         conn.commit()
         watcher.apply_event(500, 'MinerActivated', {'miner': 'hk_a', 'active': True})
@@ -675,8 +684,8 @@ class TestHistoricalActiveState:
         crown = replay_crown_time_window(
             store=store,
             event_watcher=watcher,
-            from_chain='tao',
-            to_chain='btc',
+            from_chain='btc',
+            to_chain='tao',
             window_start=100,
             window_end=1100,
             rewardable_hotkeys={'hk_a', 'hk_b'},
@@ -714,10 +723,10 @@ class TestHistoricalActiveState:
         store = ValidatorStateStore(db_path=tmp_path / 'state.db')
         watcher = make_watcher(store, active={'hk_a', 'hk_b'})
         conn = store.require_connection()
-        for hk, rate in (('hk_a', 0.00030), ('hk_b', 0.00020)):
+        for hk, rate in (('hk_a', 300.0), ('hk_b', 200.0)):
             conn.execute(
                 'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
-                (hk, 'tao', 'btc', rate, 0),
+                (hk, 'btc', 'tao', rate, 0),
             )
         conn.commit()
         # At block 500: A both deactivates and picks up a swap. Both events
@@ -730,8 +739,8 @@ class TestHistoricalActiveState:
         crown = replay_crown_time_window(
             store=store,
             event_watcher=watcher,
-            from_chain='tao',
-            to_chain='btc',
+            from_chain='btc',
+            to_chain='tao',
             window_start=100,
             window_end=1100,
             rewardable_hotkeys={'hk_a', 'hk_b'},
@@ -753,18 +762,18 @@ class TestHistoricalActiveState:
         v.event_watcher.active_miners.add('hk_a')
         seed_active(v.event_watcher, 'hk_a', active=True, block=0)
         conn = v.state_store.require_connection()
-        for hk, rate in (('hk_a', 0.00030), ('hk_b', 0.00020)):
+        for hk, rate in (('hk_a', 300.0), ('hk_b', 200.0)):
             conn.execute(
                 'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
-                (hk, 'tao', 'btc', rate, 0),
+                (hk, 'btc', 'tao', rate, 0),
             )
         conn.commit()
         v.event_watcher.apply_event(9_000, 'MinerActivated', {'miner': 'hk_a', 'active': False})
 
         rewards, _ = calculate_miner_rewards(v)
 
-        # hk_b (uid 0) is the only rewardable + active miner, earns tao→btc.
-        np.testing.assert_allclose(rewards[0], POOL_TAO_BTC, atol=1e-6)
+        # hk_b (uid 0) is the only rewardable + active miner, earns btc→tao.
+        np.testing.assert_allclose(rewards[0], POOL_BTC_TAO, atol=1e-6)
         np.testing.assert_allclose(rewards.sum(), 1.0, atol=1e-6)
         v.state_store.close()
 


### PR DESCRIPTION
## Summary
- `crown_holders_at_instant` always sorted rates descending. For `(tao, btc)` rates are stored as TAO per BTC where lower = better for the swapper, so the worse miner won the crown — mirror of the CLI bug fixed in #261, just on the validator's reward path.
- Thread a `lower_rate_wins` flag through `replay_crown_time_window` → `crown_holders_at_instant`, derived once from `canonical_pair`. Default stays `False` so the canonical `(btc, tao)` direction keeps highest-wins.
- Existing replay tests that incidentally relied on highest-wins semantics for `(tao, btc)` are switched to canonical `(btc, tao)` — they were never about direction semantics and the diff stays mechanical. Added one helper-level regression that exercises the lowest-wins branch.

## Reproduction
With miners UID 2 (BTC→TAO 301, TAO→BTC 251) and UID 4 (BTC→TAO 300, TAO→BTC 250) and 8% total distributable across the two direction pools:
- Before: UID 2 takes both pools (0.08), UID 4 gets 0.
- After: UID 2 wins BTC→TAO (0.04), UID 4 wins TAO→BTC (0.04).

## Test plan
- [x] `pytest tests/test_scoring_v1.py` — 47 pass
- [x] `pytest` — full suite 402 pass
- [x] `ruff check` clean, `ruff format --check` clean
- [ ] E2E happy-path swap on dev environment