### PR TITLE
fix(miner): persist intent before broadcast to prevent dest double-send (#296)

### DIFF
--- a/allways/miner/fulfillment.py
+++ b/allways/miner/fulfillment.py
@@ -85,7 +85,15 @@ class SwapFulfiller:
         self.load_sent_cache()
 
     def load_sent_cache(self):
-        """Load persisted send results from disk to prevent double-sends after restart."""
+        """Load persisted send results from disk to prevent double-sends after restart.
+
+        v2 (#296): a SentSwap with empty ``to_tx_hash`` is a pending sentinel —
+        intent persisted before broadcast but never updated with the real hash,
+        which means the process crashed between ``send_dest_funds`` returning
+        and the post-broadcast cache update. Surface these loudly and refuse
+        to re-broadcast on restart; operator must reconcile manually by
+        scanning chain for any tx the miner address sent for that swap.
+        """
         if not self.sent_cache_path or not self.sent_cache_path.exists():
             return
         try:
@@ -98,6 +106,16 @@ class SwapFulfiller:
                 )
             if self.sent:
                 bt.logging.info(f'Restored {len(self.sent)} cached send(s) from disk')
+            pending = [sid for sid, s in self.sent.items() if not s.to_tx_hash]
+            if pending:
+                bt.logging.critical(
+                    f'PENDING SEND MARKERS FOUND on startup: {pending}. The miner crashed '
+                    f'between broadcasting the destination tx and persisting its hash. '
+                    f'Manual reconciliation required: scan the destination chain for any '
+                    f'tx FROM this miner address matching each swap, and either update the '
+                    f'cache with the real tx hash or remove the entry. These swap IDs will '
+                    f'be SKIPPED until the cache is corrected — this prevents double-broadcast.'
+                )
         except Exception as e:
             bt.logging.warning(f'Failed to load sent cache: {e}')
 
@@ -276,9 +294,33 @@ class SwapFulfiller:
 
         # Step 3: Send destination funds — unless we already did on a previous
         # pass, in which case we skip straight to the mark_fulfilled retry.
+        # v2 (#296): a cached SentSwap with empty ``to_tx_hash`` is a pending
+        # sentinel from a prior crash mid-broadcast (load_sent_cache logs the
+        # critical warning). Refuse to process — operator must reconcile.
+        if sent is not None and not sent.to_tx_hash:
+            bt.logging.warning(
+                f'Swap {swap.id}: cached as pending mid-broadcast (empty tx_hash) — '
+                f'skipping to prevent double-broadcast. Operator must reconcile cache.'
+            )
+            return False
         if sent is None:
+            # v2 (#296): persist a pending sentinel BEFORE broadcasting so a
+            # crash between the send_dest_funds call returning and the
+            # post-broadcast cache update is detectable on restart and we
+            # refuse to re-broadcast. Without this sentinel, the prior cache
+            # would be silently empty and the next process_swap pass would
+            # broadcast a SECOND destination tx for the same swap.
+            pending = SentSwap(to_tx_hash='', to_tx_block=0, marked_fulfilled=False)
+            self.sent[swap.id] = pending
+            self.save_sent_cache()
+
             send_result = self.send_dest_funds(swap, user_receives_amount)
             if not send_result:
+                # Broadcast attempt failed cleanly — drop the sentinel so a
+                # subsequent retry can re-attempt. This is safe because no
+                # tx left this process.
+                self.sent.pop(swap.id, None)
+                self.save_sent_cache()
                 bt.logging.error(f'Swap {swap.id}: failed to send dest funds')
                 return False
             to_tx_hash, to_tx_block = send_result


### PR DESCRIPTION
## Summary

Closes #296. **S0 race — preventable on-chain double-spend.**

`process_swap` broadcasts the destination tx via `send_dest_funds()`, then writes the `SentSwap` record to the in-memory dict + `save_sent_cache()`:

```python
if sent is None:
    send_result = self.send_dest_funds(swap, user_receives_amount)   # ← on-chain side effect
    if not send_result:
        return False
    to_tx_hash, to_tx_block = send_result
    sent = SentSwap(to_tx_hash=to_tx_hash, ...)
    self.sent[swap.id] = sent
    self.save_sent_cache()                                            # ← persist
```

If the miner is killed between the broadcast returning and the persist completing (SIGKILL/OOM/hardware fault/container shutdown), the destination tx is on-chain but the cache has no record. On restart, `sent is None` → `process_swap` broadcasts a **second** destination tx for the same swap. The BTC provider's in-process `broadcasted_txids` set is also empty after restart, so its dedup is gone.

## Fix: persist intent before side effect

Write a pending sentinel (`SentSwap` with empty `to_tx_hash`) to the cache **before** calling `send_dest_funds`. Three outcomes are now safe:

| Crash window | Behavior |
|---|---|
| Between sentinel-persist and broadcast | Sentinel exists, no tx broadcast → restart sees pending, refuses to process, logs critical. No double-broadcast. |
| After broadcast but before post-broadcast cache update | Sentinel exists, real tx is on-chain → restart sees pending, refuses to process, logs critical. No double-broadcast. |
| Broadcast fails cleanly (`send_dest_funds` returns falsy) | Sentinel is dropped before returning → next pass can retry. No stuck pending entry. |

Trade-off acknowledged: if the crash window is hit on a real swap, that single swap's fulfillment stalls until operator reconciles (look up tx by scanning dest chain for miner-address sends matching the swap, then update or delete the cache entry).

That trade is strictly correct: a stuck swap can be recovered; a double-spend cannot.

## Change

`allways/miner/fulfillment.py`: **+43 / -1**. No `SentSwap` dataclass change (empty `to_tx_hash` is the sentinel — backward compatible with the existing 3-field cache schema). No new imports.

```diff
+ # v2 (#296): persist a pending sentinel BEFORE broadcasting
+ pending = SentSwap(to_tx_hash='', to_tx_block=0, marked_fulfilled=False)
+ self.sent[swap.id] = pending
+ self.save_sent_cache()
+
  send_result = self.send_dest_funds(swap, user_receives_amount)
  if not send_result:
+     # broadcast failed cleanly — drop the sentinel so a retry can re-attempt
+     self.sent.pop(swap.id, None)
+     self.save_sent_cache()
      ...
```

Plus `load_sent_cache` scans for empty-`to_tx_hash` entries on startup and logs `bt.logging.critical(...)` with the swap IDs + reconciliation instructions.

Plus `process_swap` checks for the sentinel up-front and refuses to operate, surfacing a `bt.logging.warning` so the operator sees the same recovery hint each retry pass.

## Test plan

- [x] AST parses cleanly: `python3 -c "import ast; ast.parse(open('allways/miner/fulfillment.py').read())"`
- [x] Verified the JSON cache schema is unchanged — the existing 3-field `[to_tx_hash, to_tx_block, marked_fulfilled]` array works for sentinels (empty string `to_tx_hash`, zero block) and real entries identically.
- [x] Verified `cleanup_stale_sends` still drops sentinels alongside completed entries when the swap leaves the active set.
- [x] Manual trace through the three crash windows above against current `process_swap` + `load_sent_cache` flow.
- [ ] Recommended follow-up: a regression test mirroring the issue's repro snippet (`test_crash_between_send_and_cache_causes_double_broadcast`) — happy to add if reviewer prefers.
