### PR TITLE
cli: warn when committing hotkey as TAO send address

### DIFF
--- a/allways/cli/swap_commands/pair.py
+++ b/allways/cli/swap_commands/pair.py
@@ -185,6 +185,17 @@ def post_pair(
     console.print(f'  Netuid:     {netuid}')
     console.print(f'  Data:       [dim]{commitment_data}[/dim]\n')
 
+    if dst_chain == 'tao' and dst_addr == wallet.hotkey.ss58_address:
+        console.print(
+            f'[yellow]Warning: TAO send address is your hotkey. Standard miners sign TAO transfers '
+            f'with the coldkey ({wallet.coldkey.ss58_address}); validators reject fulfillments whose '
+            f'sender does not match the committed address. Commit the coldkey unless you run a '
+            f'customized miner that signs from the hotkey.[/yellow]\n'
+        )
+        if not yes and not click.confirm('Post with hotkey as TAO send address anyway?', default=False):
+            console.print('[yellow]Cancelled[/yellow]')
+            return
+
     if not yes and not click.confirm('Confirm posting this pair?'):
         console.print('[yellow]Cancelled[/yellow]')
         return


### PR DESCRIPTION
## Summary
- Surfaces the silent-fail mode behind testnet swap #10: a miner committed their hotkey SS58 as their TAO destination address in `alw pair`, but `bt.Subtensor.transfer(wallet=...)` signs from the coldkey, so the validator's sender-mismatch defense rejected every fulfillment until timeout.
- Prints a yellow warning and requires an explicit second confirmation when the TAO `dst_addr` equals `wallet.hotkey.ss58_address`, with the coldkey shown inline so the fix is one paste away. `--yes` still bypasses for the rare miner who has wired up custom hotkey-signed transfers.

## Test plan
- [ ] `alw pair btc <btc_addr> tao <hotkey_ss58> 350` shows the warning and second confirm
- [ ] `alw pair btc <btc_addr> tao <coldkey_ss58> 350` posts without the extra warning
- [ ] `alw pair ... -y` skips both confirms (override path)