### PR TITLE
fix(swap): abort TAO transfer when receipt parse fails (#297)

### DIFF
--- a/allways/chain_providers/subtensor.py
+++ b/allways/chain_providers/subtensor.py
@@ -325,10 +325,21 @@ class SubtensorProvider(ChainProvider):
                 receipt = response.extrinsic_receipt
                 tx_hash = receipt.extrinsic_hash
                 block_num = self.subtensor.substrate.get_block_number(receipt.block_hash)
-            except Exception:
-                bt.logging.warning('Could not parse transfer receipt, using fallback')
-                tx_hash = getattr(getattr(response, 'extrinsic_receipt', None), 'extrinsic_hash', '') or 'tao_transfer'
-                block_num = self.subtensor.get_current_block()
+            except Exception as e:
+                # Previously this fell back to the literal string 'tao_transfer'
+                # as the tx hash, which then propagated through pending_swap.json,
+                # the SwapConfirmSynapse, and the proof_message — validators
+                # searched for a TAO tx with that decoded hash, found nothing,
+                # and the user's funds stranded with no recovery path. Fail
+                # loudly instead so the caller surfaces the broadcast/parse
+                # split-brain rather than persisting a bogus tx hash.
+                bt.logging.error(f'Failed to parse transfer receipt: {e}')
+                return None
+            if not tx_hash:
+                bt.logging.error(
+                    'extrinsic_hash missing from receipt despite successful broadcast'
+                )
+                return None
             bt.logging.info(f'Sent {amount} rao to {to_address} (tx: {tx_hash}, block: {block_num})')
             return (tx_hash, block_num)
         except Exception as e:

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -570,9 +570,26 @@ def send_tao_transfer(wallet, subtensor, to_address: str, amount_rao: int) -> Op
         block = 0
         if getattr(receipt, 'block_hash', None):
             block = subtensor.substrate.get_block_number(receipt.block_hash) or 0
-    except Exception:
-        tx_hash = getattr(getattr(response, 'extrinsic_receipt', None), 'extrinsic_hash', '') or 'tao_transfer'
-        block = 0
+    except Exception as e:
+        # Previously this fell back to the literal string 'tao_transfer' as the
+        # tx hash. That string then propagated through pending_swap.json, the
+        # SwapConfirmSynapse, and the proof_message — validators searched for a
+        # TAO tx with that decoded hash, found nothing, and the user's funds
+        # stranded with no recovery path. Surface the parse failure to the
+        # caller (which already handles None via `if send_result is not None`)
+        # so the broadcast/parse split-brain doesn't persist a bogus tx hash
+        # to pending_swap.json.
+        console.print(
+            f'[red]TAO transfer broadcast succeeded but receipt parse failed: {e}[/red]\n'
+            '[red]Aborting swap; rerun once the node is responsive.[/red]'
+        )
+        return None
+    if not tx_hash:
+        console.print(
+            '[red]extrinsic_hash missing from receipt despite successful broadcast.[/red]\n'
+            '[red]Aborting swap to avoid stranding funds with a bogus pending entry.[/red]'
+        )
+        return None
     console.print(f'[green]TAO sent (tx: {tx_hash})[/green]')
     return (tx_hash, int(block))
 


### PR DESCRIPTION
## Summary

Closes #297. **S0 funds-stranding bug.**

`send_tao_transfer()` and `SubtensorProvider.send_tao()` both fell back to the literal string `'tao_transfer'` as the tx hash when parsing `receipt.extrinsic_hash` threw or returned empty:

```python
except Exception:
    tx_hash = getattr(getattr(response, 'extrinsic_receipt', None), 'extrinsic_hash', '') or 'tao_transfer'
```

The literal then propagated through `pending_swap.json`, `SwapConfirmSynapse.from_tx_hash`, and the proof_message `'allways-swap:tao_transfer'`. Validators looked up a TAO tx with the hex-decoded version of that literal, found nothing, and the user's funds stranded with no recovery path.

## Change

Surface the parse failure as a clean `None` return at both sites. Both functions already type as `Optional[Tuple[str, int]]` and the swap flow caller at `swap.py:1104-1106` already branches on `if send_result is not None`, so this fits the existing contract.

| Site | Before | After |
|---|---|---|
| `cli/swap_commands/swap.py:567-577` | `tx_hash = '...' or 'tao_transfer'` | clear console error + `return None` |
| `chain_providers/subtensor.py:324-333` | `tx_hash = '...' or 'tao_transfer'` | `bt.logging.error` + `return None` |

Both sites also guard the previously-unhandled "parse succeeded but `tx_hash` is empty" edge — that path used to leak through to the success branch with an empty-string hash.

## Why `None` and not `raise`

Issue suggested `raise RuntimeError(...)`. Verified at the call site (`swap.py:1104`):

```python
for attempt in range(2):
    send_result = send_tao_transfer(...)
    if send_result is not None:
        ...
```

The retry-loop caller already understands `None` as a clean failure and retries up to twice. Raising would crash the CLI and lose the retry semantics. `None` matches the function's existing `Optional[...]` signature and the existing failure path immediately above (`if not response.success: return None`).

## Scope

`allways/cli/swap_commands/swap.py`: **+14 / -3**
`allways/chain_providers/subtensor.py`: **+15 / -3**
Total: **+29 / -6**, two files. No new imports, no signature changes.

## Test plan

- [x] Both files AST-parse cleanly (`python3 -c "import ast; ast.parse(...)"`)
- [x] Caller pattern at `swap.py:1104` confirmed to handle `None` (retries up to twice, then exits gracefully)
- [x] No grep hits for `'tao_transfer'` literal anywhere else in the repo (`git grep "tao_transfer"` only matches the function name and the test cassette filenames)
- [x] No callers downstream rely on the bogus literal as a sentinel — all consumers of the returned tuple destructure into `(from_tx_hash, ...)` and use the hash for chain lookups, so a missing tuple correctly skips that flow
