### PR TITLE
bump version to 1.0.0 for MVP release

### DIFF
--- a/allways/__init__.py
+++ b/allways/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '0.1.0'
+__version__ = '1.0.0'
 version_split = __version__.split('.')
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "allways"
-version = "0.1.0"
+version = "1.0.0"
 description = "Allways - Universal Transaction Layer: Trustless cross-chain swaps on Bittensor Subnet 7"
 license = "MIT"
 requires-python = ">=3.10,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "allways"
-version = "0.1.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "base58" },


### PR DESCRIPTION
## Summary
- Bumps `__version__` and `pyproject.toml` from `0.1.0` → `1.0.0` ahead of the MVP release.
- `__spec_version__` recomputes from `101` → `1000` (formula: `major*1000 + minor*10 + patch`).

## Test plan
- [ ] `alw --version` reports `1.0.0`
- [ ] Validator/miner neurons start cleanly with the new spec version