### PR TITLE
refactor: fold remaining extension-flow wrappers through _exec_logged

### DIFF
--- a/allways/contract_client.py
+++ b/allways/contract_client.py
@@ -1013,9 +1013,16 @@ class AllwaysContractClient:
         log_msg: str,
         args: Optional[dict] = None,
         value: int = 0,
+        wait_for_inclusion: bool = True,
     ) -> str:
         self.ensure_initialized()
-        tx_hash = self.exec_contract_raw(method, args=args, keypair=wallet.hotkey, value=value)
+        tx_hash = self.exec_contract_raw(
+            method,
+            args=args,
+            keypair=wallet.hotkey,
+            value=value,
+            wait_for_inclusion=wait_for_inclusion,
+        )
         bt.logging.info(f'{log_msg}: {tx_hash}')
         return tx_hash
 
@@ -1064,36 +1071,30 @@ class AllwaysContractClient:
         from_tx_hash: bytes,
         target_block: int,
     ) -> str:
-        self.ensure_initialized()
-        tx_hash = self.exec_contract_raw(
+        return self._exec_logged(
             'propose_extend_reservation',
-            args={'miner': miner_hotkey, 'from_tx_hash': from_tx_hash, 'target_block': target_block},
-            keypair=wallet.hotkey,
+            wallet,
+            f'Propose extend reservation miner={miner_hotkey} target={target_block}',
+            {'miner': miner_hotkey, 'from_tx_hash': from_tx_hash, 'target_block': target_block},
             wait_for_inclusion=False,
         )
-        bt.logging.info(f'Propose extend reservation miner={miner_hotkey} target={target_block}: {tx_hash}')
-        return tx_hash
 
     def challenge_extend_reservation(self, wallet: bt.Wallet, miner_hotkey: str) -> str:
-        self.ensure_initialized()
-        tx_hash = self.exec_contract_raw(
+        return self._exec_logged(
             'challenge_extend_reservation',
-            args={'miner': miner_hotkey},
-            keypair=wallet.hotkey,
+            wallet,
+            f'Challenge extend reservation miner={miner_hotkey}',
+            {'miner': miner_hotkey},
             wait_for_inclusion=False,
         )
-        bt.logging.info(f'Challenge extend reservation miner={miner_hotkey}: {tx_hash}')
-        return tx_hash
 
     def finalize_extend_reservation(self, wallet: bt.Wallet, miner_hotkey: str) -> str:
-        self.ensure_initialized()
-        tx_hash = self.exec_contract_raw(
+        return self._exec_logged(
             'finalize_extend_reservation',
-            args={'miner': miner_hotkey},
-            keypair=wallet.hotkey,
+            wallet,
+            f'Finalize extend reservation miner={miner_hotkey}',
+            {'miner': miner_hotkey},
         )
-        bt.logging.info(f'Finalize extend reservation miner={miner_hotkey}: {tx_hash}')
-        return tx_hash
 
     def propose_extend_timeout(
         self,
@@ -1101,36 +1102,30 @@ class AllwaysContractClient:
         swap_id: int,
         target_block: int,
     ) -> str:
-        self.ensure_initialized()
-        tx_hash = self.exec_contract_raw(
+        return self._exec_logged(
             'propose_extend_timeout',
-            args={'swap_id': swap_id, 'target_block': target_block},
-            keypair=wallet.hotkey,
+            wallet,
+            f'Propose extend timeout swap={swap_id} target={target_block}',
+            {'swap_id': swap_id, 'target_block': target_block},
             wait_for_inclusion=False,
         )
-        bt.logging.info(f'Propose extend timeout swap={swap_id} target={target_block}: {tx_hash}')
-        return tx_hash
 
     def challenge_extend_timeout(self, wallet: bt.Wallet, swap_id: int) -> str:
-        self.ensure_initialized()
-        tx_hash = self.exec_contract_raw(
+        return self._exec_logged(
             'challenge_extend_timeout',
-            args={'swap_id': swap_id},
-            keypair=wallet.hotkey,
+            wallet,
+            f'Challenge extend timeout swap={swap_id}',
+            {'swap_id': swap_id},
             wait_for_inclusion=False,
         )
-        bt.logging.info(f'Challenge extend timeout swap={swap_id}: {tx_hash}')
-        return tx_hash
 
     def finalize_extend_timeout(self, wallet: bt.Wallet, swap_id: int) -> str:
-        self.ensure_initialized()
-        tx_hash = self.exec_contract_raw(
+        return self._exec_logged(
             'finalize_extend_timeout',
-            args={'swap_id': swap_id},
-            keypair=wallet.hotkey,
+            wallet,
+            f'Finalize extend timeout swap={swap_id}',
+            {'swap_id': swap_id},
         )
-        bt.logging.info(f'Finalize extend timeout swap={swap_id}: {tx_hash}')
-        return tx_hash
 
     def _decode_pending_extension(self, data: bytes) -> Optional[PendingExtension]:
         """Decode an Option<PendingExtension> SCALE payload."""


### PR DESCRIPTION
Closes #305

## Summary

Direct follow-on to #91, which standardized 23 write wrappers through `_exec_logged` but left the six propose/challenge/finalize wrappers for reservation and swap-timeout extensions out of scope. Those six were skipped because four of them pass `wait_for_inclusion=False` — a parameter the helper didn't accept.

This PR extends `_exec_logged` with `wait_for_inclusion: bool = True` and collapses the six remaining wrappers to single `return self._exec_logged(...)` delegations. Default `True` preserves byte-identical behavior for the 23 callers already routed through the helper; the four no-wait sites pass the kwarg explicitly.

## Motivation

- **Single source of truth for write-side extrinsic submission** — these six were the only write paths that could drift independently from `_exec_logged` (e.g., if pre-flight balance probing or log wording evolves).
- **Lower-friction extension** — future propose/challenge/finalize triples inherit the one-line shape instead of resurrecting the 5-line block.
- **Smaller surface area** — duplication eliminated; public signatures, log-message wording, and the `wait_for_inclusion=False` semantics documented at [allways/contract_client.py:529-535](allways/contract_client.py#L529-L535) are preserved.

## Changes

- **[allways/contract_client.py](allways/contract_client.py):**
  - `_exec_logged` ([L1009-L1027](allways/contract_client.py#L1009-L1027)): added `wait_for_inclusion: bool = True` kwarg, threaded through to `exec_contract_raw`
  - Collapsed six wrappers ([L1067-L1131](allways/contract_client.py#L1067-L1131)) to single delegations:
    - **Reservation extension:** `propose_extend_reservation` (no-wait), `challenge_extend_reservation` (no-wait), `finalize_extend_reservation` (waits)
    - **Timeout extension:** `propose_extend_timeout` (no-wait), `challenge_extend_timeout` (no-wait), `finalize_extend_timeout` (waits)
  - Net **+32 / −37** (−5 LOC plus removal of all duplication)

## Type of Change

- Refactoring (consolidation, no behavior change)

## Test plan

- [x] `uv run pytest tests/` — 411 passed
- [x] `uv run pytest tests/test_optimistic_extensions.py` — 31 passed (covers all six wrappers)
- [x] `uv run ruff check allways/ neurons/` — all checks passed
- [x] `uv run ruff format --check allways/contract_client.py` — already formatted
- [x] `uv run pre-commit run --files allways/contract_client.py` — all hooks passed
- [x] Public signatures, log-message wording, and `wait_for_inclusion` semantics preserved — verified by diff review
