### PR TITLE
cli: fix non-interactive --from-address abort and stale-reservation crash

### DIFF
--- a/allways/cli/main.py
+++ b/allways/cli/main.py
@@ -38,13 +38,16 @@ if os.environ.get('_ALW_COMPLETE'):
             _sys.modules[_pkg + _suffix] = _mock
 
 import json  # noqa: E402
+from pathlib import Path  # noqa: E402
 
 import click  # noqa: E402
 from click.shell_completion import get_completion_class  # noqa: E402
-from dotenv import load_dotenv  # noqa: E402
+from dotenv import find_dotenv, load_dotenv  # noqa: E402
 from rich.table import Table  # noqa: E402
 
-load_dotenv()
+# Precedence: shell env > project .env (CWD walk-up) > ~/.allways/.env. override=False makes earlier loads win.
+load_dotenv(find_dotenv(usecwd=True), override=False)
+load_dotenv(Path.home() / '.allways' / '.env', override=False)
 
 from allways.cli.help import StyledAliasGroup, StyledGroup  # noqa: E402
 from allways.cli.swap_commands.helpers import ALLWAYS_DIR, CONFIG_FILE, apply_global_flags, console  # noqa: E402

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -610,9 +610,7 @@ def swap_now_command(
         console.print('[red]Source and destination chains must be different[/red]')
         return
 
-    # Non-interactive (--yes) mode silently dropped into a click.prompt for
-    # --from-address on non-TAO source chains, which then aborted with no
-    # actionable error. Fail fast with a clear message instead.
+    # Non-TAO source needs --from-address up front; otherwise the later prompt aborts under --yes.
     if skip_confirm and from_chain_opt and from_chain_opt != 'tao' and not from_address_opt:
         console.print(
             f'[red]--from-address is required for {from_chain_opt.upper()} source in non-interactive mode (--yes).[/red]\n'

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -610,6 +610,16 @@ def swap_now_command(
         console.print('[red]Source and destination chains must be different[/red]')
         return
 
+    # Non-interactive (--yes) mode silently dropped into a click.prompt for
+    # --from-address on non-TAO source chains, which then aborted with no
+    # actionable error. Fail fast with a clear message instead.
+    if skip_confirm and from_chain_opt and from_chain_opt != 'tao' and not from_address_opt:
+        console.print(
+            f'[red]--from-address is required for {from_chain_opt.upper()} source in non-interactive mode (--yes).[/red]\n'
+            f'[dim]Pass your {from_chain_opt.upper()} source address explicitly, e.g. --from-address bc1q...[/dim]'
+        )
+        return
+
     console.print('\n[bold]Allways Swap[/bold]\n')
 
     # Check for pending reservation

--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -1053,11 +1053,8 @@ def view_reservation():
         console.print('[red]Failed to read reservation status from contract.[/red]')
         return
 
-    # Without hydration the chain/amount fields are empty defaults — the table
-    # renderer below would crash on `get_chain('')`. Hydrate failure means the
-    # on-chain reservation is gone (expired, replaced, or resolved-and-pruned),
-    # so the local file is stale. Clear it and report no active reservation
-    # rather than dump a traceback.
+    # No matching on-chain reservation — local file is stale; clearing it
+    # also avoids a `get_chain('')` crash in the table renderer below.
     if not hydrated:
         console.print('\n[yellow]No active reservation.[/yellow]')
         console.print('[dim]Local state referenced a reservation that is no longer on-chain — cleared.[/dim]\n')

--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -1043,7 +1043,7 @@ def view_reservation():
         console.print('\n[yellow]No active reservation found.[/yellow]')
         console.print('[dim]Run `alw swap now` to initiate a swap.[/dim]\n')
         return
-    hydrate_pending_swap(state, client)
+    hydrated = hydrate_pending_swap(state, client)
 
     current_block = subtensor.get_current_block()
     with loading('Reading reservation...'):
@@ -1051,6 +1051,17 @@ def view_reservation():
 
     if status.kind == 'rpc_error':
         console.print('[red]Failed to read reservation status from contract.[/red]')
+        return
+
+    # Without hydration the chain/amount fields are empty defaults — the table
+    # renderer below would crash on `get_chain('')`. Hydrate failure means the
+    # on-chain reservation is gone (expired, replaced, or resolved-and-pruned),
+    # so the local file is stale. Clear it and report no active reservation
+    # rather than dump a traceback.
+    if not hydrated:
+        console.print('\n[yellow]No active reservation.[/yellow]')
+        console.print('[dim]Local state referenced a reservation that is no longer on-chain — cleared.[/dim]\n')
+        clear_pending_swap()
         return
 
     console.print('\n[bold]Swap Reservation[/bold]\n')


### PR DESCRIPTION
## Summary

Two CLI bumps that an agent running through the [llms.txt quickstart](https://test.all-ways.io/llms.txt) hit on first contact:

- `alw swap now --yes` with a BTC source and no `--from-address` would drop into a `click.prompt` and then abort with `Aborted!` — no message naming the missing flag. Now it errors fast with a one-liner pointing at `--from-address`.
- `alw view reservation` crashed with `KeyError: ''` when the local `pending_swap.json` referred to a reservation that had already resolved and been pruned on-chain. `hydrate_pending_swap` left the chain fields at their empty defaults, then `get_chain('')` blew up. Now it clears the stale file and reports "no active reservation".

## Test plan

- [ ] `alw swap now --from btc --to tao --amount 0.001 --receive-address 5C... --auto --yes` (no `--from-address`) → red error, exit cleanly.
- [ ] Same command with `--from-address bc1q...` → behaves as before.
- [ ] With a stale `~/.allways/pending_swap.json` (no matching on-chain reservation) → `alw view reservation` prints "No active reservation." and clears the file instead of tracebacking.
- [ ] `alw view reservation` with an active reservation still renders the table normally.