### PR TITLE
miner: drop free-balance pre-flight gate, add blind-spot logging

### DIFF
--- a/allways/contract_client.py
+++ b/allways/contract_client.py
@@ -536,13 +536,15 @@ class AllwaysContractClient:
         signer_address = keypair.ss58_address
         try:
             account_info = self.substrate_call(lambda s: s.query('System', 'Account', [signer_address]))
+            account_data = account_info.value if hasattr(account_info, 'value') else account_info
+            free_balance = account_data.get('data', {}).get('free', 0)
+            if free_balance < MIN_BALANCE_FOR_TX_RAO:
+                bt.logging.warning(
+                    f'{method}: low free balance on {signer_address} ({free_balance} rao); '
+                    f'submitting anyway — chain will reject if truly insufficient'
+                )
         except Exception as e:
-            raise ContractError(f'{method}: balance query failed: {e}') from e
-
-        account_data = account_info.value if hasattr(account_info, 'value') else account_info
-        free_balance = account_data.get('data', {}).get('free', 0)
-        if free_balance < MIN_BALANCE_FOR_TX_RAO:
-            raise ContractError(f'{method}: free={free_balance}')
+            bt.logging.debug(f'{method}: pre-flight balance probe failed, proceeding: {e}')
 
         def submit_extrinsic(s):
             call = s.compose_call(

--- a/allways/miner/fulfillment.py
+++ b/allways/miner/fulfillment.py
@@ -207,6 +207,10 @@ class SwapFulfiller:
         # credentials live on the provider itself.
         from_address = None if swap.to_chain == 'tao' else self.my_addresses.get(swap.to_chain)
 
+        bt.logging.info(
+            f'Swap {swap.id}: initiating dest send of {user_receives_amount} to {swap.user_to_address} '
+            f'on {swap.to_chain}'
+        )
         result = provider.send_amount(swap.user_to_address, user_receives_amount, from_address=from_address)
         if result:
             tx_hash, block_num = result
@@ -239,6 +243,7 @@ class SwapFulfiller:
         if sent and sent.marked_fulfilled:
             # Already finished on a previous pass. Contract state catches up
             # when validators confirm — nothing to retry here.
+            bt.logging.debug(f'Swap {swap.id}: already marked fulfilled locally, awaiting validator confirm')
             return True
 
         bt.logging.info(f'Processing swap {swap.id}: {swap.from_chain} -> {swap.to_chain}')

--- a/allways/miner/fulfillment.py
+++ b/allways/miner/fulfillment.py
@@ -79,6 +79,7 @@ class SwapFulfiller:
         # neuron's reload mutates what we read here.
         self.my_addresses: Dict[str, str] = my_addresses if my_addresses is not None else {}
         self.sent: Dict[int, SentSwap] = {}
+        self.mark_fulfilled_attempts: Dict[int, int] = {}
         self.sent_cache_path = sent_cache_path
         self.load_sent_cache()
 
@@ -117,8 +118,9 @@ class SwapFulfiller:
         stale = [sid for sid in self.sent if sid not in active_swap_ids]
         for sid in stale:
             self.sent.pop(sid)
-            bt.logging.debug(f'Cleaned up stale send cache for swap {sid}')
+            self.mark_fulfilled_attempts.pop(sid, None)
         if stale:
+            bt.logging.info(f'Cleaned up stale send cache for {len(stale)} swap(s): {stale}')
             self.save_sent_cache()
 
     def verify_swap_safety(self, swap: Swap) -> Optional[Tuple[int, str]]:
@@ -289,8 +291,17 @@ class SwapFulfiller:
             )
             sent.marked_fulfilled = True
             self.save_sent_cache()
+            self.mark_fulfilled_attempts.pop(swap.id, None)
             bt.logging.success(f'Swap {swap.id}: marked as fulfilled')
             return True
         except ContractError as e:
-            bt.logging.error(f'Swap {swap.id}: failed to mark fulfilled on contract: {e}')
+            attempts = self.mark_fulfilled_attempts.get(swap.id, 0) + 1
+            self.mark_fulfilled_attempts[swap.id] = attempts
+            try:
+                blocks_to_deadline = swap.timeout_block - self.subtensor.get_current_block()
+                deadline_str = f'{blocks_to_deadline} blocks to deadline'
+            except Exception:
+                deadline_str = 'deadline unknown'
+            log = bt.logging.warning if attempts >= 3 else bt.logging.error
+            log(f'Swap {swap.id}: mark_fulfilled failed (attempt {attempts}, {deadline_str}): {e}')
             return False

--- a/allways/miner/swap_poller.py
+++ b/allways/miner/swap_poller.py
@@ -46,6 +46,11 @@ class SwapPoller:
             swap = self.client.get_swap(swap_id)
             if swap and swap.miner_hotkey == self.miner_hotkey:
                 if swap.status in (SwapStatus.ACTIVE, SwapStatus.FULFILLED):
+                    if swap.id not in self.active:
+                        bt.logging.info(
+                            f'Discovered swap {swap.id}: {swap.from_chain} -> {swap.to_chain}, '
+                            f'tao_amount={swap.tao_amount}, status={swap.status.name}'
+                        )
                     self.active[swap.id] = swap
                     fresh.add(swap.id)
         if next_id > 1:

--- a/allways/miner/swap_poller.py
+++ b/allways/miner/swap_poller.py
@@ -57,17 +57,19 @@ class SwapPoller:
             self.last_scanned_id = next_id - 1
 
         # 2. Refresh active set — skip freshly discovered swaps, remove resolved
-        resolved = []
+        resolved: list[tuple[int, str]] = []
         for swap_id in list(self.active):
             if swap_id in fresh:
                 continue
             swap = self.client.get_swap(swap_id)
             if swap is None or swap.status not in (SwapStatus.ACTIVE, SwapStatus.FULFILLED):
-                resolved.append(swap_id)
+                terminal = swap.status.name if swap is not None else 'GONE'
+                resolved.append((swap_id, terminal))
             else:
                 self.active[swap_id] = swap
-        for sid in resolved:
+        for sid, terminal in resolved:
             self.active.pop(sid, None)
+            bt.logging.debug(f'Swap {sid}: dropped from active (status={terminal})')
 
         # 3. Return categorized by contract status
         active_swaps = [s for s in self.active.values() if s.status == SwapStatus.ACTIVE]

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -120,6 +120,10 @@ class Miner(BaseMinerNeuron):
                 self.my_addresses.clear()
                 self.my_addresses.update(fresh)
                 bt.logging.info(f'Miner addresses refreshed after rate post: {self.my_addresses}')
+            else:
+                bt.logging.warning(
+                    'Rate-posted flag set but no commitment readable on chain yet; address cache left untouched'
+                )
             self.rate_flag_path.unlink(missing_ok=True)
         except Exception as e:
             bt.logging.debug(f'Rate-posted flag check failed: {e}')

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -107,6 +107,10 @@ class Miner(BaseMinerNeuron):
             bt.logging.warning(f'Could not read own commitment at startup: {e}')
             return {}
         if pair is None:
+            bt.logging.warning(
+                f'No on-chain commitment found for hotkey {hotkey}; miner will not be able to fulfill swaps '
+                'until `alw miner post` is run'
+            )
             return {}
         return {pair.from_chain: pair.from_address, pair.to_chain: pair.to_address}
 


### PR DESCRIPTION
## Summary
- Strip the free-balance pre-flight gate in `exec_contract_raw`. It raised a `ContractError` whenever the signer's balance dipped under `MIN_BALANCE_FOR_TX_RAO` (originally 0.25 TAO, now 0.02 TAO), silently aborting `mark_fulfilled` and friends before the chain ever evaluated them. The chain itself remains the source of truth for insufficient-balance rejections; we keep a warning log so low-balance conditions are still visible.
- Add four surgical log lines at miner blind spots:
  - `swap_poller.poll_inner`: info when a swap is first discovered as assigned to this miner.
  - `fulfillment.process_swap`: debug on the idempotent early-return after a prior `mark_fulfilled` succeeded but the contract status hasn't caught up.
  - `fulfillment.send_dest_funds`: info immediately before the destination-chain transfer kicks off, so a hung send is locatable.
  - `miner.maybe_reload_my_addresses`: warn when the rate-posted flag is set but no commitment is readable yet.

## Test plan
- [x] `ruff format && ruff check` clean on changed files
- [x] `pytest tests/` — 403 passed
- [ ] Smoke through dev environment: `./down.sh --force && ./up.sh --chains btc && ./tests/run.sh --chains btc --suite 02`