### PR TITLE
fix: validate netuid before int() in get_cli_context

### DIFF
--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -580,7 +580,10 @@ def resolve_source_tx_block(
         # If we can't reach subtensor the lookup can't proceed anyway — bail
         # honestly rather than fake a current-block guess and crash on the
         # first verify_transaction RPC.
-        console.print(f'[yellow]Skipping client-side tx lookup — subtensor unreachable ({type(e).__name__}).[/yellow]')
+        console.print(
+            f'[yellow]Skipping client-side tx lookup — '
+            f'subtensor unreachable ({type(e).__name__}).[/yellow]'
+        )
         return 0
     try:
         reservation_ttl = int(client.get_reservation_ttl())

--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -28,6 +28,21 @@ PENDING_SWAP_FILE = ALLWAYS_DIR / 'pending_swap.json'
 
 console = Console()
 
+
+def parse_non_negative_int(value: str, param: str = 'netuid') -> int:
+    """Validate and convert a string to a non-negative integer.
+
+    Raises click.UsageError with a clear message on invalid input.
+    """
+    if not isinstance(value, str):
+        value = str(value)
+    value = value.strip()
+    if not value:
+        raise click.UsageError(f'{param} must not be empty')
+    if not value.isdigit():
+        raise click.UsageError(f'{param} must be a non-negative integer, got: {value!r}')
+    return int(value)
+
 SECONDS_PER_BLOCK = 12
 
 SWAP_STATUS_COLORS = {
@@ -247,7 +262,10 @@ def get_cli_context(
     if 'netuid' not in config:
         config['netuid'] = NETUID_FINNEY
     else:
-        config['netuid'] = int(config['netuid'])
+        try:
+            config['netuid'] = parse_non_negative_int(config['netuid'], param='netuid')
+        except click.UsageError as e:
+            raise click.UsageError(str(e)) from None
     return config, wallet, subtensor, client
 
 


### PR DESCRIPTION
## Description
Fix #236 - Validate `netuid` before `int()` coercion in `get_cli_context()`.

## Changes
- Add `parse_non_negative_int()` helper function
- Validate `netuid` value before conversion
- Raise `click.UsageError` with clear message instead of `ValueError` traceback

## Testing
- [x] `alw view rates --netuid notanumber` now shows clear error
- [x] `alw view rates --netuid 5` works correctly
- [x] `alw view rates --netuid ""` now shows clear error
- [x] Config with invalid netuid shows error on command run