### PR TITLE
fix: validate --network in get_cli_context before passing to subtensor (#203)

### DIFF
--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -221,6 +221,13 @@ def get_effective_config() -> dict:
     return config
 
 
+_KNOWN_NETWORKS = {
+    'finney': 'wss://entrypoint-finney.opentensor.ai:443',
+    'test': 'wss://test.finney.opentensor.ai:443',
+    'local': 'ws://127.0.0.1:9944',
+}
+
+
 def get_cli_context(
     need_wallet: bool = True,
     need_client: bool = True,
@@ -231,6 +238,10 @@ def get_cli_context(
     """
     config = get_effective_config()
     network = config.get('network', 'finney')
+    if network not in _KNOWN_NETWORKS and not network.startswith(('ws://', 'wss://')):
+        raise click.UsageError(
+            f"Invalid network '{network}'. Valid values: {', '.join(_KNOWN_NETWORKS)} or a ws:///wss:// URL."
+        )
     with console.status(
         f'[cyan]Synchronizing with chain [dim]{network}[/dim]...[/cyan]', spinner='dots', spinner_style='cyan'
     ):


### PR DESCRIPTION
## Description

Fix #203 — `get_cli_context` passes the `--network` value directly to `bt.Subtensor(network=...)` without validation. Invalid network names produce cryptic errors from the substrate layer instead of a clear CLI message.

## Changes

- Add `_KNOWN_NETWORKS` dict in helpers.py (mirrors `KNOWN_NETWORKS` in main.py)
- Validate network is a known name or a `ws://`/`wss://` URL before calling `bt.Subtensor`
- Raise `click.UsageError` with valid options on invalid input

## Testing

- [x] `network=finney` → passes validation
- [x] `network=ws://127.0.0.1:9944` → passes validation
- [x] `network=invalid` → raises clear error with valid options