### PR TITLE
constants: set mainnet CONTRACT_ADDRESS to deployed finney contract

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -6,7 +6,7 @@ NETUID_LOCAL = 2
 
 # ─── Contract ──────────────────────────────────────────────
 # Mainnet default; override via CONTRACT_ADDRESS env var.
-CONTRACT_ADDRESS = '5FTkUEhRmLPsALn4b7bJpVFhDQqohGbc6khnmA2aiYFLMZYP'
+CONTRACT_ADDRESS = '5DjJmTpcHZvF3aZZEafKBdo3ksmdUSZ8bBBUSFhW3Ce3xf1J'
 
 # ─── Polling ──────────────────────────────────────────────
 # Bittensor base-neuron heartbeat, not the scoring/forward cadence.


### PR DESCRIPTION
## Summary
- Replace the placeholder mainnet contract address in `allways/constants.py` with the deployed finney contract: `5DjJmTpcHZvF3aZZEafKBdo3ksmdUSZ8bBBUSFhW3Ce3xf1J`.
- This is the only place in the repo where the address was hardcoded; everywhere else reads from `CONTRACT_ADDRESS` (or its `.env` override).

## Test plan
- [ ] CI green
- [ ] `alw status` against finney points at the new contract by default (no `CONTRACT_ADDRESS` env override needed)