### PR TITLE
fix: alw view active-swaps --status completed/timed_out shows helpful message

### DIFF
--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -576,6 +576,13 @@ def view_active_swaps(status: str):
         swaps = [s for s in swaps if s.status == target_status]
 
     if not swaps:
+        if status and status.lower() in ('completed', 'timed_out'):
+            console.print(
+                f'[green]No {status} swaps found.[/green]\n'
+                f'[dim]Resolved swaps are removed from on-chain storage. '
+                f'View history at:[/dim] {_dashboard_url()}'
+            )
+            return
         console.print('[yellow]No swaps found[/yellow]\n')
         return
 


### PR DESCRIPTION
## Description
Fix #246 - `view_active_swaps --status completed|timed_out` now shows a helpful message instead of silently returning empty results.

## Changes
- Detect terminal status filters (completed/timed_out)
- Show message explaining terminal swaps are removed from storage
- Point user to dashboard URL for swap history

## Testing
- [x] `alw view active-swaps --status completed` shows dashboard URL
- [x] `alw view active-swaps --status timed_out` shows dashboard URL
- [x] `alw view active-swaps --status active` still works normally
- [x] `alw view active-swaps` (no filter) still works normally