### PR TITLE
miner: surface real send failure cause + tighten error logs

### DIFF
--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -571,8 +571,12 @@ class BitcoinProvider(ChainProvider):
 
             for i, inp in enumerate(psbt.inputs):
                 if inp.witness_utxo is None and inp.non_witness_utxo is None:
-                    sel = selected[i]
-                    self._send_error(f'PSBT input {i} missing utxo (txid={sel.get("txid")}, vout={sel.get("vout")})')
+                    sel = selected[i] if i < len(selected) else None
+                    utxo_repr = f'txid={sel["txid"]}, vout={sel["vout"]}' if sel else f'no selected[{i}]'
+                    self._send_error(
+                        f'PSBT input {i} missing utxo '
+                        f'(psbt.inputs={len(psbt.inputs)}, selected={len(selected)}, {utxo_repr})'
+                    )
                     return None
 
             num_sigs = psbt.sign_with(privkey)

--- a/allways/miner/fulfillment.py
+++ b/allways/miner/fulfillment.py
@@ -191,7 +191,7 @@ class SwapFulfiller:
             bt.logging.warning(f'Swap {swap.id}: provider unreachable, will retry: {e}')
             return False
         except Exception as e:
-            bt.logging.error(f'Swap {swap.id}: verification error: {e}')
+            bt.logging.error(f'Swap {swap.id}: verification error: {type(e).__name__}: {e}')
             return False
 
     def send_dest_funds(self, swap: Swap, user_receives_amount: int) -> Optional[Tuple[str, int]]:
@@ -221,9 +221,10 @@ class SwapFulfiller:
                 f'on {swap.to_chain} (tx: {tx_hash}, block: {block_num})'
             )
         else:
+            reason = getattr(provider, 'last_send_error', None) or 'no provider error captured'
             bt.logging.error(
                 f'Swap {swap.id}: failed to send {user_receives_amount} to {swap.user_to_address} '
-                f'on {swap.to_chain} — check wallet balance and node connectivity'
+                f'on {swap.to_chain}: {reason}'
             )
         return result
 

--- a/allways/miner/swap_poller.py
+++ b/allways/miner/swap_poller.py
@@ -33,7 +33,7 @@ class SwapPoller:
             self.last_poll_ok = True
             return result
         except Exception as e:
-            bt.logging.error(f'SwapPoller poll error: {e}')
+            bt.logging.error(f'SwapPoller poll error: {type(e).__name__}: {e}')
             self.last_poll_ok = False
             return [], []
 

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -176,7 +176,7 @@ class Miner(BaseMinerNeuron):
                 if not success:
                     bt.logging.debug(f'Swap {swap.id} not ready for fulfillment yet')
             except Exception as e:
-                bt.logging.error(f'Error processing swap {swap.id}: {e}')
+                bt.logging.error(f'Error processing swap {swap.id}: {type(e).__name__}: {e}')
 
 
 # Main entry point


### PR DESCRIPTION
## Summary
- Two miner BTC fulfillments (swap 17 / swap 13) failed with logs blaming wallet balance, but both wallets actually had 2–6× the needed funds. Root error was an embit `IndexError` inside `send_amount_lightweight` that the existing diagnostic block self-crashed on (`selected[i]` when `len(psbt.inputs) > len(selected)` — invariant break still unexplained), so the message bubbled up as the misleading "check wallet balance and node connectivity".
- Hardens the `bitcoin.py` validation loop to bound-check `selected[i]` and log `psbt.inputs`/`selected` lengths, so the next occurrence captures the actual state.
- Replaces the wallet-balance fallback in `fulfillment.py:send_dest_funds` with `provider.last_send_error`, which is what the provider already populates for exactly this purpose.
- Adds `type(e).__name__` to three catch-all error logs (`verify_user_sent_funds`, miner forward loop, `SwapPoller.poll`) so swallowed exceptions aren't ambiguous.

## Test plan
- [x] `ruff format` + `ruff check` clean on all four files
- [ ] Watch the next BTC fulfillment failure — diagnostic should now show `psbt.inputs=N, selected=M, txid=…` (or the actual provider reason) instead of the wallet-balance line