### PR TITLE
cli: fix swapped netuid/hotkey args in view reservation hydration

### DIFF
--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -379,7 +379,9 @@ def hydrate_pending_swap(state: PendingSwapState, client) -> bool:
     try:
         from allways.commitments import read_miner_commitment
 
-        miner_pair = read_miner_commitment(getattr(client, 'subtensor', None), state.miner_hotkey, state.netuid)
+        subtensor = getattr(client, 'subtensor', None)
+        metagraph = subtensor.metagraph(state.netuid) if subtensor is not None else None
+        miner_pair = read_miner_commitment(subtensor, state.netuid, state.miner_hotkey, metagraph=metagraph)
         if miner_pair:
             state.miner_uid = miner_pair.uid
             state.miner_from_address = miner_pair.from_address


### PR DESCRIPTION
## Summary
- `hydrate_pending_swap` was calling `read_miner_commitment(subtensor, hotkey, netuid)` instead of `(subtensor, netuid, hotkey)`. The substrate `CommitmentOf` query then ran with nonsense params, returned `None`, the silent `except` swallowed the miss, and `miner_uid` / `miner_from_address` stayed at their dataclass defaults — so `alw view reservation` always showed `UID 0` and a blank miner-side address.
- Also pass the metagraph so the function can resolve hotkey → uid (without it, `uid` defaults to `0` even on a successful read).
- Introduced in #250.

## Test plan
- [ ] `./down.sh --force && ./up.sh --chains btc` then `alw swap now` and `alw view reservation` — verify the correct miner UID and miner BTC address render.
- [ ] `./tests/run.sh --chains btc --suite 02`