### PR TITLE
miner: fix BTC lightweight-send vin/vout leak from embit mutable default

### DIFF
--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -539,8 +539,9 @@ class BitcoinProvider(ChainProvider):
             selected, total_in, fee = coin_selection
             change = total_in - amount - fee
 
-            # Build transaction
-            tx = Transaction(version=2, locktime=0)
+            # Build transaction. embit's Transaction.__init__ has mutable default
+            # args (vin=[], vout=[]) — passing fresh lists avoids cross-call leakage.
+            tx = Transaction(version=2, vin=[], vout=[], locktime=0)
             for utxo in selected:
                 txid_bytes = bytes.fromhex(utxo['txid'])
                 tx.vin.append(TransactionInput(txid_bytes, utxo['vout']))
@@ -553,7 +554,8 @@ class BitcoinProvider(ChainProvider):
             if change > 546:  # dust threshold
                 tx.vout.append(TransactionOutput(change, my_script))
 
-            # Sign transaction
+            # Sign transaction. Do NOT write to psbt.unknown — embit's PSBT.__init__
+            # has a shared mutable default (unknown={}) that would leak across calls.
             psbt = PSBT(tx)
             if is_segwit:
                 for i, utxo in enumerate(selected):

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -172,9 +172,7 @@ class Miner(BaseMinerNeuron):
 
         for swap in active_swaps:
             try:
-                success = self.swap_fulfiller.process_swap(swap)
-                if not success:
-                    bt.logging.debug(f'Swap {swap.id} not ready for fulfillment yet')
+                self.swap_fulfiller.process_swap(swap)
             except Exception as e:
                 bt.logging.error(f'Error processing swap {swap.id}: {type(e).__name__}: {e}')
 


### PR DESCRIPTION
## The error

Miner BTC fulfillment crashes during `send_amount_lightweight` with:

```
ERROR | bittensor:bitcoin.py:112 | embit send failed: IndexError: list index out of range

Traceback (most recent call last):
  File "/app/allways/chain_providers/bitcoin.py", line 574, in send_amount_lightweight
    sel = selected[i]
          ~~~~~~~~^^^
IndexError: list index out of range
```

The embit-send `try/except` catches it and returns `None`, so the miner process stays alive — but the dest send never lands, and on a long-running miner *every* BTC swap fulfillment fails this way until restart. Reproduced on at least two different miner processes on testnet (different sender wallets, different swaps), with byte-identical tracebacks at the same source line, confirming the issue is dependency-level rather than environment-specific.

## Why it was happening

embit's `Transaction.__init__` uses mutable list literals as defaults:

```python
# embit/transaction.py
def __init__(self, version=2, vin=[], vout=[], locktime=0):
    ...
    self.vin = vin    # ← shared default list, aliased across all calls
    self.vout = vout  # ← same
```

Our call site at `bitcoin.py:543` was `Transaction(version=2, locktime=0)` with no `vin`/`vout` passed — so every Transaction in the process got `self.vin =` *the same list object*. We then did `for utxo in selected: tx.vin.append(...)`, which mutated the shared default in place.

Consequence: **once a single BTC `send_amount_lightweight` call had run in the process, the shared `vin` list permanently held that call's inputs, and every subsequent call inherited them.** The accumulation is monotonic — successful sends, failed sends, and retries all leak equally, because the leak happens before any return path.

Trace through what happens on the second send:

- First call (process startup): `tx.vin` starts empty. Append `[utxo_A]` → 1 entry. PSBT mirrors → 1 slot. `witness_utxo` set on slot 0. Validation passes. Sign+broadcast succeed. Returns `tx_hash`. The leaked default now holds `[utxo_A]` for the rest of the process.
- Second call (any new BTC swap, or any retry of the first): `tx.vin = [utxo_A]` (the leak). Append `[utxo_B]` → `[utxo_A, utxo_B]` = 2 entries. PSBT mirrors → 2 slots. The segwit setter loop iterates `selected` (length 1), so only slot 0 gets `witness_utxo`. Validation hits slot 1 with no `witness_utxo` → tries `selected[1]` → **IndexError**.

So the trigger threshold is "process has run ≥1 BTC `send_amount_lightweight` before this attempt." A perfectly healthy first send is sufficient to arm the trap; a healthy second send is impossible without a process restart. CLI `alw swap now` exercises the same code path, so on a host that does both miner fulfillment and CLI sends, either one can pollute the other.

This is also what was happening behind commit 427662a (#267)'s `'NoneType' has no attribute 'script_pubkey'` symptom from inside embit — same root cause, same accumulating PSBT inputs without a `witness_utxo`. The validation guard in that PR was a workaround for the symptom; this PR fixes the upstream cause.

## Changes

- **`allways/chain_providers/bitcoin.py:543`** — Pass `vin=[], vout=[]` explicitly so each call evaluates fresh `[]` literals at the call site, bypassing embit's shared default.
- **`allways/chain_providers/bitcoin.py:557`** — Comment on `PSBT(tx)` construction noting that `psbt.unknown` must not be written to: PSBT has the same `unknown={}` shared-default footgun. Not currently exercised by our code, but cheap to flag for future devs.
- **`neurons/miner.py:173-178`** — Drop the `Swap N not ready for fulfillment yet` debug log. It fired on every `process_swap=False` return — including hard send failures — making error chains read as if the system intentionally backed off when it had actually crashed. The inner logs at each false-return site already describe the cause accurately (`failed safety checks`, `waiting for source funds confirmation`, `failed to send dest funds`, `mark_fulfilled failed`).

## Operational note

A miner running an old build needs a process restart after pulling this fix — the leaked default's contents persist for the lifetime of the Python process, so the patch alone does not drain pre-existing pollution.

## Test plan

- [ ] Restart a testnet miner against this branch, observe BTC fulfillment succeeds on the first swap and on subsequent swaps in the same process (the failure mode required ≥2 sends to manifest).
- [ ] Confirm `alw swap now` (CLI) still signs and broadcasts on the same `send_amount_lightweight` path.
- [ ] Verify miner logs no longer emit `Swap N not ready for fulfillment yet` after a `failed to send dest funds` error.