### PR TITLE
fix: bare global --netuid without value yields misleading Click error (#238)

### DIFF
--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -195,10 +195,13 @@ def parse_global_flags() -> dict:
                 continue
         # Handle --flag value form
         if arg in _GLOBAL_FLAGS:
-            if i + 1 < len(sys.argv):
+            if i + 1 < len(sys.argv) and not sys.argv[i + 1].startswith('--'):
                 overrides[_GLOBAL_FLAGS[arg]] = sys.argv[i + 1]
                 i += 2
                 continue
+            else:
+                console.print(f'[red]Error: {arg} requires a value[/red]')
+                sys.exit(1)
         new_argv.append(arg)
         i += 1
     sys.argv[:] = new_argv


### PR DESCRIPTION
## Description
Fix issue where `--netuid` without a following value yields a misleading Click error.

**Problem:** When `--netuid` appears without a following token, the global-flag stripper does not consume it; it stays on `argv`, and Click reports `No such option: --netuid` on the subcommand.

**Solution:**
- Detect when `--netuid` (or any global flag) is followed by another flag (starting with `--`) or end of argv
- Show clear error message: `Error: --netuid requires a value`
- Exit with code 1 instead of letting Click report misleading error

## Changes
- `allways/cli/swap_commands/helpers.py`: Add validation in `parse_global_flags()` to check if flag value is missing or is another flag

## Related Issue
Closes #238

## Testing
```bash
# Should show clear error instead of Click error
alw view rates --netuid
# Expected: Error: --netuid requires a value
```