### PR TITLE
neuron: reconnect substrate when chain head freezes across polls

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -10,6 +10,8 @@ CONTRACT_ADDRESS = '5FTkUEhRmLPsALn4b7bJpVFhDQqohGbc6khnmA2aiYFLMZYP'
 # Bittensor base-neuron heartbeat, not the scoring/forward cadence.
 MINER_POLL_INTERVAL_SECONDS = 12
 VALIDATOR_POLL_INTERVAL_SECONDS = 12
+# Consecutive polls of zero block progress before we force a substrate reconnect.
+STALE_BLOCK_POLL_THRESHOLD = 30
 
 # ─── Commitment Format ────────────────────────────────────
 COMMITMENT_VERSION = 1

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -39,6 +39,8 @@ async def forward(self: Validator) -> None:
     tracker: SwapTracker = self.swap_tracker
     verifier: SwapVerifier = self.swap_verifier
 
+    self.check_block_progress(self.reconnect_and_propagate)
+
     clear_provider_caches(self)
 
     # Sync events first so ReservationExtensionFinalized writes from the

--- a/neurons/base/neuron.py
+++ b/neurons/base/neuron.py
@@ -1,11 +1,13 @@
 import copy
 import time
 from abc import ABC, abstractmethod
+from typing import Callable
 
 import bittensor as bt
 from websockets.exceptions import ConnectionClosedError
 
 from allways import __spec_version__ as spec_version
+from allways.constants import STALE_BLOCK_POLL_THRESHOLD
 from allways.utils.config import add_args, check_config, config
 from allways.utils.misc import ttl_get_block
 
@@ -67,6 +69,29 @@ class BaseNeuron(ABC):
             f'using network: {self.subtensor.chain_endpoint}'
         )
         self.step = 0
+        self.last_seen_block = 0
+        self.stale_block_polls = 0
+
+    def check_block_progress(self, reconnect: Callable[[], None]) -> None:
+        """Reconnect if the substrate WS appears wedged — chain head frozen across many polls."""
+        try:
+            current_block = self.subtensor.get_current_block()
+        except Exception as e:
+            bt.logging.debug(f'block-progress watchdog: get_current_block failed: {e}')
+            return
+
+        if current_block == self.last_seen_block:
+            self.stale_block_polls += 1
+        else:
+            self.stale_block_polls = 0
+            self.last_seen_block = current_block
+
+        if self.stale_block_polls >= STALE_BLOCK_POLL_THRESHOLD:
+            bt.logging.warning(
+                f'chain head frozen at {current_block} for {self.stale_block_polls} polls, reconnecting subtensor'
+            )
+            reconnect()
+            self.stale_block_polls = 0
 
     def reconnect_subtensor(self):
         """Recreate subtensor connection when WebSocket goes stale."""

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -135,6 +135,7 @@ class Miner(BaseMinerNeuron):
 
     async def forward(self):
         """Main miner forward pass — polls for swaps and processes each one."""
+        self.check_block_progress(self.reconnect_and_propagate)
         self.maybe_reload_my_addresses()
 
         active_swaps, _fulfilled = self.swap_poller.poll()


### PR DESCRIPTION
## Summary
- Adds a block-progress watchdog on `BaseNeuron`: if `get_current_block()` returns the same value for 30 consecutive polls (~6 min), force `reconnect`.
- Detects the wedged-but-alive WS case where reads succeed against stale cached state and the existing exception-based reconnect never fires.
- Wired into both miner and validator forward loops via each neuron's `reconnect_and_propagate`.

## Test plan
- [ ] `ruff format && ruff check` clean
- [ ] `tests/run.sh --chains btc --suite 02` happy path still passes
- [ ] Manual: kill subtensor mid-run and confirm watchdog fires within ~6 min once block stops advancing