### PR TITLE
fix: validate tao ss58 checksums

### DIFF
--- a/allways/chain_providers/subtensor.py
+++ b/allways/chain_providers/subtensor.py
@@ -1,10 +1,9 @@
-import re
 from hashlib import blake2b
 from typing import Any, Dict, Optional, Tuple
 
 import bittensor as bt
 from bittensor import Keypair
-from bittensor.utils import ss58_encode
+from bittensor.utils import is_valid_ss58_address, ss58_encode
 
 from allways.chain_providers.base import ChainProvider, ProviderUnreachableError, TransactionInfo
 from allways.chains import CHAIN_TAO, ChainDefinition
@@ -276,9 +275,9 @@ class SubtensorProvider(ChainProvider):
     def is_valid_address(self, address: str) -> bool:
         """Validate an SS58 address."""
         try:
-            if not address or len(address) != 48:
+            if not isinstance(address, str) or len(address) != 48:
                 return False
-            return bool(re.match(r'^[1-9A-HJ-NP-Za-km-z]{48}$', address))
+            return is_valid_ss58_address(address)
         except Exception:
             return False
 

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -451,6 +451,14 @@ class TestIsValidAddress:
         # Contains 0, O, I, l — invalid in base58
         assert p.is_valid_address('0' * 48) is False
 
+    def test_invalid_checksum(self):
+        p = self.provider()
+        assert p.is_valid_address('5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQZ') is False
+
+    def test_base58_shape_without_valid_ss58_payload(self):
+        p = self.provider()
+        assert p.is_valid_address('1' * 48) is False
+
     def test_empty(self):
         p = self.provider()
         assert p.is_valid_address('') is False


### PR DESCRIPTION
## Summary
- validate TAO addresses with Bittensor's SS58 checksum validator instead of regex-only shape checks
- add regression coverage for checksum-mutated and base58-shaped invalid addresses

## Issue
Closes #200

## Validation
- uv run ruff check allways/ neurons/ tests/test_scale.py
- uv run pytest tests/test_scale.py::TestIsValidAddress -q
- uv run pre-commit run --all-files
- uv run pytest tests/