### PR TITLE
fix: report missing global flag values

### DIFF
--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -196,15 +196,18 @@ def parse_global_flags() -> dict:
         if '=' in arg:
             flag, value = arg.split('=', 1)
             if flag in _GLOBAL_FLAGS:
+                if value == '':
+                    raise click.UsageError(f'{flag} requires a value')
                 overrides[_GLOBAL_FLAGS[flag]] = value
                 i += 1
                 continue
         # Handle --flag value form
         if arg in _GLOBAL_FLAGS:
-            if i + 1 < len(sys.argv):
-                overrides[_GLOBAL_FLAGS[arg]] = sys.argv[i + 1]
-                i += 2
-                continue
+            if i + 1 >= len(sys.argv) or sys.argv[i + 1].startswith('--'):
+                raise click.UsageError(f'{arg} requires a value')
+            overrides[_GLOBAL_FLAGS[arg]] = sys.argv[i + 1]
+            i += 2
+            continue
         new_argv.append(arg)
         i += 1
     sys.argv[:] = new_argv

--- a/tests/test_global_flags.py
+++ b/tests/test_global_flags.py
@@ -1,0 +1,29 @@
+import sys
+
+import click
+import pytest
+
+from allways.cli.swap_commands.helpers import parse_global_flags
+
+
+def test_bare_netuid_global_flag_reports_missing_value(monkeypatch):
+    monkeypatch.setattr(sys, 'argv', ['alw', 'view', 'rates', '--netuid'])
+
+    with pytest.raises(click.UsageError, match='--netuid requires a value'):
+        parse_global_flags()
+
+
+def test_empty_netuid_global_flag_reports_missing_value(monkeypatch):
+    monkeypatch.setattr(sys, 'argv', ['alw', 'view', 'rates', '--netuid='])
+
+    with pytest.raises(click.UsageError, match='--netuid requires a value'):
+        parse_global_flags()
+
+
+def test_netuid_global_flag_with_value_is_stripped(monkeypatch):
+    monkeypatch.setattr(sys, 'argv', ['alw', 'view', 'rates', '--netuid', '7'])
+
+    overrides = parse_global_flags()
+
+    assert overrides == {'netuid': '7'}
+    assert sys.argv == ['alw', 'view', 'rates']


### PR DESCRIPTION
## Summary

- raise a clear `UsageError` when global flags like `--netuid` are missing a value
- handle both bare `--netuid` and empty `--netuid=` forms before leftover options reach Click
- add parser-level regression coverage for missing and valid global flag values

Fixes #238

## Testing

- `pytest tests/test_global_flags.py tests/test_chains.py -q`
- `ruff check allways/cli/swap_commands/helpers.py tests/test_global_flags.py`
- `ruff format --check allways/cli/swap_commands/helpers.py tests/test_global_flags.py`
- `git diff --check`
