### PR TITLE
fix(dendrite): skip axon on is_validator RPC failure instead of silently including (#168)

### DIFF
--- a/allways/cli/dendrite_lite.py
+++ b/allways/cli/dendrite_lite.py
@@ -61,8 +61,17 @@ def discover_validators(
             try:
                 if not contract_client.is_validator(metagraph.hotkeys[uid]):
                     continue
-            except Exception:
-                pass
+            except Exception as e:
+                # #168: skip on RPC failure rather than silently including the
+                # axon. Mirrors the validator-side fix from #73/#92 — falling
+                # through to axons.append on an unverified hotkey leaks
+                # non-validators into the broadcast list and produces
+                # confusing rejections downstream.
+                bt.logging.debug(
+                    f'Skipping uid={uid} hotkey={metagraph.hotkeys[uid][:12]}...: '
+                    f'is_validator RPC failed: {e}'
+                )
+                continue
         axons.append(axon)
 
     return axons


### PR DESCRIPTION
## Summary

Closes #168.

`dendrite_lite.discover_validators` (allways/cli/dendrite_lite.py:60-66) wraps `contract_client.is_validator(...)` in `try / except Exception: pass`. The `pass` falls through to `axons.append(axon)`, so any RPC failure during validator-permit checking silently includes the unverified hotkey in the CLI broadcast list. Issue #73 / PR #92 already addressed the same pattern on the validator-side dendrite — CLI parity here.

## Change

```diff
-            except Exception:
-                pass
+            except Exception as e:
+                bt.logging.debug(
+                    f'Skipping uid={uid} hotkey={metagraph.hotkeys[uid][:12]}...: '
+                    f'is_validator RPC failed: {e}'
+                )
+                continue
```

Bind the exception, log a debug message naming the uid + hotkey prefix + RPC error, and `continue`. Matches the existing `continue` branches above for `not validator_permit` and `not is_serving`.

## Why this is safe

- The function's contract is "return the validator-permit-AND-is-validator-confirmed list." Silently including hotkeys that weren't confirmed violates that contract.
- The CLI swap flow downstream of `discover_validators` rejects responses from non-validators — surfacing via `confusing rejection` rather than `quietly skipping that hotkey upstream`. Better to drop early.
- Debug-level log preserves diagnostic info for operators running with `--logging.debug` without polluting the normal CLI experience.

## Scope

`allways/cli/dendrite_lite.py`: **+11 / -2**. No new imports (bt.logging already imported).

## Test plan

- [x] AST parses cleanly: `python3 -c "import ast; ast.parse(open('allways/cli/dendrite_lite.py').read())"`
- [x] Behavior matches PR #92's validator-side fix pattern (skip-on-RPC-fail, log, continue).
- [x] Confirmed `bt.logging` is imported at top of file (line 5).