### PR TITLE
raise direction pool weights to 50/50 to attract miners

### DIFF
--- a/allways/__init__.py
+++ b/allways/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 version_split = __version__.split('.')
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -53,8 +53,8 @@ SCORING_WINDOW_BLOCKS = 1200  # ~4 hours at 12s/block — also the scoring caden
 SCORING_EMA_ALPHA = 1.0  # Instantaneous — no smoothing across passes
 CREDIBILITY_WINDOW_BLOCKS = 216_000  # ~30 days
 DIRECTION_POOLS: dict[tuple[str, str], float] = {
-    ('tao', 'btc'): 0.04,
-    ('btc', 'tao'): 0.04,
+    ('tao', 'btc'): 0.5,
+    ('btc', 'tao'): 0.5,
 }
 # 100% → 1.0, 90% → 0.729, 80% → 0.512, 50% → 0.125
 SUCCESS_EXPONENT: int = 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "allways"
-version = "1.0.0"
+version = "1.0.1"
 description = "Allways - Universal Transaction Layer: Trustless cross-chain swaps on Bittensor Subnet 7"
 license = "MIT"
 requires-python = ">=3.10,<3.15"

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -17,8 +17,8 @@ from allways.validator.scoring import (
 )
 from allways.validator.state_store import ValidatorStateStore
 
-POOL_TAO_BTC = 0.04
-POOL_BTC_TAO = 0.04
+POOL_TAO_BTC = 0.5
+POOL_BTC_TAO = 0.5
 MIN_COLLATERAL = 100_000_000  # 0.1 TAO
 
 METADATA_PATH = Path(__file__).parent.parent / 'allways' / 'metadata' / 'allways_swap_manager.json'

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "allways"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "base58" },


### PR DESCRIPTION
## Summary
- Bumps `DIRECTION_POOLS` from `0.04` to `0.5` per direction so the validator distributes 100% of emission to crown-holding miners in the steady state instead of recycling ~92% to UID 53.
- Updates the mirrored test constants in `tests/test_scoring_v1.py`.

## Why
No miners have joined yet. The current 4%/4% split means the headline emission a miner sees is tiny relative to the rest of the pool flowing to the subnet owner. Raising both pools to 50% maximises the on-chain incentive without touching any other scoring mechanic.

## Behaviour
- Steady state: 100% of validator weight goes to crown miners (50% per direction).
- Empty bucket: that direction's 50% recycles to UID 53 via the existing remainder logic in `scoring.py:124-126`.
- Halt and cold-start (empty scores) still recycle 100% to UID 53 — those paths are unchanged.

## Validator rollout
Validators on the old constants will route 92% to UID 53; validators on the new constants will route ~0%. Until vTrust-weighted validators upgrade, miner emission will be a weighted average of the two regimes.

## Test plan
- [x] `ruff check allways/constants.py tests/test_scoring_v1.py` clean
- [x] `pytest tests/test_scoring_v1.py` — 47/47 pass
- [ ] Observe a non-zero miner registration once released