### PR TITLE
cli: surface what's-being-waited-on hint in view swap

### DIFF
--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -619,7 +619,16 @@ def build_swap_text(swap, chain_info=True, current_block: int = 0, client=None):
     aborting the swap render.
     """
     color = SWAP_STATUS_COLORS.get(swap.status, 'white')
-    parts = [f'\n[bold]Swap #{swap.id}[/bold] — [{color}]{swap.status.name}[/{color}]\n']
+    parts = [f'\n[bold]Swap #{swap.id}[/bold] — [{color}]{swap.status.name}[/{color}]']
+
+    # In-flight status hint — answers "what's being waited on" so the
+    # `○ Completed —` row in the timeline below has context. Mirrors the
+    # per-status copy on the dashboard's swap detail page.
+    if swap.status == SwapStatus.ACTIVE:
+        parts.append('  [dim]Awaiting miner fulfillment — destination tx incoming.[/dim]')
+    elif swap.status == SwapStatus.FULFILLED:
+        parts.append('  [dim]Awaiting validator quorum — destination delivered, votes pending.[/dim]')
+    parts.append('')
 
     src = swap.from_chain.upper()
     dst = swap.to_chain.upper()


### PR DESCRIPTION
## Summary
- Adds a one-line dim status hint under the `Swap #N — STATUS` header in `alw view swap` (and `--watch`) so the `○ Completed —` placeholder has context.
- Hint copy mirrors the dashboard's swap detail page, shortened for the TUI:
  - `ACTIVE` → "Awaiting miner fulfillment — destination tx incoming."
  - `FULFILLED` → "Awaiting validator quorum — destination delivered, votes pending."
  - `COMPLETED` / `TIMED_OUT` → no hint (timeline glyphs already convey the terminal state).

## Test plan
- [ ] `alw view swap <id>` against an `ACTIVE` swap shows the miner-fulfillment hint.
- [ ] `alw view swap <id>` against a `FULFILLED` swap shows the validator-quorum hint.
- [ ] `alw view swap <id> --watch` picks up the new hint as status transitions.
- [ ] `alw view swap <id>` against `COMPLETED` / `TIMED_OUT` swaps still renders without the hint line.