### PR TITLE
neurons: surface stalled-state blind spots in logs

### DIFF
--- a/allways/miner/fulfillment.py
+++ b/allways/miner/fulfillment.py
@@ -80,10 +80,6 @@ class SwapFulfiller:
         self.my_addresses: Dict[str, str] = my_addresses if my_addresses is not None else {}
         self.sent: Dict[int, SentSwap] = {}
         self.mark_fulfilled_attempts: Dict[int, int] = {}
-        # Swap IDs we've already warned about being inside the cushion window.
-        # Without this, the same warning fires every poll for the entire
-        # cushion duration (often 30+ identical lines), drowning out other
-        # signals while the swap stays stuck.
         self.cushion_warned: Set[int] = set()
         self.sent_cache_path = sent_cache_path
         self.load_sent_cache()
@@ -121,9 +117,6 @@ class SwapFulfiller:
     def cleanup_stale_sends(self, active_swap_ids: Set[int]):
         """Remove cached send results for swaps no longer active."""
         stale = [sid for sid in self.sent if sid not in active_swap_ids]
-        # Sent dest funds but never confirmed mark_fulfilled landed = the
-        # most expensive failure mode the miner has (paid out, didn't get
-        # crown credit). Surface separately so operators can grep for it.
         unmarked = [sid for sid in stale if not self.sent[sid].marked_fulfilled]
         for sid in stale:
             self.sent.pop(sid)
@@ -313,11 +306,6 @@ class SwapFulfiller:
             bt.logging.success(f'Swap {swap.id}: marked as fulfilled')
             return True
         except ContractError as e:
-            # Contract rejections (e.g. swap already resolved by validators,
-            # status no longer FULFILLABLE) are terminal — retrying just
-            # logs the same error every poll. Surface them once at info so
-            # the noise floor stays low and the operator can see the
-            # actual transient-RPC vs contract-state distinction.
             if is_contract_rejection(e):
                 bt.logging.info(f'Swap {swap.id}: mark_fulfilled rejected by contract (likely already resolved): {e}')
                 return False

--- a/allways/miner/fulfillment.py
+++ b/allways/miner/fulfillment.py
@@ -11,7 +11,7 @@ import bittensor as bt
 from allways.chain_providers.base import ChainProvider, ProviderUnreachableError
 from allways.classes import Swap
 from allways.constants import DEFAULT_MINER_TIMEOUT_CUSHION_BLOCKS
-from allways.contract_client import AllwaysContractClient, ContractError
+from allways.contract_client import AllwaysContractClient, ContractError, is_contract_rejection
 from allways.utils.rate import expected_swap_amounts
 
 
@@ -80,6 +80,11 @@ class SwapFulfiller:
         self.my_addresses: Dict[str, str] = my_addresses if my_addresses is not None else {}
         self.sent: Dict[int, SentSwap] = {}
         self.mark_fulfilled_attempts: Dict[int, int] = {}
+        # Swap IDs we've already warned about being inside the cushion window.
+        # Without this, the same warning fires every poll for the entire
+        # cushion duration (often 30+ identical lines), drowning out other
+        # signals while the swap stays stuck.
+        self.cushion_warned: Set[int] = set()
         self.sent_cache_path = sent_cache_path
         self.load_sent_cache()
 
@@ -116,11 +121,21 @@ class SwapFulfiller:
     def cleanup_stale_sends(self, active_swap_ids: Set[int]):
         """Remove cached send results for swaps no longer active."""
         stale = [sid for sid in self.sent if sid not in active_swap_ids]
+        # Sent dest funds but never confirmed mark_fulfilled landed = the
+        # most expensive failure mode the miner has (paid out, didn't get
+        # crown credit). Surface separately so operators can grep for it.
+        unmarked = [sid for sid in stale if not self.sent[sid].marked_fulfilled]
         for sid in stale:
             self.sent.pop(sid)
             self.mark_fulfilled_attempts.pop(sid, None)
+        self.cushion_warned -= self.cushion_warned - active_swap_ids
         if stale:
             bt.logging.info(f'Cleaned up stale send cache for {len(stale)} swap(s): {stale}')
+            if unmarked:
+                bt.logging.warning(
+                    f'Stale send(s) without confirmed mark_fulfilled — funds may have been sent without '
+                    f'on-chain credit: {unmarked}'
+                )
             self.save_sent_cache()
 
     def verify_swap_safety(self, swap: Swap) -> Optional[Tuple[int, str]]:
@@ -142,10 +157,12 @@ class SwapFulfiller:
         current_block = self.subtensor.get_current_block()
         effective_deadline = swap.timeout_block - self.timeout_cushion_blocks
         if current_block >= effective_deadline:
-            bt.logging.warning(
-                f'Swap {swap.id}: inside cushion window '
-                f'(block {current_block} >= {swap.timeout_block} - {self.timeout_cushion_blocks})'
-            )
+            if swap.id not in self.cushion_warned:
+                bt.logging.warning(
+                    f'Swap {swap.id}: inside cushion window '
+                    f'(block {current_block} >= {swap.timeout_block} - {self.timeout_cushion_blocks})'
+                )
+                self.cushion_warned.add(swap.id)
             return None
 
         # Rate and address from swap struct (snapshotted at initiation)
@@ -296,6 +313,14 @@ class SwapFulfiller:
             bt.logging.success(f'Swap {swap.id}: marked as fulfilled')
             return True
         except ContractError as e:
+            # Contract rejections (e.g. swap already resolved by validators,
+            # status no longer FULFILLABLE) are terminal — retrying just
+            # logs the same error every poll. Surface them once at info so
+            # the noise floor stays low and the operator can see the
+            # actual transient-RPC vs contract-state distinction.
+            if is_contract_rejection(e):
+                bt.logging.info(f'Swap {swap.id}: mark_fulfilled rejected by contract (likely already resolved): {e}')
+                return False
             attempts = self.mark_fulfilled_attempts.get(swap.id, 0) + 1
             self.mark_fulfilled_attempts[swap.id] = attempts
             try:

--- a/allways/miner/swap_poller.py
+++ b/allways/miner/swap_poller.py
@@ -69,7 +69,11 @@ class SwapPoller:
                 self.active[swap_id] = swap
         for sid, terminal in resolved:
             self.active.pop(sid, None)
-            bt.logging.debug(f'Swap {sid}: dropped from active (status={terminal})')
+            # Every entry in ``self.active`` is one of OUR swaps (poller
+            # filters by miner_hotkey at insert), so a drop is a real
+            # outcome — COMPLETED, TIMED_OUT, or unexpectedly GONE from
+            # contract storage. Operator needs this at info, not debug.
+            bt.logging.info(f'Swap {sid}: dropped from active (status={terminal})')
 
         # 3. Return categorized by contract status
         active_swaps = [s for s in self.active.values() if s.status == SwapStatus.ACTIVE]

--- a/allways/miner/swap_poller.py
+++ b/allways/miner/swap_poller.py
@@ -69,10 +69,6 @@ class SwapPoller:
                 self.active[swap_id] = swap
         for sid, terminal in resolved:
             self.active.pop(sid, None)
-            # Every entry in ``self.active`` is one of OUR swaps (poller
-            # filters by miner_hotkey at insert), so a drop is a real
-            # outcome — COMPLETED, TIMED_OUT, or unexpectedly GONE from
-            # contract storage. Operator needs this at info, not debug.
             bt.logging.info(f'Swap {sid}: dropped from active (status={terminal})')
 
         # 3. Return categorized by contract status

--- a/allways/validator/chain_verification.py
+++ b/allways/validator/chain_verification.py
@@ -146,11 +146,6 @@ class SwapVerifier:
             swap.miner_to_address,
         )
 
-        # Partial-pass tells operators which side is gating confirm. The
-        # underlying verify_tx logs are rate-limited by-confirmation-count
-        # and don't name source vs dest from the outside; this synthesis
-        # line does. log_on_change keys per-swap state so it fires once
-        # per transition, not every forward step.
         if source_ok != dest_ok:
             log_on_change(
                 f'partial:{swap.id}',

--- a/allways/validator/chain_verification.py
+++ b/allways/validator/chain_verification.py
@@ -7,6 +7,7 @@ import bittensor as bt
 
 from allways.chain_providers.base import ChainProvider, ProviderUnreachableError, TransactionInfo
 from allways.classes import Swap
+from allways.utils.logging import log_on_change
 from allways.utils.rate import expected_swap_amounts
 
 
@@ -144,5 +145,18 @@ class SwapVerifier:
             swap.to_tx_block,
             swap.miner_to_address,
         )
+
+        # Partial-pass tells operators which side is gating confirm. The
+        # underlying verify_tx logs are rate-limited by-confirmation-count
+        # and don't name source vs dest from the outside; this synthesis
+        # line does. log_on_change keys per-swap state so it fires once
+        # per transition, not every forward step.
+        if source_ok != dest_ok:
+            log_on_change(
+                f'partial:{swap.id}',
+                (source_ok, dest_ok),
+                f'Swap {swap.id}: partial verification (source={source_ok}, dest={dest_ok}) — '
+                f'{"dest" if source_ok else "source"} side blocking confirm',
+            )
 
         return source_ok and dest_ok

--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -473,6 +473,14 @@ class ContractEventWatcher:
         current = self.open_swap_count.get(hotkey, 0)
         new_count = current + delta
         if new_count < 0:
+            # Implies a missed SwapInitiated (cold-start bootstrap gap or
+            # event-decoder regression). Silent drop is what we want for
+            # safety, but it skews crown-time scoring without a trace —
+            # warn so an unexpected discrepancy is investigable.
+            bt.logging.warning(
+                f'EventWatcher: dropping busy delta {delta} for {hotkey[:8]} at block {block_num} '
+                f'(current count={current}, would go negative — missed SwapInitiated?)'
+            )
             return
         self.open_swap_count[hotkey] = new_count
         self.busy_events.append(BusyEvent(hotkey=hotkey, delta=delta, block=block_num))

--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -473,10 +473,6 @@ class ContractEventWatcher:
         current = self.open_swap_count.get(hotkey, 0)
         new_count = current + delta
         if new_count < 0:
-            # Implies a missed SwapInitiated (cold-start bootstrap gap or
-            # event-decoder regression). Silent drop is what we want for
-            # safety, but it skews crown-time scoring without a trace —
-            # warn so an unexpected discrepancy is investigable.
             bt.logging.warning(
                 f'EventWatcher: dropping busy delta {delta} for {hotkey[:8]} at block {block_num} '
                 f'(current count={current}, would go negative — missed SwapInitiated?)'

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -61,7 +61,11 @@ async def forward(self: Validator) -> None:
     # would be silently lost to the purge before init ever sees the row.
     initialize_pending_user_reservations(self)
 
-    self.state_store.purge_expired_pending_confirms()
+    purged = self.state_store.purge_expired_pending_confirms()
+    if purged:
+        bt.logging.info(
+            f'forward: purged {purged} expired pending_confirms (reservations elapsed without tx confirmation)'
+        )
 
     poll_commitments(self)
 
@@ -389,6 +393,10 @@ def purge_deregistered_hotkeys(self: Validator) -> None:
     for hk in stale:
         self.state_store.delete_hotkey(hk)
     self.last_known_rates = {k: v for k, v in self.last_known_rates.items() if k[0] not in stale}
+    # Wiping rate_events + swap_outcomes for a hotkey alters scoring inputs
+    # silently otherwise — surface the dereg-driven cleanup at info so an
+    # unexpected drop in distributed share has a paper trail.
+    bt.logging.info(f'forward: dropped state for {len(stale)} deregistered miner(s)')
 
 
 async def confirm_miner_fulfillments(
@@ -422,6 +430,12 @@ async def confirm_miner_fulfillments(
                 bt.logging.success(f'Swap {swap.id}: verified complete, confirmed')
             # On vote failure, voting.confirm_swap already logs the error;
             # the entry stays in tracker and retries next step.
+        else:
+            # Synthesis-level breadcrumb at DEBUG — sits one layer above
+            # ``verify_tx``'s per-side rate-limited logs so an operator
+            # tracing a stuck FULFILLED swap can confirm we hit this cycle
+            # without inferring it from the absence of a confirm.
+            bt.logging.debug(f'Swap {swap.id}: verification incomplete this cycle, deferring confirm')
     return uncertain
 
 

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -393,9 +393,6 @@ def purge_deregistered_hotkeys(self: Validator) -> None:
     for hk in stale:
         self.state_store.delete_hotkey(hk)
     self.last_known_rates = {k: v for k, v in self.last_known_rates.items() if k[0] not in stale}
-    # Wiping rate_events + swap_outcomes for a hotkey alters scoring inputs
-    # silently otherwise — surface the dereg-driven cleanup at info so an
-    # unexpected drop in distributed share has a paper trail.
     bt.logging.info(f'forward: dropped state for {len(stale)} deregistered miner(s)')
 
 
@@ -431,10 +428,6 @@ async def confirm_miner_fulfillments(
             # On vote failure, voting.confirm_swap already logs the error;
             # the entry stays in tracker and retries next step.
         else:
-            # Synthesis-level breadcrumb at DEBUG — sits one layer above
-            # ``verify_tx``'s per-side rate-limited logs so an operator
-            # tracing a stuck FULFILLED swap can confirm we hit this cycle
-            # without inferring it from the absence of a confirm.
             bt.logging.debug(f'Swap {swap.id}: verification incomplete this cycle, deferring confirm')
     return uncertain
 

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -157,6 +157,11 @@ class Miner(BaseMinerNeuron):
                 self.reconnect_and_propagate()
                 self.consecutive_poll_failures = 0
             return
+        # Recovery from a streak of failures was previously silent — the only
+        # signal was the absence of the next warning, leaving the prior
+        # ``consecutive poll failures`` line as the most recent state.
+        if self.consecutive_poll_failures > 0:
+            bt.logging.info(f'Poll recovered after {self.consecutive_poll_failures} consecutive failure(s)')
         self.consecutive_poll_failures = 0
 
         active_count = len(self.swap_poller.active)

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -157,9 +157,6 @@ class Miner(BaseMinerNeuron):
                 self.reconnect_and_propagate()
                 self.consecutive_poll_failures = 0
             return
-        # Recovery from a streak of failures was previously silent — the only
-        # signal was the absence of the next warning, leaving the prior
-        # ``consecutive poll failures`` line as the most recent state.
         if self.consecutive_poll_failures > 0:
             bt.logging.info(f'Poll recovered after {self.consecutive_poll_failures} consecutive failure(s)')
         self.consecutive_poll_failures = 0


### PR DESCRIPTION
## Summary

Surgical, low-noise logging for places where validator and miner state changes silently. Each addition closes a specific blind spot operators could only see indirectly today (or not at all).

### Validator

- `forward.py` — log when `purge_expired_pending_confirms` removes rows. Caller previously discarded the count, so user-side reservation expiry was invisible.
- `forward.py confirm_miner_fulfillments` — DEBUG synthesis line when `verify_miner_fulfillment` returns False (no exception). Per-side `verify_tx` already logs at DEBUG; this one names that we hit the cycle so a stuck FULFILLED swap isn't inferred from the absence of a confirm.
- `chain_verification.py verify_miner_fulfillment` — partial-pass log via `log_on_change` when `source_ok != dest_ok`, naming which side is gating confirm. Transition-only via `log_on_change` keyed on `(swap_id, state)`.
- `event_watcher.py apply_busy_delta` — WARN when a -1 would drop the open-swap count below 0. The drop itself is the right behavior, but it skews crown-time scoring without a paper trail (missed `SwapInitiated` from a bootstrap gap, etc.).
- `forward.py purge_deregistered_hotkeys` — log dropping `rate_events` + `swap_outcomes` for deregistered miners. Otherwise an unexpected drop in a miner's distributed share has no operator-visible cause.

### Miner

- `swap_poller.py` — promote the terminal-drop log from DEBUG to INFO. Every entry in `self.active` is THIS miner's swap, so a drop is a real outcome (COMPLETED, TIMED_OUT, or GONE) the operator should see.
- `fulfillment.py mark_fulfilled` retry — distinguish `is_contract_rejection` from RPC error. Contract rejections (swap already resolved) are terminal; treating them as transient errors spammed the log every poll.
- `fulfillment.py verify_swap_safety` — rate-limit the cushion-window WARN per swap_id. Currently fires every poll for the entire cushion duration (often 30+ identical lines).
- `neurons/miner.py forward` — log RPC recovery when `consecutive_poll_failures` resets from non-zero. Recovery was previously silent.
- `fulfillment.py cleanup_stale_sends` — WARN separately when a stale send has `marked_fulfilled=False`. That's the most expensive miner failure mode (paid out without on-chain credit) and previously folded into a generic info line.

## Test plan
- [x] `ruff format .` + `ruff check .` clean on touched files
- [x] Full pytest suite passes (408 tests)
- [ ] Verify in dev env (`./up.sh --chains btc` → suite 02): cushion log fires once not many times; partial-pass line appears for in-flight swaps; deregistered-miner cleanup line appears when a hotkey leaves the metagraph