### PR TITLE
log per-round scoring trace so non-earners can self-diagnose

### DIFF
--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -7,7 +7,7 @@ unclaimed pool recycles to ``RECYCLE_UID``. Entry point is
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import IntEnum
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
@@ -27,6 +27,22 @@ from allways.validator.state_store import ValidatorStateStore
 
 if TYPE_CHECKING:
     from neurons.validator import Validator
+
+
+# Per-direction breakdown threaded through replay so log_scoring_trace can
+# explain who held crown, who was outbid, and why pool was recycled.
+@dataclass
+class DirectionTrace:
+    pool: float = 0.0
+    crown_blocks: Dict[str, float] = field(default_factory=dict)
+    unfilled_blocks: int = 0
+    best_rate: float = 0.0  # rate of the winning miner at the last filled interval
+
+
+# Cap non-earner diagnostic lines so a full 256-UID metagraph can't bloat one
+# scoring round into thousands of log lines. Sized to cover all realistically
+# active miners.
+SCORING_TRACE_NON_EARNER_CAP = 30
 
 
 def score_and_reward_miners(self: Validator) -> None:
@@ -99,7 +115,11 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
     credibility_since = max(0, self.block - CREDIBILITY_WINDOW_BLOCKS)
     success_stats = self.state_store.get_success_rates_since(credibility_since)
 
+    direction_traces: Dict[Tuple[str, str], DirectionTrace] = {}
+
     for (from_chain, to_chain), pool in DIRECTION_POOLS.items():
+        trace = DirectionTrace(pool=pool)
+        direction_traces[(from_chain, to_chain)] = trace
         crown_blocks = replay_crown_time_window(
             store=self.state_store,
             event_watcher=self.event_watcher,
@@ -108,6 +128,7 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
             window_start=window_start,
             window_end=window_end,
             rewardable_hotkeys=rewardable_hotkeys,
+            trace=trace,
         )
         total = sum(crown_blocks.values())
         if total == 0:
@@ -123,11 +144,21 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
 
     recycle_uid = RECYCLE_UID if RECYCLE_UID < n_uids else 0
     distributed = float(rewards.sum())
-    rewards[recycle_uid] += max(0.0, 1.0 - distributed)
+    recycled = max(0.0, 1.0 - distributed)
+    rewards[recycle_uid] += recycled
 
-    bt.logging.info(
-        f'V1 scoring: window=[{window_start}, {window_end}], '
-        f'distributed={distributed:.6f}, recycled={max(0.0, 1.0 - distributed):.6f}'
+    log_scoring_trace(
+        self,
+        window_start=window_start,
+        window_end=window_end,
+        hotkey_to_uid=hotkey_to_uid,
+        rewardable_hotkeys=rewardable_hotkeys,
+        direction_traces=direction_traces,
+        rewards=rewards,
+        success_stats=success_stats,
+        distributed=distributed,
+        recycled=recycled,
+        recycle_uid=recycle_uid,
     )
 
     return rewards, set(range(n_uids))
@@ -142,6 +173,124 @@ def success_rate(stats: Optional[Tuple[int, int]]) -> float:
     if total == 0:
         return 1.0
     return completed / total
+
+
+def log_scoring_trace(
+    self: Validator,
+    *,
+    window_start: int,
+    window_end: int,
+    hotkey_to_uid: Dict[str, int],
+    rewardable_hotkeys: Set[str],
+    direction_traces: Dict[Tuple[str, str], DirectionTrace],
+    rewards: np.ndarray,
+    success_stats: Dict[str, Tuple[int, int]],
+    distributed: float,
+    recycled: float,
+    recycle_uid: int,
+) -> None:
+    """Emit one multi-line log entry per scoring round so a miner can answer
+    "why did I earn what I earned" from logs alone — per-direction crown
+    breakdown, per-rewarded UID, per-non-earner reason, recycle attribution."""
+    lines: List[str] = [
+        f'V1 scoring: window=[{window_start}, {window_end}], distributed={distributed:.6f}, recycled={recycled:.6f}'
+    ]
+
+    for (from_c, to_c), trace in direction_traces.items():
+        sorted_holders = sorted(trace.crown_blocks.items(), key=lambda kv: -kv[1])
+        holders_str = ', '.join(
+            f'UID{hotkey_to_uid[hk]}: {blk:.0f} blk' for hk, blk in sorted_holders if hk in hotkey_to_uid
+        )
+        lines.append(
+            f'  [{from_c}→{to_c}] pool={trace.pool:g} holders={{{holders_str}}} unfilled={trace.unfilled_blocks} blk'
+        )
+
+    earner_uids = sorted(
+        (uid for uid in range(len(rewards)) if rewards[uid] > 0),
+        key=lambda u: -float(rewards[u]),
+    )
+    for uid in earner_uids:
+        hk = self.metagraph.hotkeys[uid]
+        crown_blk = sum(t.crown_blocks.get(hk, 0.0) for t in direction_traces.values())
+        # UID 53's reward equals (crown earnings) + (recycle remainder). The
+        # recycle line below attributes the remainder separately.
+        if uid == recycle_uid and crown_blk == 0:
+            continue
+        sr = success_rate(success_stats.get(hk))
+        lines.append(
+            f'  uid={uid} hotkey={hk[:8]}.. crown_blk={crown_blk:.0f} sr={sr:.3f} reward={float(rewards[uid]):.3f}'
+        )
+
+    ever_active: Set[str] = set(self.event_watcher.get_active_miners_at(window_start))
+    for e in self.event_watcher.get_active_events_in_range(window_start, window_end):
+        if e['active']:
+            ever_active.add(e['hotkey'])
+
+    last_known_rates = getattr(self, 'last_known_rates', {}) or {}
+    rates_by_hotkey: Dict[str, Dict[Tuple[str, str], float]] = {}
+    for (hk, from_c, to_c), r in last_known_rates.items():
+        if r > 0:
+            rates_by_hotkey.setdefault(hk, {})[(from_c, to_c)] = r
+
+    non_earner_lines: List[str] = []
+    for hk in rewardable_hotkeys:
+        uid = hotkey_to_uid.get(hk)
+        if uid is None or uid == recycle_uid:
+            continue
+        if rewards[uid] > 0:
+            continue
+        latest_rates = rates_by_hotkey.get(hk, {})
+        # Skip dormant UIDs: no rate posted AND never active in window. Those
+        # are usually never-onboarded slots and would drown out the diagnostic.
+        if not latest_rates and hk not in ever_active:
+            continue
+        sr = success_rate(success_stats.get(hk))
+        reason = diagnose_non_earner(hk, latest_rates, sr, ever_active, direction_traces)
+        non_earner_lines.append(f'  uid={uid} hotkey={hk[:8]}.. crown_blk=0 reason="{reason}" sr={sr:.3f}')
+        if len(non_earner_lines) >= SCORING_TRACE_NON_EARNER_CAP:
+            break
+
+    lines.extend(non_earner_lines)
+
+    if recycled > 0:
+        unfilled_parts = [
+            f'{trace.unfilled_blocks} unfilled blk in {f}→{t}'
+            for (f, t), trace in direction_traces.items()
+            if trace.unfilled_blocks > 0
+        ]
+        cause = '; '.join(unfilled_parts) if unfilled_parts else 'no crown winners'
+        lines.append(f'  recycled={recycled:.3f} → UID{recycle_uid} (subnet owner) cause={cause}')
+
+    bt.logging.info('\n'.join(lines))
+
+
+def diagnose_non_earner(
+    hotkey: str,
+    latest_rates: Dict[Tuple[str, str], float],
+    sr: float,
+    ever_active: Set[str],
+    direction_traces: Dict[Tuple[str, str], DirectionTrace],
+) -> str:
+    """One of: no_rate_posted, not_active_during_window, slashed_credibility_zero,
+    outbid(...). Reasons are evaluated in disqualification order so the
+    earliest failing check wins."""
+    if not latest_rates:
+        return 'no_rate_posted'
+    if hotkey not in ever_active:
+        return 'not_active_during_window'
+    if sr <= 0:
+        return 'slashed_credibility_zero'
+    parts: List[str] = []
+    for direction, own in latest_rates.items():
+        trace = direction_traces.get(direction)
+        best = trace.best_rate if trace is not None else 0.0
+        if best > 0:
+            parts.append(f'{direction[0]}→{direction[1]}: own={own:g} vs best={best:g}')
+    if parts:
+        return 'outbid (' + '; '.join(parts) + ')'
+    # Has rates and was active but no direction had a competing winner —
+    # usually the qualifying-but-only-direction edge case.
+    return 'no_competition_in_posted_directions'
 
 
 # ─── Crown-time replay ───────────────────────────────────────────────────
@@ -236,6 +385,7 @@ def replay_crown_time_window(
     window_start: int,
     window_end: int,
     rewardable_hotkeys: Set[str],
+    trace: Optional[DirectionTrace] = None,
 ) -> Dict[str, float]:
     """Walk the merged event stream, return ``{hotkey: crown_blocks_float}``.
     Ties at the same rate split credit evenly. A miner qualifies for crown
@@ -244,7 +394,11 @@ def replay_crown_time_window(
     are evaluated per-block via the replay — a miner's status at scoring
     time is irrelevant other than metagraph membership (used to credit the
     UID). Collateral-floor invariants are trusted to the contract's active
-    flag; halt state is handled at ``score_and_reward_miners`` entry."""
+    flag; halt state is handled at ``score_and_reward_miners`` entry.
+
+    When ``trace`` is supplied, unfilled-interval counts and the latest
+    winning rate are recorded for downstream diagnostic logging.
+    """
     rates, busy_count, active_set = reconstruct_window_start_state(
         store, event_watcher, from_chain, to_chain, window_start, rewardable_hotkeys
     )
@@ -272,7 +426,12 @@ def replay_crown_time_window(
             lower_rate_wins=lower_rate_wins,
         )
         if not holders:
+            if trace is not None:
+                trace.unfilled_blocks += duration
             return
+        winner_rate = rates.get(holders[0], 0.0)
+        if trace is not None and winner_rate > 0:
+            trace.best_rate = winner_rate
         split = duration / len(holders)
         for hk in holders:
             crown_blocks[hk] = crown_blocks.get(hk, 0.0) + split
@@ -298,6 +457,8 @@ def replay_crown_time_window(
         prev_block = event.block
 
     credit_interval(prev_block, window_end)
+    if trace is not None:
+        trace.crown_blocks = dict(crown_blocks)
     return crown_blocks
 
 

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -23,6 +23,7 @@ from allways.constants import (
     SUCCESS_EXPONENT,
 )
 from allways.validator.event_watcher import ContractEventWatcher
+from allways.validator.scoring_trace import log_scoring_trace
 from allways.validator.state_store import ValidatorStateStore
 
 if TYPE_CHECKING:
@@ -106,6 +107,7 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
     rewards = np.zeros(n_uids, dtype=np.float32)
     credibility_since = max(0, self.block - CREDIBILITY_WINDOW_BLOCKS)
     success_stats = self.state_store.get_success_rates_since(credibility_since)
+    success_rates = {hk: success_rate(success_stats.get(hk)) for hk in rewardable_hotkeys}
 
     direction_traces: Dict[Tuple[str, str], DirectionTrace] = {}
 
@@ -131,8 +133,7 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
             if uid is None:
                 continue  # dereg'd mid-window; credit forfeited
             share = blocks / total
-            sr = success_rate(success_stats.get(hotkey))
-            rewards[uid] += pool * share * (sr**SUCCESS_EXPONENT)
+            rewards[uid] += pool * share * (success_rates[hotkey] ** SUCCESS_EXPONENT)
 
     recycle_uid = RECYCLE_UID if RECYCLE_UID < n_uids else 0
     distributed = float(rewards.sum())
@@ -145,7 +146,7 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
         window_end=window_end,
         direction_traces=direction_traces,
         rewards=rewards,
-        success_stats=success_stats,
+        success_rates=success_rates,
         distributed=distributed,
         recycled=recycled,
     )
@@ -162,115 +163,6 @@ def success_rate(stats: Optional[Tuple[int, int]]) -> float:
     if total == 0:
         return 1.0
     return completed / total
-
-
-def log_scoring_trace(
-    self: Validator,
-    *,
-    window_start: int,
-    window_end: int,
-    direction_traces: Dict[Tuple[str, str], DirectionTrace],
-    rewards: np.ndarray,
-    success_stats: Dict[str, Tuple[int, int]],
-    distributed: float,
-    recycled: float,
-) -> None:
-    hotkeys = self.metagraph.hotkeys
-    recycle_uid = RECYCLE_UID if RECYCLE_UID < len(rewards) else 0
-    hotkey_to_uid = {hk: uid for uid, hk in enumerate(hotkeys)}
-
-    lines = [
-        f'V1 scoring: window=[{window_start}, {window_end}], distributed={distributed:.6f}, recycled={recycled:.6f}'
-    ]
-
-    for (from_c, to_c), trace in direction_traces.items():
-        holders = ', '.join(
-            f'UID{hotkey_to_uid[hk]}: {blk:.0f} blk'
-            for hk, blk in sorted(trace.crown_blocks.items(), key=lambda kv: -kv[1])
-            if hk in hotkey_to_uid
-        )
-        lines.append(
-            f'  [{from_c}→{to_c}] pool={trace.pool:g} holders={{{holders}}} unfilled={trace.unfilled_blocks} blk'
-        )
-
-    for uid in sorted((u for u in range(len(rewards)) if rewards[u] > 0), key=lambda u: -float(rewards[u])):
-        hk = hotkeys[uid]
-        crown_blk = sum(t.crown_blocks.get(hk, 0.0) for t in direction_traces.values())
-        if uid == recycle_uid and crown_blk == 0:
-            continue
-        crown_reward = float(rewards[uid]) - (recycled if uid == recycle_uid else 0.0)
-        sr = success_rate(success_stats.get(hk))
-        lines.append(f'  uid={uid} hotkey={hk[:8]}.. crown_blk={crown_blk:.0f} sr={sr:.3f} reward={crown_reward:.3f}')
-
-    lines.extend(
-        non_earner_lines(self, window_start, window_end, rewards, success_stats, direction_traces, recycle_uid)
-    )
-
-    if recycled > 0:
-        parts = [
-            f'{t.unfilled_blocks} unfilled blk in {f}→{to}'
-            for (f, to), t in direction_traces.items()
-            if t.unfilled_blocks > 0
-        ]
-        cause = '; '.join(parts) or 'no crown winners'
-        lines.append(f'  recycled={recycled:.3f} → UID{recycle_uid} (subnet owner) cause={cause}')
-
-    bt.logging.info('\n'.join(lines))
-
-
-def non_earner_lines(
-    self: Validator,
-    window_start: int,
-    window_end: int,
-    rewards: np.ndarray,
-    success_stats: Dict[str, Tuple[int, int]],
-    direction_traces: Dict[Tuple[str, str], DirectionTrace],
-    recycle_uid: int,
-) -> List[str]:
-    ever_active = set(self.event_watcher.get_active_miners_at(window_start))
-    for e in self.event_watcher.get_active_events_in_range(window_start, window_end):
-        if e['active']:
-            ever_active.add(e['hotkey'])
-
-    rates_by_hotkey: Dict[str, Dict[Tuple[str, str], float]] = {}
-    for (hk, from_c, to_c), r in (getattr(self, 'last_known_rates', {}) or {}).items():
-        if r > 0:
-            rates_by_hotkey.setdefault(hk, {})[(from_c, to_c)] = r
-
-    out: List[str] = []
-    for uid, hk in enumerate(self.metagraph.hotkeys):
-        if uid == recycle_uid or rewards[uid] > 0:
-            continue
-        latest_rates = rates_by_hotkey.get(hk, {})
-        if not latest_rates and hk not in ever_active:
-            continue
-        sr = success_rate(success_stats.get(hk))
-        reason = diagnose_non_earner(hk, latest_rates, sr, ever_active, direction_traces)
-        out.append(f'  uid={uid} hotkey={hk[:8]}.. crown_blk=0 reason="{reason}" sr={sr:.3f}')
-        if len(out) >= 30:
-            break
-    return out
-
-
-def diagnose_non_earner(
-    hotkey: str,
-    latest_rates: Dict[Tuple[str, str], float],
-    sr: float,
-    ever_active: Set[str],
-    direction_traces: Dict[Tuple[str, str], DirectionTrace],
-) -> str:
-    if not latest_rates:
-        return 'no_rate_posted'
-    if hotkey not in ever_active:
-        return 'not_active_during_window'
-    if sr <= 0:
-        return 'slashed_credibility_zero'
-    parts = [
-        f'{direction[0]}→{direction[1]}: own={own:g} vs best={direction_traces[direction].best_rate:g}'
-        for direction, own in latest_rates.items()
-        if direction in direction_traces and direction_traces[direction].best_rate > 0
-    ]
-    return 'outbid (' + '; '.join(parts) + ')' if parts else 'no_competing_winner'
 
 
 # ─── Crown-time replay ───────────────────────────────────────────────────

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -143,14 +143,11 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
         self,
         window_start=window_start,
         window_end=window_end,
-        hotkey_to_uid=hotkey_to_uid,
-        rewardable_hotkeys=rewardable_hotkeys,
         direction_traces=direction_traces,
         rewards=rewards,
         success_stats=success_stats,
         distributed=distributed,
         recycled=recycled,
-        recycle_uid=recycle_uid,
     )
 
     return rewards, set(range(n_uids))
@@ -172,15 +169,16 @@ def log_scoring_trace(
     *,
     window_start: int,
     window_end: int,
-    hotkey_to_uid: Dict[str, int],
-    rewardable_hotkeys: Set[str],
     direction_traces: Dict[Tuple[str, str], DirectionTrace],
     rewards: np.ndarray,
     success_stats: Dict[str, Tuple[int, int]],
     distributed: float,
     recycled: float,
-    recycle_uid: int,
 ) -> None:
+    hotkeys = self.metagraph.hotkeys
+    recycle_uid = RECYCLE_UID if RECYCLE_UID < len(rewards) else 0
+    hotkey_to_uid = {hk: uid for uid, hk in enumerate(hotkeys)}
+
     lines = [
         f'V1 scoring: window=[{window_start}, {window_end}], distributed={distributed:.6f}, recycled={recycled:.6f}'
     ]
@@ -196,38 +194,17 @@ def log_scoring_trace(
         )
 
     for uid in sorted((u for u in range(len(rewards)) if rewards[u] > 0), key=lambda u: -float(rewards[u])):
-        hk = self.metagraph.hotkeys[uid]
+        hk = hotkeys[uid]
         crown_blk = sum(t.crown_blocks.get(hk, 0.0) for t in direction_traces.values())
         if uid == recycle_uid and crown_blk == 0:
             continue
-        own_reward = float(rewards[uid]) - (recycled if uid == recycle_uid else 0.0)
+        crown_reward = float(rewards[uid]) - (recycled if uid == recycle_uid else 0.0)
         sr = success_rate(success_stats.get(hk))
-        lines.append(f'  uid={uid} hotkey={hk[:8]}.. crown_blk={crown_blk:.0f} sr={sr:.3f} reward={own_reward:.3f}')
+        lines.append(f'  uid={uid} hotkey={hk[:8]}.. crown_blk={crown_blk:.0f} sr={sr:.3f} reward={crown_reward:.3f}')
 
-    ever_active = set(self.event_watcher.get_active_miners_at(window_start))
-    for e in self.event_watcher.get_active_events_in_range(window_start, window_end):
-        if e['active']:
-            ever_active.add(e['hotkey'])
-
-    rates_by_hotkey: Dict[str, Dict[Tuple[str, str], float]] = {}
-    for (hk, from_c, to_c), r in (getattr(self, 'last_known_rates', {}) or {}).items():
-        if r > 0:
-            rates_by_hotkey.setdefault(hk, {})[(from_c, to_c)] = r
-
-    emitted = 0
-    for hk in rewardable_hotkeys:
-        uid = hotkey_to_uid.get(hk)
-        if uid is None or uid == recycle_uid or rewards[uid] > 0:
-            continue
-        latest_rates = rates_by_hotkey.get(hk, {})
-        if not latest_rates and hk not in ever_active:
-            continue
-        sr = success_rate(success_stats.get(hk))
-        reason = diagnose_non_earner(hk, latest_rates, sr, ever_active, direction_traces)
-        lines.append(f'  uid={uid} hotkey={hk[:8]}.. crown_blk=0 reason="{reason}" sr={sr:.3f}')
-        emitted += 1
-        if emitted >= 30:
-            break
+    lines.extend(
+        non_earner_lines(self, window_start, window_end, rewards, success_stats, direction_traces, recycle_uid)
+    )
 
     if recycled > 0:
         parts = [
@@ -239,6 +216,40 @@ def log_scoring_trace(
         lines.append(f'  recycled={recycled:.3f} → UID{recycle_uid} (subnet owner) cause={cause}')
 
     bt.logging.info('\n'.join(lines))
+
+
+def non_earner_lines(
+    self: Validator,
+    window_start: int,
+    window_end: int,
+    rewards: np.ndarray,
+    success_stats: Dict[str, Tuple[int, int]],
+    direction_traces: Dict[Tuple[str, str], DirectionTrace],
+    recycle_uid: int,
+) -> List[str]:
+    ever_active = set(self.event_watcher.get_active_miners_at(window_start))
+    for e in self.event_watcher.get_active_events_in_range(window_start, window_end):
+        if e['active']:
+            ever_active.add(e['hotkey'])
+
+    rates_by_hotkey: Dict[str, Dict[Tuple[str, str], float]] = {}
+    for (hk, from_c, to_c), r in (getattr(self, 'last_known_rates', {}) or {}).items():
+        if r > 0:
+            rates_by_hotkey.setdefault(hk, {})[(from_c, to_c)] = r
+
+    out: List[str] = []
+    for uid, hk in enumerate(self.metagraph.hotkeys):
+        if uid == recycle_uid or rewards[uid] > 0:
+            continue
+        latest_rates = rates_by_hotkey.get(hk, {})
+        if not latest_rates and hk not in ever_active:
+            continue
+        sr = success_rate(success_stats.get(hk))
+        reason = diagnose_non_earner(hk, latest_rates, sr, ever_active, direction_traces)
+        out.append(f'  uid={uid} hotkey={hk[:8]}.. crown_blk=0 reason="{reason}" sr={sr:.3f}')
+        if len(out) >= 30:
+            break
+    return out
 
 
 def diagnose_non_earner(

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -29,20 +29,12 @@ if TYPE_CHECKING:
     from neurons.validator import Validator
 
 
-# Per-direction breakdown threaded through replay so log_scoring_trace can
-# explain who held crown, who was outbid, and why pool was recycled.
 @dataclass
 class DirectionTrace:
     pool: float = 0.0
     crown_blocks: Dict[str, float] = field(default_factory=dict)
     unfilled_blocks: int = 0
-    best_rate: float = 0.0  # rate of the winning miner at the last filled interval
-
-
-# Cap non-earner diagnostic lines so a full 256-UID metagraph can't bloat one
-# scoring round into thousands of log lines. Sized to cover all realistically
-# active miners.
-SCORING_TRACE_NON_EARNER_CAP = 30
+    best_rate: float = 0.0
 
 
 def score_and_reward_miners(self: Validator) -> None:
@@ -189,76 +181,61 @@ def log_scoring_trace(
     recycled: float,
     recycle_uid: int,
 ) -> None:
-    """Emit one multi-line log entry per scoring round so a miner can answer
-    "why did I earn what I earned" from logs alone — per-direction crown
-    breakdown, per-rewarded UID, per-non-earner reason, recycle attribution."""
-    lines: List[str] = [
+    lines = [
         f'V1 scoring: window=[{window_start}, {window_end}], distributed={distributed:.6f}, recycled={recycled:.6f}'
     ]
 
     for (from_c, to_c), trace in direction_traces.items():
-        sorted_holders = sorted(trace.crown_blocks.items(), key=lambda kv: -kv[1])
-        holders_str = ', '.join(
-            f'UID{hotkey_to_uid[hk]}: {blk:.0f} blk' for hk, blk in sorted_holders if hk in hotkey_to_uid
+        holders = ', '.join(
+            f'UID{hotkey_to_uid[hk]}: {blk:.0f} blk'
+            for hk, blk in sorted(trace.crown_blocks.items(), key=lambda kv: -kv[1])
+            if hk in hotkey_to_uid
         )
         lines.append(
-            f'  [{from_c}→{to_c}] pool={trace.pool:g} holders={{{holders_str}}} unfilled={trace.unfilled_blocks} blk'
+            f'  [{from_c}→{to_c}] pool={trace.pool:g} holders={{{holders}}} unfilled={trace.unfilled_blocks} blk'
         )
 
-    earner_uids = sorted(
-        (uid for uid in range(len(rewards)) if rewards[uid] > 0),
-        key=lambda u: -float(rewards[u]),
-    )
-    for uid in earner_uids:
+    for uid in sorted((u for u in range(len(rewards)) if rewards[u] > 0), key=lambda u: -float(rewards[u])):
         hk = self.metagraph.hotkeys[uid]
         crown_blk = sum(t.crown_blocks.get(hk, 0.0) for t in direction_traces.values())
-        # UID 53's reward equals (crown earnings) + (recycle remainder). The
-        # recycle line below attributes the remainder separately.
         if uid == recycle_uid and crown_blk == 0:
             continue
+        own_reward = float(rewards[uid]) - (recycled if uid == recycle_uid else 0.0)
         sr = success_rate(success_stats.get(hk))
-        lines.append(
-            f'  uid={uid} hotkey={hk[:8]}.. crown_blk={crown_blk:.0f} sr={sr:.3f} reward={float(rewards[uid]):.3f}'
-        )
+        lines.append(f'  uid={uid} hotkey={hk[:8]}.. crown_blk={crown_blk:.0f} sr={sr:.3f} reward={own_reward:.3f}')
 
-    ever_active: Set[str] = set(self.event_watcher.get_active_miners_at(window_start))
+    ever_active = set(self.event_watcher.get_active_miners_at(window_start))
     for e in self.event_watcher.get_active_events_in_range(window_start, window_end):
         if e['active']:
             ever_active.add(e['hotkey'])
 
-    last_known_rates = getattr(self, 'last_known_rates', {}) or {}
     rates_by_hotkey: Dict[str, Dict[Tuple[str, str], float]] = {}
-    for (hk, from_c, to_c), r in last_known_rates.items():
+    for (hk, from_c, to_c), r in (getattr(self, 'last_known_rates', {}) or {}).items():
         if r > 0:
             rates_by_hotkey.setdefault(hk, {})[(from_c, to_c)] = r
 
-    non_earner_lines: List[str] = []
+    emitted = 0
     for hk in rewardable_hotkeys:
         uid = hotkey_to_uid.get(hk)
-        if uid is None or uid == recycle_uid:
-            continue
-        if rewards[uid] > 0:
+        if uid is None or uid == recycle_uid or rewards[uid] > 0:
             continue
         latest_rates = rates_by_hotkey.get(hk, {})
-        # Skip dormant UIDs: no rate posted AND never active in window. Those
-        # are usually never-onboarded slots and would drown out the diagnostic.
         if not latest_rates and hk not in ever_active:
             continue
         sr = success_rate(success_stats.get(hk))
         reason = diagnose_non_earner(hk, latest_rates, sr, ever_active, direction_traces)
-        non_earner_lines.append(f'  uid={uid} hotkey={hk[:8]}.. crown_blk=0 reason="{reason}" sr={sr:.3f}')
-        if len(non_earner_lines) >= SCORING_TRACE_NON_EARNER_CAP:
+        lines.append(f'  uid={uid} hotkey={hk[:8]}.. crown_blk=0 reason="{reason}" sr={sr:.3f}')
+        emitted += 1
+        if emitted >= 30:
             break
 
-    lines.extend(non_earner_lines)
-
     if recycled > 0:
-        unfilled_parts = [
-            f'{trace.unfilled_blocks} unfilled blk in {f}→{t}'
-            for (f, t), trace in direction_traces.items()
-            if trace.unfilled_blocks > 0
+        parts = [
+            f'{t.unfilled_blocks} unfilled blk in {f}→{to}'
+            for (f, to), t in direction_traces.items()
+            if t.unfilled_blocks > 0
         ]
-        cause = '; '.join(unfilled_parts) if unfilled_parts else 'no crown winners'
+        cause = '; '.join(parts) or 'no crown winners'
         lines.append(f'  recycled={recycled:.3f} → UID{recycle_uid} (subnet owner) cause={cause}')
 
     bt.logging.info('\n'.join(lines))
@@ -271,26 +248,18 @@ def diagnose_non_earner(
     ever_active: Set[str],
     direction_traces: Dict[Tuple[str, str], DirectionTrace],
 ) -> str:
-    """One of: no_rate_posted, not_active_during_window, slashed_credibility_zero,
-    outbid(...). Reasons are evaluated in disqualification order so the
-    earliest failing check wins."""
     if not latest_rates:
         return 'no_rate_posted'
     if hotkey not in ever_active:
         return 'not_active_during_window'
     if sr <= 0:
         return 'slashed_credibility_zero'
-    parts: List[str] = []
-    for direction, own in latest_rates.items():
-        trace = direction_traces.get(direction)
-        best = trace.best_rate if trace is not None else 0.0
-        if best > 0:
-            parts.append(f'{direction[0]}→{direction[1]}: own={own:g} vs best={best:g}')
-    if parts:
-        return 'outbid (' + '; '.join(parts) + ')'
-    # Has rates and was active but no direction had a competing winner —
-    # usually the qualifying-but-only-direction edge case.
-    return 'no_competition_in_posted_directions'
+    parts = [
+        f'{direction[0]}→{direction[1]}: own={own:g} vs best={direction_traces[direction].best_rate:g}'
+        for direction, own in latest_rates.items()
+        if direction in direction_traces and direction_traces[direction].best_rate > 0
+    ]
+    return 'outbid (' + '; '.join(parts) + ')' if parts else 'no_competing_winner'
 
 
 # ─── Crown-time replay ───────────────────────────────────────────────────
@@ -394,11 +363,7 @@ def replay_crown_time_window(
     are evaluated per-block via the replay — a miner's status at scoring
     time is irrelevant other than metagraph membership (used to credit the
     UID). Collateral-floor invariants are trusted to the contract's active
-    flag; halt state is handled at ``score_and_reward_miners`` entry.
-
-    When ``trace`` is supplied, unfilled-interval counts and the latest
-    winning rate are recorded for downstream diagnostic logging.
-    """
+    flag; halt state is handled at ``score_and_reward_miners`` entry."""
     rates, busy_count, active_set = reconstruct_window_start_state(
         store, event_watcher, from_chain, to_chain, window_start, rewardable_hotkeys
     )

--- a/allways/validator/scoring_trace.py
+++ b/allways/validator/scoring_trace.py
@@ -1,0 +1,128 @@
+"""Per-round scoring log block: how the pool was distributed, who held
+crown, why each non-earner earned nothing, why pool recycled. Pure
+presentation — never mutates state."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, List, Set, Tuple
+
+import bittensor as bt
+import numpy as np
+
+from allways.constants import RECYCLE_UID
+
+if TYPE_CHECKING:
+    from allways.validator.scoring import DirectionTrace
+    from neurons.validator import Validator
+
+
+NON_EARNER_LINE_CAP = 30
+
+
+def log_scoring_trace(
+    self: Validator,
+    *,
+    window_start: int,
+    window_end: int,
+    direction_traces: Dict[Tuple[str, str], DirectionTrace],
+    rewards: np.ndarray,
+    success_rates: Dict[str, float],
+    distributed: float,
+    recycled: float,
+) -> None:
+    hotkeys = self.metagraph.hotkeys
+    recycle_uid = RECYCLE_UID if RECYCLE_UID < len(rewards) else 0
+    hotkey_to_uid = {hk: uid for uid, hk in enumerate(hotkeys)}
+
+    lines = [
+        f'V1 scoring: window=[{window_start}, {window_end}], distributed={distributed:.6f}, recycled={recycled:.6f}'
+    ]
+
+    for (from_c, to_c), trace in direction_traces.items():
+        holders = ', '.join(
+            f'UID{hotkey_to_uid[hk]}: {blk:.0f} blk'
+            for hk, blk in sorted(trace.crown_blocks.items(), key=lambda kv: -kv[1])
+            if hk in hotkey_to_uid
+        )
+        lines.append(
+            f'  [{from_c}→{to_c}] pool={trace.pool:g} holders={{{holders}}} unfilled={trace.unfilled_blocks} blk'
+        )
+
+    for uid in sorted((u for u in range(len(rewards)) if rewards[u] > 0), key=lambda u: -float(rewards[u])):
+        hk = hotkeys[uid]
+        crown_blk = sum(t.crown_blocks.get(hk, 0.0) for t in direction_traces.values())
+        if uid == recycle_uid and crown_blk == 0:
+            continue
+        crown_reward = float(rewards[uid]) - (recycled if uid == recycle_uid else 0.0)
+        sr = success_rates.get(hk, 1.0)
+        lines.append(f'  uid={uid} hotkey={hk[:8]}.. crown_blk={crown_blk:.0f} sr={sr:.3f} reward={crown_reward:.3f}')
+
+    lines.extend(
+        non_earner_lines(self, window_start, window_end, rewards, success_rates, direction_traces, recycle_uid)
+    )
+
+    if recycled > 0:
+        parts = [
+            f'{t.unfilled_blocks} unfilled blk in {f}→{to}'
+            for (f, to), t in direction_traces.items()
+            if t.unfilled_blocks > 0
+        ]
+        cause = '; '.join(parts) or 'no crown winners'
+        lines.append(f'  recycled={recycled:.3f} → UID{recycle_uid} (subnet owner) cause={cause}')
+
+    bt.logging.info('\n'.join(lines))
+
+
+def non_earner_lines(
+    self: Validator,
+    window_start: int,
+    window_end: int,
+    rewards: np.ndarray,
+    success_rates: Dict[str, float],
+    direction_traces: Dict[Tuple[str, str], DirectionTrace],
+    recycle_uid: int,
+) -> List[str]:
+    ever_active = set(self.event_watcher.get_active_miners_at(window_start))
+    for e in self.event_watcher.get_active_events_in_range(window_start, window_end):
+        if e['active']:
+            ever_active.add(e['hotkey'])
+
+    rates_by_hotkey: Dict[str, Dict[Tuple[str, str], float]] = {}
+    for (hk, from_c, to_c), r in (getattr(self, 'last_known_rates', {}) or {}).items():
+        if r > 0:
+            rates_by_hotkey.setdefault(hk, {})[(from_c, to_c)] = r
+
+    out: List[str] = []
+    for uid, hk in enumerate(self.metagraph.hotkeys):
+        if uid == recycle_uid or rewards[uid] > 0:
+            continue
+        latest_rates = rates_by_hotkey.get(hk, {})
+        if not latest_rates and hk not in ever_active:
+            continue
+        sr = success_rates.get(hk, 1.0)
+        reason = diagnose_non_earner(hk, latest_rates, sr, ever_active, direction_traces)
+        out.append(f'  uid={uid} hotkey={hk[:8]}.. crown_blk=0 reason="{reason}" sr={sr:.3f}')
+        if len(out) >= NON_EARNER_LINE_CAP:
+            break
+    return out
+
+
+def diagnose_non_earner(
+    hotkey: str,
+    latest_rates: Dict[Tuple[str, str], float],
+    sr: float,
+    ever_active: Set[str],
+    direction_traces: Dict[Tuple[str, str], DirectionTrace],
+) -> str:
+    if not latest_rates:
+        return 'no_rate_posted'
+    if hotkey not in ever_active:
+        return 'not_active_during_window'
+    if sr <= 0:
+        return 'slashed_credibility_zero'
+    parts = [
+        f'{direction[0]}→{direction[1]}: own={own:g} vs best={direction_traces[direction].best_rate:g}'
+        for direction, own in latest_rates.items()
+        if direction in direction_traces and direction_traces[direction].best_rate > 0
+    ]
+    return 'outbid (' + '; '.join(parts) + ')' if parts else 'no_competing_winner'


### PR DESCRIPTION
## Why

Today the only scoring log line is
`V1 scoring: window=[X, Y], distributed=Z, recycled=W`.

When a miner asks *"why didn't I earn anything?"* the answer requires
reconstructing the round by hand from the events DB. Recent example: a
new miner saw 100% of his weight share go to UID 53 (recycle) + UID 136
and asked what he'd done wrong. The answer (outbid in both directions,
50% success rate from a prior timeout) was extractable but not from logs.

## What

Adds a single multi-line `bt.logging.info` entry per scoring round:

```
V1 scoring: window=[8168612, 8169812], distributed=0.850, recycled=0.150
  [btc→tao] pool=0.5 holders={UID136: 1200 blk} unfilled=0 blk
  [tao→btc] pool=0.5 holders={UID60: 62 blk, UID136: 779 blk} unfilled=359 blk
  uid=136 hotkey=5EZMAK8i.. crown_blk=1979 sr=1.000 reward=0.799
  uid=60  hotkey=5Hj2J1u9.. crown_blk=62   sr=1.000 reward=0.052
  uid=189 hotkey=5EvkLKgQ.. crown_blk=0 reason="outbid (btc→tao: own=209.08 vs best=255; tao→btc: own=313.63 vs best=255)" sr=0.500
  recycled=0.150 → UID53 (subnet owner) cause=359 unfilled blk in tao→btc
```

Reasons emitted in disqualification order: `no_rate_posted`,
`not_active_during_window`, `slashed_credibility_zero`, `outbid(...)`,
`no_competition_in_posted_directions`.

Non-earner lines capped at 30 to keep a full 256-UID metagraph from
bloating one round; truly dormant UIDs (no rate posted *and* never
active in the window) are skipped so the diagnostic stays focused on
miners actually trying to compete.

## How

- New `DirectionTrace` dataclass holds per-direction crown blocks,
  unfilled-interval count, and last winning rate.
- `replay_crown_time_window` takes an optional `trace` kwarg; default
  None preserves the existing single-return-value contract used by
  every existing test.
- `calculate_miner_rewards` allocates one trace per direction and
  passes them to `log_scoring_trace`, which renders the block above.
- `diagnose_non_earner` evaluates the four standard reasons against
  the per-hotkey rate snapshot (`Validator.last_known_rates`) and the
  ever-active set reconstructed from `event_watcher` events.

## Test plan
- [x] `pytest tests/` → 411 passed
- [x] `ruff format && ruff check` clean
- [ ] Verify on lena after merge: tail `aw-vali` logs at the next
      scoring round and confirm the trace lines appear

## Notes
- Single multi-line log entry per round (as discussed) so it's one
  atomic log message; each line is self-prefixed (`uid=`, `[btc→tao]`,
  `recycled=`) so log aggregators that split on newlines still keep
  per-line context.
- If we ever want this on the dashboard, the `DirectionTrace` +
  per-uid summary is the natural payload to persist to a
  `scoring_rounds` table — but no DB work in this PR.