### PR TITLE
validator: revert late-confirm of fulfilled-in-window swaps (#274)

### DIFF
--- a/allways/validator/swap_tracker.py
+++ b/allways/validator/swap_tracker.py
@@ -176,23 +176,11 @@ class SwapTracker:
         self.voted_ids -= self.voted_ids - active_ids
 
     def get_fulfilled(self, current_block: int) -> List[Swap]:
-        """Active FULFILLED swaps eligible for confirm.
-
-        Past-deadline confirms are allowed iff the miner's mark_fulfilled
-        landed in-window (``fulfilled_block <= timeout_block``). That keeps
-        the deadline as a hard cutoff for the miner's *claim* while letting
-        an honest miner who delivered on time get late credit when the
-        validator was absent (e.g., post-restart). A miner who raced
-        mark_fulfilled past deadline falls through to enforce_swap_timeouts.
-
-        ``current_block`` is unused but kept for API compatibility with the
-        adjacent ``get_near_timeout_fulfilled`` / ``get_timed_out`` helpers.
-        """
-        del current_block
+        """Active FULFILLED swaps not yet past timeout (ready for verification)."""
         return [
             s
             for s in self.active.values()
-            if s.status == SwapStatus.FULFILLED and (s.timeout_block == 0 or s.fulfilled_block <= s.timeout_block)
+            if s.status == SwapStatus.FULFILLED and (s.timeout_block == 0 or current_block <= s.timeout_block)
         ]
 
     def get_near_timeout_fulfilled(self, current_block: int) -> List[Swap]:

--- a/tests/test_swap_tracker.py
+++ b/tests/test_swap_tracker.py
@@ -281,35 +281,20 @@ class TestGetFulfilled:
         result = tracker.get_fulfilled(current_block=100)
         assert [s.id for s in result] == [2]
 
-    def test_includes_past_deadline_when_fulfilled_in_window(self):
-        """Cat 2 — honest miner claimed in-window, validator missed the
-        confirm window (e.g., outage). Late confirm is allowed."""
+    def test_excludes_past_timeout(self):
         tracker = make_tracker()
-        late_but_honest = make_swap(swap_id=3, timeout_block=100)
-        late_but_honest.status = SwapStatus.FULFILLED
-        late_but_honest.fulfilled_block = 90  # in-window claim
-        tracker.active[3] = late_but_honest
+        expired = make_swap(swap_id=3, timeout_block=100)
+        expired.status = SwapStatus.FULFILLED
+        tracker.active[3] = expired
 
-        # Both before and after deadline, the swap stays eligible.
-        assert tracker.get_fulfilled(current_block=99) == [late_but_honest]
-        assert tracker.get_fulfilled(current_block=500) == [late_but_honest]
-
-    def test_excludes_when_fulfilled_past_deadline(self):
-        """Cat 3 — miner raced mark_fulfilled past deadline. No late confirm;
-        falls to enforce_swap_timeouts."""
-        tracker = make_tracker()
-        late_claim = make_swap(swap_id=4, timeout_block=100)
-        late_claim.status = SwapStatus.FULFILLED
-        late_claim.fulfilled_block = 105  # claimed past deadline
-        tracker.active[4] = late_claim
-
-        assert tracker.get_fulfilled(current_block=200) == []
+        assert tracker.get_fulfilled(current_block=101) == []
+        assert tracker.get_fulfilled(current_block=100) == [expired]
 
     def test_timeout_zero_treated_as_unbounded(self):
         tracker = make_tracker()
-        swap = make_swap(swap_id=5, timeout_block=0)
+        swap = make_swap(swap_id=4, timeout_block=0)
         swap.status = SwapStatus.FULFILLED
-        tracker.active[5] = swap
+        tracker.active[4] = swap
 
         assert tracker.get_fulfilled(current_block=999_999) == [swap]
 


### PR DESCRIPTION
## Summary

Reverts #274. Real swap was slashed unfairly because the change was asymmetric: `get_fulfilled` was relaxed to allow past-deadline confirms when `s.fulfilled_block <= s.timeout_block`, but `get_timed_out` was left as-is. After deadline, the swap appeared in both lists; the forward loop ran verification first (no confirm if confs<min) then the timeout sweep slashed it the same step.

Concrete case (validator on isaiah, swap 12 TAO→BTC):

```
22:20:17  Swap 12 → FULFILLED, BTC tx visible (0 confs)
22:24:56  Propose timeout extension → 7058732 (tier 0)
22:29:02  Extension finalized
22:46:53  1/3 dest confs, 4 blocks until timeout
22:51:02  TIMEOUT extrinsic at block 7058750 (past 7058732) → miner slashed
```

Beyond the asymmetry, waiting indefinitely for late confs lets a slow-fee dest tx that may never confirm stall the swap forever. The hard `current_block <= timeout_block` gate keeps the deadline a real deadline. The post-restart late-discovery scenario #274 aimed at is rare; not worth the regression.

The reservation/extension-side reservation-15 expiry is a separate, pre-existing bug (forward-cadence margin in propose guard) — not addressed here.

## Test plan

- [x] `ruff format . && ruff check .` clean
- [x] `pytest tests/` — 404 passed
- [ ] After merge, restart `aw-vali` on isaiah; confirm next FULFILLED swap that misses dest confs by deadline still slashes (no regression vs. pre-#274), and a swap that confirms in-window still confirms