### PR TITLE
fix: normalize swap now chain options

### DIFF
--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -618,6 +618,10 @@ def swap_now_command(
         pass
 
     # Validate provided chain options early
+    if from_chain_opt:
+        from_chain_opt = from_chain_opt.lower()
+    if to_chain_opt:
+        to_chain_opt = to_chain_opt.lower()
     if from_chain_opt and from_chain_opt not in SUPPORTED_CHAINS:
         console.print(f'[red]Unknown source chain: {from_chain_opt}[/red]')
         return

--- a/tests/test_swap_now_cli.py
+++ b/tests/test_swap_now_cli.py
@@ -1,0 +1,42 @@
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from allways.cli.swap_commands.swap import swap_now_command
+
+
+def test_swap_now_accepts_uppercase_chain_options():
+    client = MagicMock()
+    client.get_halted.return_value = False
+
+    with (
+        patch(
+            'allways.cli.swap_commands.swap.get_cli_context', return_value=({'netuid': 7}, object(), object(), client)
+        ),
+        patch('allways.cli.swap_commands.swap.load_pending_swap', return_value=None),
+        patch('allways.cli.swap_commands.swap.create_chain_providers', return_value={}),
+        patch('allways.cli.swap_commands.swap.read_miner_commitments', return_value=[]),
+    ):
+        result = CliRunner().invoke(
+            swap_now_command,
+            [
+                '--from',
+                'BTC',
+                '--to',
+                'TAO',
+                '--amount',
+                '0.001',
+                '--receive-address',
+                '5test',
+                '--from-address',
+                'bc1qtest',
+                '--from-tx-hash',
+                'abc123',
+                '--auto',
+                '--yes',
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert 'Unknown source chain' not in result.output
+    assert 'No miners currently post rates for BTC/TAO.' in result.output


### PR DESCRIPTION
## Summary

- normalize `alw swap now --from/--to` chain options before validation
- add CLI coverage showing uppercase `BTC` / `TAO` reaches miner lookup instead of being rejected

Fixes #248

## Testing

- `pytest tests/test_swap_now_cli.py tests/test_chains.py -q`
- `ruff check allways/cli/swap_commands/swap.py tests/test_swap_now_cli.py`
- `ruff format --check allways/cli/swap_commands/swap.py tests/test_swap_now_cli.py`
- `git diff --check`
