### PR TITLE
cli: agent-feedback follow-ups (resume --send, fee target, view-reservation label)

### DIFF
--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -40,21 +40,6 @@ def detect_address_type(address: str) -> str:
     return 'unknown'
 
 
-def _network_from_address(address: str) -> str:
-    """Return 'mainnet', 'testnet', 'regtest', or '' if unknown."""
-    if address.startswith(('bc1q', 'bc1p')):
-        return 'mainnet'
-    if address.startswith(('tb1q', 'tb1p')):
-        return 'testnet'
-    if address.startswith(('bcrt1q', 'bcrt1p')):
-        return 'regtest'
-    if address.startswith(('1', '3')):
-        return 'mainnet'
-    if address.startswith(('m', 'n', '2')):
-        return 'testnet'
-    return ''
-
-
 def to_mainnet_wif(wif: str) -> str:
     """Convert a testnet/regtest WIF (0xef) to mainnet (0x80) for signing libraries."""
     decoded = base58.b58decode_check(wif)
@@ -636,23 +621,7 @@ class BitcoinProvider(ChainProvider):
                 return None
             atype, script, addr = type_to_script[detected]
             if addr != from_address:
-                # A network mismatch (WIF derives bc1q… but committed is tb1q…
-                # or vice-versa) is indistinguishable from a true key mismatch
-                # at the address level — both fail equality. The most common
-                # cause in practice is BTC_NETWORK not being loaded in the
-                # caller's env (e.g. invoking the provider directly without
-                # going through the CLI's dotenv loader), so surface that hint
-                # instead of leaving the user chasing a wrong-key red herring.
-                derived_net = _network_from_address(addr)
-                committed_net = _network_from_address(from_address)
-                if derived_net and committed_net and derived_net != committed_net:
-                    self._send_error(
-                        f'WIF key derives {addr} ({derived_net}) but committed address is '
-                        f'{from_address} ({committed_net}) — BTC_NETWORK mismatch '
-                        f"(provider sees network='{self.network}'; check BTC_NETWORK env / .env loading)"
-                    )
-                else:
-                    self._send_error(f'WIF key derives {addr} but committed address is {from_address} — key mismatch')
+                self._send_error(f'WIF key derives {addr} but committed address is {from_address} — key mismatch')
                 return None
             resp = self.btc_api_get(f'/address/{addr}/utxo', timeout=15)
             resp.raise_for_status()

--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -40,6 +40,21 @@ def detect_address_type(address: str) -> str:
     return 'unknown'
 
 
+def _network_from_address(address: str) -> str:
+    """Return 'mainnet', 'testnet', 'regtest', or '' if unknown."""
+    if address.startswith(('bc1q', 'bc1p')):
+        return 'mainnet'
+    if address.startswith(('tb1q', 'tb1p')):
+        return 'testnet'
+    if address.startswith(('bcrt1q', 'bcrt1p')):
+        return 'regtest'
+    if address.startswith(('1', '3')):
+        return 'mainnet'
+    if address.startswith(('m', 'n', '2')):
+        return 'testnet'
+    return ''
+
+
 def to_mainnet_wif(wif: str) -> str:
     """Convert a testnet/regtest WIF (0xef) to mainnet (0x80) for signing libraries."""
     decoded = base58.b58decode_check(wif)
@@ -621,7 +636,23 @@ class BitcoinProvider(ChainProvider):
                 return None
             atype, script, addr = type_to_script[detected]
             if addr != from_address:
-                self._send_error(f'WIF key derives {addr} but committed address is {from_address} — key mismatch')
+                # A network mismatch (WIF derives bc1q… but committed is tb1q…
+                # or vice-versa) is indistinguishable from a true key mismatch
+                # at the address level — both fail equality. The most common
+                # cause in practice is BTC_NETWORK not being loaded in the
+                # caller's env (e.g. invoking the provider directly without
+                # going through the CLI's dotenv loader), so surface that hint
+                # instead of leaving the user chasing a wrong-key red herring.
+                derived_net = _network_from_address(addr)
+                committed_net = _network_from_address(from_address)
+                if derived_net and committed_net and derived_net != committed_net:
+                    self._send_error(
+                        f'WIF key derives {addr} ({derived_net}) but committed address is '
+                        f'{from_address} ({committed_net}) — BTC_NETWORK mismatch '
+                        f"(provider sees network='{self.network}'; check BTC_NETWORK env / .env loading)"
+                    )
+                else:
+                    self._send_error(f'WIF key derives {addr} but committed address is {from_address} — key mismatch')
                 return None
             resp = self.btc_api_get(f'/address/{addr}/utxo', timeout=15)
             resp.raise_for_status()

--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -384,8 +384,16 @@ def hydrate_pending_swap(state: PendingSwapState, client) -> bool:
         miner_pair = read_miner_commitment(subtensor, state.netuid, state.miner_hotkey, metagraph=metagraph)
         if miner_pair:
             state.miner_uid = miner_pair.uid
-            state.miner_from_address = miner_pair.from_address
-            state.rate_str = miner_pair.rate_str
+            # Commitment is stored canonical (alphabetical chains). For a
+            # reverse-direction swap the miner's receiving address lives in
+            # ``to_address``, not ``from_address`` — keep the side that
+            # matches state.from_chain so view-reservation labels line up.
+            if state.from_chain == miner_pair.from_chain:
+                state.miner_from_address = miner_pair.from_address
+                state.rate_str = miner_pair.rate_str
+            else:
+                state.miner_from_address = miner_pair.to_address
+                state.rate_str = miner_pair.counter_rate_str
     except Exception:
         pass
     # User receives = gross dest amount minus 1% protocol fee.

--- a/allways/cli/swap_commands/resume.py
+++ b/allways/cli/swap_commands/resume.py
@@ -39,7 +39,7 @@ from allways.contract_client import ContractError
     '--send',
     'auto_send',
     is_flag=True,
-    help='Broadcast source funds automatically (TAO via wallet, BTC via BTC_PRIVATE_KEY); fails fast if no tx is on file and signing creds are missing',
+    help='Broadcast source funds automatically (TAO via wallet, BTC via BTC_PRIVATE_KEY)',
 )
 @click.option('--yes', 'skip_confirm', is_flag=True, help='Skip confirmation prompts')
 def resume_reservation_command(from_tx_hash_opt: Optional[str], auto_send: bool, skip_confirm: bool):
@@ -191,12 +191,6 @@ def resume_reservation_command(from_tx_hash_opt: Optional[str], auto_send: bool,
             if state.from_chain == 'tao':
                 send_result = send_tao_transfer(wallet, subtensor, state.miner_from_address, state.from_amount)
             else:
-                if not (os.environ.get('BTC_PRIVATE_KEY') or '').strip():
-                    console.print(
-                        '[red]--send needs BTC_PRIVATE_KEY in env (lightweight mode) — none found. '
-                        'Set it in .env or shell env, or rerun without --send and broadcast manually.[/red]'
-                    )
-                    return
                 send_result = send_btc(
                     chain_providers,
                     config,

--- a/allways/cli/swap_commands/resume.py
+++ b/allways/cli/swap_commands/resume.py
@@ -4,7 +4,6 @@ import os
 import time
 from typing import Optional
 
-import bittensor as bt
 import click
 from rich.panel import Panel
 
@@ -27,6 +26,8 @@ from allways.cli.swap_commands.swap import (
     from_smallest_unit,
     poll_for_swap_with_progress,
     resolve_recent_swap_id,
+    send_btc,
+    send_tao_transfer,
     sign_and_broadcast_confirm,
 )
 from allways.contract_client import ContractError
@@ -186,13 +187,24 @@ def resume_reservation_command(from_tx_hash_opt: Optional[str], auto_send: bool,
             from_tx_hash_opt = saved_tx
             used_saved_tx = True
         elif auto_send:
-            send_result = _auto_send_source_funds(
-                state=state,
-                wallet=wallet,
-                subtensor=subtensor,
-                chain_providers=chain_providers,
-                send_label=send_label,
-            )
+            console.print(f'\n[dim]Sending {send_label} to {state.miner_from_address}...[/dim]')
+            if state.from_chain == 'tao':
+                send_result = send_tao_transfer(wallet, subtensor, state.miner_from_address, state.from_amount)
+            else:
+                if not (os.environ.get('BTC_PRIVATE_KEY') or '').strip():
+                    console.print(
+                        '[red]--send needs BTC_PRIVATE_KEY in env (lightweight mode) — none found. '
+                        'Set it in .env or shell env, or rerun without --send and broadcast manually.[/red]'
+                    )
+                    return
+                send_result = send_btc(
+                    chain_providers,
+                    config,
+                    state.miner_from_address,
+                    state.from_amount,
+                    from_address=state.user_from_address,
+                    interactive=False,
+                )
             if send_result is None:
                 return
             from_tx_hash_opt, just_broadcast_block = send_result
@@ -296,75 +308,3 @@ def resume_reservation_command(from_tx_hash_opt: Optional[str], auto_send: bool,
         from allways.cli.swap_commands.swap import display_receipt
 
         display_receipt(final_swap)
-
-
-def _auto_send_source_funds(*, state, wallet, subtensor, chain_providers, send_label: str):
-    """Broadcast the source-chain payment for an open reservation.
-
-    Returns ``(tx_hash, broadcast_block)`` on success, ``None`` on failure.
-    Block is best-effort — 0 is acceptable since a fresh tx is still in
-    mempool and validators fall back to scanning by hash.
-    """
-    console.print(f'\n[dim]Sending {send_label} to {state.miner_from_address}...[/dim]')
-
-    if state.from_chain == 'tao':
-        try:
-            with loading('Submitting TAO transfer to chain...'):
-                response = subtensor.transfer(
-                    wallet=wallet,
-                    destination_ss58=state.miner_from_address,
-                    amount=bt.Balance.from_rao(state.from_amount),
-                    wait_for_inclusion=True,
-                    wait_for_finalization=False,
-                )
-        except Exception as e:
-            console.print(f'[red]TAO transfer failed: {type(e).__name__}: {e}[/red]')
-            return None
-        if not response.success:
-            console.print(f'[red]TAO transfer failed: {response.message}[/red]')
-            return None
-        try:
-            receipt = response.extrinsic_receipt
-            tx_hash = receipt.extrinsic_hash
-            block = 0
-            if getattr(receipt, 'block_hash', None):
-                block = subtensor.substrate.get_block_number(receipt.block_hash) or 0
-        except Exception:
-            tx_hash = response.extrinsic
-            block = 0
-        if not tx_hash:
-            console.print('[red]TAO transfer returned no tx hash.[/red]')
-            return None
-        console.print(f'[green]TAO sent (tx: {tx_hash})[/green]')
-        return (tx_hash, int(block))
-
-    # BTC path: route through send_btc, but bypass its interactive
-    # tx-hash fallback — failed sends in --send mode should error out so
-    # the calling agent sees a non-zero exit instead of a hung prompt.
-    provider = chain_providers.get('btc')
-    is_lightweight = getattr(provider, 'mode', None) == 'lightweight'
-    if is_lightweight and not (os.environ.get('BTC_PRIVATE_KEY') or '').strip():
-        console.print(
-            '[red]--send needs BTC_PRIVATE_KEY in env (lightweight mode) — none found. '
-            'Set it in .env or shell env, or rerun without --send and broadcast manually.[/red]'
-        )
-        return None
-
-    try:
-        result = provider.send_amount(
-            state.miner_from_address,
-            state.from_amount,
-            from_address=state.user_from_address,
-        )
-    except Exception as e:
-        console.print(f'[red]BTC send failed: {type(e).__name__}: {e}[/red]')
-        return None
-
-    if not result:
-        reason = getattr(provider, 'last_send_error', None) or 'unknown error'
-        console.print(f'[red]BTC send failed: {reason}[/red]')
-        return None
-
-    tx_hash, block = result[0], (result[1] if len(result) > 1 else 0)
-    console.print(f'[green]BTC sent (tx: {tx_hash})[/green]')
-    return (tx_hash, int(block))

--- a/allways/cli/swap_commands/resume.py
+++ b/allways/cli/swap_commands/resume.py
@@ -4,6 +4,7 @@ import os
 import time
 from typing import Optional
 
+import bittensor as bt
 import click
 from rich.panel import Panel
 
@@ -33,8 +34,14 @@ from allways.contract_client import ContractError
 
 @click.command('resume-reservation')
 @click.option('--from-tx-hash', 'from_tx_hash_opt', default=None, help='Source tx hash (skip fund sending)')
+@click.option(
+    '--send',
+    'auto_send',
+    is_flag=True,
+    help='Broadcast source funds automatically (TAO via wallet, BTC via BTC_PRIVATE_KEY); fails fast if no tx is on file and signing creds are missing',
+)
 @click.option('--yes', 'skip_confirm', is_flag=True, help='Skip confirmation prompts')
-def resume_reservation_command(from_tx_hash_opt: Optional[str], skip_confirm: bool):
+def resume_reservation_command(from_tx_hash_opt: Optional[str], auto_send: bool, skip_confirm: bool):
     """Resume an interrupted pre-initiate reservation.
 
     \b
@@ -55,7 +62,10 @@ def resume_reservation_command(from_tx_hash_opt: Optional[str], skip_confirm: bo
     \b
     Non-interactive mode (for scripting/agents):
         alw swap resume-reservation --from-tx-hash abc123... --yes
+        alw swap resume-reservation --send --yes
     """
+    if from_tx_hash_opt and auto_send:
+        raise click.UsageError('--from-tx-hash and --send are mutually exclusive')
     state = load_pending_swap()
     if not state:
         console.print('[yellow]No pending swap found.[/yellow]')
@@ -168,11 +178,24 @@ def resume_reservation_command(from_tx_hash_opt: Optional[str], skip_confirm: bo
     ephemeral_wallet = get_ephemeral_wallet()
 
     used_saved_tx = False
+    just_broadcast_block = 0
     if not from_tx_hash_opt:
         saved_tx = (state.from_tx_hash or '').strip()
         if saved_tx:
             console.print(f'\n[green]Source tx already broadcast:[/green] [cyan]{saved_tx}[/cyan]')
             from_tx_hash_opt = saved_tx
+            used_saved_tx = True
+        elif auto_send:
+            send_result = _auto_send_source_funds(
+                state=state,
+                wallet=wallet,
+                subtensor=subtensor,
+                chain_providers=chain_providers,
+                send_label=send_label,
+            )
+            if send_result is None:
+                return
+            from_tx_hash_opt, just_broadcast_block = send_result
             used_saved_tx = True
         else:
             console.print(f'\n  Send [green]{send_label}[/green] to: [cyan]{state.miner_from_address}[/cyan]\n')
@@ -184,9 +207,9 @@ def resume_reservation_command(from_tx_hash_opt: Optional[str], skip_confirm: bo
     from_tx_hash = from_tx_hash_opt.strip()
     mark_pending_swap_tx_sent(from_tx_hash)
 
-    # Saved hash is fresh from swap now — still in mempool, lookup would just print noise.
+    # Saved/auto-sent hash is fresh — still in mempool, lookup would just print noise.
     if used_saved_tx:
-        from_tx_block = 0
+        from_tx_block = just_broadcast_block
     else:
         from_tx_block = resolve_source_tx_block(
             provider=provider,
@@ -273,3 +296,75 @@ def resume_reservation_command(from_tx_hash_opt: Optional[str], skip_confirm: bo
         from allways.cli.swap_commands.swap import display_receipt
 
         display_receipt(final_swap)
+
+
+def _auto_send_source_funds(*, state, wallet, subtensor, chain_providers, send_label: str):
+    """Broadcast the source-chain payment for an open reservation.
+
+    Returns ``(tx_hash, broadcast_block)`` on success, ``None`` on failure.
+    Block is best-effort — 0 is acceptable since a fresh tx is still in
+    mempool and validators fall back to scanning by hash.
+    """
+    console.print(f'\n[dim]Sending {send_label} to {state.miner_from_address}...[/dim]')
+
+    if state.from_chain == 'tao':
+        try:
+            with loading('Submitting TAO transfer to chain...'):
+                response = subtensor.transfer(
+                    wallet=wallet,
+                    destination_ss58=state.miner_from_address,
+                    amount=bt.Balance.from_rao(state.from_amount),
+                    wait_for_inclusion=True,
+                    wait_for_finalization=False,
+                )
+        except Exception as e:
+            console.print(f'[red]TAO transfer failed: {type(e).__name__}: {e}[/red]')
+            return None
+        if not response.success:
+            console.print(f'[red]TAO transfer failed: {response.message}[/red]')
+            return None
+        try:
+            receipt = response.extrinsic_receipt
+            tx_hash = receipt.extrinsic_hash
+            block = 0
+            if getattr(receipt, 'block_hash', None):
+                block = subtensor.substrate.get_block_number(receipt.block_hash) or 0
+        except Exception:
+            tx_hash = response.extrinsic
+            block = 0
+        if not tx_hash:
+            console.print('[red]TAO transfer returned no tx hash.[/red]')
+            return None
+        console.print(f'[green]TAO sent (tx: {tx_hash})[/green]')
+        return (tx_hash, int(block))
+
+    # BTC path: route through send_btc, but bypass its interactive
+    # tx-hash fallback — failed sends in --send mode should error out so
+    # the calling agent sees a non-zero exit instead of a hung prompt.
+    provider = chain_providers.get('btc')
+    is_lightweight = getattr(provider, 'mode', None) == 'lightweight'
+    if is_lightweight and not (os.environ.get('BTC_PRIVATE_KEY') or '').strip():
+        console.print(
+            '[red]--send needs BTC_PRIVATE_KEY in env (lightweight mode) — none found. '
+            'Set it in .env or shell env, or rerun without --send and broadcast manually.[/red]'
+        )
+        return None
+
+    try:
+        result = provider.send_amount(
+            state.miner_from_address,
+            state.from_amount,
+            from_address=state.user_from_address,
+        )
+    except Exception as e:
+        console.print(f'[red]BTC send failed: {type(e).__name__}: {e}[/red]')
+        return None
+
+    if not result:
+        reason = getattr(provider, 'last_send_error', None) or 'unknown error'
+        console.print(f'[red]BTC send failed: {reason}[/red]')
+        return None
+
+    tx_hash, block = result[0], (result[1] if len(result) > 1 else 0)
+    console.print(f'[green]BTC sent (tx: {tx_hash})[/green]')
+    return (tx_hash, int(block))

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -3,7 +3,7 @@
 import os
 import sys
 import time
-from typing import Optional
+from typing import Optional, Tuple
 
 import bittensor as bt
 import click
@@ -465,12 +465,19 @@ def send_btc(
     amount_sat: int,
     from_address: str = None,
     fee_rate_override: Optional[int] = None,
+    interactive: bool = True,
 ):
     """Send BTC, retry on failure, fall back to manual tx-hash entry.
 
     In lightweight mode there is no Bitcoin Core fallback — both paths route
     through the same Blockstream API — so we don't pretend otherwise.
-    Returns (tx_hash, block_number) or None (manual fallback failed/skipped).
+
+    ``interactive`` controls the failure path: when False (e.g. ``alw swap
+    resume-reservation --send``), broadcast errors return None instead of
+    prompting for a retry or a manual tx hash, so scripted callers get a
+    deterministic exit instead of a hung prompt.
+
+    Returns (tx_hash, block_number) or None.
     """
     provider = chain_providers.get('btc')
     is_local = is_local_network(config.get('network', 'finney'))
@@ -490,7 +497,7 @@ def send_btc(
         console.print('[dim]Sending BTC via Bitcoin Core RPC...[/dim]')
         return provider.send_amount(to_address, amount_sat)
 
-    max_retries = 2
+    max_retries = 2 if interactive else 0
     for attempt in range(max_retries + 1):
         result = attempt_send()
         if result:
@@ -508,6 +515,8 @@ def send_btc(
         else:
             console.print('[yellow]BTC send failed.[/yellow]')
 
+        if not interactive:
+            return None
         if attempt >= max_retries:
             console.print('[yellow]Giving up after retries.[/yellow]')
             break
@@ -528,6 +537,44 @@ def send_btc(
         )
         return None
     return (tx_hash.strip(), 0)
+
+
+def send_tao_transfer(wallet, subtensor, to_address: str, amount_rao: int) -> Optional[Tuple[str, int]]:
+    """Single attempt at a TAO coldkey transfer.
+
+    Returns ``(tx_hash, block_number)`` on success, ``None`` on failure
+    (caller decides whether to retry / surface the error).
+    """
+    try:
+        with loading('Submitting TAO transfer to chain...'):
+            response = subtensor.transfer(
+                wallet=wallet,
+                destination_ss58=to_address,
+                amount=bt.Balance.from_rao(amount_rao),
+                wait_for_inclusion=True,
+                wait_for_finalization=False,
+            )
+    except Exception as e:
+        console.print(f'[red]Transfer error ({type(e).__name__}): {e}[/red]')
+        return None
+
+    if not response.success:
+        # Extrinsic may have been submitted but rejected on-chain;
+        # post-tx is a valid recovery if the user has the hash.
+        console.print(f'[red]TAO transfer failed: {response.message}[/red]')
+        return None
+
+    try:
+        receipt = response.extrinsic_receipt
+        tx_hash = receipt.extrinsic_hash
+        block = 0
+        if getattr(receipt, 'block_hash', None):
+            block = subtensor.substrate.get_block_number(receipt.block_hash) or 0
+    except Exception:
+        tx_hash = getattr(getattr(response, 'extrinsic_receipt', None), 'extrinsic_hash', '') or 'tao_transfer'
+        block = 0
+    console.print(f'[green]TAO sent (tx: {tx_hash})[/green]')
+    return (tx_hash, int(block))
 
 
 # =========================================================================
@@ -1043,45 +1090,22 @@ def swap_now_command(
         from_tx_hash = None
         if from_chain == 'tao':
             for attempt in range(2):
-                try:
-                    with loading('Submitting TAO transfer to chain...'):
-                        response = subtensor.transfer(
-                            wallet=wallet,
-                            destination_ss58=selected_pair.from_address,
-                            amount=bt.Balance.from_rao(from_amount),
-                            wait_for_inclusion=True,
-                            wait_for_finalization=False,
-                        )
-                    if not response.success:
-                        # Extrinsic may have been submitted but rejected on-chain;
-                        # post-tx is a valid recovery if the user has the hash.
-                        console.print(f'[red]TAO transfer failed: {response.message}[/red]')
-                        console.print(
-                            '[yellow]If the tx did broadcast, resume with: alw swap post-tx <tx_hash>[/yellow]'
-                        )
-                        return
-                    try:
-                        receipt = response.extrinsic_receipt
-                        from_tx_hash = receipt.extrinsic_hash
-                        if getattr(receipt, 'block_hash', None):
-                            from_tx_block = subtensor.substrate.get_block_number(receipt.block_hash) or 0
-                    except Exception:
-                        from_tx_hash = (
-                            getattr(getattr(response, 'extrinsic_receipt', None), 'extrinsic_hash', '')
-                            or 'tao_transfer'
-                        )
-                    console.print(f'[green]TAO sent (tx: {from_tx_hash})[/green]')
+                send_result = send_tao_transfer(wallet, subtensor, selected_pair.from_address, from_amount)
+                if send_result is not None:
+                    from_tx_hash, from_tx_block = send_result
                     mark_pending_swap_tx_sent(from_tx_hash)
                     break
-                except Exception as e:
-                    console.print(f'[red]Transfer error ({type(e).__name__}): {e}[/red]')
-                    if attempt == 0 and click.confirm('Retry?', default=True):
-                        time.sleep(1)
-                        continue
-                    # Pre-broadcast failure: no tx hash exists, so post-tx
-                    # recovery isn't applicable. Just let the reservation lapse.
-                    console.print('[yellow]Reservation will expire on its own — start a new swap when ready.[/yellow]')
-                    return
+                if attempt == 0 and click.confirm('Retry?', default=True):
+                    time.sleep(1)
+                    continue
+                # Either the transfer landed but was rejected (post-tx recovery
+                # would apply if the user has the hash) or the broadcast itself
+                # failed (no hash — just let the reservation lapse).
+                console.print(
+                    '[yellow]If the tx did broadcast, resume with: alw swap post-tx <tx_hash>. '
+                    'Otherwise the reservation will expire on its own — start a new swap when ready.[/yellow]'
+                )
+                return
         else:
             send_result = send_btc(
                 chain_providers,

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -905,7 +905,13 @@ def swap_now_command(
     ):
         try:
             pinned_btc_fee_rate = btc_provider.estimate_fee_rate(override=btc_fee_rate_opt)
-            origin = 'override via --btc-fee-rate' if btc_fee_rate_opt is not None else 'auto-estimated'
+            if btc_fee_rate_opt is not None:
+                origin = 'override via --btc-fee-rate'
+            else:
+                # estimate_fee_rate targets 2-3 block confirmation. Surface that
+                # so the user knows the auto-estimate is not next-block urgent
+                # and won't compare it against a "too low" mempool reading.
+                origin = 'auto-estimated · targets 2-3 block confirmation (~20-30 min on mainnet)'
             btc_fee_line = f'  BTC Fee Rate: ~{pinned_btc_fee_rate} sat/vB  [dim]({origin})[/dim]\n'
         except Exception:
             pass  # display-only; send path will fall back to estimating itself


### PR DESCRIPTION
## Summary
Three small CLI fixes from a recent agent-driven swap pass — only the items that are still real after a fresh look at `test`.

- **`alw swap resume-reservation --send`** — broadcasts source funds (TAO via wallet, BTC via `BTC_PRIVATE_KEY`) so a scripted agent can pick up an interrupted reservation without dropping into a Python session to send funds manually. Existing `--from-tx-hash` and `--yes` flows are unchanged; `--send` and `--from-tx-hash` are mutually exclusive. Routes through the same `send_btc` / new `send_tao_transfer` helpers `alw swap now` uses, with `send_btc(interactive=False)` suppressing the `Retry?` / manual-tx-hash prompts so non-interactive callers fail fast instead of hanging.
- **`alw swap now` BTC fee summary** — appends the actual confirmation target ("auto-estimated · targets 2-3 block confirmation (~20-30 min on mainnet)") so a low-looking `5 sat/vB` does not read as next-block urgent. The estimator already targets 2-3 blocks; this just surfaces it.
- **`alw view reservation` label/value mismatch** — `hydrate_pending_swap` was overwriting `state.miner_from_address` with the canonical-direction `from_address` from the miner commitment, which is always the BTC side for the BTC/TAO pair. For a reverse-direction swap (TAO→BTC) that meant `to (miner TAO)` rendered the miner's `tb1q…` BTC address. Picks the side whose chain matches `state.from_chain` instead.

Items not addressed (validated as already-fixed or not reproducible against `test`):
- `--auto` selecting offline miners — eligibility filter at `swap.py:691-694` already excludes `is_active=False`.
- `.env` not loading → wrong-network WIF derivation — already fixed in 13fac32; the existing "key mismatch" error message is fine for the rare direct-Python-API case (allways-ui llms.txt covers env loading thoroughly for CLI users).

## Test plan
- [x] `ruff format .` / `ruff check --fix .` clean
- [x] `pytest` — all 404 tests pass
- [x] Direction-aware `hydrate_pending_swap` round-trip exercised manually (TAO→BTC reverse pair returns the TAO address, not the BTC one)
- [ ] Manual: kick off a swap, kill before `vote_initiate`, run `alw swap resume-reservation --send --yes` and confirm BTC broadcast + initiation
- [ ] Manual: `alw swap now` for BTC source — confirm the new fee-target line