### PR TITLE
bump pyproject.toml to 1.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "allways"
-version = "1.0.1"
+version = "1.0.2"
 description = "Allways - Universal Transaction Layer: Trustless cross-chain swaps on Bittensor Subnet 7"
 license = "MIT"
 requires-python = ">=3.10,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "allways"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "base58" },


### PR DESCRIPTION
## Why

`allways/__init__.py` was bumped to `1.0.2` in #317 but `pyproject.toml`
was left at `1.0.1`. Aligning the two before cutting the v1.0.2 release.

## Verification

```
$ grep -rn "1\.0\.[12]" pyproject.toml allways/__init__.py
pyproject.toml:3:version = "1.0.2"
allways/__init__.py:1:__version__ = '1.0.2'
```

Smart-contract `Cargo.toml` stays at `1.0.0` — the contract is deployed
immutable and its source wasn't touched in this release cycle.