### PR TITLE
validator: confirm late-but-honest swaps instead of slashing

### DIFF
--- a/allways/validator/swap_tracker.py
+++ b/allways/validator/swap_tracker.py
@@ -176,11 +176,23 @@ class SwapTracker:
         self.voted_ids -= self.voted_ids - active_ids
 
     def get_fulfilled(self, current_block: int) -> List[Swap]:
-        """Active FULFILLED swaps not yet past timeout (ready for verification)."""
+        """Active FULFILLED swaps eligible for confirm.
+
+        Past-deadline confirms are allowed iff the miner's mark_fulfilled
+        landed in-window (``fulfilled_block <= timeout_block``). That keeps
+        the deadline as a hard cutoff for the miner's *claim* while letting
+        an honest miner who delivered on time get late credit when the
+        validator was absent (e.g., post-restart). A miner who raced
+        mark_fulfilled past deadline falls through to enforce_swap_timeouts.
+
+        ``current_block`` is unused but kept for API compatibility with the
+        adjacent ``get_near_timeout_fulfilled`` / ``get_timed_out`` helpers.
+        """
+        del current_block
         return [
             s
             for s in self.active.values()
-            if s.status == SwapStatus.FULFILLED and (s.timeout_block == 0 or current_block <= s.timeout_block)
+            if s.status == SwapStatus.FULFILLED and (s.timeout_block == 0 or s.fulfilled_block <= s.timeout_block)
         ]
 
     def get_near_timeout_fulfilled(self, current_block: int) -> List[Swap]:

--- a/tests/test_swap_tracker.py
+++ b/tests/test_swap_tracker.py
@@ -281,20 +281,35 @@ class TestGetFulfilled:
         result = tracker.get_fulfilled(current_block=100)
         assert [s.id for s in result] == [2]
 
-    def test_excludes_past_timeout(self):
+    def test_includes_past_deadline_when_fulfilled_in_window(self):
+        """Cat 2 — honest miner claimed in-window, validator missed the
+        confirm window (e.g., outage). Late confirm is allowed."""
         tracker = make_tracker()
-        expired = make_swap(swap_id=3, timeout_block=100)
-        expired.status = SwapStatus.FULFILLED
-        tracker.active[3] = expired
+        late_but_honest = make_swap(swap_id=3, timeout_block=100)
+        late_but_honest.status = SwapStatus.FULFILLED
+        late_but_honest.fulfilled_block = 90  # in-window claim
+        tracker.active[3] = late_but_honest
 
-        assert tracker.get_fulfilled(current_block=101) == []
-        assert tracker.get_fulfilled(current_block=100) == [expired]
+        # Both before and after deadline, the swap stays eligible.
+        assert tracker.get_fulfilled(current_block=99) == [late_but_honest]
+        assert tracker.get_fulfilled(current_block=500) == [late_but_honest]
+
+    def test_excludes_when_fulfilled_past_deadline(self):
+        """Cat 3 — miner raced mark_fulfilled past deadline. No late confirm;
+        falls to enforce_swap_timeouts."""
+        tracker = make_tracker()
+        late_claim = make_swap(swap_id=4, timeout_block=100)
+        late_claim.status = SwapStatus.FULFILLED
+        late_claim.fulfilled_block = 105  # claimed past deadline
+        tracker.active[4] = late_claim
+
+        assert tracker.get_fulfilled(current_block=200) == []
 
     def test_timeout_zero_treated_as_unbounded(self):
         tracker = make_tracker()
-        swap = make_swap(swap_id=4, timeout_block=0)
+        swap = make_swap(swap_id=5, timeout_block=0)
         swap.status = SwapStatus.FULFILLED
-        tracker.active[4] = swap
+        tracker.active[5] = swap
 
         assert tracker.get_fulfilled(current_block=999_999) == [swap]
 


### PR DESCRIPTION
## Summary

Lifts the unfair late-slash on miners who delivered on time but the validator was absent past the deadline (e.g., post-restart, or — until #273 — silently dropped from the tracker by a substrate WS race).

The contract's `confirm_swap` only requires `status == Fulfilled` (no `timeout_block` guard, see `lib.rs:960`). The hard cutoff lived only in the validator's `swap_tracker.get_fulfilled` filter. Replacing `current_block <= timeout_block` with `fulfilled_block <= timeout_block` keeps the deadline meaningful where it should be — the miner's *claim* — and lets the validator credit honest deliveries it found late.

| Category | `current_block > timeout_block` | `fulfilled_block <= timeout_block` | Behavior before | Behavior after |
|---|---|---|---|---|
| 1. In-window | no | yes | confirm | confirm (unchanged) |
| 2. Late-but-honest | yes | yes | timeout / slash | confirm if verified, else timeout |
| 3. Late-claim (miner raced past deadline) | yes | no | timeout / slash | timeout / slash (unchanged) |

Cat 3 keeps its teeth: a miner who calls `mark_fulfilled` past deadline still has `fulfilled_block > timeout_block` and falls through to `enforce_swap_timeouts`. Verification still gates the confirm vote — if the dest tx isn't real or isn't confirmed, no confirm fires and the timeout sweep slashes them as today.

## Test plan

- [x] `ruff format . && ruff check .` clean
- [x] `pytest tests/` — 405 passed
- [x] New tracker tests:
  - `test_includes_past_deadline_when_fulfilled_in_window` (Cat 2)
  - `test_excludes_when_fulfilled_past_deadline` (Cat 3)
  - existing `test_timeout_zero_treated_as_unbounded` still passes
- [ ] After merge, rebuild + restart `aw-vali` on isaiah; observe a future swap that gets fulfilled close to deadline.