### PR TITLE
fix(cli): warn on duplicate global flags instead of silently last-wins (#243)

### DIFF
--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -186,8 +186,15 @@ def parse_global_flags() -> dict:
 
     Strips matched flags and their values from sys.argv so Click
     subcommands don't choke on unknown options.
+
+    #243: a duplicate global flag (e.g. ``--netuid 7 --netuid 8``) used to
+    silently last-wins. Now the duplicate is still last-wins (preserving
+    backward-compatible behavior for any scripts that relied on it), but the
+    override is surfaced via stderr so an operator typing it by mistake
+    sees the resolution rather than getting a silent surprise downstream.
     """
     overrides = {}
+    seen: dict = {}  # canonical key -> (raw flag, prior value) for dup detection
     new_argv = [sys.argv[0]]
     i = 1
     while i < len(sys.argv):
@@ -196,13 +203,32 @@ def parse_global_flags() -> dict:
         if '=' in arg:
             flag, value = arg.split('=', 1)
             if flag in _GLOBAL_FLAGS:
-                overrides[_GLOBAL_FLAGS[flag]] = value
+                key = _GLOBAL_FLAGS[flag]
+                if key in seen:
+                    prior_flag, prior_value = seen[key]
+                    print(
+                        f'warning: duplicate global flag {flag} {value!r} '
+                        f'overrides earlier {prior_flag} {prior_value!r}',
+                        file=sys.stderr,
+                    )
+                seen[key] = (flag, value)
+                overrides[key] = value
                 i += 1
                 continue
         # Handle --flag value form
         if arg in _GLOBAL_FLAGS:
             if i + 1 < len(sys.argv):
-                overrides[_GLOBAL_FLAGS[arg]] = sys.argv[i + 1]
+                key = _GLOBAL_FLAGS[arg]
+                value = sys.argv[i + 1]
+                if key in seen:
+                    prior_flag, prior_value = seen[key]
+                    print(
+                        f'warning: duplicate global flag {arg} {value!r} '
+                        f'overrides earlier {prior_flag} {prior_value!r}',
+                        file=sys.stderr,
+                    )
+                seen[key] = (arg, value)
+                overrides[key] = value
                 i += 2
                 continue
         new_argv.append(arg)


### PR DESCRIPTION
## Summary

Closes #243.

`alw view rates --netuid 7 --netuid 8` previously took 8 silently — no indication anywhere that 7 was discarded. `parse_global_flags` simply overwrote the dict entry on the second match.

## Change

Track seen canonical keys in `parse_global_flags`. On a duplicate, **keep the existing last-wins behavior** (preserves any operator scripts that depended on it) but surface the override via `stderr`:

```
warning: duplicate global flag --netuid '8' overrides earlier --netuid '7'
```

Same handling for both `--flag value` and `--flag=value` forms.

## Why warn rather than reject

Issue says "Warn or reject duplicate globals." I picked **warn** to:

- Avoid breaking existing scripts that may rely on the override pattern (e.g., wrapper scripts that prepend defaults and then accept user overrides).
- Stay parser-side conservative: rejection at parse time would terminate the whole command, often with no obvious recovery for the operator.
- Make the silent failure visible immediately so a typo gets caught at the first run.

If maintainers prefer hard rejection instead, happy to flip — change is one branch in the same function.

## Scope

`allways/cli/swap_commands/helpers.py`: **+28 / -2**. No new imports (`sys` already imported). Output goes via `print(..., file=sys.stderr)` so it doesn't pollute stdout for any tooling that pipes the CLI's normal output.

## Test plan

- [x] AST parses cleanly: `python3 -c "import ast; ast.parse(...)"`
- [x] Logic verified manually:
  - `argv=['alw', 'view', 'rates', '--netuid', '7', '--netuid', '8']` → `overrides={'netuid': '8'}` + stderr warning
  - `argv=['alw', 'view', 'rates', '--netuid=7', '--netuid=8']` → same outcome
  - `argv=['alw', 'view', 'rates', '--netuid', '7']` → `overrides={'netuid': '7'}` + no warning
- [x] Confirmed `sys.stderr` is the right channel — CLI's normal stdout output (rates table, etc.) stays intact for piping.