### PR TITLE
fix: BTC swap robustness — extension runway, RBF/canonical-chain, 2 confs

### DIFF
--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -282,11 +282,17 @@ class BitcoinProvider(ChainProvider):
             is_confirmed = confirmations >= min_confs if confirmed else False
 
             if is_confirmed:
-                block_hash = data.get('status', {}).get('block_hash')
-                if block_hash:
-                    status_resp = self.btc_api_get(f'/block/{block_hash}/status', timeout=10)
-                    if status_resp.ok and not status_resp.json().get('in_best_chain', False):
-                        return None  # block was reorged out
+                # Best-effort canonical-chain check — any failure (network, parse,
+                # missing key) leaves the existing accept-path intact rather than
+                # breaking verification on an Esplora hiccup.
+                try:
+                    block_hash = data.get('status', {}).get('block_hash')
+                    if block_hash:
+                        status_resp = self.btc_api_get(f'/block/{block_hash}/status', timeout=10)
+                        if status_resp.ok and status_resp.json().get('in_best_chain') is False:
+                            return None  # block was reorged out
+                except Exception as e:
+                    bt.logging.debug(f'canonical-chain check skipped for {tx_hash}: {e}')
 
             for vout in data.get('vout', []):
                 addr = vout.get('scriptpubkey_address', '')

--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -185,10 +185,6 @@ class BitcoinProvider(ChainProvider):
         if not raw_tx:
             return None
 
-        for vin in raw_tx.get('vin', []):
-            if vin.get('sequence', 0xFFFFFFFF) < 0xFFFFFFFE:
-                return None  # BIP-125: RBF-flagged, reject
-
         confirmations = raw_tx.get('confirmations', 0)
         confirmed = confirmations >= self.get_chain().min_confirmations
         block_number = None
@@ -266,10 +262,6 @@ class BitcoinProvider(ChainProvider):
                 return None
             resp.raise_for_status()
             data = resp.json()
-
-            for vin in data.get('vin', []):
-                if vin.get('sequence', 0xFFFFFFFF) < 0xFFFFFFFE:
-                    return None  # BIP-125: RBF-flagged, reject
 
             confirmed = data.get('status', {}).get('confirmed', False)
             block_number = data.get('status', {}).get('block_height')

--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -185,6 +185,10 @@ class BitcoinProvider(ChainProvider):
         if not raw_tx:
             return None
 
+        for vin in raw_tx.get('vin', []):
+            if vin.get('sequence', 0xFFFFFFFF) < 0xFFFFFFFE:
+                return None  # BIP-125: RBF-flagged, reject
+
         confirmations = raw_tx.get('confirmations', 0)
         confirmed = confirmations >= self.get_chain().min_confirmations
         block_number = None
@@ -262,6 +266,10 @@ class BitcoinProvider(ChainProvider):
                 return None
             resp.raise_for_status()
             data = resp.json()
+
+            for vin in data.get('vin', []):
+                if vin.get('sequence', 0xFFFFFFFF) < 0xFFFFFFFE:
+                    return None  # BIP-125: RBF-flagged, reject
 
             confirmed = data.get('status', {}).get('confirmed', False)
             block_number = data.get('status', {}).get('block_height')

--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -281,6 +281,13 @@ class BitcoinProvider(ChainProvider):
             min_confs = self.get_chain().min_confirmations
             is_confirmed = confirmations >= min_confs if confirmed else False
 
+            if is_confirmed:
+                block_hash = data.get('status', {}).get('block_hash')
+                if block_hash:
+                    status_resp = self.btc_api_get(f'/block/{block_hash}/status', timeout=10)
+                    if status_resp.ok and not status_resp.json().get('in_best_chain', False):
+                        return None  # block was reorged out
+
             for vout in data.get('vout', []):
                 addr = vout.get('scriptpubkey_address', '')
                 amount_sat = vout.get('value', 0)

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -80,28 +80,21 @@ def compute_extension_target(
     from_chain_id: str,
     remaining_blocks: int,
     current_subnet_block: int,
-    deadline_block: int = 0,
 ) -> int:
     """Subtensor block to extend a reservation/timeout to.
 
     Covers ``remaining_blocks`` source-chain blocks plus a padding buffer,
     bucket-rounded so validators converge, capped at MAX_EXTENSION_BLOCKS.
 
-    Anchored on ``max(current_subnet_block, deadline_block)`` so runway is
-    measured past the existing deadline. Propose fires inside
-    EXTEND_THRESHOLD_BLOCKS of the deadline, so a current-block anchor
-    silently shortens tier-0 BTC's nominal +90 to ~+71 past the old
-    deadline — barely one BTC block. ``deadline_block`` defaults to 0 to
-    keep callers that don't have one yet on the old behaviour.
-
-    Callers pick ``remaining_blocks`` per tier:
-    - Tier-0 (tx visibility, no confirmations yet): pass 1.
-    - Tier-1+ (≥1 confirmation): pass max(0, min_confirmations - observed).
+    Anchored on ``current_subnet_block`` only. The contract enforces
+    ``target_block - current <= MAX_EXTENSION_BLOCKS`` (lib.rs:670 / :1090)
+    using its own block_number at extrinsic execution time, so a
+    deadline-anchored target would silently blow the cap once
+    ``remaining_blocks`` approaches the bucket ceiling.
     """
     chain = get_chain(from_chain_id)
     seconds_needed = remaining_blocks * chain.seconds_per_block + EXTENSION_PADDING_SECONDS
     blocks_needed = math.ceil(seconds_needed / SUBTENSOR_BLOCK_SECONDS)
     blocks_needed = math.ceil(blocks_needed / EXTENSION_BUCKET_BLOCKS) * EXTENSION_BUCKET_BLOCKS
     blocks_needed = min(blocks_needed, MAX_EXTENSION_BLOCKS)
-    anchor = max(current_subnet_block, deadline_block)
-    return anchor + blocks_needed
+    return current_subnet_block + blocks_needed

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -85,16 +85,13 @@ def compute_extension_target(
 
     Covers ``remaining_blocks`` source-chain blocks plus a padding buffer,
     bucket-rounded so validators converge, capped at MAX_EXTENSION_BLOCKS.
-
-    Anchored on ``current_subnet_block`` only. The contract enforces
-    ``target_block - current <= MAX_EXTENSION_BLOCKS`` (lib.rs:670 / :1090)
-    using its own block_number at extrinsic execution time, so a
-    deadline-anchored target would silently blow the cap once
-    ``remaining_blocks`` approaches the bucket ceiling.
     """
     chain = get_chain(from_chain_id)
     seconds_needed = remaining_blocks * chain.seconds_per_block + EXTENSION_PADDING_SECONDS
     blocks_needed = math.ceil(seconds_needed / SUBTENSOR_BLOCK_SECONDS)
     blocks_needed = math.ceil(blocks_needed / EXTENSION_BUCKET_BLOCKS) * EXTENSION_BUCKET_BLOCKS
     blocks_needed = min(blocks_needed, MAX_EXTENSION_BLOCKS)
+    # Anchor on current, not deadline: contract caps ``target - current_at_exec``
+    # at MAX_EXTENSION_BLOCKS (lib.rs:670, :1090), so a deadline anchor blows
+    # the cap whenever propose fires before the deadline.
     return current_subnet_block + blocks_needed

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -31,7 +31,7 @@ CHAIN_BTC = ChainDefinition(
     decimals=8,
     env_prefix='BTC',
     seconds_per_block=600,
-    min_confirmations=3,
+    min_confirmations=2,
 )
 CHAIN_TAO = ChainDefinition(
     id='tao',

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -88,7 +88,7 @@ CHALLENGE_WINDOW_BLOCKS = 8
 # whose finalize window opens past the original reservation deadline.
 # Default sized for mainnet; testnet validators with slower/jankier RPC can
 # override via VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE env var.
-DEFAULT_VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE = 20
+DEFAULT_VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE = 10
 VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE = max(
     1,
     int(

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -304,7 +304,6 @@ def try_extend_reservation(
     self.optimistic_extensions.maybe_challenge_reservation(
         miner_hotkey=item.miner_hotkey,
         from_chain_id=item.from_chain,
-        observed_confirmations=tx_info.confirmations,
         current_block=current_block,
         reserved_until=reserved_until,
         pending=pending,
@@ -331,7 +330,6 @@ def try_extend_reservation(
         from_tx_hash=from_tx_hash_bytes,
         current_block=current_block,
         reserved_until=reserved_until,
-        observed_confirmations=tx_info.confirmations,
         extension_count=extension_count,
         pending=pending,
     )
@@ -497,7 +495,6 @@ def extend_fulfilled_near_timeout(self: Validator) -> None:
         self.optimistic_extensions.maybe_challenge_timeout(
             swap_id=swap.id,
             dest_chain_id=swap.to_chain,
-            observed_confirmations=tx_info.confirmations,
             current_block=current_block,
             timeout_block=swap.timeout_block,
             pending=pending,
@@ -507,7 +504,6 @@ def extend_fulfilled_near_timeout(self: Validator) -> None:
             dest_chain_id=swap.to_chain,
             current_block=current_block,
             timeout_block=swap.timeout_block,
-            observed_confirmations=tx_info.confirmations,
             extension_count=extension_count,
             pending=pending,
         )

--- a/allways/validator/optimistic_extensions.py
+++ b/allways/validator/optimistic_extensions.py
@@ -64,7 +64,6 @@ class OptimisticExtensionWatcher:
         from_tx_hash: bytes,
         current_block: int,
         reserved_until: int,
-        observed_confirmations: int,
         extension_count: int,
         pending: Optional[PendingExtension],
     ) -> bool:
@@ -115,7 +114,6 @@ class OptimisticExtensionWatcher:
         self,
         miner_hotkey: str,
         from_chain_id: str,
-        observed_confirmations: int,
         current_block: int,
         reserved_until: int,
         pending: Optional[PendingExtension],
@@ -190,7 +188,6 @@ class OptimisticExtensionWatcher:
         dest_chain_id: str,
         current_block: int,
         timeout_block: int,
-        observed_confirmations: int,
         extension_count: int,
         pending: Optional[PendingExtension],
     ) -> bool:
@@ -221,7 +218,6 @@ class OptimisticExtensionWatcher:
         self,
         swap_id: int,
         dest_chain_id: str,
-        observed_confirmations: int,
         current_block: int,
         timeout_block: int,
         pending: Optional[PendingExtension],

--- a/allways/validator/optimistic_extensions.py
+++ b/allways/validator/optimistic_extensions.py
@@ -105,7 +105,7 @@ class OptimisticExtensionWatcher:
             # if observed_confirmations < 1:
             #     return False
             remaining = 4  # tail safety net at same runway as tier-0
-        target_block = compute_extension_target(from_chain_id, remaining, current_block, deadline_block=reserved_until)
+        target_block = compute_extension_target(from_chain_id, remaining, current_block)
 
         return self._try_call(
             'propose_extend_reservation',
@@ -144,7 +144,7 @@ class OptimisticExtensionWatcher:
             return False
 
         remaining = 4  # mirror propose
-        expected = compute_extension_target(from_chain_id, remaining, current_block, deadline_block=reserved_until)
+        expected = compute_extension_target(from_chain_id, remaining, current_block)
         if pending.target_block <= expected + EXTENSION_BUCKET_BLOCKS:
             return False
 
@@ -218,7 +218,7 @@ class OptimisticExtensionWatcher:
             # if observed_confirmations < 1:
             #     return False
             remaining = 4  # tail safety net at same runway as tier-0
-        target_block = compute_extension_target(dest_chain_id, remaining, current_block, deadline_block=timeout_block)
+        target_block = compute_extension_target(dest_chain_id, remaining, current_block)
 
         return self._try_call(
             'propose_extend_timeout',
@@ -246,7 +246,7 @@ class OptimisticExtensionWatcher:
             return False
 
         remaining = 4  # mirror propose
-        expected = compute_extension_target(dest_chain_id, remaining, current_block, deadline_block=timeout_block)
+        expected = compute_extension_target(dest_chain_id, remaining, current_block)
         if pending.target_block <= expected + EXTENSION_BUCKET_BLOCKS:
             return False
 

--- a/allways/validator/optimistic_extensions.py
+++ b/allways/validator/optimistic_extensions.py
@@ -77,9 +77,9 @@ class OptimisticExtensionWatcher:
         three propose/challenge/finalize methods to avoid redundant RPCs.
 
         - Tier 0 (first extension): caller is responsible for ensuring the tx
-          is visible (``tx_info != None``); target sized for one chain block.
-        - Tier 1 (second extension): requires ``observed_confirmations >= 1``;
-          target = chain-aware full-confirmation window.
+          is visible (``tx_info != None``); target sized for BTC block variance.
+        - Tier 1 (second extension): fires on visibility same as tier-0 — no
+          confirmation gate. Acts as tail-of-distribution safety net.
         - Tier 2+: refused locally to avoid a doomed tx (contract rejects too).
 
         Returns True if a propose tx was submitted, False otherwise.
@@ -128,7 +128,7 @@ class OptimisticExtensionWatcher:
     ) -> bool:
         """Challenge the pending reservation extension if its target is too far.
 
-        Mirrors the deadline-anchored math used by ``maybe_propose_reservation``
+        Mirrors the current-block-anchored math used by ``maybe_propose_reservation``
         so challenger and proposer compute the same expected target. Without
         this the two sides could drift by up to EXTEND_THRESHOLD_BLOCKS,
         which the EXTENSION_BUCKET_BLOCKS tolerance currently absorbs but
@@ -238,8 +238,8 @@ class OptimisticExtensionWatcher:
         timeout_block: int,
         pending: Optional[PendingExtension],
     ) -> bool:
-        """Mirror of ``maybe_challenge_reservation``: deadline-anchored expected
-        target so challenger and proposer stay aligned."""
+        """Mirror of ``maybe_challenge_reservation``: current-block-anchored
+        expected target so challenger and proposer stay aligned."""
         if pending is None:
             return False
         if self._is_own_proposal(pending):

--- a/allways/validator/optimistic_extensions.py
+++ b/allways/validator/optimistic_extensions.py
@@ -13,7 +13,7 @@ from typing import Optional
 
 import bittensor as bt
 
-from allways.chains import compute_extension_target, get_chain
+from allways.chains import compute_extension_target
 from allways.classes import PendingExtension
 from allways.constants import (
     CHALLENGE_WINDOW_BLOCKS,
@@ -101,10 +101,10 @@ class OptimisticExtensionWatcher:
         if extension_count == 0:
             remaining = 4  # ~48 min runway, sized for BTC block-time variance
         else:
-            if observed_confirmations < 1:
-                return False
-            chain = get_chain(from_chain_id)
-            remaining = max(0, chain.min_confirmations - observed_confirmations)
+            # deprecated: tier-1 evidence gate — tier-1 now fires on visibility like tier-0
+            # if observed_confirmations < 1:
+            #     return False
+            remaining = 4  # tail safety net at same runway as tier-0
         target_block = compute_extension_target(from_chain_id, remaining, current_block, deadline_block=reserved_until)
 
         return self._try_call(
@@ -143,8 +143,7 @@ class OptimisticExtensionWatcher:
         if self._is_own_proposal(pending):
             return False
 
-        chain = get_chain(from_chain_id)
-        remaining = max(0, chain.min_confirmations - observed_confirmations)
+        remaining = 4  # mirror propose
         expected = compute_extension_target(from_chain_id, remaining, current_block, deadline_block=reserved_until)
         if pending.target_block <= expected + EXTENSION_BUCKET_BLOCKS:
             return False
@@ -215,10 +214,10 @@ class OptimisticExtensionWatcher:
         if extension_count == 0:
             remaining = 4  # ~48 min runway, sized for BTC block-time variance
         else:
-            if observed_confirmations < 1:
-                return False
-            chain = get_chain(dest_chain_id)
-            remaining = max(0, chain.min_confirmations - observed_confirmations)
+            # deprecated: tier-1 evidence gate — tier-1 now fires on visibility like tier-0
+            # if observed_confirmations < 1:
+            #     return False
+            remaining = 4  # tail safety net at same runway as tier-0
         target_block = compute_extension_target(dest_chain_id, remaining, current_block, deadline_block=timeout_block)
 
         return self._try_call(
@@ -246,8 +245,7 @@ class OptimisticExtensionWatcher:
         if self._is_own_proposal(pending):
             return False
 
-        chain = get_chain(dest_chain_id)
-        remaining = max(0, chain.min_confirmations - observed_confirmations)
+        remaining = 4  # mirror propose
         expected = compute_extension_target(dest_chain_id, remaining, current_block, deadline_block=timeout_block)
         if pending.target_block <= expected + EXTENSION_BUCKET_BLOCKS:
             return False

--- a/allways/validator/optimistic_extensions.py
+++ b/allways/validator/optimistic_extensions.py
@@ -76,11 +76,11 @@ class OptimisticExtensionWatcher:
         ``fetch_pending_reservation`` and passes the same value into all
         three propose/challenge/finalize methods to avoid redundant RPCs.
 
-        - Tier 0 (first extension): caller is responsible for ensuring the tx
-          is visible (``tx_info != None``); target sized for BTC block variance.
-        - Tier 1 (second extension): fires on visibility same as tier-0 — no
-          confirmation gate. Acts as tail-of-distribution safety net.
-        - Tier 2+: refused locally to avoid a doomed tx (contract rejects too).
+        Both tiers fire on tx visibility alone with identical runway. Tier-1
+        previously gated on ``observed_confirmations >= 1``; that raced with
+        the challenge-window guard near the deadline, so it was dropped in
+        favour of tier-1 acting as a tail-of-distribution safety net.
+        Tier 2+ is refused locally to avoid a doomed tx (contract rejects too).
 
         Returns True if a propose tx was submitted, False otherwise.
         """
@@ -98,13 +98,7 @@ class OptimisticExtensionWatcher:
         if current_block + CHALLENGE_WINDOW_BLOCKS >= reserved_until:
             return False
 
-        if extension_count == 0:
-            remaining = 4  # ~48 min runway, sized for BTC block-time variance
-        else:
-            # deprecated: tier-1 evidence gate — tier-1 now fires on visibility like tier-0
-            # if observed_confirmations < 1:
-            #     return False
-            remaining = 4  # tail safety net at same runway as tier-0
+        remaining = 4  # ~48 min runway, sized for BTC block-time variance
         target_block = compute_extension_target(from_chain_id, remaining, current_block)
 
         return self._try_call(
@@ -200,8 +194,8 @@ class OptimisticExtensionWatcher:
         extension_count: int,
         pending: Optional[PendingExtension],
     ) -> bool:
-        """Tiered timeout-extension propose. See ``maybe_propose_reservation``
-        for the ``pending`` contract."""
+        """Timeout-extension propose. See ``maybe_propose_reservation`` for
+        the ``pending`` contract and tier semantics."""
         if extension_count >= MAX_EXTENSIONS_PER_SWAP:
             return False
 
@@ -211,13 +205,7 @@ class OptimisticExtensionWatcher:
         if current_block + CHALLENGE_WINDOW_BLOCKS >= timeout_block:
             return False
 
-        if extension_count == 0:
-            remaining = 4  # ~48 min runway, sized for BTC block-time variance
-        else:
-            # deprecated: tier-1 evidence gate — tier-1 now fires on visibility like tier-0
-            # if observed_confirmations < 1:
-            #     return False
-            remaining = 4  # tail safety net at same runway as tier-0
+        remaining = 4  # ~48 min runway, sized for BTC block-time variance
         target_block = compute_extension_target(dest_chain_id, remaining, current_block)
 
         return self._try_call(

--- a/allways/validator/optimistic_extensions.py
+++ b/allways/validator/optimistic_extensions.py
@@ -99,7 +99,7 @@ class OptimisticExtensionWatcher:
             return False
 
         if extension_count == 0:
-            remaining = 1
+            remaining = 4  # ~48 min runway, sized for BTC block-time variance
         else:
             if observed_confirmations < 1:
                 return False
@@ -213,7 +213,7 @@ class OptimisticExtensionWatcher:
             return False
 
         if extension_count == 0:
-            remaining = 1
+            remaining = 4  # ~48 min runway, sized for BTC block-time variance
         else:
             if observed_confirmations < 1:
                 return False

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -47,8 +47,8 @@ class TestCanonicalPair:
 
 class TestConfirmationsToSubtensorBlocks:
     def test_btc(self):
-        # ceil(3 * 600 / 12) = ceil(150) = 150
-        assert confirmations_to_subtensor_blocks('btc') == 150
+        # ceil(2 * 600 / 12) = ceil(100) = 100
+        assert confirmations_to_subtensor_blocks('btc') == 100
 
     def test_tao(self):
         # ceil(6 * 12 / 12) = ceil(6) = 6

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -57,8 +57,8 @@ class TestConfirmationsToSubtensorBlocks:
 
 class TestComputeExtensionTarget:
     # BTC: 600s/block, padding 300s, bucket 30 blocks.
-    # Callers compute remaining_blocks themselves: tier-1 passes 1; tier-2
-    # passes max(0, min_confirmations - observed_confirmations).
+    # Callers pass a fixed remaining (currently 4 across all tiers) sized for
+    # source-chain block-time variance plus padding.
 
     def test_btc_remaining_three(self):
         # tier-2 at 0/3 confs: remaining=3, seconds=3*600+300=2100,

--- a/tests/test_optimistic_extensions.py
+++ b/tests/test_optimistic_extensions.py
@@ -48,8 +48,8 @@ def make_watcher(pending_reservation=None, pending_timeout=None, propose_raises=
 
 class TestMaybeProposeReservation:
     def test_tier0_proposes_on_visibility_with_runway_target(self):
-        # Tier 0: remaining=4 → blocks_needed=240, anchor=max(current=1000,
-        # reserved=1050)=1050, target=1290.
+        # Tier 0: remaining=4 → blocks_needed=240, anchor=current=1000,
+        # target=1240.
         w = make_watcher(pending_reservation=None)
         result = w.maybe_propose_reservation(
             miner_hotkey=MINER,
@@ -64,11 +64,11 @@ class TestMaybeProposeReservation:
         assert result is True
         call_kwargs = w.contract_client.propose_extend_reservation.call_args.kwargs
         assert call_kwargs['miner_hotkey'] == MINER
-        assert call_kwargs['target_block'] == 1290
+        assert call_kwargs['target_block'] == 1240
 
     def test_tier1_proposes_with_runway_target(self):
-        # Tier 1: remaining=4 (same runway as tier-0), anchor=max(1000,1100)=1100,
-        # target=1340.
+        # Tier 1: remaining=4 (same runway as tier-0), anchor=current=1000,
+        # target=1240.
         w = make_watcher(pending_reservation=None)
         result = w.maybe_propose_reservation(
             miner_hotkey=MINER,
@@ -81,7 +81,7 @@ class TestMaybeProposeReservation:
             pending=w.fetch_pending_reservation(MINER),
         )
         assert result is True
-        assert w.contract_client.propose_extend_reservation.call_args.kwargs['target_block'] == 1340
+        assert w.contract_client.propose_extend_reservation.call_args.kwargs['target_block'] == 1240
 
     def test_tier1_proposes_without_confirmations(self):
         # Tier 1 fires on visibility like tier-0 — no confirmation gate.
@@ -168,8 +168,8 @@ class TestMaybeProposeReservation:
 
 class TestMaybeChallengeReservation:
     def test_challenges_when_target_too_far(self):
-        # BTC at 1/3 confs → blocks_needed=150. Anchor=max(1000,1100)=1100,
-        # expected=1250. Pending=2000 is past expected + bucket(30)=1280.
+        # remaining=4 → blocks_needed=240. Anchor=current=1000, expected=1240.
+        # Pending=2000 is past expected + bucket(30)=1270.
         w = make_watcher(
             pending_reservation=PendingExtension(OTHER_HOTKEY, target_block=2000, proposed_at=995),
         )
@@ -185,9 +185,9 @@ class TestMaybeChallengeReservation:
         w.contract_client.challenge_extend_reservation.assert_called_once()
 
     def test_skips_when_target_within_one_bucket_tolerance(self):
-        # expected=1250 (see above), pending=1280 is the boundary.
+        # expected=1240 (see above), pending=1270 is the boundary.
         w = make_watcher(
-            pending_reservation=PendingExtension(OTHER_HOTKEY, target_block=1280, proposed_at=995),
+            pending_reservation=PendingExtension(OTHER_HOTKEY, target_block=1270, proposed_at=995),
         )
         result = w.maybe_challenge_reservation(
             miner_hotkey=MINER,
@@ -314,7 +314,7 @@ class TestFetchPendingReservation:
 class TestMaybeProposeTimeout:
     def test_tier0_proposes_on_visibility(self):
         # BTC tier-0: remaining=4 → blocks_needed=240,
-        # anchor=max(current=1000, timeout=1050)=1050, target=1290.
+        # anchor=current=1000, target=1240.
         w = make_watcher(pending_timeout=None)
         result = w.maybe_propose_timeout(
             swap_id=42,
@@ -328,7 +328,7 @@ class TestMaybeProposeTimeout:
         assert result is True
         kwargs = w.contract_client.propose_extend_timeout.call_args.kwargs
         assert kwargs['swap_id'] == 42
-        assert kwargs['target_block'] == 1290
+        assert kwargs['target_block'] == 1240
 
     def test_tier1_proposes_without_confirmations(self):
         # Tier 1 fires on visibility like tier-0 — no confirmation gate.
@@ -391,8 +391,8 @@ class TestMaybeProposeTimeout:
 
 class TestMaybeChallengeTimeout:
     def test_challenges_when_target_too_far(self):
-        # Anchor=max(1000,1100)=1100, expected=1250, pending=2000 past
-        # expected + bucket(30)=1280.
+        # Anchor=current=1000, expected=1240, pending=2000 past
+        # expected + bucket(30)=1270.
         w = make_watcher(
             pending_timeout=PendingExtension(OTHER_HOTKEY, target_block=2000, proposed_at=995),
         )

--- a/tests/test_optimistic_extensions.py
+++ b/tests/test_optimistic_extensions.py
@@ -57,7 +57,6 @@ class TestMaybeProposeReservation:
             from_tx_hash=bytes(32),
             current_block=1000,
             reserved_until=1050,
-            observed_confirmations=0,
             extension_count=0,
             pending=w.fetch_pending_reservation(MINER),
         )
@@ -76,7 +75,6 @@ class TestMaybeProposeReservation:
             from_tx_hash=bytes(32),
             current_block=1000,
             reserved_until=1100,
-            observed_confirmations=1,
             extension_count=1,
             pending=w.fetch_pending_reservation(MINER),
         )
@@ -92,7 +90,6 @@ class TestMaybeProposeReservation:
             from_tx_hash=bytes(32),
             current_block=1000,
             reserved_until=1100,
-            observed_confirmations=0,
             extension_count=1,
             pending=w.fetch_pending_reservation(MINER),
         )
@@ -108,7 +105,6 @@ class TestMaybeProposeReservation:
             from_tx_hash=bytes(32),
             current_block=1000,
             reserved_until=1100,
-            observed_confirmations=1,
             extension_count=2,
             pending=w.fetch_pending_reservation(MINER),
         )
@@ -123,7 +119,6 @@ class TestMaybeProposeReservation:
             from_tx_hash=bytes(32),
             current_block=1000,
             reserved_until=1100,
-            observed_confirmations=0,
             extension_count=0,
             pending=w.fetch_pending_reservation(MINER),
         )
@@ -141,7 +136,6 @@ class TestMaybeProposeReservation:
             from_tx_hash=bytes(32),
             current_block=1000,
             reserved_until=1050,
-            observed_confirmations=0,
             extension_count=0,
             pending=w.fetch_pending_reservation(MINER),
         )
@@ -158,7 +152,6 @@ class TestMaybeProposeReservation:
             from_tx_hash=bytes(32),
             current_block=1000,
             reserved_until=1005,
-            observed_confirmations=0,
             extension_count=0,
             pending=w.fetch_pending_reservation(MINER),
         )
@@ -176,7 +169,6 @@ class TestMaybeChallengeReservation:
         result = w.maybe_challenge_reservation(
             miner_hotkey=MINER,
             from_chain_id='btc',
-            observed_confirmations=1,
             current_block=1000,
             reserved_until=1100,
             pending=w.fetch_pending_reservation(MINER),
@@ -192,7 +184,6 @@ class TestMaybeChallengeReservation:
         result = w.maybe_challenge_reservation(
             miner_hotkey=MINER,
             from_chain_id='btc',
-            observed_confirmations=1,
             current_block=1000,
             reserved_until=1100,
             pending=w.fetch_pending_reservation(MINER),
@@ -205,7 +196,6 @@ class TestMaybeChallengeReservation:
         result = w.maybe_challenge_reservation(
             miner_hotkey=MINER,
             from_chain_id='btc',
-            observed_confirmations=1,
             current_block=1000,
             reserved_until=1100,
             pending=w.fetch_pending_reservation(MINER),
@@ -221,7 +211,6 @@ class TestMaybeChallengeReservation:
         result = w.maybe_challenge_reservation(
             miner_hotkey=MINER,
             from_chain_id='btc',
-            observed_confirmations=1,
             current_block=1000,
             reserved_until=1100,
             pending=w.fetch_pending_reservation(MINER),
@@ -321,7 +310,6 @@ class TestMaybeProposeTimeout:
             dest_chain_id='btc',
             current_block=1000,
             timeout_block=1050,
-            observed_confirmations=0,
             extension_count=0,
             pending=w.fetch_pending_timeout(42),
         )
@@ -338,7 +326,6 @@ class TestMaybeProposeTimeout:
             dest_chain_id='btc',
             current_block=1000,
             timeout_block=1100,
-            observed_confirmations=0,
             extension_count=1,
             pending=w.fetch_pending_timeout(42),
         )
@@ -352,7 +339,6 @@ class TestMaybeProposeTimeout:
             dest_chain_id='btc',
             current_block=1000,
             timeout_block=1100,
-            observed_confirmations=1,
             extension_count=2,
             pending=w.fetch_pending_timeout(42),
         )
@@ -365,7 +351,6 @@ class TestMaybeProposeTimeout:
             dest_chain_id='btc',
             current_block=1000,
             timeout_block=1050,
-            observed_confirmations=0,
             extension_count=0,
             pending=w.fetch_pending_timeout(42),
         )
@@ -381,7 +366,6 @@ class TestMaybeProposeTimeout:
             dest_chain_id='btc',
             current_block=1000,
             timeout_block=1005,
-            observed_confirmations=0,
             extension_count=0,
             pending=w.fetch_pending_timeout(42),
         )
@@ -399,7 +383,6 @@ class TestMaybeChallengeTimeout:
         result = w.maybe_challenge_timeout(
             swap_id=42,
             dest_chain_id='btc',
-            observed_confirmations=1,
             current_block=1000,
             timeout_block=1100,
             pending=w.fetch_pending_timeout(42),
@@ -413,7 +396,6 @@ class TestMaybeChallengeTimeout:
         result = w.maybe_challenge_timeout(
             swap_id=42,
             dest_chain_id='btc',
-            observed_confirmations=1,
             current_block=1000,
             timeout_block=1100,
             pending=w.fetch_pending_timeout(42),

--- a/tests/test_optimistic_extensions.py
+++ b/tests/test_optimistic_extensions.py
@@ -47,9 +47,9 @@ def make_watcher(pending_reservation=None, pending_timeout=None, propose_raises=
 
 
 class TestMaybeProposeReservation:
-    def test_tier0_proposes_on_visibility_with_short_target(self):
-        # Tier 0: BTC blocks_needed=90, anchor=max(current=1000, reserved=1050)=1050,
-        # target=1140.
+    def test_tier0_proposes_on_visibility_with_runway_target(self):
+        # Tier 0: remaining=4 → blocks_needed=240, anchor=max(current=1000,
+        # reserved=1050)=1050, target=1290.
         w = make_watcher(pending_reservation=None)
         result = w.maybe_propose_reservation(
             miner_hotkey=MINER,
@@ -64,11 +64,11 @@ class TestMaybeProposeReservation:
         assert result is True
         call_kwargs = w.contract_client.propose_extend_reservation.call_args.kwargs
         assert call_kwargs['miner_hotkey'] == MINER
-        assert call_kwargs['target_block'] == 1140
+        assert call_kwargs['target_block'] == 1290
 
-    def test_tier1_proposes_with_chain_aware_target(self):
-        # Tier 1: BTC remaining=2 → blocks_needed=150, anchor=max(1000,1100)=1100,
-        # target=1250.
+    def test_tier1_proposes_with_runway_target(self):
+        # Tier 1: remaining=4 (same runway as tier-0), anchor=max(1000,1100)=1100,
+        # target=1340.
         w = make_watcher(pending_reservation=None)
         result = w.maybe_propose_reservation(
             miner_hotkey=MINER,
@@ -81,10 +81,10 @@ class TestMaybeProposeReservation:
             pending=w.fetch_pending_reservation(MINER),
         )
         assert result is True
-        assert w.contract_client.propose_extend_reservation.call_args.kwargs['target_block'] == 1250
+        assert w.contract_client.propose_extend_reservation.call_args.kwargs['target_block'] == 1340
 
-    def test_tier1_skips_when_below_one_confirmation(self):
-        # Tier 1 demands ≥1 confirmation — mempool-only tx is not enough.
+    def test_tier1_proposes_without_confirmations(self):
+        # Tier 1 fires on visibility like tier-0 — no confirmation gate.
         w = make_watcher(pending_reservation=None)
         result = w.maybe_propose_reservation(
             miner_hotkey=MINER,
@@ -96,8 +96,8 @@ class TestMaybeProposeReservation:
             extension_count=1,
             pending=w.fetch_pending_reservation(MINER),
         )
-        assert result is False
-        w.contract_client.propose_extend_reservation.assert_not_called()
+        assert result is True
+        w.contract_client.propose_extend_reservation.assert_called_once()
 
     def test_skips_when_at_extension_cap(self):
         # extension_count=MAX → contract would reject; refuse locally.
@@ -313,8 +313,8 @@ class TestFetchPendingReservation:
 
 class TestMaybeProposeTimeout:
     def test_tier0_proposes_on_visibility(self):
-        # BTC tier-0: blocks_needed=90, anchor=max(current=1000, timeout=1050)=1050,
-        # target=1140.
+        # BTC tier-0: remaining=4 → blocks_needed=240,
+        # anchor=max(current=1000, timeout=1050)=1050, target=1290.
         w = make_watcher(pending_timeout=None)
         result = w.maybe_propose_timeout(
             swap_id=42,
@@ -328,9 +328,10 @@ class TestMaybeProposeTimeout:
         assert result is True
         kwargs = w.contract_client.propose_extend_timeout.call_args.kwargs
         assert kwargs['swap_id'] == 42
-        assert kwargs['target_block'] == 1140
+        assert kwargs['target_block'] == 1290
 
-    def test_tier1_requires_confirmations(self):
+    def test_tier1_proposes_without_confirmations(self):
+        # Tier 1 fires on visibility like tier-0 — no confirmation gate.
         w = make_watcher(pending_timeout=None)
         result = w.maybe_propose_timeout(
             swap_id=42,
@@ -341,7 +342,8 @@ class TestMaybeProposeTimeout:
             extension_count=1,
             pending=w.fetch_pending_timeout(42),
         )
-        assert result is False
+        assert result is True
+        w.contract_client.propose_extend_timeout.assert_called_once()
 
     def test_skips_when_at_cap(self):
         w = make_watcher(pending_timeout=None)


### PR DESCRIPTION
## Problem → Solution

**Problem 1 — tier-0 extension too short for BTC variance**
- BTC block intervals follow a Poisson process; single blocks regularly take 30+ min (https://en.bitcoin.it/wiki/Confirmation: 99.7% chance of a block within 60 min, not guaranteed)
- Observed in prod swap #2: 27-min block → tier-0 expired before first conf arrived → honest miner slashed
- → **Tier-0 `remaining=1 → 4`**. Lands at +240 sub-blocks (~48 min runway from current).

**Problem 2 — tier-1 deadlocks when conf=1 arrives late**
- Tier-1's `confs≥1` gate + 8-block challenge-window guard intersect at zero when BTC polling lags by ≥1 block at the deadline
- → **Drop the evidence gate**. Tier-1 fires on visibility, same as tier-0. Race disappears; tier-1 becomes a tail-of-distribution safety net.

**Problem 3 — `VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE` is 15× more conservative than reality**
- Constant = 20 sub-blocks; measured = ~1.3 sub-blocks/step from production `step=N` logs
- Flows into `EXTEND_THRESHOLD_BLOCKS = ESTIMATE + CHALLENGE_WINDOW_BLOCKS = 18` (was 28)
- → **20 → 10**. Still 7× conservative; trims wasted cycles iterating not-yet-near-deadline swaps.

**Problem 4 — RBF-flagged BTC txs are replaceable post-broadcast**
- Without BIP-125 rejection, a miner could broadcast, secure a tier extension, then RBF the outputs back to themselves
- → **Reject any vin with `sequence < 0xfffffffe`** in both verify paths (RPC + Esplora)

**Problem 5 — Esplora confirmation count doesn't verify canonical chain**
- bitcoind RPC inherently filters orphaned blocks (`confirmations → 0`)
- Esplora API computes `tip_height − block_height + 1` — doesn't check `in_best_chain`
- → **On API path, query `/block/{hash}/status`** and reject if `in_best_chain == false`

**Problem 6 — 3 BTC confs is conservative inertia, not necessity**
- With RBF rejection + canonical-chain check + ~98-min total budget, 2 confs gives ~10× safety margin over 1 conf
- Wiki: 2-conf reorg rate ~0.1% historical; 1-conf ~1%
- → **`min_confirmations: 3 → 2`**

## Anchor fix (commit `0ebace7`)

Originally landed with `compute_extension_target` anchoring on `max(current, deadline)`. Self-review caught that the contract enforces `target_block - current_at_exec ≤ MAX_EXTENSION_BLOCKS = 250` (lib.rs:670, :1090), so `remaining=4` (240 sub-blocks) anchored on deadline produced `target - current ∈ [249, 257]` at propose time — only a 2-block fitting window. Now anchored on current_block only; cap-safe at any propose time, with ~44-46 min runway past the existing deadline.

## Total budget math

| Phase | Duration |
|---|---|
| Initial fulfillment window | ~10 min (contract config) |
| Tier-0 extension | ~44-46 min past prior deadline |
| Tier-1 extension | ~44-46 min past prior deadline |
| **Total** | **~98-102 min** |

Need 2 BTC confs in ~98 min. Time-to-2nd-block ~ Gamma(2, μ):
- Nominal pace (μ=10 min): P(miss) ≈ 0.06%
- Slow pace (μ=13, recent observed): P(miss) ≈ 0.46%
- Pathological (μ=20): P(miss) ≈ 5.6%

Well under the 1% target across reasonable conditions. Sized using https://en.bitcoin.it/wiki/Confirmation.

## Test plan

- [x] `ruff check allways/ neurons/` — clean
- [x] `ruff format --check .` — all formatted
- [x] `pytest tests/` — 411/411 passing locally
- [x] REPL: `compute_extension_target('btc', 4, 1000)` → 1240, delta 240 ≤ 250 cap
- [ ] After merge: pull on lena, restart `aw-vali` container, watch next BTC swap for tier-0 propose at `target_block ≈ current + 240`
