### PR TITLE
cli: honor saved source tx in resume-reservation

### DIFF
--- a/allways/cli/swap_commands/resume.py
+++ b/allways/cli/swap_commands/resume.py
@@ -167,9 +167,6 @@ def resume_reservation_command(from_tx_hash_opt: Optional[str], skip_confirm: bo
 
     ephemeral_wallet = get_ephemeral_wallet()
 
-    # Prompt for source tx hash if not provided. If `swap now` already
-    # broadcast and persisted the source tx, skip the "Send X to Y" prompt
-    # — re-asking risks a double-send.
     used_saved_tx = False
     if not from_tx_hash_opt:
         saved_tx = (state.from_tx_hash or '').strip()
@@ -185,15 +182,9 @@ def resume_reservation_command(from_tx_hash_opt: Optional[str], skip_confirm: bo
                 return
 
     from_tx_hash = from_tx_hash_opt.strip()
-    # The user has asserted they've sent funds — persist the tx hash so
-    # `alw view reservation` reflects that, even if validators reject below.
     mark_pending_swap_tx_sent(from_tx_hash)
 
-    # Reservation-wide block lookup so a resumed tx still ±3-hints the
-    # validator. 0 = miss (falls back to validator-side scan). Skip the
-    # lookup when we're reusing a freshly-broadcast hash from `swap now`
-    # — the tx is almost certainly still in mempool, so the scan would
-    # just print "not found" noise right after we said "already broadcast".
+    # Saved hash is fresh from swap now — still in mempool, lookup would just print noise.
     if used_saved_tx:
         from_tx_block = 0
     else:

--- a/allways/cli/swap_commands/resume.py
+++ b/allways/cli/swap_commands/resume.py
@@ -170,11 +170,13 @@ def resume_reservation_command(from_tx_hash_opt: Optional[str], skip_confirm: bo
     # Prompt for source tx hash if not provided. If `swap now` already
     # broadcast and persisted the source tx, skip the "Send X to Y" prompt
     # — re-asking risks a double-send.
+    used_saved_tx = False
     if not from_tx_hash_opt:
         saved_tx = (state.from_tx_hash or '').strip()
         if saved_tx:
             console.print(f'\n[green]Source tx already broadcast:[/green] [cyan]{saved_tx}[/cyan]')
             from_tx_hash_opt = saved_tx
+            used_saved_tx = True
         else:
             console.print(f'\n  Send [green]{send_label}[/green] to: [cyan]{state.miner_from_address}[/cyan]\n')
             from_tx_hash_opt = click.prompt('Enter transaction hash after sending (or "skip" to exit)', default='')
@@ -188,16 +190,22 @@ def resume_reservation_command(from_tx_hash_opt: Optional[str], skip_confirm: bo
     mark_pending_swap_tx_sent(from_tx_hash)
 
     # Reservation-wide block lookup so a resumed tx still ±3-hints the
-    # validator. 0 = miss (falls back to validator-side scan).
-    from_tx_block = resolve_source_tx_block(
-        provider=provider,
-        tx_hash=from_tx_hash,
-        expected_recipient=state.miner_from_address,
-        expected_amount=state.from_amount,
-        subtensor=subtensor,
-        client=client,
-        reserved_until_block=reserved_until,
-    )
+    # validator. 0 = miss (falls back to validator-side scan). Skip the
+    # lookup when we're reusing a freshly-broadcast hash from `swap now`
+    # — the tx is almost certainly still in mempool, so the scan would
+    # just print "not found" noise right after we said "already broadcast".
+    if used_saved_tx:
+        from_tx_block = 0
+    else:
+        from_tx_block = resolve_source_tx_block(
+            provider=provider,
+            tx_hash=from_tx_hash,
+            expected_recipient=state.miner_from_address,
+            expected_amount=state.from_amount,
+            subtensor=subtensor,
+            client=client,
+            reserved_until_block=reserved_until,
+        )
 
     console.print('\n[dim]Confirming with validators...[/dim]')
     accepted, queued, info = sign_and_broadcast_confirm(

--- a/allways/cli/swap_commands/resume.py
+++ b/allways/cli/swap_commands/resume.py
@@ -167,13 +167,20 @@ def resume_reservation_command(from_tx_hash_opt: Optional[str], skip_confirm: bo
 
     ephemeral_wallet = get_ephemeral_wallet()
 
-    # Prompt for source tx hash if not provided
+    # Prompt for source tx hash if not provided. If `swap now` already
+    # broadcast and persisted the source tx, skip the "Send X to Y" prompt
+    # — re-asking risks a double-send.
     if not from_tx_hash_opt:
-        console.print(f'\n  Send [green]{send_label}[/green] to: [cyan]{state.miner_from_address}[/cyan]\n')
-        from_tx_hash_opt = click.prompt('Enter transaction hash after sending (or "skip" to exit)', default='')
-        if not from_tx_hash_opt or from_tx_hash_opt.lower() == 'skip':
-            console.print('[yellow]Swap paused. Resume later with: alw swap resume-reservation[/yellow]')
-            return
+        saved_tx = (state.from_tx_hash or '').strip()
+        if saved_tx:
+            console.print(f'\n[green]Source tx already broadcast:[/green] [cyan]{saved_tx}[/cyan]')
+            from_tx_hash_opt = saved_tx
+        else:
+            console.print(f'\n  Send [green]{send_label}[/green] to: [cyan]{state.miner_from_address}[/cyan]\n')
+            from_tx_hash_opt = click.prompt('Enter transaction hash after sending (or "skip" to exit)', default='')
+            if not from_tx_hash_opt or from_tx_hash_opt.lower() == 'skip':
+                console.print('[yellow]Swap paused. Resume later with: alw swap resume-reservation[/yellow]')
+                return
 
     from_tx_hash = from_tx_hash_opt.strip()
     # The user has asserted they've sent funds — persist the tx hash so


### PR DESCRIPTION
## Summary
- `alw swap resume-reservation` now reuses the source tx hash already persisted by `alw swap now`, so users who Ctrl+C out of the post-broadcast polling loop aren't re-prompted to "Send X to Y" — which read like an instruction to send again and risked a double-send.
- Falls back to the existing prompt only when no saved hash is on file (legacy state, or resume invoked before broadcast).
- `--from-tx-hash` flag still wins, matching `post-tx`.

## Test plan
- [ ] `alw swap now` → Ctrl+C after BTC broadcast → `alw swap resume-reservation` shows "Source tx already broadcast: …" and confirms with validators without prompting for a hash
- [ ] `alw swap resume-reservation` with no prior broadcast still prompts for the hash as before
- [ ] `alw swap resume-reservation --from-tx-hash <hash>` still bypasses the prompt