### PR TITLE
fix: persist validator+miner state across container restarts

### DIFF
--- a/docker-compose.miner.yml
+++ b/docker-compose.miner.yml
@@ -10,6 +10,7 @@ services:
       - "${PORT}:${PORT}"
     volumes:
       - ${WALLET_PATH}:/root/.bittensor/wallets:ro
+      - ./data/allways:/root/.allways
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
 

--- a/docker-compose.vali.yml
+++ b/docker-compose.vali.yml
@@ -11,6 +11,7 @@ services:
       - "${PORT}:${PORT}"
     volumes:
       - ${WALLET_PATH}:/root/.bittensor/wallets:ro
+      - ./data/allways:/root/.allways
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -17,9 +17,11 @@ import bittensor as bt
 from dotenv import load_dotenv
 
 from allways.chain_providers import create_chain_providers
+from allways.commitments import read_miner_commitments
 from allways.constants import (
     DEFAULT_FULFILLMENT_TIMEOUT_BLOCKS,
     FEE_DIVISOR,
+    SCORING_WINDOW_BLOCKS,
 )
 from allways.contract_client import AllwaysContractClient
 from allways.validator.axon_handlers import (
@@ -115,6 +117,7 @@ class Validator(BaseValidatorNeuron):
             metagraph_hotkeys=list(self.metagraph.hotkeys),
             contract_client=self.contract_client,
         )
+        self.bootstrap_miner_rates()
 
         self.swap_tracker = SwapTracker(client=self.contract_client)
         self.swap_tracker.initialize()
@@ -151,6 +154,46 @@ class Validator(BaseValidatorNeuron):
         self.attach_axon_handlers()
 
         bt.logging.info(f'Validator initialized: hotkey={self.wallet.hotkey.ss58_address}')
+
+    def bootstrap_miner_rates(self) -> None:
+        """Cold-start anchor for rate events. Without this, a validator with a
+        fresh state.db (first run, or a container recreate that loses the
+        writable layer) has no rate visible at window_start on the first
+        scoring pass, so every miner reads as 'no rate posted' and the entire
+        pool recycles to RECYCLE_UID. Read current commitments from chain and
+        seed one anchor event per (hotkey, direction) at cursor — mirrors the
+        active-flag anchor that event_watcher.initialize already does."""
+        try:
+            pairs = read_miner_commitments(self.subtensor, self.config.netuid)
+        except Exception as e:
+            bt.logging.warning(f'Rate bootstrap: commitment read failed: {e}')
+            return
+
+        anchor_block = max(0, self.block - SCORING_WINDOW_BLOCKS)
+        current_hotkeys = set(self.metagraph.hotkeys)
+        seeded = 0
+        for pair in pairs:
+            if pair.hotkey not in current_hotkeys:
+                continue
+            for from_c, to_c, r in (
+                (pair.from_chain, pair.to_chain, pair.rate),
+                (pair.to_chain, pair.from_chain, pair.counter_rate),
+            ):
+                if r <= 0:
+                    continue
+                self.last_known_rates[(pair.hotkey, from_c, to_c)] = r
+                existing = self.state_store.get_latest_rate_before(pair.hotkey, from_c, to_c, anchor_block)
+                if existing is None:
+                    self.state_store.insert_rate_event(
+                        hotkey=pair.hotkey,
+                        from_chain=from_c,
+                        to_chain=to_c,
+                        rate=r,
+                        block=anchor_block,
+                    )
+                    seeded += 1
+        if seeded:
+            bt.logging.info(f'Rate bootstrap: seeded {seeded} anchor(s) at block {anchor_block}')
 
     def attach_axon_handlers(self):
         """Attach all synapse handlers to the axon."""


### PR DESCRIPTION
## Why

The validator running on lena tonight lost its entire \`state.db\` when
watchtower pulled the new v1.0.2 image — the writable layer of the old
container was destroyed by \`cleanup=true\`. Result: first post-restart
scoring round routed 100 % of emissions to UID 53 (RECYCLE).

We rely on SQLite persistence for \`rate_events\`, \`swap_outcomes\`,
and \`pending_confirms\`. The code was written assuming \`~/.allways/\`
survives restarts; the deployment config was defeating that.

## What

### 1. Volume mount (deploy fix)

\`docker-compose.{vali,miner}.yml\` were only binding \`~/.bittensor/wallets\`.
Add \`./data/allways:/root/.allways\` so state.db (validator) and
sent_cache / rate-posted flags (miner) survive watchtower-driven
container recreates.

### 2. Rate bootstrap from chain (code fix)

Even with the mount in place, a brand-new validator or one whose
state.db was wiped would still hit the same bug on its first scoring
round — \`reconstruct_window_start_state\` had no rate visible at
\`window_start\`, so every miner read as \"no rate posted\" and the
entire pool recycled.

Add \`Validator.bootstrap_miner_rates()\` (~30 lines) called once after
\`event_watcher.initialize\`. Reads current on-chain commitments and
seeds one anchor rate event per (hotkey, direction) at
\`cursor = current_block − SCORING_WINDOW_BLOCKS\`. Only inserts if no
event already exists at that cursor (idempotent across restarts).
Mirrors the active-flag anchoring \`event_watcher.initialize\` already
does, via a normal contract storage read (no archive node needed).

## Operator action after merge

For existing deployments, after pulling and recreating:

\`\`\`bash
mkdir -p ./data/allways      # next to docker-compose.yml
docker compose up -d         # picks up the new mount
\`\`\`

Subsequent watchtower updates preserve state automatically.

## Test plan
- [x] \`pytest tests/\` → 411 passed
- [x] \`ruff format && ruff check\` clean
- [ ] After deploy, confirm next \`V1 scoring\` round on lena shows non-zero distributed (i.e. UID 136/189 actually credited instead of 100 % recycle)
- [ ] Confirm state.db persists across a manual \`docker compose up -d --force-recreate\`