### PR TITLE
refactor: move to_smallest_unit/from_smallest_unit to helpers.py

### DIFF
--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -171,6 +171,27 @@ def from_rao(amount_rao: int) -> float:
     return amount_rao / TAO_TO_RAO
 
 
+def to_smallest_unit(amount: float, chain_id: str) -> int:
+    """Convert a human-readable amount to the smallest unit for a chain.
+
+    Uses Decimal to avoid IEEE 754 float artifacts (e.g. 0.1 * 10^9 = 99999999).
+    """
+    from decimal import Decimal
+
+    from allways.chain_defs import get_chain
+
+    chain = get_chain(chain_id)
+    return int(Decimal(str(amount)) * (10**chain.decimals))
+
+
+def from_smallest_unit(amount: int, chain_id: str) -> float:
+    """Convert from smallest unit to human-readable amount."""
+    from allways.chain_defs import get_chain
+
+    chain = get_chain(chain_id)
+    return amount / (10**chain.decimals)
+
+
 def load_cli_config() -> dict:
     """Load CLI configuration from ~/.allways/config.json."""
     if not CONFIG_FILE.exists():

--- a/allways/cli/swap_commands/quote.py
+++ b/allways/cli/swap_commands/quote.py
@@ -1,7 +1,5 @@
 """alw swap quote - Preview rates and estimated receive amounts before swapping."""
 
-from decimal import Decimal
-
 import click
 from rich.table import Table
 
@@ -13,6 +11,7 @@ from allways.cli.swap_commands.helpers import (
     get_cli_context,
     loading,
     read_miner_commitments,
+    to_smallest_unit,
 )
 from allways.constants import FEE_DIVISOR
 from allways.contract_client import ContractError
@@ -73,8 +72,7 @@ def quote_command(from_chain: str, to_chain: str, amount: float):
     netuid = config['netuid']
 
     # Convert to smallest units
-    src_chain_def = get_chain(from_chain)
-    from_amount = int(Decimal(str(amount)) * (10**src_chain_def.decimals))
+    from_amount = to_smallest_unit(amount, from_chain)
 
     fee_divisor = FEE_DIVISOR
     fee_pct = 100 / fee_divisor

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -15,6 +15,8 @@ from allways.chains import SUPPORTED_CHAINS, canonical_pair, get_chain
 from allways.classes import SwapStatus
 from allways.cli.dendrite_lite import broadcast_synapse, discover_validators, get_ephemeral_wallet
 from allways.cli.help import StyledGroup
+
+# to_smallest_unit and from_smallest_unit moved to helpers.py
 from allways.cli.swap_commands.helpers import (
     PendingSwapState,
     blocks_to_minutes_str,
@@ -22,6 +24,7 @@ from allways.cli.swap_commands.helpers import (
     console,
     find_matching_miners,
     from_rao,
+    from_smallest_unit,
     get_cli_context,
     is_local_network,
     load_pending_swap,
@@ -31,6 +34,7 @@ from allways.cli.swap_commands.helpers import (
     resolve_source_tx_block,
     save_pending_swap,
     sign_or_prompt_external,
+    to_smallest_unit,
 )
 from allways.cli.validator_rejections import RejectionInfo, render_and_aggregate
 from allways.commitments import read_miner_commitments
@@ -39,24 +43,6 @@ from allways.contract_client import ContractError
 from allways.synapses import SwapConfirmSynapse, SwapReserveSynapse
 from allways.utils.proofs import reserve_proof_message, swap_proof_message
 from allways.utils.rate import apply_fee_deduction, calculate_to_amount, check_swap_viability, derive_tao_leg
-
-
-def to_smallest_unit(amount: float, chain_id: str) -> int:
-    """Convert a human-readable amount to the smallest unit for a chain.
-
-    Uses Decimal to avoid IEEE 754 float artifacts (e.g. 0.1 * 10^9 = 99999999).
-    """
-    from decimal import Decimal
-
-    chain = get_chain(chain_id)
-    return int(Decimal(str(amount)) * (10**chain.decimals))
-
-
-def from_smallest_unit(amount: int, chain_id: str) -> float:
-    """Convert from smallest unit to human-readable amount."""
-    chain = get_chain(chain_id)
-    return amount / (10**chain.decimals)
-
 
 # =========================================================================
 # Shared functions (used by swap command, post_tx command)


### PR DESCRIPTION
## Summary

`to_smallest_unit` and `from_smallest_unit` lived in `swap.py` as
module-level privates while `helpers.py` already hosted the sibling
`to_rao`/`from_rao` conversions. Additionally, `quote.py` reimplemented
`to_smallest_unit` inline with a raw `Decimal` expression — duplicating
logic that already existed.

## Changes

- Move `to_smallest_unit`/`from_smallest_unit` from `swap.py` into
  `helpers.py`, next to `to_rao`/`from_rao`
- Update `swap.py` to import them from `helpers` instead of defining locally
- Replace the inline `Decimal` expression in `quote.py` with a call to
  `to_smallest_unit` and drop the now-unused `Decimal` import

## Scope

Pure move + one callsite swap. No behavior change, no signature change.

Fixes #81