### PR TITLE
btc/validator: stop cross-swap tx-hash reuse and surface contract rejection variant

### DIFF
--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -107,6 +107,10 @@ class BitcoinProvider(ChainProvider):
         # callers can surface a useful message without scraping logs.
         self.last_send_error: Optional[str] = None
 
+        # Scopes find_recent_outgoing reuse to this process — a fresh `alw swap`
+        # run can't return a tx hash already consumed by an earlier swap.
+        self.broadcasted_txids: set[str] = set()
+
     def _send_error(self, msg: str) -> None:
         self.last_send_error = msg
         bt.logging.error(msg)
@@ -525,8 +529,10 @@ class BitcoinProvider(ChainProvider):
                 return None
             my_script, my_address, utxos, addr_type = result
 
+            # Reuse only txids this process broadcast — otherwise (from, to, amount)
+            # would match a prior-swap tx that the contract has already consumed.
             existing = self.find_recent_outgoing(my_address, to_address, amount)
-            if existing:
+            if existing and existing in self.broadcasted_txids:
                 bt.logging.info(f'Reusing prior tx {existing} from {my_address} → {to_address} ({amount} sat)')
                 return (existing, 0)
 
@@ -690,16 +696,20 @@ class BitcoinProvider(ChainProvider):
             resp = self.btc_api_post('/tx', data=raw_hex, timeout=30)
         except Exception as e:
             if expected_txid and self.tx_exists(expected_txid):
+                self.broadcasted_txids.add(expected_txid)
                 return expected_txid
             self._send_error(f'Broadcast failed: {e}')
             return None
 
         if resp.status_code != 200:
             if expected_txid and self.tx_exists(expected_txid):
+                self.broadcasted_txids.add(expected_txid)
                 return expected_txid
             self._send_error(f'Broadcast rejected ({resp.status_code}): {resp.text.strip()}')
             return None
-        return resp.text.strip()
+        txid = resp.text.strip()
+        self.broadcasted_txids.add(txid)
+        return txid
 
     def estimate_fee_rate(self, override: Optional[int] = None) -> int:
         """Estimate fee rate (sat/vbyte) from Blockstream.

--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -692,24 +692,27 @@ class BitcoinProvider(ChainProvider):
         except Exception:
             pass
 
+        # Record the txid before broadcasting so a same-session retry can
+        # reclaim it via find_recent_outgoing even if the response is lost
+        # before tx_exists has caught up. A truly-rejected broadcast leaves
+        # the entry harmlessly — Esplora won't surface it for matching.
+        if expected_txid:
+            self.broadcasted_txids.add(expected_txid)
+
         try:
             resp = self.btc_api_post('/tx', data=raw_hex, timeout=30)
         except Exception as e:
             if expected_txid and self.tx_exists(expected_txid):
-                self.broadcasted_txids.add(expected_txid)
                 return expected_txid
             self._send_error(f'Broadcast failed: {e}')
             return None
 
         if resp.status_code != 200:
             if expected_txid and self.tx_exists(expected_txid):
-                self.broadcasted_txids.add(expected_txid)
                 return expected_txid
             self._send_error(f'Broadcast rejected ({resp.status_code}): {resp.text.strip()}')
             return None
-        txid = resp.text.strip()
-        self.broadcasted_txids.add(txid)
-        return txid
+        return resp.text.strip()
 
     def estimate_fee_rate(self, override: Optional[int] = None) -> int:
         """Estimate fee rate (sat/vbyte) from Blockstream.

--- a/allways/cli/validator_rejections.py
+++ b/allways/cli/validator_rejections.py
@@ -281,6 +281,16 @@ _RULES: list[_Rule] = [
         lambda ctx: 'Internal: missing chain fields in the request.',
     ),
     (
+        'duplicate_source_tx',
+        'vote_initiate: duplicatesourcetx',
+        True,
+        lambda ctx: (
+            'Source transaction was already used in a prior swap, so the contract rejected '
+            'the new initiation. Start a fresh swap with [bold]alw swap[/bold] so a new '
+            'source transaction is broadcast.'
+        ),
+    ),
+    (
         'contract_rejected',
         'contract rejected',
         False,

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -18,7 +18,7 @@ from Crypto.Hash import keccak
 from allways.classes import MinerPair
 from allways.commitments import read_miner_commitment
 from allways.constants import RESERVATION_COOLDOWN_BLOCKS
-from allways.contract_client import AllwaysContractClient, ContractError, is_contract_rejection
+from allways.contract_client import AllwaysContractClient, ContractError
 from allways.synapses import MinerActivateSynapse, SwapConfirmSynapse, SwapReserveSynapse
 from allways.utils.scale import encode_bytes, encode_str, encode_u128
 from allways.validator.state_store import PendingConfirm
@@ -386,8 +386,7 @@ async def handle_swap_reserve(
 
     except ContractError as e:
         bt.logging.error(f'{ctx} failed: {e}')
-        reason = 'Contract rejected the reservation' if is_contract_rejection(e) else str(e)
-        reject_synapse(synapse, reason)
+        reject_synapse(synapse, str(e))
     except Exception as e:
         bt.logging.error(f'{ctx} failed: {e}')
         reject_synapse(synapse, str(e))
@@ -584,8 +583,7 @@ async def handle_swap_confirm(
 
     except ContractError as e:
         bt.logging.error(f'{ctx} failed: {e}')
-        reason = 'Contract rejected the swap initiation' if is_contract_rejection(e) else str(e)
-        reject_synapse(synapse, reason)
+        reject_synapse(synapse, str(e))
     except Exception as e:
         bt.logging.error(f'{ctx} failed: {e}')
         reject_synapse(synapse, str(e))

--- a/tests/test_axon_handlers.py
+++ b/tests/test_axon_handlers.py
@@ -329,23 +329,23 @@ class TestSourceTxVerification:
 
 
 class TestErrorHandling:
-    def test_contract_rejection_surfaces_generic_message(self):
-        """Known contract rejection → short user-facing reason, not a raw
-        ContractTrapped string."""
+    def test_contract_rejection_surfaces_variant_detail(self):
+        """Contract rejections must carry the variant + description through to
+        the user — generic placeholders previously hid actionable info such as
+        DuplicateSourceTx."""
         validator = make_validator()
-        validator.axon_contract_client.get_miner_reserved_until.side_effect = ContractError('ContractTrapped: ...')
-        with patch('allways.validator.axon_handlers.is_contract_rejection', return_value=True):
-            result = run_handler(validator, make_synapse())
+        err = 'vote_initiate: DuplicateSourceTx — Source transaction hash already used in another swap'
+        validator.axon_contract_client.get_miner_reserved_until.side_effect = ContractError(err)
+        result = run_handler(validator, make_synapse())
         assert result.accepted is False
-        assert 'Contract rejected' in result.rejection_reason
+        assert 'DuplicateSourceTx' in result.rejection_reason
 
     def test_non_rejection_contract_error_surfaces_raw(self):
         """RPC/connectivity errors (not contract rejections) include detail
         so the caller can distinguish transient failures from rejections."""
         validator = make_validator()
         validator.axon_contract_client.get_miner_reserved_until.side_effect = ContractError('connection reset')
-        with patch('allways.validator.axon_handlers.is_contract_rejection', return_value=False):
-            result = run_handler(validator, make_synapse())
+        result = run_handler(validator, make_synapse())
         assert result.accepted is False
         assert 'connection reset' in result.rejection_reason
 

--- a/tests/test_bitcoin_signing.py
+++ b/tests/test_bitcoin_signing.py
@@ -1,7 +1,8 @@
 """Tests for BIP-137 message signing and verification in BitcoinProvider."""
 
 import os
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 from bitcoin_message_tool.bmt import sign_message, verify_message
 
@@ -223,3 +224,50 @@ class TestBitcoinProviderVerifyFromProof:
         # not crash, because no valid signature binds to it.
         result = provider.verify_from_proof('bcrt1qtestnettestaddresstestaddresstestaddr', TEST_MESSAGE, 'AAAA')
         assert result is False
+
+
+class TestBroadcastedTxidsTracking:
+    """Pin the find_recent_outgoing reuse contract: cross-process leakage is
+    impossible (fresh provider = empty set), and same-session retries can
+    still recover a broadcast whose response was lost."""
+
+    SAMPLE_RAW_TX = (
+        '0200000001abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789'
+        '0000000000ffffffff0100e1f5050000000017a9140000000000000000000000000000000000000000870'
+        '0000000'
+    )
+
+    def _expected_txid(self, raw_hex: str) -> str:
+        from embit.transaction import Transaction as EmbitTx
+
+        return EmbitTx.from_string(raw_hex).txid().hex()
+
+    def test_successful_broadcast_records_txid(self):
+        provider = make_lightweight_provider()
+        txid = self._expected_txid(self.SAMPLE_RAW_TX)
+        with patch.object(provider, 'btc_api_post', return_value=SimpleNamespace(status_code=200, text=txid)):
+            result = provider.broadcast_tx(self.SAMPLE_RAW_TX)
+        assert result == txid
+        assert txid in provider.broadcasted_txids
+
+    def test_broadcast_with_lost_response_still_records_txid(self):
+        """If the post errors and tx_exists hasn't propagated yet, the txid
+        must still be in the set — otherwise a same-session retry that
+        finds the tx via find_recent_outgoing won't be allowed to reuse it
+        and will broadcast a duplicate."""
+        provider = make_lightweight_provider()
+        txid = self._expected_txid(self.SAMPLE_RAW_TX)
+        post = MagicMock(side_effect=ConnectionError('lost'))
+        with (
+            patch.object(provider, 'btc_api_post', post),
+            patch.object(provider, 'tx_exists', return_value=False),
+        ):
+            result = provider.broadcast_tx(self.SAMPLE_RAW_TX)
+        assert result is None
+        assert txid in provider.broadcasted_txids
+
+    def test_fresh_provider_starts_with_empty_set(self):
+        """Each `alw swap` invocation gets a clean set — the prior swap's
+        consumed tx hash can't leak across processes."""
+        provider = make_lightweight_provider()
+        assert provider.broadcasted_txids == set()

--- a/tests/test_validator_rejections.py
+++ b/tests/test_validator_rejections.py
@@ -118,6 +118,15 @@ def test_unmatched_falls_back_to_raw():
     assert info.deterministic is False  # unknown → safer to allow retry
 
 
+def test_duplicate_source_tx_translates_with_deterministic_flag():
+    raw = 'vote_initiate: DuplicateSourceTx — Source transaction hash already used in another swap'
+    info = render_and_aggregate(_silent_console(), [FakeResp(accepted=False, rejection_reason=raw)])
+    assert info.category == 'duplicate_source_tx'
+    assert info.deterministic is True
+    assert 'already used' in info.headline.lower()
+    assert 'alw swap' in info.headline
+
+
 def test_swap_confirm_tx_not_found_is_transient():
     info = render_and_aggregate(
         _silent_console(),


### PR DESCRIPTION
## Summary
Two fixes that together address the silent-failure pattern Lando hit on swap #6 (reservation expired with no on-chain initiation, CLI said "BTC sent").

- **`BitcoinProvider.send_amount_lightweight` no longer reuses tx hashes across swaps.** The `find_recent_outgoing` heuristic matched any tx in the last 5 min by `(from, to, amount)`. Back-to-back swaps to the same miner for the same amount produced an identical tuple, so the function returned the *prior* swap's tx hash instead of broadcasting a new one. The contract correctly rejected it as `DuplicateSourceTx`, but the CLI logged success.
  - Track txids this provider instance has broadcast in `self.broadcasted_txids`.
  - Gate the `find_recent_outgoing` reuse on membership in that set.
  - Same-process broadcast retries still recover (we record the txid in `broadcast_tx`); a fresh `alw swap` invocation starts with an empty set, so cross-swap leakage is impossible.
- **Validator now surfaces the actual contract rejection variant.** `handle_swap_reserve` and `handle_swap_confirm` were replacing the `ContractError` message with `'Contract rejected the {reservation,swap initiation}'`, hiding the variant name (e.g. `DuplicateSourceTx — Source transaction hash already used in another swap`). They now pass `str(e)` through.
- **CLI gets a friendly translation for the duplicate-source-tx case** with `deterministic=True`, so the user is told to start a fresh swap rather than prompted to retry the same tx.

## Test plan
- [x] `ruff format` + `ruff check` pass on all touched files
- [x] `pytest` — full suite green (405 passed)
- [x] Updated `test_contract_rejection_surfaces_variant_detail` to assert the variant name now flows through
- [x] Added `test_duplicate_source_tx_translates_with_deterministic_flag` covering the new CLI rule
- [ ] E2E sanity: run swap suite against dev environment after merge to confirm the same-miner repeat-swap path no longer reuses a consumed tx hash