### PR TITLE
validator: env-overridable forward-step blocks estimate

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -1,3 +1,5 @@
+import os
+
 # ─── Network ───────────────────────────────────────────────
 NETUID_FINNEY = 7
 NETUID_LOCAL = 2
@@ -84,7 +86,18 @@ CHALLENGE_WINDOW_BLOCKS = 8
 # step (base poll + per-step work + jitter). Used as a safety margin when
 # sizing extension targets so a single delayed step doesn't strand a propose
 # whose finalize window opens past the original reservation deadline.
-VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE = 20
+# Default sized for mainnet; testnet validators with slower/jankier RPC can
+# override via VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE env var.
+DEFAULT_VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE = 20
+VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE = max(
+    1,
+    int(
+        os.environ.get(
+            'VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE',
+            DEFAULT_VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE,
+        )
+    ),
+)
 # Vote to extend when this many blocks remain. Sized for one forward step
 # to land the propose tx and the challenge window to elapse — without that
 # runway the propose is orphaned and the reservation expires anyway.


### PR DESCRIPTION
## Summary

`VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE` is hardcoded at 20, but actual forward-step cadence varies materially between deployments. Recent isaiah samples: ~5-6 blocks/step normally, ~12-15 blocks/step during transient RPC slowness. Mainnet may differ again.

The constant feeds `EXTEND_THRESHOLD_BLOCKS = VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE + CHALLENGE_WINDOW_BLOCKS`, which gates when near-deadline reservation/timeout extensions fire. When the real cadence exceeds the estimate, propose can fire too late: finalize lands after the original deadline and the contract reverts. Reservation 15 (request `0xa1121903…`) expired this way — propose at block ~7058798, deadline 7058812, finalize attempted at ~7058820 → `ContractReverted`.

This change makes the estimate operator-tunable per environment without a code change. Uses the same env-override pattern as `CONTRACT_ADDRESS` and `MINER_TIMEOUT_CUSHION_BLOCKS`.

## Behavior

```bash
# default (mainnet)
$ python -c "from allways.constants import VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE, EXTEND_THRESHOLD_BLOCKS; print(VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE, EXTEND_THRESHOLD_BLOCKS)"
20 28

# testnet override
$ VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE=40 python -c "..."
40 48
```

## Test plan

- [x] `ruff format . && ruff check .` clean
- [x] `pytest tests/` — 404 passed (no behavior change at default)
- [x] Manual: env override and default both produce expected `VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE` / `EXTEND_THRESHOLD_BLOCKS` values
- [ ] Post-merge: set `VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE=40` in isaiah's compose env so the override survives the next watchtower image pull

## Out of scope

The deeper reservation-extension-timing bug (propose guard not accounting for forward cadence at all) is separate. This PR just gives operators a knob to compensate while we design that fix.