### PR TITLE
validator: harden swap tracker against silent state loss

### DIFF
--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -422,7 +422,7 @@ def mark_pending_swap_tx_sent(tx_hash: str) -> None:
 # Fallback when the contract's reservation TTL can't be read. Mirrors the
 # contract default (see ``reservation_ttl`` init in
 # allways/smart-contracts/ink/lib.rs); update both together.
-_DEFAULT_RESERVATION_TTL_BLOCKS = 4032
+_DEFAULT_RESERVATION_TTL_BLOCKS = 50  # ~10 min
 
 
 @dataclass

--- a/allways/contract_client.py
+++ b/allways/contract_client.py
@@ -490,6 +490,10 @@ class AllwaysContractClient:
 
         except ContractError:
             raise
+        except RECONNECT_EXCEPTIONS:
+            # Don't mask transient WS failures as "no result" — callers need
+            # to distinguish "RPC blip, retry me" from "contract returned None".
+            raise
         except Exception as e:
             bt.logging.debug(f'Raw contract read {method} failed: {e}')
             return None

--- a/allways/contract_client.py
+++ b/allways/contract_client.py
@@ -43,6 +43,7 @@ Layout
 
 import os
 import struct
+import threading
 from typing import Any, Callable, List, Optional, Tuple, TypeVar
 
 import bittensor as bt
@@ -360,6 +361,9 @@ class AllwaysContractClient:
         self.reconnect_subtensor = reconnect_subtensor
         self.readonly_keypair = Keypair.create_from_uri('//Alice')
         self.initialized = False
+        # substrate-interface's WebSocketProvider isn't thread-safe; serialize
+        # access so concurrent threads can't both land in recv at the same time.
+        self._substrate_lock = threading.Lock()
 
         if not self.contract_address:
             bt.logging.warning('Allways contract address not set')
@@ -377,18 +381,19 @@ class AllwaysContractClient:
         receipt returned, the retry composes a fresh nonce and submits a
         second extrinsic that can also land.
         """
-        try:
-            return fn(self.subtensor.substrate)
-        except RECONNECT_EXCEPTIONS as e:
-            if self.reconnect_subtensor is None:
-                raise
-            bt.logging.warning(f'Substrate WS error ({e!s}); reconnecting and retrying once')
+        with self._substrate_lock:
             try:
-                self.reconnect_subtensor()
-            except Exception as reconnect_err:
-                bt.logging.error(f'Substrate reconnect callback failed: {reconnect_err}')
-                raise e from reconnect_err
-            return fn(self.subtensor.substrate)
+                return fn(self.subtensor.substrate)
+            except RECONNECT_EXCEPTIONS as e:
+                if self.reconnect_subtensor is None:
+                    raise
+                bt.logging.warning(f'Substrate WS error ({e!s}); reconnecting and retrying once')
+                try:
+                    self.reconnect_subtensor()
+                except Exception as reconnect_err:
+                    bt.logging.error(f'Substrate reconnect callback failed: {reconnect_err}')
+                    raise e from reconnect_err
+                return fn(self.subtensor.substrate)
 
     def ensure_initialized(self):
         if not self.contract_address:

--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 import bittensor as bt
 
+from allways.classes import SwapStatus
 from allways.constants import SCORING_WINDOW_BLOCKS
 from allways.utils.scale import (
     decode_account_id,
@@ -416,6 +417,8 @@ class ContractEventWatcher:
                     resolved_block=block_num,
                 )
                 self.apply_busy_delta(block_num, miner, -1)
+                if self.swap_tracker is not None:
+                    self.swap_tracker.resolve(swap_id, SwapStatus.COMPLETED, block_num)
         elif name == 'SwapTimedOut':
             swap_id = values.get('swap_id')
             miner = values.get('miner', '')
@@ -427,6 +430,8 @@ class ContractEventWatcher:
                     resolved_block=block_num,
                 )
                 self.apply_busy_delta(block_num, miner, -1)
+                if self.swap_tracker is not None:
+                    self.swap_tracker.resolve(swap_id, SwapStatus.TIMED_OUT, block_num)
         elif name == 'ReservationExtensionFinalized':
             # Event-driven cache update for the local pending_confirms row —
             # replaces the polling refresh that the legacy vote-extend flow

--- a/allways/validator/swap_tracker.py
+++ b/allways/validator/swap_tracker.py
@@ -13,10 +13,6 @@ from allways.contract_client import AllwaysContractClient
 
 ACTIVE_STATUSES = (SwapStatus.ACTIVE, SwapStatus.FULFILLED)
 
-# Consecutive None polls tolerated before treating a swap as resolved. Smooths
-# RPC flakes without the fragile timeout-block inference the V1 tracker used.
-NULL_SWAP_RETRY_LIMIT = 3
-
 # Cold-start backward scan halts after this many consecutive None lookups.
 # Resolved swaps are pruned from contract storage (`swaps.remove`), so a long
 # run of Nones means we've passed the live-swap region. Block-age cutoffs
@@ -44,7 +40,6 @@ class SwapTracker:
         self.last_scanned_id = 0
         self.active: Dict[int, Swap] = {}
         self.voted_ids: Set[int] = set()
-        self.null_retry_count: Dict[int, int] = {}
 
     def initialize(self):
         """Cold start: scan backward from latest swap to seed active set.
@@ -80,14 +75,16 @@ class SwapTracker:
         bt.logging.info(f'SwapTracker initialized: active={len(self.active)}, last_scanned_id={self.last_scanned_id}')
 
     def resolve(self, swap_id: int, status: SwapStatus, block: int):
-        """Drop a swap from tracking after our vote reached quorum."""
+        """Drop a swap from tracking after our vote reached quorum or after
+        the watcher observed a SwapCompleted/SwapTimedOut event. Idempotent
+        — no-op when the swap isn't tracked."""
         swap = self.active.pop(swap_id, None)
         if swap is None:
             return
         swap.status = status
         swap.completed_block = block
         self.voted_ids.discard(swap_id)
-        self.null_retry_count.pop(swap_id, None)
+        bt.logging.info(f'Swap {swap_id}: dropped from active ({status.name} at block {block})')
 
     def mark_voted(self, swap_id: int):
         """Mark a swap as voted on to prevent redundant confirm/timeout extrinsics."""
@@ -139,7 +136,6 @@ class SwapTracker:
                     bt.logging.info(f'Swap {swap.id} [{_swap_label(swap)}]: now {swap.status.name}, monitoring')
                 self.active[swap.id] = swap
                 fresh.add(swap.id)
-                self.null_retry_count.pop(swap.id, None)
 
         if next_id > 1:
             self.last_scanned_id = next_id - 1
@@ -150,49 +146,27 @@ class SwapTracker:
             self.prune_stale_voted_ids()
             return
 
-        # Null and transient errors share one retry policy — a missing swap
-        # is either an RPC flake or a freshly-resolved entry the event
-        # watcher will record. Retry a few times, then drop.
-        resolved_ids: List[int] = []
+        # Refresh: update active swaps, drop on terminal status. A None or
+        # transient RPC error leaves the swap in active — resolution is owned
+        # by the event watcher (SwapCompleted/SwapTimedOut → tracker.resolve).
         for sid in stale_ids:
             try:
                 result = await asyncio.to_thread(self.client.get_swap, sid)
             except Exception as e:
-                # Transient RPC error — leave the swap in active and don't
-                # advance null-retry. Retried next poll.
                 bt.logging.debug(f'SwapTracker refresh({sid}) failed, will retry: {e}')
                 continue
-
             if result is None:
-                if self.bump_null_retry(sid):
-                    resolved_ids.append(sid)
-            elif result.status in ACTIVE_STATUSES:
+                continue
+            if result.status in ACTIVE_STATUSES:
                 prev = self.active.get(sid)
                 if prev is not None and prev.status != result.status:
                     bt.logging.info(f'Swap {sid} [{_swap_label(result)}]: {prev.status.name} -> {result.status.name}')
                 self.active[sid] = result
-                self.null_retry_count.pop(sid, None)
             else:
-                resolved_ids.append(sid)
-
-        for sid in resolved_ids:
-            self.active.pop(sid, None)
-            self.voted_ids.discard(sid)
-            self.null_retry_count.pop(sid, None)
-
-        if resolved_ids:
-            bt.logging.debug(f'SwapTracker: resolved {len(resolved_ids)}, {len(self.active)} still active')
+                # Terminal status from chain — drop with reason for observability.
+                self.resolve(sid, result.status, result.completed_block or 0)
 
         self.prune_stale_voted_ids()
-
-    def bump_null_retry(self, swap_id: int) -> bool:
-        """Returns True when the retry limit is hit and the caller should
-        treat the swap as resolved."""
-        retries = self.null_retry_count.get(swap_id, 0) + 1
-        if retries >= NULL_SWAP_RETRY_LIMIT:
-            return True
-        self.null_retry_count[swap_id] = retries
-        return False
 
     def prune_stale_voted_ids(self) -> None:
         """Drop any voted state for swaps no longer being tracked. Normally

--- a/allways/validator/swap_tracker.py
+++ b/allways/validator/swap_tracker.py
@@ -121,27 +121,25 @@ class SwapTracker:
         next_id = await asyncio.to_thread(self.client.get_next_swap_id)
 
         # --- Discovery phase: scan new swap IDs ---
+        # Sequential — substrate WS isn't thread-safe (see contract_client mutex);
+        # parallel fanout used to surface as silent get_swap Nones. RESCAN_WINDOW
+        # re-checks recent IDs so a transient skip self-heals next poll.
         fresh: Set[int] = set()
         start_id = max(1, min(self.last_scanned_id + 1, next_id - RESCAN_WINDOW))
-        new_ids = list(range(start_id, next_id))
-        if new_ids:
-            # return_exceptions=True keeps one flaky get_swap from killing the step.
-            swaps = await asyncio.gather(
-                *[asyncio.to_thread(self.client.get_swap, sid) for sid in new_ids],
-                return_exceptions=True,
-            )
-            for sid, result in zip(new_ids, swaps):
-                if isinstance(result, Exception):
-                    bt.logging.debug(f'SwapTracker: get_swap({sid}) failed during discovery: {result}')
-                    continue
-                swap = result
-                if swap is None:
-                    continue
-                if swap.status in ACTIVE_STATUSES:
-                    if swap.id not in self.active:
-                        bt.logging.info(f'Swap {swap.id} [{_swap_label(swap)}]: now {swap.status.name}, monitoring')
-                    self.active[swap.id] = swap
-                    fresh.add(swap.id)
+        for sid in range(start_id, next_id):
+            try:
+                swap = await asyncio.to_thread(self.client.get_swap, sid)
+            except Exception as e:
+                bt.logging.debug(f'SwapTracker discovery({sid}) failed, will retry: {e}')
+                continue
+            if swap is None:
+                continue
+            if swap.status in ACTIVE_STATUSES:
+                if swap.id not in self.active:
+                    bt.logging.info(f'Swap {swap.id} [{_swap_label(swap)}]: now {swap.status.name}, monitoring')
+                self.active[swap.id] = swap
+                fresh.add(swap.id)
+                self.null_retry_count.pop(swap.id, None)
 
         if next_id > 1:
             self.last_scanned_id = next_id - 1
@@ -152,19 +150,18 @@ class SwapTracker:
             self.prune_stale_voted_ids()
             return
 
-        swaps = await asyncio.gather(
-            *[asyncio.to_thread(self.client.get_swap, sid) for sid in stale_ids],
-            return_exceptions=True,
-        )
-
         # Null and transient errors share one retry policy — a missing swap
         # is either an RPC flake or a freshly-resolved entry the event
         # watcher will record. Retry a few times, then drop.
         resolved_ids: List[int] = []
-        for sid, result in zip(stale_ids, swaps):
-            if isinstance(result, Exception):
-                bt.logging.debug(f'SwapTracker: get_swap({sid}) failed during refresh: {result}')
-                result = None
+        for sid in stale_ids:
+            try:
+                result = await asyncio.to_thread(self.client.get_swap, sid)
+            except Exception as e:
+                # Transient RPC error — leave the swap in active and don't
+                # advance null-retry. Retried next poll.
+                bt.logging.debug(f'SwapTracker refresh({sid}) failed, will retry: {e}')
+                continue
 
             if result is None:
                 if self.bump_null_retry(sid):

--- a/allways/validator/swap_tracker.py
+++ b/allways/validator/swap_tracker.py
@@ -24,6 +24,12 @@ NULL_SWAP_RETRY_LIMIT = 3
 # current volume — bump if the gap between contiguous active swap IDs grows.
 MAX_INIT_GAP = 20
 
+# Re-fetch the last N swap IDs each poll regardless of last_scanned_id so a
+# silent get_swap None during discovery self-heals next poll. Mirrors the
+# miner's RESCAN_WINDOW (#264). Bounded by subnet-wide swap creation rate
+# per forward step, not by the validator's tracked-set size.
+RESCAN_WINDOW = 16
+
 
 def _swap_label(swap: Swap) -> str:
     return f'{swap.from_chain.upper()}->{swap.to_chain.upper()}'
@@ -116,7 +122,8 @@ class SwapTracker:
 
         # --- Discovery phase: scan new swap IDs ---
         fresh: Set[int] = set()
-        new_ids = list(range(self.last_scanned_id + 1, next_id))
+        start_id = max(1, min(self.last_scanned_id + 1, next_id - RESCAN_WINDOW))
+        new_ids = list(range(start_id, next_id))
         if new_ids:
             # return_exceptions=True keeps one flaky get_swap from killing the step.
             swaps = await asyncio.gather(
@@ -131,9 +138,10 @@ class SwapTracker:
                 if swap is None:
                     continue
                 if swap.status in ACTIVE_STATUSES:
+                    if swap.id not in self.active:
+                        bt.logging.info(f'Swap {swap.id} [{_swap_label(swap)}]: now {swap.status.name}, monitoring')
                     self.active[swap.id] = swap
                     fresh.add(swap.id)
-                    bt.logging.info(f'Swap {swap.id} [{_swap_label(swap)}]: now {swap.status.name}, monitoring')
 
         if next_id > 1:
             self.last_scanned_id = next_id - 1

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -63,7 +63,11 @@ class Validator(BaseValidatorNeuron):
         )
         self.chain_providers = create_chain_providers(check=True, require_send=False, subtensor=self.subtensor)
 
-        timeout_blocks = self.contract_client.get_fulfillment_timeout() or DEFAULT_FULFILLMENT_TIMEOUT_BLOCKS
+        try:
+            timeout_blocks = self.contract_client.get_fulfillment_timeout() or DEFAULT_FULFILLMENT_TIMEOUT_BLOCKS
+        except Exception as e:
+            bt.logging.warning(f'fulfillment_timeout read failed at init, using default: {e}')
+            timeout_blocks = DEFAULT_FULFILLMENT_TIMEOUT_BLOCKS
         self.fee_divisor = FEE_DIVISOR
 
         # Single store owning every validator-local table. Must be created

--- a/tests/test_event_watcher.py
+++ b/tests/test_event_watcher.py
@@ -107,6 +107,63 @@ class TestSwapOutcomePersistence:
         assert stats['hk_a'] == (2, 1)
         w.state_store.close()
 
+    def test_completed_event_resolves_tracker(self, tmp_path: Path):
+        from allways.validator.swap_tracker import SwapTracker
+
+        w = make_watcher(tmp_path)
+        tracker = SwapTracker(client=MagicMock())
+        from allways.classes import Swap, SwapStatus
+
+        tracker.active[42] = Swap(
+            id=42,
+            user_hotkey='u',
+            miner_hotkey='hk_a',
+            from_chain='btc',
+            to_chain='tao',
+            from_amount=1,
+            to_amount=1,
+            tao_amount=1,
+            user_from_address='u',
+            user_to_address='u',
+            status=SwapStatus.FULFILLED,
+            initiated_block=1,
+            timeout_block=100,
+        )
+        w.swap_tracker = tracker
+
+        w.apply_event(150, 'SwapCompleted', {'swap_id': 42, 'miner': 'hk_a'})
+
+        assert 42 not in tracker.active
+        w.state_store.close()
+
+    def test_timed_out_event_resolves_tracker(self, tmp_path: Path):
+        from allways.classes import Swap, SwapStatus
+        from allways.validator.swap_tracker import SwapTracker
+
+        w = make_watcher(tmp_path)
+        tracker = SwapTracker(client=MagicMock())
+        tracker.active[43] = Swap(
+            id=43,
+            user_hotkey='u',
+            miner_hotkey='hk_a',
+            from_chain='btc',
+            to_chain='tao',
+            from_amount=1,
+            to_amount=1,
+            tao_amount=1,
+            user_from_address='u',
+            user_to_address='u',
+            status=SwapStatus.FULFILLED,
+            initiated_block=1,
+            timeout_block=100,
+        )
+        w.swap_tracker = tracker
+
+        w.apply_event(200, 'SwapTimedOut', {'swap_id': 43, 'miner': 'hk_a'})
+
+        assert 43 not in tracker.active
+        w.state_store.close()
+
 
 class TestBusyIntervals:
     def test_initiate_marks_busy_then_complete_frees(self, tmp_path: Path):

--- a/tests/test_swap_tracker.py
+++ b/tests/test_swap_tracker.py
@@ -1,17 +1,16 @@
-"""SwapTracker: active-set management, null-swap retries, RPC resilience.
+"""SwapTracker: active-set management and RPC resilience.
 
-Outcome persistence moved to ``ContractEventWatcher`` in C14 — SwapTracker
-no longer writes to ``swap_outcomes``. These tests cover what the tracker
-actually owns: maintaining the active set as swaps move through their
-lifecycle and tolerating per-swap RPC flakes without aborting the forward
-step.
+Outcome persistence is owned by ``ContractEventWatcher``, and resolution
+is event-driven: SwapCompleted/SwapTimedOut → tracker.resolve(). The
+tracker holds an authoritative active set; transient None / RPC errors
+during refresh are treated as "no information", never as resolution.
 """
 
 import asyncio
 from unittest.mock import MagicMock
 
 from allways.classes import Swap, SwapStatus
-from allways.validator.swap_tracker import MAX_INIT_GAP, NULL_SWAP_RETRY_LIMIT, SwapTracker
+from allways.validator.swap_tracker import MAX_INIT_GAP, SwapTracker
 
 
 def make_swap(swap_id: int, miner_hotkey: str = 'hk_a', timeout_block: int = 500) -> Swap:
@@ -47,17 +46,15 @@ class TestResolve:
 
         assert 45 not in tracker.active
 
-    def test_resolve_clears_voted_and_retry_state(self):
+    def test_resolve_clears_voted_state(self):
         tracker = make_tracker()
         swap = make_swap(swap_id=46)
         tracker.active[swap.id] = swap
         tracker.mark_voted(46)
-        tracker.null_retry_count[46] = 2
 
         tracker.resolve(swap_id=46, status=SwapStatus.COMPLETED, block=300)
 
         assert not tracker.is_voted(46)
-        assert 46 not in tracker.null_retry_count
 
     def test_resolve_unknown_swap_is_noop(self):
         tracker = make_tracker()
@@ -137,8 +134,9 @@ class TestInitialize:
         assert 20 not in tracker.active
 
 
-class TestNullSwapRetry:
-    def test_transient_null_does_not_drop_immediately(self):
+class TestRefreshNullHandling:
+    def test_null_leaves_swap_in_active(self):
+        """Resolution is event-driven; refresh-time None is no-op."""
         tracker = make_tracker()
         swap = make_swap(swap_id=50)
         tracker.active[swap.id] = swap
@@ -147,43 +145,20 @@ class TestNullSwapRetry:
         tracker.client.get_next_swap_id.return_value = 51
         tracker.client.get_swap.return_value = None
 
-        asyncio.run(tracker.poll_inner())
+        for _ in range(5):
+            asyncio.run(tracker.poll_inner())
 
         assert 50 in tracker.active
-        assert tracker.null_retry_count.get(50) == 1
 
-    def test_null_drops_after_retry_limit(self):
+    def test_event_driven_resolve_drops_swap(self):
+        """The watcher's SwapCompleted/SwapTimedOut path drives resolution."""
         tracker = make_tracker()
         swap = make_swap(swap_id=51)
         tracker.active[swap.id] = swap
-        tracker.last_scanned_id = 51
 
-        tracker.client.get_next_swap_id.return_value = 52
-        tracker.client.get_swap.return_value = None
-
-        for _ in range(NULL_SWAP_RETRY_LIMIT):
-            asyncio.run(tracker.poll_inner())
+        tracker.resolve(swap_id=51, status=SwapStatus.COMPLETED, block=600)
 
         assert 51 not in tracker.active
-        assert 51 not in tracker.null_retry_count
-
-    def test_successful_refetch_resets_retry_count(self):
-        tracker = make_tracker()
-        swap = make_swap(swap_id=52)
-        tracker.active[swap.id] = swap
-        tracker.last_scanned_id = 52
-        tracker.null_retry_count[52] = 1
-
-        refreshed = make_swap(swap_id=52)
-        refreshed.status = SwapStatus.FULFILLED
-        tracker.client.get_next_swap_id.return_value = 53
-        tracker.client.get_swap.return_value = refreshed
-
-        asyncio.run(tracker.poll_inner())
-
-        assert 52 in tracker.active
-        assert tracker.active[52].status == SwapStatus.FULFILLED
-        assert 52 not in tracker.null_retry_count
 
     def test_terminal_status_drops_without_retry(self):
         tracker = make_tracker()
@@ -225,10 +200,9 @@ class TestRPCResilience:
 
         asyncio.run(tracker.poll_inner())
 
-        # Transient RPC error must not bump null-retry — that's how a flaky WS
-        # ends up dropping a still-active swap (see commit history for #11).
+        # Transient RPC error must not drop the swap — that's how a flaky WS
+        # used to silently strand still-active swaps.
         assert 60 in tracker.active
-        assert 60 not in tracker.null_retry_count
         assert tracker.active[61].status == SwapStatus.FULFILLED
 
     def test_exception_does_not_drop_swap(self):
@@ -239,11 +213,10 @@ class TestRPCResilience:
         tracker.client.get_next_swap_id.return_value = 71
         tracker.client.get_swap.side_effect = RuntimeError('rpc down')
 
-        for _ in range(NULL_SWAP_RETRY_LIMIT + 2):
+        for _ in range(5):
             asyncio.run(tracker.poll_inner())
 
         assert 70 in tracker.active
-        assert 70 not in tracker.null_retry_count
 
     def test_discovery_exception_does_not_break_pass(self):
         """Flaky get_swap during new-ID discovery is skipped, not fatal."""

--- a/tests/test_swap_tracker.py
+++ b/tests/test_swap_tracker.py
@@ -225,11 +225,13 @@ class TestRPCResilience:
 
         asyncio.run(tracker.poll_inner())
 
+        # Transient RPC error must not bump null-retry — that's how a flaky WS
+        # ends up dropping a still-active swap (see commit history for #11).
         assert 60 in tracker.active
-        assert tracker.null_retry_count.get(60) == 1
+        assert 60 not in tracker.null_retry_count
         assert tracker.active[61].status == SwapStatus.FULFILLED
 
-    def test_exception_counts_toward_retry_limit(self):
+    def test_exception_does_not_drop_swap(self):
         tracker = make_tracker()
         tracker.active[70] = make_swap(swap_id=70)
         tracker.last_scanned_id = 70
@@ -237,10 +239,11 @@ class TestRPCResilience:
         tracker.client.get_next_swap_id.return_value = 71
         tracker.client.get_swap.side_effect = RuntimeError('rpc down')
 
-        for _ in range(NULL_SWAP_RETRY_LIMIT):
+        for _ in range(NULL_SWAP_RETRY_LIMIT + 2):
             asyncio.run(tracker.poll_inner())
 
-        assert 70 not in tracker.active
+        assert 70 in tracker.active
+        assert 70 not in tracker.null_retry_count
 
     def test_discovery_exception_does_not_break_pass(self):
         """Flaky get_swap during new-ID discovery is skipped, not fatal."""


### PR DESCRIPTION
## Summary

Fixes the swap-#11 stuck-state class of bug. A transient substrate WS race during the validator's `SwapTracker.poll_inner` made `get_swap` return None; three Nones in a row tripped `bump_null_retry` and the tracker silently dropped a still-FULFILLED swap, never voting confirm or timeout. Recovery required restarting the validator.

Six surgical commits, defense in depth — each independently closes the bug, together they make this whole class of silent-loss impossible.

1. **`contract_client: serialize substrate access with a mutex`** — substrate-interface's WS isn't thread-safe; one lock around `substrate_call` kills the `cannot call recv while another thread is already running recv` race at the source.
2. **`contract_client: re-raise substrate ws errors instead of swallowing as None`** — `raw_contract_read` now lets `RECONNECT_EXCEPTIONS` propagate so callers can distinguish "RPC blip" from "no result". `validator init` gets a defensive try/except for the one read that ran before its own retry loop.
3. **`cli: align reservation-ttl fallback with 50-block contract default`** — drift fix: CLI fallback was 4032, contract is 50.
4. **`validator: rescan recent swap IDs each poll (mirror miner #264)`** — `RESCAN_WINDOW=16` re-checks recent IDs each poll for self-healing discovery. Mirrors `deb6b71`.
5. **`validator: sequentialize tracker poll substrate reads`** — replaces `asyncio.gather` over `to_thread(get_swap)` with sequential awaits in both phases. On exception during refresh, leave the swap in active.
6. **`validator: resolve swaps via watcher events; drop null-retry inference`** — `SwapCompleted` / `SwapTimedOut` now call `swap_tracker.resolve()`. Removes `NULL_SWAP_RETRY_LIMIT` / `null_retry_count` / `bump_null_retry` entirely; refresh-time None is a no-op. Resolve log bumped to INFO with reason.

## Test plan

- [x] `ruff format . && ruff check .` clean
- [x] `pytest tests/` — 404 passed
- [x] Updated `test_swap_tracker.py` to assert new "exception does not drop" semantics
- [x] Added two `test_event_watcher.py` cases for `SwapCompleted` / `SwapTimedOut` → `tracker.resolve` wiring
- [ ] Restart `aw-vali` on isaiah after merge — `initialize()` will re-discover swap #11 and resolve it
- [ ] Watch validator logs for the new INFO drop messages on the next swap lifecycle