### PR TITLE
fix(swap_reserve): reject reserves that over-commit source balance (#…

### DIFF
--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -343,6 +343,31 @@ async def handle_swap_reserve(
                 reject_synapse(synapse, 'Insufficient miner collateral', ctx)
                 return synapse
 
+            # Aggregate-balance gate: the per-request balance check above
+            # only verifies the source can fund THIS swap in isolation.
+            # Without considering the user's other still-live reservations
+            # from the same source address, a user with funds for one swap
+            # could lock multiple miners simultaneously and deny capacity
+            # to honest users (issue #295). The contract has no source-
+            # address index, so the validator consults its event-driven
+            # mirror (ReservationIndex) for the cumulative committed
+            # amount and rejects if balance can't cover committed + new.
+            reservation_index = getattr(validator, 'reservation_index', None)
+            if reservation_index is not None:
+                committed = reservation_index.committed_amount_for_address(
+                    from_address=synapse.from_address,
+                    from_chain=synapse.from_chain,
+                    current_block=cur_block,
+                    exclude_miner=miner,
+                )
+                if balance < committed + synapse.from_amount:
+                    reject_synapse(
+                        synapse,
+                        f'Insufficient source balance: {committed} already committed across other live reservations',
+                        ctx,
+                    )
+                    return synapse
+
             min_collateral = validator.bounds_cache.min_collateral()
             if min_collateral > 0 and collateral < min_collateral:
                 reject_synapse(synapse, 'Miner collateral below minimum', ctx)

--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -31,6 +31,7 @@ from allways.utils.scale import (
     decode_u128,
     strip_hex_prefix,
 )
+from allways.validator.reservation_index import ReservationIndex
 from allways.validator.state_store import ValidatorStateStore
 from allways.validator.swap_tracker import SwapTracker
 
@@ -209,6 +210,8 @@ class ContractEventWatcher:
         metadata_path: Path,
         state_store: ValidatorStateStore,
         swap_tracker: Optional[SwapTracker] = None,
+        reservation_index: Optional[ReservationIndex] = None,
+        contract_client: Any = None,
     ):
         self.substrate = substrate
         self.contract_address = contract_address
@@ -217,6 +220,17 @@ class ContractEventWatcher:
         # watcher (cycle in current init order). Timeout extension finalize
         # writes are skipped until this is set.
         self.swap_tracker = swap_tracker
+        # Validator-side mirror of the on-chain reservations table; used by
+        # ``handle_swap_reserve`` to enforce that a single source address
+        # cannot reserve more miners than its visible balance covers
+        # (issue #295). Optional so legacy callers / tests that don't need
+        # the cross-miner check can still construct a watcher.
+        self.reservation_index = reservation_index
+        # Reservations are upserted via the MinerReserved event, but the
+        # event payload only carries (miner, reserved_until); the
+        # from_addr/from_amount/from_chain fields needed by the index live
+        # in the contract storage and have to be fetched on the spot.
+        self.contract_client = contract_client
         self.registry = load_event_registry(metadata_path)
         self.cursor: int = 0
         self.last_prune_block: int = 0
@@ -289,6 +303,11 @@ class ContractEventWatcher:
         """Cold start: snapshot contract state for every metagraph miner, then
         rewind the cursor by one scoring window so ``sync_to`` backfills it
         before the first scoring pass runs."""
+        if contract_client is not None and self.contract_client is None:
+            # Late-bind the contract_client so MinerReserved handling has a
+            # client to read full reservation rows from. Initializers that
+            # already injected a client at construction time keep theirs.
+            self.contract_client = contract_client
         if metagraph_hotkeys and contract_client is not None:
             for hotkey in metagraph_hotkeys:
                 try:
@@ -296,6 +315,16 @@ class ContractEventWatcher:
                         self.active_miners.add(hotkey)
                 except Exception as e:
                     bt.logging.debug(f'EventWatcher bootstrap: active flag read failed for {hotkey[:8]}: {e}')
+            if self.reservation_index is not None:
+                # Hydrate the reservation mirror by reading every metagraph
+                # hotkey once. After this, MinerReserved / SwapInitiated /
+                # ReservationCancelled events keep it in sync incrementally
+                # so the per-request reserve check is O(active_reservations).
+                self.reservation_index.hydrate_from_contract(
+                    contract_client=contract_client,
+                    miner_hotkeys=metagraph_hotkeys,
+                    current_block=current_block,
+                )
             # Without this seed, a miner already serving a swap at startup
             # would be treated as idle until the next terminal event.
             try:
@@ -414,6 +443,14 @@ class ContractEventWatcher:
             swap_id = values.get('swap_id')
             miner = values.get('miner', '')
             if miner:
+                # Reservation has been consumed into a live swap; the
+                # contract removes the row in clear_confirmed_reservation,
+                # so the validator-side mirror must drop it too. Without
+                # this drop, ``committed_amount_for_address`` would keep
+                # counting the swap's source amount as a held reservation
+                # and reject the user's *next* unrelated reserve attempt.
+                if self.reservation_index is not None:
+                    self.reservation_index.remove(miner)
                 # Skip if this swap's +1 was already seeded from the contract's
                 # live active-swap list at bootstrap — otherwise a restart
                 # whose replay window covers the original SwapInitiated would
@@ -421,6 +458,23 @@ class ContractEventWatcher:
                 if isinstance(swap_id, int) and swap_id in self.bootstrapped_swap_ids:
                     return
                 self.apply_busy_delta(block_num, miner, +1)
+        elif name == 'MinerReserved':
+            # MinerReserved only carries (miner, reserved_until) — fetch the
+            # full Reservation row so the index can answer queries keyed on
+            # (from_address, from_chain) without another RPC at request time.
+            miner = values.get('miner', '')
+            if miner and self.reservation_index is not None and self.contract_client is not None:
+                try:
+                    res = self.contract_client.get_reservation(miner)
+                except Exception as e:
+                    bt.logging.warning(f'EventWatcher: get_reservation({miner[:8]}) on MinerReserved failed: {e}')
+                    res = None
+                if res is not None:
+                    self.reservation_index.upsert(miner, res)
+        elif name == 'ReservationCancelled':
+            miner = values.get('miner', '')
+            if miner and self.reservation_index is not None:
+                self.reservation_index.remove(miner)
         elif name == 'SwapCompleted':
             swap_id = values.get('swap_id')
             miner = values.get('miner', '')

--- a/allways/validator/reservation_index.py
+++ b/allways/validator/reservation_index.py
@@ -1,0 +1,137 @@
+"""Validator-side mirror of live on-chain reservations.
+
+The smart contract keys reservations by miner only (see
+``smart-contracts/ink/lib.rs::reservations``); there is no
+source-address index. That left ``handle_swap_reserve`` validating
+the user's source balance against the *current* request only and
+ignoring any other still-live reservations the same source address
+already holds, so a user with funds for one swap could lock multiple
+miners simultaneously and stall real liquidity (see issue #295).
+
+This index sits next to the ``ContractEventWatcher`` and is kept in
+sync via three contract events:
+
+* ``MinerReserved``       — fetch the full reservation and upsert.
+* ``ReservationCancelled``— drop the entry.
+* ``SwapInitiated``       — drop the entry (reservation became a swap).
+
+The reserve handler queries
+:meth:`ReservationIndex.committed_amount_for_address` to obtain the
+total ``from_amount`` already committed by the requestor's source
+address on that chain, then rejects any new reservation whose
+``from_amount`` would push the cumulative commitment past the user's
+visible source-chain balance.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING, Dict, Iterable, Optional
+
+import bittensor as bt
+
+from allways.classes import Reservation
+
+if TYPE_CHECKING:
+    from allways.contract_client import AllwaysContractClient
+
+
+class ReservationIndex:
+    """Thread-safe mirror of live ``(miner_hotkey -> Reservation)`` rows.
+
+    All public mutators take an internal lock; reads also lock so that
+    iteration is safe while the event watcher upserts on the forward
+    thread and an axon handler reads on a worker thread.
+    """
+
+    def __init__(self) -> None:
+        self._by_miner: Dict[str, Reservation] = {}
+        self._lock = threading.Lock()
+
+    # ─── Mutation ──────────────────────────────────────────────────────
+
+    def upsert(self, miner_hotkey: str, reservation: Reservation) -> None:
+        if not miner_hotkey or reservation is None:
+            return
+        with self._lock:
+            self._by_miner[miner_hotkey] = reservation
+
+    def remove(self, miner_hotkey: str) -> None:
+        if not miner_hotkey:
+            return
+        with self._lock:
+            self._by_miner.pop(miner_hotkey, None)
+
+    def reset(self, reservations: Optional[Dict[str, Reservation]] = None) -> None:
+        with self._lock:
+            self._by_miner = dict(reservations or {})
+
+    # ─── Bootstrap ─────────────────────────────────────────────────────
+
+    def hydrate_from_contract(
+        self,
+        contract_client: 'AllwaysContractClient',
+        miner_hotkeys: Iterable[str],
+        current_block: int,
+    ) -> None:
+        """Seed the index from contract reads at validator startup.
+
+        Skips entries whose ``reserved_until`` is already in the past
+        — they will be cleared lazily by the contract on the next
+        ``vote_reserve`` for the same miner.
+        """
+        loaded: Dict[str, Reservation] = {}
+        for hotkey in miner_hotkeys:
+            try:
+                res = contract_client.get_reservation(hotkey)
+            except Exception as e:
+                bt.logging.debug(f'ReservationIndex bootstrap: get_reservation({hotkey[:8]}) failed: {e}')
+                continue
+            if res is None:
+                continue
+            if res.reserved_until < current_block:
+                continue
+            loaded[hotkey] = res
+        with self._lock:
+            self._by_miner = loaded
+        bt.logging.info(f'ReservationIndex hydrated with {len(loaded)} live reservations')
+
+    # ─── Queries ───────────────────────────────────────────────────────
+
+    def committed_amount_for_address(
+        self,
+        from_address: str,
+        from_chain: str,
+        current_block: int,
+        exclude_miner: Optional[str] = None,
+    ) -> int:
+        """Sum ``from_amount`` over live reservations matching the source.
+
+        Filters on both ``from_addr`` and ``from_chain`` because a
+        user's spendable balance is per-chain — a BTC reservation has
+        no claim on the user's TAO balance and vice versa. Expired
+        rows still in the index (e.g. a missed ``ReservationCancelled``
+        event) are ignored via the ``reserved_until`` gate.
+        """
+        if not from_address or not from_chain:
+            return 0
+        total = 0
+        with self._lock:
+            for hotkey, res in self._by_miner.items():
+                if exclude_miner is not None and hotkey == exclude_miner:
+                    continue
+                if res.reserved_until < current_block:
+                    continue
+                if res.from_addr != from_address or res.from_chain != from_chain:
+                    continue
+                total = total + res.from_amount
+        return total
+
+    def snapshot(self) -> Dict[str, Reservation]:
+        """Return a shallow copy — for tests/debug only."""
+        with self._lock:
+            return dict(self._by_miner)
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._by_miner)

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -38,6 +38,7 @@ from allways.validator.chain_verification import SwapVerifier
 from allways.validator.event_watcher import ContractEventWatcher
 from allways.validator.forward import forward
 from allways.validator.optimistic_extensions import OptimisticExtensionWatcher
+from allways.validator.reservation_index import ReservationIndex
 from allways.validator.state_store import ValidatorStateStore
 from allways.validator.swap_tracker import SwapTracker
 from neurons.base.validator import BaseValidatorNeuron
@@ -100,11 +101,20 @@ class Validator(BaseValidatorNeuron):
         # in-memory dicts and trusts the contract's active flag for all
         # collateral-floor invariants.
         metadata_path = Path(__file__).resolve().parent.parent / 'allways' / 'metadata' / 'allways_swap_manager.json'
+        # Validator-side mirror of the contract's reservations table. The
+        # reserve handler consults this to enforce that a single source
+        # address cannot tie up more miners than its visible balance covers
+        # (issue #295). Built before the watcher so the watcher can pump
+        # MinerReserved / SwapInitiated / ReservationCancelled events into
+        # it during sync.
+        self.reservation_index = ReservationIndex()
         self.event_watcher = ContractEventWatcher(
             substrate=self.subtensor.substrate,
             contract_address=self.contract_client.contract_address,
             metadata_path=metadata_path,
             state_store=self.state_store,
+            reservation_index=self.reservation_index,
+            contract_client=self.contract_client,
         )
         self.event_watcher.initialize(
             current_block=self.block,

--- a/tests/test_reservation_index.py
+++ b/tests/test_reservation_index.py
@@ -1,0 +1,385 @@
+"""Unit tests for ReservationIndex and event-watcher integration.
+
+The index is the validator's defense against a single source address
+locking multiple miners simultaneously by spreading its visible balance
+across concurrent reservations (issue #295). These tests cover the
+three surfaces that have to work end-to-end for the defense to hold:
+
+1. ``ReservationIndex`` aggregation logic — sum / filter / expire.
+2. ``ContractEventWatcher.apply_event`` upserts/removes the right
+   rows in response to MinerReserved / ReservationCancelled /
+   SwapInitiated.
+3. ``handle_swap_reserve`` rejects an over-commit by consulting the
+   index inside the lock, with the rejection message shaped so the
+   existing ``insufficient_source_balance`` translator rule still
+   matches.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from allways.classes import MinerPair, Reservation
+from allways.synapses import SwapReserveSynapse
+from allways.validator.axon_handlers import handle_swap_reserve
+from allways.validator.event_watcher import ContractEventWatcher
+from allways.validator.reservation_index import ReservationIndex
+from allways.validator.state_store import ValidatorStateStore
+
+METADATA_PATH = Path(__file__).parent.parent / 'allways' / 'metadata' / 'allways_swap_manager.json'
+TEST_CONTRACT_ADDRESS = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
+
+
+def make_reservation(
+    *,
+    from_addr: str = 'bc1-user',
+    from_chain: str = 'btc',
+    to_chain: str = 'tao',
+    from_amount: int = 100_000,
+    tao_amount: int = 345_000_000,
+    to_amount: int = 345_000_000,
+    reserved_until: int = 2_000,
+) -> Reservation:
+    return Reservation(
+        hash='0x' + '00' * 32,
+        from_addr=from_addr,
+        from_chain=from_chain,
+        to_chain=to_chain,
+        tao_amount=tao_amount,
+        from_amount=from_amount,
+        to_amount=to_amount,
+        reserved_until=reserved_until,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ReservationIndex (pure logic)
+# ---------------------------------------------------------------------------
+
+
+class TestReservationIndexAggregation:
+    def test_sum_across_two_miners_same_address_and_chain(self):
+        idx = ReservationIndex()
+        idx.upsert('miner-a', make_reservation(from_amount=100))
+        idx.upsert('miner-b', make_reservation(from_amount=250))
+        total = idx.committed_amount_for_address(from_address='bc1-user', from_chain='btc', current_block=1_000)
+        assert total == 350
+
+    def test_skips_different_source_address(self):
+        idx = ReservationIndex()
+        idx.upsert('miner-a', make_reservation(from_addr='bc1-user', from_amount=100))
+        idx.upsert('miner-b', make_reservation(from_addr='bc1-other', from_amount=999))
+        total = idx.committed_amount_for_address(from_address='bc1-user', from_chain='btc', current_block=1_000)
+        assert total == 100
+
+    def test_skips_different_from_chain(self):
+        """Source-chain balance is per-chain — a TAO-side reservation must
+        not consume the user's BTC balance even if the SS58/string ever
+        collides."""
+        idx = ReservationIndex()
+        idx.upsert('miner-a', make_reservation(from_chain='btc', from_amount=100))
+        idx.upsert('miner-b', make_reservation(from_chain='tao', from_amount=999))
+        total = idx.committed_amount_for_address(from_address='bc1-user', from_chain='btc', current_block=1_000)
+        assert total == 100
+
+    def test_ignores_expired_rows(self):
+        """Expired rows are removed lazily on-chain (next vote_reserve), so the
+        index may briefly hold stale entries; the reserved_until gate keeps
+        them from inflating the committed total."""
+        idx = ReservationIndex()
+        idx.upsert('miner-a', make_reservation(from_amount=100, reserved_until=500))
+        idx.upsert('miner-b', make_reservation(from_amount=200, reserved_until=2_000))
+        total = idx.committed_amount_for_address(from_address='bc1-user', from_chain='btc', current_block=1_000)
+        assert total == 200
+
+    def test_exclude_miner_drops_a_specific_row(self):
+        """``exclude_miner`` lets the reserve handler skip the requested miner
+        if its prior reservation just expired (defense-in-depth — the
+        contract already rejects double-reserve, but the validator should
+        not double-count itself either)."""
+        idx = ReservationIndex()
+        idx.upsert('miner-a', make_reservation(from_amount=100))
+        idx.upsert('miner-b', make_reservation(from_amount=200))
+        total = idx.committed_amount_for_address(
+            from_address='bc1-user',
+            from_chain='btc',
+            current_block=1_000,
+            exclude_miner='miner-a',
+        )
+        assert total == 200
+
+    def test_remove_clears_entry(self):
+        idx = ReservationIndex()
+        idx.upsert('miner-a', make_reservation(from_amount=100))
+        idx.remove('miner-a')
+        assert idx.committed_amount_for_address('bc1-user', 'btc', 1_000) == 0
+
+    def test_empty_address_or_chain_returns_zero(self):
+        """Defensive: an empty source address or chain (malformed request)
+        would otherwise compare against any row with the same default
+        value and over-report the committed amount."""
+        idx = ReservationIndex()
+        idx.upsert('miner-a', make_reservation(from_amount=100))
+        assert idx.committed_amount_for_address('', 'btc', 1_000) == 0
+        assert idx.committed_amount_for_address('bc1-user', '', 1_000) == 0
+
+
+class TestReservationIndexHydrate:
+    def test_hydrate_loads_only_live_rows(self):
+        """Bootstrap reads every metagraph hotkey once. Expired rows are
+        skipped — they will be cleared lazily by the contract on the next
+        vote_reserve, no need to mirror them locally."""
+        client = MagicMock()
+        client.get_reservation.side_effect = lambda hk: {
+            'hk-a': make_reservation(from_amount=100, reserved_until=2_000),
+            'hk-b': None,
+            'hk-c': make_reservation(from_amount=999, reserved_until=500),  # expired
+        }.get(hk)
+        idx = ReservationIndex()
+        idx.hydrate_from_contract(client, ['hk-a', 'hk-b', 'hk-c'], current_block=1_000)
+        assert len(idx) == 1
+        assert idx.committed_amount_for_address('bc1-user', 'btc', 1_000) == 100
+
+    def test_hydrate_swallows_per_hotkey_errors(self):
+        """A failing read on one hotkey must not abort the whole bootstrap;
+        without this guarantee a single flaky RPC could leave the validator
+        permanently un-mirrored and silently re-open the over-commit hole."""
+        client = MagicMock()
+
+        def side(hotkey):
+            if hotkey == 'hk-bad':
+                raise RuntimeError('rpc blew up')
+            return make_reservation(from_amount=42, reserved_until=2_000)
+
+        client.get_reservation.side_effect = side
+        idx = ReservationIndex()
+        idx.hydrate_from_contract(client, ['hk-bad', 'hk-ok'], current_block=1_000)
+        assert len(idx) == 1
+
+
+# ---------------------------------------------------------------------------
+# ContractEventWatcher integration
+# ---------------------------------------------------------------------------
+
+
+def make_watcher_with_index(tmp_path: Path) -> tuple[ContractEventWatcher, ReservationIndex, MagicMock]:
+    store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+    idx = ReservationIndex()
+    client = MagicMock()
+    watcher = ContractEventWatcher(
+        substrate=MagicMock(),
+        contract_address=TEST_CONTRACT_ADDRESS,
+        metadata_path=METADATA_PATH,
+        state_store=store,
+        reservation_index=idx,
+        contract_client=client,
+    )
+    return watcher, idx, client
+
+
+class TestEventWatcherUpdatesIndex:
+    def test_miner_reserved_upserts_via_contract_read(self, tmp_path: Path):
+        """MinerReserved only carries (miner, reserved_until); the watcher
+        must follow up with get_reservation so the index stores the full
+        row (from_addr / from_chain / from_amount) needed at reserve time."""
+        watcher, idx, client = make_watcher_with_index(tmp_path)
+        client.get_reservation.return_value = make_reservation(from_amount=500)
+        watcher.apply_event(100, 'MinerReserved', {'miner': 'hk-a', 'reserved_until': 2_000})
+        client.get_reservation.assert_called_once_with('hk-a')
+        assert idx.committed_amount_for_address('bc1-user', 'btc', 1_000) == 500
+        watcher.state_store.close()
+
+    def test_reservation_cancelled_drops_entry(self, tmp_path: Path):
+        watcher, idx, _ = make_watcher_with_index(tmp_path)
+        idx.upsert('hk-a', make_reservation(from_amount=500))
+        watcher.apply_event(101, 'ReservationCancelled', {'miner': 'hk-a'})
+        assert idx.committed_amount_for_address('bc1-user', 'btc', 1_000) == 0
+        watcher.state_store.close()
+
+    def test_swap_initiated_drops_reservation(self, tmp_path: Path):
+        """When a reservation transitions into a live swap, the contract
+        clears the reservation row in clear_confirmed_reservation. The
+        validator-side mirror must drop it too — otherwise the user's
+        next unrelated reserve attempt would be rejected for an amount
+        that's already been spent into the swap."""
+        watcher, idx, _ = make_watcher_with_index(tmp_path)
+        idx.upsert('hk-a', make_reservation(from_amount=500))
+        watcher.apply_event(102, 'SwapInitiated', {'swap_id': 7, 'miner': 'hk-a'})
+        assert idx.committed_amount_for_address('bc1-user', 'btc', 1_000) == 0
+        watcher.state_store.close()
+
+    def test_miner_reserved_failed_read_does_not_crash(self, tmp_path: Path):
+        """A transient RPC failure when fetching the full reservation must
+        not propagate into apply_event — that would stall sync_to and cause
+        a re-replay that would still fail. The row stays missing from the
+        index until the next bootstrap or a future MinerReserved retry."""
+        watcher, idx, client = make_watcher_with_index(tmp_path)
+        client.get_reservation.side_effect = RuntimeError('rpc down')
+        watcher.apply_event(100, 'MinerReserved', {'miner': 'hk-a', 'reserved_until': 2_000})
+        assert len(idx) == 0
+        watcher.state_store.close()
+
+
+# ---------------------------------------------------------------------------
+# handle_swap_reserve: cumulative-balance gate
+# ---------------------------------------------------------------------------
+
+
+def make_reserve_synapse(
+    miner_hotkey: str = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
+    from_amount: int = 100_000,
+    from_address: str = 'bc1-user',
+    from_chain: str = 'btc',
+    to_chain: str = 'tao',
+) -> SwapReserveSynapse:
+    return SwapReserveSynapse(
+        miner_hotkey=miner_hotkey,
+        tao_amount=345_000_000,
+        from_amount=from_amount,
+        to_amount=345_000_000,
+        from_address=from_address,
+        from_address_proof='proof',
+        block_anchor=900,
+        from_chain=from_chain,
+        to_chain=to_chain,
+    )
+
+
+def make_reserve_validator(
+    *,
+    block: int = 1_000,
+    miner_active: bool = True,
+    miner_has_swap: bool = False,
+    miner_reserved_until: int = 0,
+    collateral: int = 1_000_000_000,
+    balance: int = 100_000,
+    cooldown: tuple = (0, 0),
+    reservation_index: ReservationIndex | None = None,
+) -> MagicMock:
+    validator = MagicMock()
+    validator.config.netuid = 2
+    validator.axon_lock = threading.Lock()
+    validator.axon_subtensor.get_current_block.return_value = block
+    validator.metagraph.hotkeys = ['5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty']
+
+    contract = MagicMock()
+    contract.get_miner_snapshot.return_value = (
+        collateral,
+        miner_active,
+        miner_has_swap,
+        miner_reserved_until,
+        0,
+    )
+    contract.get_cooldown.return_value = cooldown
+    contract.vote_reserve.return_value = '0xtxhash'
+    validator.axon_contract_client = contract
+
+    btc = MagicMock()
+    btc.verify_from_proof.return_value = True
+    btc.get_balance.return_value = balance
+    validator.axon_chain_providers = {'btc': btc, 'tao': MagicMock()}
+
+    bounds = MagicMock()
+    bounds.min_collateral.return_value = 0
+    bounds.min_swap_amount.return_value = 0
+    bounds.max_swap_amount.return_value = 0
+    validator.bounds_cache = bounds
+
+    validator.reservation_index = reservation_index
+    validator.wallet = MagicMock()
+    return validator
+
+
+def run_reserve_handler(validator, synapse, commitment=None):
+    if commitment is None:
+        commitment = MinerPair(
+            uid=1,
+            hotkey=synapse.miner_hotkey,
+            from_chain='btc',
+            from_address='bc1-miner',
+            to_chain='tao',
+            to_address='5miner',
+            rate=345.0,
+            rate_str='345',
+            counter_rate=0.0029,
+            counter_rate_str='0.0029',
+        )
+    with patch('allways.validator.axon_handlers.read_miner_commitment', return_value=commitment):
+        return asyncio.run(handle_swap_reserve(validator, synapse))
+
+
+class TestReserveCumulativeBalanceGate:
+    def test_rejects_when_other_reservations_exhaust_balance(self):
+        """User has just enough BTC balance for one swap. Index already
+        shows the same address holds another live reservation against a
+        different miner — the new request must be rejected with the
+        ``insufficient_source_balance`` prefix so the CLI translator
+        renders the dedicated headline."""
+        idx = ReservationIndex()
+        idx.upsert(
+            '5OtherMiner000000000000000000000000000000000000000',
+            make_reservation(from_addr='bc1-user', from_chain='btc', from_amount=80_000),
+        )
+        validator = make_reserve_validator(balance=100_000, reservation_index=idx)
+        synapse = make_reserve_synapse(from_amount=80_000)
+        result = run_reserve_handler(validator, synapse)
+        assert result.accepted is False
+        assert result.rejection_reason.lower().startswith('insufficient source balance')
+        # Critical: must not have voted on the contract.
+        validator.axon_contract_client.vote_reserve.assert_not_called()
+
+    def test_accepts_when_total_committed_plus_request_fits_balance(self):
+        """Balance covers committed + new request — the request should pass
+        the gate and proceed to vote_reserve."""
+        idx = ReservationIndex()
+        idx.upsert(
+            '5OtherMiner000000000000000000000000000000000000000',
+            make_reservation(from_addr='bc1-user', from_chain='btc', from_amount=40_000),
+        )
+        validator = make_reserve_validator(balance=200_000, reservation_index=idx)
+        synapse = make_reserve_synapse(from_amount=80_000)
+        result = run_reserve_handler(validator, synapse)
+        assert result.accepted is True
+        validator.axon_contract_client.vote_reserve.assert_called_once()
+
+    def test_other_address_committed_does_not_count(self):
+        """A different user's reservations against the same miner pool must
+        not consume *this* user's balance budget."""
+        idx = ReservationIndex()
+        idx.upsert(
+            '5OtherMiner000000000000000000000000000000000000000',
+            make_reservation(from_addr='bc1-someone-else', from_chain='btc', from_amount=999_999),
+        )
+        validator = make_reserve_validator(balance=100_000, reservation_index=idx)
+        synapse = make_reserve_synapse(from_amount=80_000)
+        result = run_reserve_handler(validator, synapse)
+        assert result.accepted is True
+
+    def test_expired_reservations_do_not_count(self):
+        idx = ReservationIndex()
+        idx.upsert(
+            '5OtherMiner000000000000000000000000000000000000000',
+            make_reservation(
+                from_addr='bc1-user',
+                from_chain='btc',
+                from_amount=999_999,
+                reserved_until=500,
+            ),
+        )
+        validator = make_reserve_validator(block=1_000, balance=100_000, reservation_index=idx)
+        synapse = make_reserve_synapse(from_amount=80_000)
+        result = run_reserve_handler(validator, synapse)
+        assert result.accepted is True
+
+    def test_no_index_attribute_falls_through(self):
+        """Tests that don't construct a ReservationIndex (legacy fixtures,
+        the dendrite-lite test paths) keep working. The aggregate gate is
+        defense-in-depth on top of the per-request balance check; missing
+        index is logged-and-skipped, not a hard failure."""
+        validator = make_reserve_validator(balance=100_000, reservation_index=None)
+        synapse = make_reserve_synapse(from_amount=80_000)
+        result = run_reserve_handler(validator, synapse)
+        assert result.accepted is True


### PR DESCRIPTION
## Problem
Closes #295

`handle_swap_reserve` validated the requestor's source-chain balanceagainst the **current** reserve request only. The smart contract(`smart-contracts/ink/lib.rs::reservations`) keys reservations byminer hotkey and exposes no source-address index, so neither sideconsidered the user's other still-live reservations from the samesource address.
A user with funds for a single swap could therefore reserve multipleminers in parallel, locking honest capacity behind reservations thatcould never all settle and starving real liquidity.

## Fix

Introduce a validator-side mirror of the on-chain reservations tableand consult it during reserve so the cumulative committed amount per source address is bounded by the user's visible balance.

- New `allways/validator/reservation_index.py` — thread-safe  `(miner_hotkey -> Reservation)` mirror with
  `committed_amount_for_address(from_address, from_chain, current_block, exclude_miner)`
  that filters by source chain (BTC funds don't back a TAO reserve) and ignores expired rows.
- `event_watcher.py` — keep the index in sync incrementally:
  - `MinerReserved` → fetch the full `Reservation` row via contract_client.get_reservation(miner)` and `upsert`.
  - `ReservationCancelled` → `remove`.
  - `SwapInitiated` → `remove` (reservation consumed into a swap;
       contract clears it in `clear_confirmed_reservation`).
  - Bootstrap path hydrates the index from the metagraph hotkeys
       once at startup so the first reserve check is already accurate.
- `axon_handlers.py::handle_swap_reserve` — after the per-request balance/collateral gates, additionally reject when
       `balance < committed + synapse.from_amount`, with the rejection message naming the amount already 
        committed across other live reservations.
- `neurons/validator.py` — construct `ReservationIndex` and inject it (plus the `contract_client`)
        into  `ContractEventWatcher` so the handler and watcher share the same instance.

The handler degrades gracefully when no index is wired (legacy /test paths) — the original per-request check still runs.

## Files changed

| File | Change |
| --- | --- |
| `allways/validator/reservation_index.py` | new — index, hydrate, query |
| `allways/validator/event_watcher.py` | wire index, handle `MinerReserved` / `ReservationCancelled` / drop on `SwapInitiated`, hydrate at bootstrap |
| `allways/validator/axon_handlers.py` | aggregate-balance gate in `handle_swap_reserve` |
| `neurons/validator.py` | construct and inject `ReservationIndex` |
| `tests/test_reservation_index.py` | new — 19 unit + integration tests |

## Test plan

- [x] `uv run pytest tests/test_reservation_index.py` — 19 new tests
  covering:
  - `committed_amount_for_address`: sums across miners for the same`(from_addr, from_chain)`, 
      ignores other addresses, other chains,expired rows, and the `exclude_miner` self-row; returns 0 for
      empty address/chain.
  - `remove` clears entries; `hydrate_from_contract` loads only live rows and swallows per-hotkey RPC errors.
  - Watcher event handling: `MinerReserved` upserts via contract read (and survives a failed read), 
    `ReservationCancelled` and `SwapInitiated` drop the row.
  - `handle_swap_reserve` end-to-end: rejects when other live
    reservations would exhaust the balance, accepts when the total fits, ignores commitments from other addresses 
    or expired reservations, and falls through cleanly when no index is attached.
- [x] `uv run pytest tests/` — full suite green.
- [x] `uv run ruff check allways/ neurons/` — clean.
- [x] `uv run pre-commit run --all-files` — clean.

## Risk / rollout

- New rejection path only fires when the same source address alreadyholds at least one other live reservation, 
   so steady- state minersee no behavior change.
- Index is in-memory and rebuilt at validator startup from contract reads; no migration needed.
- `contract_client` and `reservation_index` are both `Optional` on `ContractEventWatcher`, so existing callers/tests 
    that don't pass  them continue to work.
