### PR TITLE
feat: emission scoring — capacity, volume, credibility ramp

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -58,15 +58,9 @@ DIRECTION_POOLS: dict[tuple[str, str], float] = {
 }
 # 100% → 1.0, 90% → 0.729, 80% → 0.512, 50% → 0.125
 SUCCESS_EXPONENT: int = 3
-# Marginal weight on realized volume vs crown share. 0 = no penalty for idle
-# crown (legacy behavior). 1 = pure volume-share emission. 0.5 means a fully-
-# idle crown holder loses half their reward; a fully-participating one keeps
-# all of it.
+# Idle-crown penalty: 0 = none, 1 = pure volume share, 0.5 = half-credit floor.
 VOLUME_WEIGHT_ALPHA: float = 0.5
-# Linear ramp toward full credibility. A miner with zero observed swaps starts
-# at 0% credibility (no benefit of the doubt); credibility rises proportionally
-# with closed swaps and tops out once ``CREDIBILITY_RAMP_OBSERVATIONS`` is hit.
-# Closes the new-miner free-emission hole without adding a hard cliff.
+# Closed swaps required for full credibility (0 → 100% linear ramp).
 CREDIBILITY_RAMP_OBSERVATIONS: int = 10
 
 # ─── Emission Recycling ────────────────────────────────────

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -58,6 +58,11 @@ DIRECTION_POOLS: dict[tuple[str, str], float] = {
 }
 # 100% → 1.0, 90% → 0.729, 80% → 0.512, 50% → 0.125
 SUCCESS_EXPONENT: int = 3
+# Marginal weight on realized volume vs crown share. 0 = no penalty for idle
+# crown (legacy behavior). 1 = pure volume-share emission. 0.5 means a fully-
+# idle crown holder loses half their reward; a fully-participating one keeps
+# all of it.
+VOLUME_WEIGHT_ALPHA: float = 0.5
 
 # ─── Emission Recycling ────────────────────────────────────
 RECYCLE_UID = 53  # Subnet owner UID

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -63,6 +63,11 @@ SUCCESS_EXPONENT: int = 3
 # idle crown holder loses half their reward; a fully-participating one keeps
 # all of it.
 VOLUME_WEIGHT_ALPHA: float = 0.5
+# Linear ramp toward full credibility. A miner with zero observed swaps starts
+# at 0% credibility (no benefit of the doubt); credibility rises proportionally
+# with closed swaps and tops out once ``CREDIBILITY_RAMP_OBSERVATIONS`` is hit.
+# Closes the new-miner free-emission hole without adding a hard cliff.
+CREDIBILITY_RAMP_OBSERVATIONS: int = 10
 
 # ─── Emission Recycling ────────────────────────────────────
 RECYCLE_UID = 53  # Subnet owner UID

--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -430,6 +430,7 @@ class ContractEventWatcher:
                     miner_hotkey=miner,
                     completed=True,
                     resolved_block=block_num,
+                    tao_amount=int(values.get('tao_amount') or 0),
                 )
                 self.apply_busy_delta(block_num, miner, -1)
                 self.bootstrapped_swap_ids.discard(swap_id)

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -1,7 +1,7 @@
 """Crown-time scoring pipeline.
 
-Reward per miner is ``pool * share * success_rate ** SUCCESS_EXPONENT``;
-unclaimed pool recycles to ``RECYCLE_UID``. Entry point is
+Reward per miner is ``pool × crown_share × sr³ × capacity × volume_factor``;
+any shortfall recycles to ``RECYCLE_UID``. Entry point is
 ``score_and_reward_miners(validator)``.
 """
 
@@ -25,7 +25,7 @@ from allways.constants import (
     VOLUME_WEIGHT_ALPHA,
 )
 from allways.validator.event_watcher import ContractEventWatcher
-from allways.validator.scoring_trace import log_scoring_trace
+from allways.validator.scoring_trace import WeightingTrace, log_scoring_trace
 from allways.validator.state_store import ValidatorStateStore
 
 if TYPE_CHECKING:
@@ -38,19 +38,6 @@ class DirectionTrace:
     crown_blocks: Dict[str, float] = field(default_factory=dict)
     unfilled_blocks: int = 0
     best_rate: float = 0.0
-
-
-@dataclass
-class WeightingTrace:
-    """Per-hotkey capacity + volume factors surfaced in the scoring log."""
-
-    collateral: int = 0
-    capacity_factor: float = 1.0
-    volume_rao: int = 0
-    crown_share: float = 0.0
-    volume_share: float = 0.0
-    participation: float = 1.0
-    volume_factor: float = 1.0
 
 
 def score_and_reward_miners(self: Validator) -> None:
@@ -126,7 +113,11 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
 
     direction_traces: Dict[Tuple[str, str], DirectionTrace] = {}
     weighting_traces: Dict[str, WeightingTrace] = {}
-    max_swap_amount = read_max_swap_amount(self)
+    try:
+        max_swap_amount = int(self.bounds_cache.max_swap_amount())
+    except Exception as e:
+        bt.logging.warning(f'max_swap_amount read failed: {e}')
+        max_swap_amount = 0
     collaterals: Dict[str, int] = {}
 
     for (from_chain, to_chain), pool in DIRECTION_POOLS.items():
@@ -151,11 +142,18 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
             if uid is None:
                 continue  # dereg'd mid-window; credit forfeited
             if hotkey not in collaterals:
-                collaterals[hotkey] = read_miner_collateral(self, hotkey)
+                try:
+                    collaterals[hotkey] = int(self.contract_client.get_miner_collateral(hotkey))
+                except Exception as e:
+                    bt.logging.warning(f'collateral read failed for {hotkey[:8]}: {e}')
+                    collaterals[hotkey] = 0
             cap = capacity_factor(collaterals[hotkey], max_swap_amount)
             wt = weighting_traces.setdefault(hotkey, WeightingTrace())
-            wt.collateral = collaterals[hotkey]
-            wt.capacity_factor = cap
+            wt.record_capacity(collateral=collaterals[hotkey], factor=cap)
+            wt.record_credibility(
+                closed_swaps=sum(success_stats.get(hotkey, (0, 0))),
+                ramp_target=CREDIBILITY_RAMP_OBSERVATIONS,
+            )
             share = blocks / total
             rewards[uid] += pool * share * (success_rates[hotkey] ** SUCCESS_EXPONENT) * cap
 
@@ -183,7 +181,6 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
         distributed=distributed,
         recycled=recycled,
         weighting_traces=weighting_traces,
-        success_stats=success_stats,
     )
 
     return rewards, set(range(n_uids))
@@ -198,11 +195,17 @@ def capacity_factor(collateral_rao: int, max_swap_amount_rao: int) -> float:
     return min(1.0, collateral_rao / max_swap_amount_rao)
 
 
-def volume_factor(volume_share: float, crown_share: float, alpha: float = VOLUME_WEIGHT_ALPHA) -> float:
-    """(1-α) + α·min(1, vol_share/crown_share). Cap kills over-serve bonus."""
-    if crown_share <= 0:
+def volume_factor(
+    vol_rao: int,
+    total_volume_rao: int,
+    crown_share: float,
+    alpha: float = VOLUME_WEIGHT_ALPHA,
+) -> float:
+    """(1-α) + α·min(1, vol_share/crown_share). Idle network or no crown → 1.0
+    (no penalty); cap kills any over-serve bonus."""
+    if total_volume_rao <= 0 or crown_share <= 0:
         return 1.0
-    participation = min(1.0, volume_share / crown_share)
+    participation = min(1.0, (vol_rao / total_volume_rao) / crown_share)
     return (1.0 - alpha) + alpha * participation
 
 
@@ -215,8 +218,7 @@ def apply_volume_weighting(
     weighting_traces: Dict[str, WeightingTrace],
     window_start: int,
 ) -> None:
-    """Multiply each crown earner's reward by their volume_factor. Idle
-    network (total_volume == 0) leaves every factor at 1.0."""
+    """Multiply each crown earner's reward by their volume_factor."""
     volumes = self.state_store.get_volume_since(window_start)
     crown_per_hotkey: Dict[str, float] = {}
     for trace in direction_traces.values():
@@ -234,39 +236,14 @@ def apply_volume_weighting(
             continue
         crown_share = crown / total_crown
         vol = volumes.get(hotkey, 0)
-        vol_share = (vol / total_volume) if total_volume > 0 else 0.0
-        factor = volume_factor(vol_share, crown_share) if total_volume > 0 else 1.0
+        factor = volume_factor(vol, total_volume, crown_share)
         rewards[uid] *= factor
-        wt = weighting_traces.setdefault(hotkey, WeightingTrace())
-        wt.volume_rao = vol
-        wt.crown_share = crown_share
-        wt.volume_share = vol_share
-        wt.participation = min(1.0, vol_share / crown_share) if crown_share > 0 else 1.0
-        wt.volume_factor = factor
-
-
-def read_max_swap_amount(self: Validator) -> int:
-    """bounds_cache read; 0 → capacity_factor fail-safes to 1.0."""
-    cache = getattr(self, 'bounds_cache', None)
-    if cache is None:
-        return 0
-    try:
-        return int(cache.max_swap_amount())
-    except Exception as e:
-        bt.logging.warning(f'max_swap_amount read failed: {e}')
-        return 0
-
-
-def read_miner_collateral(self: Validator, hotkey: str) -> int:
-    """contract_client read; 0 on error → capacity_factor = 0 for that miner."""
-    client = getattr(self, 'contract_client', None)
-    if client is None:
-        return 0
-    try:
-        return int(client.get_miner_collateral(hotkey))
-    except Exception as e:
-        bt.logging.warning(f'collateral read failed for {hotkey[:8]}: {e}')
-        return 0
+        weighting_traces.setdefault(hotkey, WeightingTrace()).record_volume(
+            vol_rao=vol,
+            total_volume_rao=total_volume,
+            crown_share=crown_share,
+            factor=factor,
+        )
 
 
 def success_rate(stats: Optional[Tuple[int, int]]) -> float:

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -21,6 +21,7 @@ from allways.constants import (
     RECYCLE_UID,
     SCORING_WINDOW_BLOCKS,
     SUCCESS_EXPONENT,
+    VOLUME_WEIGHT_ALPHA,
 )
 from allways.validator.event_watcher import ContractEventWatcher
 from allways.validator.scoring_trace import log_scoring_trace
@@ -36,6 +37,20 @@ class DirectionTrace:
     crown_blocks: Dict[str, float] = field(default_factory=dict)
     unfilled_blocks: int = 0
     best_rate: float = 0.0
+
+
+@dataclass
+class WeightingTrace:
+    """Per-hotkey capacity + volume factors surfaced into the scoring log so a
+    miner can self-diagnose why their reward < headline crown share."""
+
+    collateral: int = 0
+    capacity_factor: float = 1.0
+    volume_rao: int = 0
+    crown_share: float = 0.0
+    volume_share: float = 0.0
+    participation: float = 1.0
+    volume_factor: float = 1.0
 
 
 def score_and_reward_miners(self: Validator) -> None:
@@ -87,7 +102,16 @@ def prune_swap_outcomes(self: Validator) -> None:
 
 def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
     """Replay the crown-time event stream over the window, derive per-miner
-    rewards, recycle any undistributed pool to ``RECYCLE_UID``."""
+    rewards, recycle any undistributed pool to ``RECYCLE_UID``.
+
+    Reward equation:
+
+        reward_i = Σ_dir (pool_d × crown_share_id × sr_i^SUCCESS_EXPONENT × capacity_i) × volume_factor_i
+
+    Where ``capacity_i = min(1.0, collateral_i / max_swap_amount)`` and
+    ``volume_factor_i = (1-α) + α * min(1.0, vol_share_i / crown_share_i)``.
+    Shortfalls from sr, capacity, and volume all flow to ``RECYCLE_UID``.
+    """
     n_uids = self.metagraph.n.item()
     if n_uids == 0:
         return np.array([], dtype=np.float32), set()
@@ -110,6 +134,9 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
     success_rates = {hk: success_rate(success_stats.get(hk)) for hk in rewardable_hotkeys}
 
     direction_traces: Dict[Tuple[str, str], DirectionTrace] = {}
+    weighting_traces: Dict[str, WeightingTrace] = {}
+    max_swap_amount = read_max_swap_amount(self)
+    collaterals: Dict[str, int] = {}
 
     for (from_chain, to_chain), pool in DIRECTION_POOLS.items():
         trace = DirectionTrace(pool=pool)
@@ -132,8 +159,23 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
             uid = hotkey_to_uid.get(hotkey)
             if uid is None:
                 continue  # dereg'd mid-window; credit forfeited
+            if hotkey not in collaterals:
+                collaterals[hotkey] = read_miner_collateral(self, hotkey)
+            cap = capacity_factor(collaterals[hotkey], max_swap_amount)
+            wt = weighting_traces.setdefault(hotkey, WeightingTrace())
+            wt.collateral = collaterals[hotkey]
+            wt.capacity_factor = cap
             share = blocks / total
-            rewards[uid] += pool * share * (success_rates[hotkey] ** SUCCESS_EXPONENT)
+            rewards[uid] += pool * share * (success_rates[hotkey] ** SUCCESS_EXPONENT) * cap
+
+    apply_volume_weighting(
+        self,
+        rewards=rewards,
+        hotkey_to_uid=hotkey_to_uid,
+        direction_traces=direction_traces,
+        weighting_traces=weighting_traces,
+        window_start=window_start,
+    )
 
     recycle_uid = RECYCLE_UID if RECYCLE_UID < n_uids else 0
     distributed = float(rewards.sum())
@@ -149,9 +191,107 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
         success_rates=success_rates,
         distributed=distributed,
         recycled=recycled,
+        weighting_traces=weighting_traces,
     )
 
     return rewards, set(range(n_uids))
+
+
+def capacity_factor(collateral_rao: int, max_swap_amount_rao: int) -> float:
+    """Fraction of the swap-size band this miner's collateral can serve.
+    Clamped to [0, 1]. Fail-safe: returns 1.0 if max_swap_amount is unset
+    (cold start / RPC failure) so the first scoring pass after restart doesn't
+    zero every miner."""
+    if max_swap_amount_rao <= 0:
+        return 1.0
+    if collateral_rao <= 0:
+        return 0.0
+    return min(1.0, collateral_rao / max_swap_amount_rao)
+
+
+def volume_factor(volume_share: float, crown_share: float, alpha: float = VOLUME_WEIGHT_ALPHA) -> float:
+    """Marginal penalty on the gap between volume served and crown held.
+
+    ``participation = min(1.0, volume_share / crown_share)`` — the cap removes
+    any reward for over-serving (no incentive to force wash swaps). A miner
+    matching their crown share with real volume scores 1.0; an idle crown
+    holder scores ``(1 - alpha)``.
+    """
+    if crown_share <= 0:
+        return 1.0  # no crown reward to multiply — factor is moot
+    participation = min(1.0, volume_share / crown_share)
+    return (1.0 - alpha) + alpha * participation
+
+
+def apply_volume_weighting(
+    self: Validator,
+    *,
+    rewards: np.ndarray,
+    hotkey_to_uid: Dict[str, int],
+    direction_traces: Dict[Tuple[str, str], DirectionTrace],
+    weighting_traces: Dict[str, WeightingTrace],
+    window_start: int,
+) -> None:
+    """Apply the volume_factor multiplier to every crown earner.
+
+    Aggregates crown across directions and volume across all completed swaps
+    in the window. When total volume is zero (idle network) every factor is
+    1.0 — we don't punish miners for a quiet window.
+    """
+    volumes = self.state_store.get_volume_since(window_start)
+    crown_per_hotkey: Dict[str, float] = {}
+    for trace in direction_traces.values():
+        for hk, blk in trace.crown_blocks.items():
+            crown_per_hotkey[hk] = crown_per_hotkey.get(hk, 0.0) + blk
+
+    total_crown = sum(crown_per_hotkey.values())
+    total_volume = sum(volumes.values())
+    if total_crown <= 0:
+        return  # no crown earners; volume factor is moot
+
+    for hotkey, crown in crown_per_hotkey.items():
+        uid = hotkey_to_uid.get(hotkey)
+        if uid is None or rewards[uid] <= 0:
+            continue
+        crown_share = crown / total_crown
+        vol = volumes.get(hotkey, 0)
+        vol_share = (vol / total_volume) if total_volume > 0 else 0.0
+        factor = volume_factor(vol_share, crown_share) if total_volume > 0 else 1.0
+        rewards[uid] *= factor
+        wt = weighting_traces.setdefault(hotkey, WeightingTrace())
+        wt.volume_rao = vol
+        wt.crown_share = crown_share
+        wt.volume_share = vol_share
+        wt.participation = min(1.0, vol_share / crown_share) if crown_share > 0 else 1.0
+        wt.volume_factor = factor
+
+
+def read_max_swap_amount(self: Validator) -> int:
+    """Read max_swap_amount via bounds_cache. Falls back to 0 (which capacity
+    interprets as 'unset → 1.0 factor') if the cache isn't wired or fails."""
+    cache = getattr(self, 'bounds_cache', None)
+    if cache is None:
+        return 0
+    try:
+        return int(cache.max_swap_amount())
+    except Exception as e:
+        bt.logging.warning(f'capacity weighting: max_swap_amount read failed, fail-safe to 0: {e}')
+        return 0
+
+
+def read_miner_collateral(self: Validator, hotkey: str) -> int:
+    """Read miner collateral via contract_client. Falls back to 0 on error
+    (which makes capacity_factor = 0 for that miner — strict). The miner is
+    on the contract's active set per replay, so a collateral read failure is
+    a real problem worth logging, not silently masking."""
+    client = getattr(self, 'contract_client', None)
+    if client is None:
+        return 0
+    try:
+        return int(client.get_miner_collateral(hotkey))
+    except Exception as e:
+        bt.logging.warning(f'capacity weighting: collateral read failed for {hotkey[:8]}: {e}')
+        return 0
 
 
 def success_rate(stats: Optional[Tuple[int, int]]) -> float:

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -42,8 +42,7 @@ class DirectionTrace:
 
 @dataclass
 class WeightingTrace:
-    """Per-hotkey capacity + volume factors surfaced into the scoring log so a
-    miner can self-diagnose why their reward < headline crown share."""
+    """Per-hotkey capacity + volume factors surfaced in the scoring log."""
 
     collateral: int = 0
     capacity_factor: float = 1.0
@@ -102,17 +101,8 @@ def prune_swap_outcomes(self: Validator) -> None:
 
 
 def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
-    """Replay the crown-time event stream over the window, derive per-miner
-    rewards, recycle any undistributed pool to ``RECYCLE_UID``.
-
-    Reward equation:
-
-        reward_i = Σ_dir (pool_d × crown_share_id × sr_i^SUCCESS_EXPONENT × capacity_i) × volume_factor_i
-
-    Where ``capacity_i = min(1.0, collateral_i / max_swap_amount)`` and
-    ``volume_factor_i = (1-α) + α * min(1.0, vol_share_i / crown_share_i)``.
-    Shortfalls from sr, capacity, and volume all flow to ``RECYCLE_UID``.
-    """
+    """Replay the crown-time event stream, derive per-miner rewards
+    (pool × crown_share × sr³ × capacity × volume_factor), recycle the rest."""
     n_uids = self.metagraph.n.item()
     if n_uids == 0:
         return np.array([], dtype=np.float32), set()
@@ -200,10 +190,7 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
 
 
 def capacity_factor(collateral_rao: int, max_swap_amount_rao: int) -> float:
-    """Fraction of the swap-size band this miner's collateral can serve.
-    Clamped to [0, 1]. Fail-safe: returns 1.0 if max_swap_amount is unset
-    (cold start / RPC failure) so the first scoring pass after restart doesn't
-    zero every miner."""
+    """min(1, collateral / max_swap). Fail-safe to 1.0 when bounds unset."""
     if max_swap_amount_rao <= 0:
         return 1.0
     if collateral_rao <= 0:
@@ -212,15 +199,9 @@ def capacity_factor(collateral_rao: int, max_swap_amount_rao: int) -> float:
 
 
 def volume_factor(volume_share: float, crown_share: float, alpha: float = VOLUME_WEIGHT_ALPHA) -> float:
-    """Marginal penalty on the gap between volume served and crown held.
-
-    ``participation = min(1.0, volume_share / crown_share)`` — the cap removes
-    any reward for over-serving (no incentive to force wash swaps). A miner
-    matching their crown share with real volume scores 1.0; an idle crown
-    holder scores ``(1 - alpha)``.
-    """
+    """(1-α) + α·min(1, vol_share/crown_share). Cap kills over-serve bonus."""
     if crown_share <= 0:
-        return 1.0  # no crown reward to multiply — factor is moot
+        return 1.0
     participation = min(1.0, volume_share / crown_share)
     return (1.0 - alpha) + alpha * participation
 
@@ -234,12 +215,8 @@ def apply_volume_weighting(
     weighting_traces: Dict[str, WeightingTrace],
     window_start: int,
 ) -> None:
-    """Apply the volume_factor multiplier to every crown earner.
-
-    Aggregates crown across directions and volume across all completed swaps
-    in the window. When total volume is zero (idle network) every factor is
-    1.0 — we don't punish miners for a quiet window.
-    """
+    """Multiply each crown earner's reward by their volume_factor. Idle
+    network (total_volume == 0) leaves every factor at 1.0."""
     volumes = self.state_store.get_volume_since(window_start)
     crown_per_hotkey: Dict[str, float] = {}
     for trace in direction_traces.values():
@@ -249,7 +226,7 @@ def apply_volume_weighting(
     total_crown = sum(crown_per_hotkey.values())
     total_volume = sum(volumes.values())
     if total_crown <= 0:
-        return  # no crown earners; volume factor is moot
+        return
 
     for hotkey, crown in crown_per_hotkey.items():
         uid = hotkey_to_uid.get(hotkey)
@@ -269,38 +246,32 @@ def apply_volume_weighting(
 
 
 def read_max_swap_amount(self: Validator) -> int:
-    """Read max_swap_amount via bounds_cache. Falls back to 0 (which capacity
-    interprets as 'unset → 1.0 factor') if the cache isn't wired or fails."""
+    """bounds_cache read; 0 → capacity_factor fail-safes to 1.0."""
     cache = getattr(self, 'bounds_cache', None)
     if cache is None:
         return 0
     try:
         return int(cache.max_swap_amount())
     except Exception as e:
-        bt.logging.warning(f'capacity weighting: max_swap_amount read failed, fail-safe to 0: {e}')
+        bt.logging.warning(f'max_swap_amount read failed: {e}')
         return 0
 
 
 def read_miner_collateral(self: Validator, hotkey: str) -> int:
-    """Read miner collateral via contract_client. Falls back to 0 on error
-    (which makes capacity_factor = 0 for that miner — strict). The miner is
-    on the contract's active set per replay, so a collateral read failure is
-    a real problem worth logging, not silently masking."""
+    """contract_client read; 0 on error → capacity_factor = 0 for that miner."""
     client = getattr(self, 'contract_client', None)
     if client is None:
         return 0
     try:
         return int(client.get_miner_collateral(hotkey))
     except Exception as e:
-        bt.logging.warning(f'capacity weighting: collateral read failed for {hotkey[:8]}: {e}')
+        bt.logging.warning(f'collateral read failed for {hotkey[:8]}: {e}')
         return 0
 
 
 def success_rate(stats: Optional[Tuple[int, int]]) -> float:
-    """Credibility-adjusted success rate. Raw ``completed / total`` is scaled
-    by a linear ramp toward full credibility at ``CREDIBILITY_RAMP_OBSERVATIONS``
-    closed swaps. Zero-outcome miners earn no trust by default — they have to
-    serve swaps to climb the ramp."""
+    """Raw success rate × linear ramp to full credibility at
+    CREDIBILITY_RAMP_OBSERVATIONS closed swaps. Zero observations → 0."""
     if not stats or stats == (0, 0):
         return 0.0
     completed, timed_out = stats

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -16,6 +16,7 @@ import numpy as np
 
 from allways.chains import canonical_pair
 from allways.constants import (
+    CREDIBILITY_RAMP_OBSERVATIONS,
     CREDIBILITY_WINDOW_BLOCKS,
     DIRECTION_POOLS,
     RECYCLE_UID,
@@ -192,6 +193,7 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
         distributed=distributed,
         recycled=recycled,
         weighting_traces=weighting_traces,
+        success_stats=success_stats,
     )
 
     return rewards, set(range(n_uids))
@@ -295,14 +297,15 @@ def read_miner_collateral(self: Validator, hotkey: str) -> int:
 
 
 def success_rate(stats: Optional[Tuple[int, int]]) -> float:
-    """All-time success rate. Zero-outcome miners default to 1.0 (optimistic)."""
-    if stats is None:
-        return 1.0
+    """Credibility-adjusted success rate. Raw ``completed / total`` is scaled
+    by a linear ramp toward full credibility at ``CREDIBILITY_RAMP_OBSERVATIONS``
+    closed swaps. Zero-outcome miners earn no trust by default — they have to
+    serve swaps to climb the ramp."""
+    if not stats or stats == (0, 0):
+        return 0.0
     completed, timed_out = stats
     total = completed + timed_out
-    if total == 0:
-        return 1.0
-    return completed / total
+    return (completed / total) * min(1.0, total / CREDIBILITY_RAMP_OBSERVATIONS)
 
 
 # ─── Crown-time replay ───────────────────────────────────────────────────

--- a/allways/validator/scoring_trace.py
+++ b/allways/validator/scoring_trace.py
@@ -4,15 +4,15 @@ presentation — never mutates state."""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, List, Set, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
 import bittensor as bt
 import numpy as np
 
-from allways.constants import RECYCLE_UID
+from allways.constants import RECYCLE_UID, TAO_TO_RAO
 
 if TYPE_CHECKING:
-    from allways.validator.scoring import DirectionTrace
+    from allways.validator.scoring import DirectionTrace, WeightingTrace
     from neurons.validator import Validator
 
 
@@ -29,10 +29,12 @@ def log_scoring_trace(
     success_rates: Dict[str, float],
     distributed: float,
     recycled: float,
+    weighting_traces: Optional[Dict[str, 'WeightingTrace']] = None,
 ) -> None:
     hotkeys = self.metagraph.hotkeys
     recycle_uid = RECYCLE_UID if RECYCLE_UID < len(rewards) else 0
     hotkey_to_uid = {hk: uid for uid, hk in enumerate(hotkeys)}
+    weighting_traces = weighting_traces or {}
 
     lines = [
         f'V1 scoring: window=[{window_start}, {window_end}], distributed={distributed:.6f}, recycled={recycled:.6f}'
@@ -55,7 +57,17 @@ def log_scoring_trace(
             continue
         crown_reward = float(rewards[uid]) - (recycled if uid == recycle_uid else 0.0)
         sr = success_rates.get(hk, 1.0)
-        lines.append(f'  uid={uid} hotkey={hk[:8]}.. crown_blk={crown_blk:.0f} sr={sr:.3f} reward={crown_reward:.3f}')
+        wt = weighting_traces.get(hk)
+        extras = ''
+        if wt is not None:
+            extras = (
+                f' cap={wt.capacity_factor:.2f} (col={wt.collateral / TAO_TO_RAO:g}t)'
+                f' vol={wt.volume_rao / TAO_TO_RAO:g}t vol_share={wt.volume_share:.2f}'
+                f' crown_share={wt.crown_share:.2f} vol_f={wt.volume_factor:.2f}'
+            )
+        lines.append(
+            f'  uid={uid} hotkey={hk[:8]}.. crown_blk={crown_blk:.0f} sr={sr:.3f}{extras} reward={crown_reward:.3f}'
+        )
 
     lines.extend(
         non_earner_lines(self, window_start, window_end, rewards, success_rates, direction_traces, recycle_uid)

--- a/allways/validator/scoring_trace.py
+++ b/allways/validator/scoring_trace.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 import bittensor as bt
 import numpy as np
 
-from allways.constants import RECYCLE_UID, TAO_TO_RAO
+from allways.constants import CREDIBILITY_RAMP_OBSERVATIONS, RECYCLE_UID, TAO_TO_RAO
 
 if TYPE_CHECKING:
     from allways.validator.scoring import DirectionTrace, WeightingTrace
@@ -30,11 +30,13 @@ def log_scoring_trace(
     distributed: float,
     recycled: float,
     weighting_traces: Optional[Dict[str, 'WeightingTrace']] = None,
+    success_stats: Optional[Dict[str, Tuple[int, int]]] = None,
 ) -> None:
     hotkeys = self.metagraph.hotkeys
     recycle_uid = RECYCLE_UID if RECYCLE_UID < len(rewards) else 0
     hotkey_to_uid = {hk: uid for uid, hk in enumerate(hotkeys)}
     weighting_traces = weighting_traces or {}
+    success_stats = success_stats or {}
 
     lines = [
         f'V1 scoring: window=[{window_start}, {window_end}], distributed={distributed:.6f}, recycled={recycled:.6f}'
@@ -57,6 +59,8 @@ def log_scoring_trace(
             continue
         crown_reward = float(rewards[uid]) - (recycled if uid == recycle_uid else 0.0)
         sr = success_rates.get(hk, 1.0)
+        closed = sum(success_stats.get(hk, (0, 0)))
+        ramp = min(1.0, closed / CREDIBILITY_RAMP_OBSERVATIONS)
         wt = weighting_traces.get(hk)
         extras = ''
         if wt is not None:
@@ -66,7 +70,9 @@ def log_scoring_trace(
                 f' crown_share={wt.crown_share:.2f} vol_f={wt.volume_factor:.2f}'
             )
         lines.append(
-            f'  uid={uid} hotkey={hk[:8]}.. crown_blk={crown_blk:.0f} sr={sr:.3f}{extras} reward={crown_reward:.3f}'
+            f'  uid={uid} hotkey={hk[:8]}.. crown_blk={crown_blk:.0f} '
+            f'sr={sr:.3f} ({closed}/{CREDIBILITY_RAMP_OBSERVATIONS} closed, ramp={ramp:.2f})'
+            f'{extras} reward={crown_reward:.3f}'
         )
 
     lines.extend(

--- a/allways/validator/scoring_trace.py
+++ b/allways/validator/scoring_trace.py
@@ -163,7 +163,7 @@ def diagnose_non_earner(
     if hotkey not in ever_active:
         return 'not_active_during_window'
     if sr <= 0:
-        return 'slashed_credibility_zero'
+        return 'credibility_zero'  # zero observations OR all-timeout history
     parts = [
         f'{direction[0]}→{direction[1]}: own={own:g} vs best={direction_traces[direction].best_rate:g}'
         for direction, own in latest_rates.items()

--- a/allways/validator/scoring_trace.py
+++ b/allways/validator/scoring_trace.py
@@ -4,6 +4,7 @@ presentation — never mutates state."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
 import bittensor as bt
@@ -12,11 +13,41 @@ import numpy as np
 from allways.constants import CREDIBILITY_RAMP_OBSERVATIONS, RECYCLE_UID, TAO_TO_RAO
 
 if TYPE_CHECKING:
-    from allways.validator.scoring import DirectionTrace, WeightingTrace
+    from allways.validator.scoring import DirectionTrace
     from neurons.validator import Validator
 
 
 NON_EARNER_LINE_CAP = 30
+
+
+@dataclass
+class WeightingTrace:
+    """Per-hotkey capacity + volume + credibility factors for the scoring log."""
+
+    collateral: int = 0
+    capacity_factor: float = 1.0
+    volume_rao: int = 0
+    crown_share: float = 0.0
+    volume_share: float = 0.0
+    participation: float = 1.0
+    volume_factor: float = 1.0
+    closed_swaps: int = 0
+    credibility_ramp: float = 0.0
+
+    def record_capacity(self, collateral: int, factor: float) -> None:
+        self.collateral = collateral
+        self.capacity_factor = factor
+
+    def record_volume(self, vol_rao: int, total_volume_rao: int, crown_share: float, factor: float) -> None:
+        self.volume_rao = vol_rao
+        self.crown_share = crown_share
+        self.volume_share = (vol_rao / total_volume_rao) if total_volume_rao > 0 else 0.0
+        self.participation = min(1.0, self.volume_share / crown_share) if crown_share > 0 else 1.0
+        self.volume_factor = factor
+
+    def record_credibility(self, closed_swaps: int, ramp_target: int) -> None:
+        self.closed_swaps = closed_swaps
+        self.credibility_ramp = min(1.0, closed_swaps / ramp_target) if ramp_target > 0 else 1.0
 
 
 def log_scoring_trace(
@@ -30,13 +61,11 @@ def log_scoring_trace(
     distributed: float,
     recycled: float,
     weighting_traces: Optional[Dict[str, 'WeightingTrace']] = None,
-    success_stats: Optional[Dict[str, Tuple[int, int]]] = None,
 ) -> None:
     hotkeys = self.metagraph.hotkeys
     recycle_uid = RECYCLE_UID if RECYCLE_UID < len(rewards) else 0
     hotkey_to_uid = {hk: uid for uid, hk in enumerate(hotkeys)}
     weighting_traces = weighting_traces or {}
-    success_stats = success_stats or {}
 
     lines = [
         f'V1 scoring: window=[{window_start}, {window_end}], distributed={distributed:.6f}, recycled={recycled:.6f}'
@@ -58,21 +87,18 @@ def log_scoring_trace(
         if uid == recycle_uid and crown_blk == 0:
             continue
         crown_reward = float(rewards[uid]) - (recycled if uid == recycle_uid else 0.0)
-        sr = success_rates.get(hk, 1.0)
-        closed = sum(success_stats.get(hk, (0, 0)))
-        ramp = min(1.0, closed / CREDIBILITY_RAMP_OBSERVATIONS)
+        sr = success_rates.get(hk, 0.0)
         wt = weighting_traces.get(hk)
         extras = ''
         if wt is not None:
             extras = (
+                f' ({wt.closed_swaps}/{CREDIBILITY_RAMP_OBSERVATIONS} closed, ramp={wt.credibility_ramp:.2f})'
                 f' cap={wt.capacity_factor:.2f} (col={wt.collateral / TAO_TO_RAO:g}t)'
                 f' vol={wt.volume_rao / TAO_TO_RAO:g}t vol_share={wt.volume_share:.2f}'
                 f' crown_share={wt.crown_share:.2f} vol_f={wt.volume_factor:.2f}'
             )
         lines.append(
-            f'  uid={uid} hotkey={hk[:8]}.. crown_blk={crown_blk:.0f} '
-            f'sr={sr:.3f} ({closed}/{CREDIBILITY_RAMP_OBSERVATIONS} closed, ramp={ramp:.2f})'
-            f'{extras} reward={crown_reward:.3f}'
+            f'  uid={uid} hotkey={hk[:8]}.. crown_blk={crown_blk:.0f} sr={sr:.3f}{extras} reward={crown_reward:.3f}'
         )
 
     lines.extend(

--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -262,15 +262,17 @@ class ValidatorStateStore:
         miner_hotkey: str,
         completed: bool,
         resolved_block: int,
+        tao_amount: int = 0,
     ) -> None:
         with self.lock:
             conn = self.require_connection()
             conn.execute(
                 """
-                INSERT OR REPLACE INTO swap_outcomes (swap_id, miner_hotkey, completed, resolved_block)
-                VALUES (?, ?, ?, ?)
+                INSERT OR REPLACE INTO swap_outcomes
+                    (swap_id, miner_hotkey, completed, resolved_block, tao_amount)
+                VALUES (?, ?, ?, ?, ?)
                 """,
-                (swap_id, miner_hotkey, 1 if completed else 0, resolved_block),
+                (swap_id, miner_hotkey, 1 if completed else 0, resolved_block, int(tao_amount or 0)),
             )
             conn.commit()
 
@@ -291,6 +293,22 @@ class ValidatorStateStore:
                 (since_block,),
             ).fetchall()
         return {r['miner_hotkey']: (int(r['completed']), int(r['timed_out'])) for r in rows}
+
+    def get_volume_since(self, since_block: int) -> Dict[str, int]:
+        """Sum ``tao_amount`` of completed swaps per miner (rao) since
+        ``since_block``. Timed-out swaps don't count toward volume."""
+        with self.lock:
+            conn = self.require_connection()
+            rows = conn.execute(
+                """
+                SELECT miner_hotkey, SUM(tao_amount) AS total
+                FROM swap_outcomes
+                WHERE resolved_block >= ? AND completed = 1
+                GROUP BY miner_hotkey
+                """,
+                (since_block,),
+            ).fetchall()
+        return {r['miner_hotkey']: int(r['total'] or 0) for r in rows}
 
     def prune_swap_outcomes_older_than(self, cutoff_block: int) -> None:
         if cutoff_block <= 0:
@@ -381,7 +399,8 @@ class ValidatorStateStore:
                     swap_id         INTEGER PRIMARY KEY,
                     miner_hotkey    TEXT NOT NULL,
                     completed       INTEGER NOT NULL,
-                    resolved_block  INTEGER NOT NULL
+                    resolved_block  INTEGER NOT NULL,
+                    tao_amount      INTEGER NOT NULL DEFAULT 0
                 );
                 CREATE INDEX IF NOT EXISTS idx_swap_outcomes_hotkey
                     ON swap_outcomes(miner_hotkey);
@@ -394,9 +413,13 @@ class ValidatorStateStore:
             # the PRAGMA-then-ALTER pattern races when two validators share the
             # same DB file: both read "column missing" and both try to add it.
             # Catching the duplicate-column error is the simplest correct form.
-            try:
-                conn.execute('ALTER TABLE pending_confirms ADD COLUMN from_tx_block INTEGER NOT NULL DEFAULT 0')
-            except sqlite3.OperationalError as e:
-                if 'duplicate column' not in str(e).lower():
-                    raise
+            for table, column, ddl in (
+                ('pending_confirms', 'from_tx_block', 'INTEGER NOT NULL DEFAULT 0'),
+                ('swap_outcomes', 'tao_amount', 'INTEGER NOT NULL DEFAULT 0'),
+            ):
+                try:
+                    conn.execute(f'ALTER TABLE {table} ADD COLUMN {column} {ddl}')
+                except sqlite3.OperationalError as e:
+                    if 'duplicate column' not in str(e).lower():
+                        raise
             conn.commit()

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -1036,61 +1036,63 @@ class TestCapacityFactorHelper:
 
 
 class TestVolumeFactorHelper:
-    """Direct unit tests for the volume_factor pure function."""
+    """Direct unit tests for the volume_factor pure function.
+
+    Signature: volume_factor(vol_rao, total_volume_rao, crown_share, alpha).
+    """
 
     def test_idle_crown_loses_alpha(self):
-        """volume_share = 0, crown_share > 0 → factor = (1 - α)."""
+        """vol=0 of total=1 → vol_share=0, participation=0 → factor = (1-α)."""
         from allways.validator.scoring import volume_factor
 
-        assert volume_factor(volume_share=0.0, crown_share=1.0, alpha=0.5) == 0.5
+        assert volume_factor(0, 1_000, crown_share=1.0, alpha=0.5) == 0.5
 
     def test_matching_volume_keeps_full_reward(self):
         from allways.validator.scoring import volume_factor
 
-        assert volume_factor(volume_share=0.5, crown_share=0.5, alpha=0.5) == 1.0
+        # 500/1000 = 0.5 vol_share, crown_share 0.5 → participation 1.0.
+        assert volume_factor(500, 1_000, crown_share=0.5, alpha=0.5) == 1.0
 
     def test_over_serving_capped_at_one(self):
-        """Cap is the anti-wash-trade guarantee — extra volume never amplifies."""
+        """Anti-wash-trade: high volume / low crown stays at 1.0."""
         from allways.validator.scoring import volume_factor
 
-        assert volume_factor(volume_share=0.9, crown_share=0.1, alpha=0.5) == 1.0
+        assert volume_factor(900, 1_000, crown_share=0.1, alpha=0.5) == 1.0
 
     def test_partial_mismatch_interpolates(self):
-        """50% participation → halfway between (1-α) and 1.0."""
+        """vol_share/crown_share = 0.5 → factor = 0.5 + 0.5*0.5 = 0.75."""
         from allways.validator.scoring import volume_factor
 
-        result = volume_factor(volume_share=0.25, crown_share=0.5, alpha=0.5)
-        # participation = 0.5 → factor = 0.5 + 0.5*0.5 = 0.75
-        assert result == 0.75
+        assert volume_factor(250, 1_000, crown_share=0.5, alpha=0.5) == 0.75
 
     def test_zero_crown_share_is_moot(self):
-        """A miner with no crown can't earn — factor is irrelevant, default 1.0."""
         from allways.validator.scoring import volume_factor
 
-        assert volume_factor(volume_share=0.5, crown_share=0.0, alpha=0.5) == 1.0
+        assert volume_factor(500, 1_000, crown_share=0.0, alpha=0.5) == 1.0
+
+    def test_idle_network_short_circuits_to_one(self):
+        """total_volume == 0 → factor = 1.0 (no penalty for a quiet window)."""
+        from allways.validator.scoring import volume_factor
+
+        assert volume_factor(0, 0, crown_share=1.0, alpha=0.5) == 1.0
 
     def test_alpha_zero_disables_volume_weighting(self):
-        """α=0 → factor is always 1.0 regardless of volume gap."""
         from allways.validator.scoring import volume_factor
 
-        for vs in (0.0, 0.25, 0.5, 0.75, 1.0):
-            assert volume_factor(volume_share=vs, crown_share=1.0, alpha=0.0) == 1.0
+        for vol in (0, 250, 500, 750, 1_000):
+            assert volume_factor(vol, 1_000, crown_share=1.0, alpha=0.0) == 1.0
 
     def test_alpha_one_is_pure_volume_share(self):
-        """α=1 → factor equals participation directly."""
         from allways.validator.scoring import volume_factor
 
-        # Idle crown → factor = 0
-        assert volume_factor(volume_share=0.0, crown_share=1.0, alpha=1.0) == 0.0
-        # Half participation → factor = 0.5
-        assert volume_factor(volume_share=0.25, crown_share=0.5, alpha=1.0) == 0.5
+        assert volume_factor(0, 1_000, crown_share=1.0, alpha=1.0) == 0.0
+        assert volume_factor(250, 1_000, crown_share=0.5, alpha=1.0) == 0.5
 
     def test_alpha_03_softer_penalty(self):
-        """α=0.3 keeps 70% on full idle, 100% on full participation."""
         from allways.validator.scoring import volume_factor
 
-        assert volume_factor(0.0, 1.0, alpha=0.3) == 0.7
-        np.testing.assert_allclose(volume_factor(0.5, 1.0, alpha=0.3), 0.85, atol=1e-6)
+        assert volume_factor(0, 1_000, crown_share=1.0, alpha=0.3) == 0.7
+        np.testing.assert_allclose(volume_factor(500, 1_000, crown_share=1.0, alpha=0.3), 0.85, atol=1e-6)
 
 
 class TestCapacityWeighting:

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -1237,6 +1237,86 @@ class TestCapacityWeighting:
         assert v.contract_client.get_miner_collateral.call_count == 1
         v.state_store.close()
 
+    def test_max_swap_amount_rpc_failure_falls_back_to_unity(self, tmp_path: Path):
+        """bounds_cache failure → max_swap=0 → capacity_factor fail-safes to 1.0
+        so a transient RPC blip can't zero every miner on a scoring pass."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
+        v = make_validator(tmp_path, hotkeys, collaterals={'hk_a': 100_000_000})
+        v.bounds_cache.max_swap_amount.side_effect = RuntimeError('rpc down')
+        self.seed_tao_btc_crown(v, 'hk_a')
+        rewards, _ = calculate_miner_rewards(v)
+        # Fail-safe: capacity factor 1.0 → hk_a earns the full tao→btc pool.
+        np.testing.assert_allclose(rewards[0], POOL_TAO_BTC, atol=1e-6)
+        v.state_store.close()
+
+
+class TestWeightingTraceRecorders:
+    """The three record_* methods on WeightingTrace own their own math —
+    direct unit coverage so changes there don't have to be inferred from
+    integration tests."""
+
+    def test_record_capacity_sets_both_fields(self):
+        from allways.validator.scoring_trace import WeightingTrace
+
+        wt = WeightingTrace()
+        wt.record_capacity(collateral=250_000_000, factor=0.5)
+        assert wt.collateral == 250_000_000
+        assert wt.capacity_factor == 0.5
+
+    def test_record_volume_computes_share_and_participation(self):
+        from allways.validator.scoring_trace import WeightingTrace
+
+        wt = WeightingTrace()
+        # vol 250 of total 1000 = 25% share; crown_share 50% → participation 50%.
+        wt.record_volume(vol_rao=250, total_volume_rao=1_000, crown_share=0.5, factor=0.75)
+        assert wt.volume_rao == 250
+        assert wt.volume_share == 0.25
+        assert wt.crown_share == 0.5
+        assert wt.participation == 0.5
+        assert wt.volume_factor == 0.75
+
+    def test_record_volume_idle_network_zeros_share(self):
+        """total_volume == 0 → volume_share = 0, participation defaults to 1.0
+        only when crown_share also 0; otherwise participation = 0."""
+        from allways.validator.scoring_trace import WeightingTrace
+
+        wt = WeightingTrace()
+        wt.record_volume(vol_rao=0, total_volume_rao=0, crown_share=1.0, factor=1.0)
+        assert wt.volume_share == 0.0
+        assert wt.participation == 0.0  # vol_share / crown_share = 0/1 = 0
+        assert wt.volume_factor == 1.0  # set by caller (idle-network short-circuit)
+
+    def test_record_volume_caps_participation_at_one(self):
+        """Over-serving: vol_share/crown_share > 1 → participation capped."""
+        from allways.validator.scoring_trace import WeightingTrace
+
+        wt = WeightingTrace()
+        wt.record_volume(vol_rao=900, total_volume_rao=1_000, crown_share=0.1, factor=1.0)
+        assert wt.participation == 1.0  # min(1.0, 0.9/0.1)
+
+    def test_record_credibility_computes_ramp(self):
+        from allways.validator.scoring_trace import WeightingTrace
+
+        wt = WeightingTrace()
+        wt.record_credibility(closed_swaps=5, ramp_target=10)
+        assert wt.closed_swaps == 5
+        assert wt.credibility_ramp == 0.5
+
+    def test_record_credibility_caps_at_one(self):
+        from allways.validator.scoring_trace import WeightingTrace
+
+        wt = WeightingTrace()
+        wt.record_credibility(closed_swaps=20, ramp_target=10)
+        assert wt.credibility_ramp == 1.0
+
+    def test_record_credibility_zero_target_is_unity(self):
+        """Defensive: ramp_target=0 → divide-by-zero guarded → 1.0."""
+        from allways.validator.scoring_trace import WeightingTrace
+
+        wt = WeightingTrace()
+        wt.record_credibility(closed_swaps=5, ramp_target=0)
+        assert wt.credibility_ramp == 1.0
+
 
 class TestVolumeWeighting:
     """End-to-end volume weighting via calculate_miner_rewards."""

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -61,14 +61,35 @@ def seed_active(watcher: ContractEventWatcher, hotkey: str, active: bool, block:
         watcher.active_miners.discard(hotkey)
 
 
-def make_validator(tmp_path: Path, hotkeys: list[str], block: int = 10_000) -> SimpleNamespace:
+def make_validator(
+    tmp_path: Path,
+    hotkeys: list[str],
+    block: int = 10_000,
+    *,
+    max_swap_amount: int = 0,
+    collaterals: dict[str, int] | None = None,
+) -> SimpleNamespace:
+    """Build a SimpleNamespace stand-in for the validator.
+
+    Defaults bypass capacity weighting (``max_swap_amount=0`` → capacity_factor
+    returns 1.0 fail-safe) and provide a zero-collateral stub. Tests that
+    exercise capacity weighting pass explicit ``max_swap_amount`` and
+    ``collaterals`` overrides.
+    """
     store = ValidatorStateStore(db_path=tmp_path / 'state.db')
     watcher = make_watcher(store, active=set(hotkeys))
+    collaterals = collaterals or {}
+    bounds_cache = MagicMock()
+    bounds_cache.max_swap_amount.return_value = max_swap_amount
+    contract_client = MagicMock()
+    contract_client.get_miner_collateral.side_effect = lambda hk: collaterals.get(hk, 0)
     return SimpleNamespace(
         block=block,
         metagraph=make_metagraph(hotkeys),
         state_store=store,
         event_watcher=watcher,
+        bounds_cache=bounds_cache,
+        contract_client=contract_client,
     )
 
 
@@ -925,3 +946,598 @@ class TestHaltShortCircuit:
         rewards = captured['rewards']
         recycle_uid = RECYCLE_UID if RECYCLE_UID < len(rewards) else 0
         assert rewards[recycle_uid] > 0  # recycle got something via normal path
+
+
+class TestCapacityFactorHelper:
+    """Direct unit tests for the capacity_factor pure function."""
+
+    def test_at_max_swap_is_full(self):
+        from allways.validator.scoring import capacity_factor
+
+        assert capacity_factor(500_000_000, 500_000_000) == 1.0
+
+    def test_half_max_swap_is_half(self):
+        from allways.validator.scoring import capacity_factor
+
+        assert capacity_factor(250_000_000, 500_000_000) == 0.5
+
+    def test_quarter_max_swap_is_quarter(self):
+        from allways.validator.scoring import capacity_factor
+
+        assert capacity_factor(125_000_000, 500_000_000) == 0.25
+
+    def test_above_max_swap_caps_at_one(self):
+        from allways.validator.scoring import capacity_factor
+
+        assert capacity_factor(2_000_000_000, 500_000_000) == 1.0
+
+    def test_zero_collateral_is_zero(self):
+        from allways.validator.scoring import capacity_factor
+
+        assert capacity_factor(0, 500_000_000) == 0.0
+
+    def test_negative_collateral_is_zero(self):
+        """Defensive — contract guarantees >=0 but the helper handles it."""
+        from allways.validator.scoring import capacity_factor
+
+        assert capacity_factor(-1, 500_000_000) == 0.0
+
+    def test_zero_max_swap_is_fail_safe_one(self):
+        """Bounds cache cold start / RPC failure returns 0; factor should
+        default to 1.0 so the first scoring pass doesn't zero everyone."""
+        from allways.validator.scoring import capacity_factor
+
+        assert capacity_factor(100_000_000, 0) == 1.0
+
+    def test_negative_max_swap_is_fail_safe_one(self):
+        from allways.validator.scoring import capacity_factor
+
+        assert capacity_factor(100_000_000, -1) == 1.0
+
+
+class TestVolumeFactorHelper:
+    """Direct unit tests for the volume_factor pure function."""
+
+    def test_idle_crown_loses_alpha(self):
+        """volume_share = 0, crown_share > 0 → factor = (1 - α)."""
+        from allways.validator.scoring import volume_factor
+
+        assert volume_factor(volume_share=0.0, crown_share=1.0, alpha=0.5) == 0.5
+
+    def test_matching_volume_keeps_full_reward(self):
+        from allways.validator.scoring import volume_factor
+
+        assert volume_factor(volume_share=0.5, crown_share=0.5, alpha=0.5) == 1.0
+
+    def test_over_serving_capped_at_one(self):
+        """Cap is the anti-wash-trade guarantee — extra volume never amplifies."""
+        from allways.validator.scoring import volume_factor
+
+        assert volume_factor(volume_share=0.9, crown_share=0.1, alpha=0.5) == 1.0
+
+    def test_partial_mismatch_interpolates(self):
+        """50% participation → halfway between (1-α) and 1.0."""
+        from allways.validator.scoring import volume_factor
+
+        result = volume_factor(volume_share=0.25, crown_share=0.5, alpha=0.5)
+        # participation = 0.5 → factor = 0.5 + 0.5*0.5 = 0.75
+        assert result == 0.75
+
+    def test_zero_crown_share_is_moot(self):
+        """A miner with no crown can't earn — factor is irrelevant, default 1.0."""
+        from allways.validator.scoring import volume_factor
+
+        assert volume_factor(volume_share=0.5, crown_share=0.0, alpha=0.5) == 1.0
+
+    def test_alpha_zero_disables_volume_weighting(self):
+        """α=0 → factor is always 1.0 regardless of volume gap."""
+        from allways.validator.scoring import volume_factor
+
+        for vs in (0.0, 0.25, 0.5, 0.75, 1.0):
+            assert volume_factor(volume_share=vs, crown_share=1.0, alpha=0.0) == 1.0
+
+    def test_alpha_one_is_pure_volume_share(self):
+        """α=1 → factor equals participation directly."""
+        from allways.validator.scoring import volume_factor
+
+        # Idle crown → factor = 0
+        assert volume_factor(volume_share=0.0, crown_share=1.0, alpha=1.0) == 0.0
+        # Half participation → factor = 0.5
+        assert volume_factor(volume_share=0.25, crown_share=0.5, alpha=1.0) == 0.5
+
+    def test_alpha_03_softer_penalty(self):
+        """α=0.3 keeps 70% on full idle, 100% on full participation."""
+        from allways.validator.scoring import volume_factor
+
+        assert volume_factor(0.0, 1.0, alpha=0.3) == 0.7
+        np.testing.assert_allclose(volume_factor(0.5, 1.0, alpha=0.3), 0.85, atol=1e-6)
+
+
+class TestCapacityWeighting:
+    """End-to-end capacity weighting via calculate_miner_rewards."""
+
+    def seed_tao_btc_crown(self, v: SimpleNamespace, hotkey: str, rate: float = 0.00020) -> None:
+        conn = v.state_store.require_connection()
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            (hotkey, 'tao', 'btc', rate, 0),
+        )
+        conn.commit()
+
+    def test_full_capacity_pays_baseline(self, tmp_path: Path):
+        """Miner with collateral = max_swap earns the full per-direction pool."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
+        v = make_validator(
+            tmp_path,
+            hotkeys,
+            max_swap_amount=500_000_000,
+            collaterals={'hk_a': 500_000_000},
+        )
+        self.seed_tao_btc_crown(v, 'hk_a')
+        rewards, _ = calculate_miner_rewards(v)
+        # hk_a holds 100% of tao→btc crown, full capacity, sr=1.0, no volume penalty.
+        np.testing.assert_allclose(rewards[0], POOL_TAO_BTC, atol=1e-6)
+        v.state_store.close()
+
+    def test_quarter_capacity_pays_quarter(self, tmp_path: Path):
+        """Collateral at 1/4 of max swap → 1/4 reward, 3/4 recycles."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
+        v = make_validator(
+            tmp_path,
+            hotkeys,
+            max_swap_amount=500_000_000,
+            collaterals={'hk_a': 125_000_000},
+        )
+        self.seed_tao_btc_crown(v, 'hk_a')
+        rewards, _ = calculate_miner_rewards(v)
+        np.testing.assert_allclose(rewards[0], POOL_TAO_BTC * 0.25, atol=1e-6)
+        # Pool conservation: hk_a got 0.125, btc→tao bucket fully recycles (0.5),
+        # plus capacity shortfall on tao→btc (0.375) → recycle = 0.875.
+        recycle_uid = RECYCLE_UID if RECYCLE_UID < len(rewards) else 0
+        np.testing.assert_allclose(rewards[recycle_uid], 0.875, atol=1e-6)
+        np.testing.assert_allclose(rewards.sum(), 1.0, atol=1e-6)
+        v.state_store.close()
+
+    def test_over_max_caps_at_full(self, tmp_path: Path):
+        """Collateral 2x max_swap → factor still 1.0, no bonus."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
+        v = make_validator(
+            tmp_path,
+            hotkeys,
+            max_swap_amount=500_000_000,
+            collaterals={'hk_a': 1_000_000_000},
+        )
+        self.seed_tao_btc_crown(v, 'hk_a')
+        rewards, _ = calculate_miner_rewards(v)
+        np.testing.assert_allclose(rewards[0], POOL_TAO_BTC, atol=1e-6)
+        v.state_store.close()
+
+    def test_zero_collateral_zeros_reward(self, tmp_path: Path):
+        """Collateral 0 with max_swap set → factor 0 → no reward, full recycle."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
+        v = make_validator(
+            tmp_path,
+            hotkeys,
+            max_swap_amount=500_000_000,
+            collaterals={'hk_a': 0},
+        )
+        self.seed_tao_btc_crown(v, 'hk_a')
+        rewards, _ = calculate_miner_rewards(v)
+        recycle_uid = RECYCLE_UID if RECYCLE_UID < len(rewards) else 0
+        assert rewards[0] == 0.0
+        np.testing.assert_allclose(rewards[recycle_uid], 1.0, atol=1e-6)
+        v.state_store.close()
+
+    def test_unequal_collateral_proportional_rewards(self, tmp_path: Path):
+        """Two miners tie crown, unequal collateral → rewards scale linearly."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a', 'hk_b'])
+        v = make_validator(
+            tmp_path,
+            hotkeys,
+            max_swap_amount=500_000_000,
+            collaterals={'hk_a': 500_000_000, 'hk_b': 100_000_000},
+        )
+        conn = v.state_store.require_connection()
+        for hk in ('hk_a', 'hk_b'):
+            conn.execute(
+                'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+                (hk, 'tao', 'btc', 0.00020, 0),
+            )
+        conn.commit()
+        rewards, _ = calculate_miner_rewards(v)
+        # Both split crown 50/50. A's capacity = 1.0, B's = 0.2. Direction pool = 0.5.
+        # A earns 0.5 * 0.5 * 1.0 = 0.25; B earns 0.5 * 0.5 * 0.2 = 0.05.
+        np.testing.assert_allclose(rewards[0], 0.25, atol=1e-6)
+        np.testing.assert_allclose(rewards[1], 0.05, atol=1e-6)
+        v.state_store.close()
+
+    def test_cold_start_max_swap_zero_is_fail_safe(self, tmp_path: Path):
+        """max_swap_amount=0 (default) bypasses capacity weighting entirely.
+        Critical: a freshly restarted validator must not zero every miner."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
+        v = make_validator(tmp_path, hotkeys)  # defaults: max_swap=0, no collateral lookup
+        self.seed_tao_btc_crown(v, 'hk_a')
+        rewards, _ = calculate_miner_rewards(v)
+        # Fail-safe path: capacity_factor = 1.0 regardless of collateral.
+        np.testing.assert_allclose(rewards[0], POOL_TAO_BTC, atol=1e-6)
+        v.state_store.close()
+
+    def test_collateral_rpc_failure_is_logged_not_fatal(self, tmp_path: Path):
+        """A failing get_miner_collateral logs and treats as 0 → factor 0 →
+        miner's reward zeroes but the scoring pass completes."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
+        v = make_validator(tmp_path, hotkeys, max_swap_amount=500_000_000)
+        v.contract_client.get_miner_collateral.side_effect = RuntimeError('rpc down')
+        self.seed_tao_btc_crown(v, 'hk_a')
+        rewards, _ = calculate_miner_rewards(v)
+        assert rewards[0] == 0.0
+        v.state_store.close()
+
+    def test_collateral_read_cached_within_pass(self, tmp_path: Path):
+        """A miner holding crown in both directions has collateral fetched once,
+        not per-direction. Keeps the RPC budget bounded."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
+        v = make_validator(
+            tmp_path,
+            hotkeys,
+            max_swap_amount=500_000_000,
+            collaterals={'hk_a': 500_000_000},
+        )
+        conn = v.state_store.require_connection()
+        for from_c, to_c in (('tao', 'btc'), ('btc', 'tao')):
+            conn.execute(
+                'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+                ('hk_a', from_c, to_c, 0.00020 if from_c == 'tao' else 200.0, 0),
+            )
+        conn.commit()
+        calculate_miner_rewards(v)
+        # hk_a held crown in both directions → exactly one RPC for collateral.
+        assert v.contract_client.get_miner_collateral.call_count == 1
+        v.state_store.close()
+
+
+class TestVolumeWeighting:
+    """End-to-end volume weighting via calculate_miner_rewards."""
+
+    def seed_tao_btc_crown(self, v: SimpleNamespace, hotkey: str, rate: float = 0.00020) -> None:
+        conn = v.state_store.require_connection()
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            (hotkey, 'tao', 'btc', rate, 0),
+        )
+        conn.commit()
+
+    def insert_volume(
+        self,
+        v: SimpleNamespace,
+        miner_hotkey: str,
+        tao_amount: int,
+        swap_id: int = 1,
+        resolved_block: int = 9_500,
+        completed: bool = True,
+    ) -> None:
+        v.state_store.insert_swap_outcome(
+            swap_id=swap_id,
+            miner_hotkey=miner_hotkey,
+            completed=completed,
+            resolved_block=resolved_block,
+            tao_amount=tao_amount,
+        )
+
+    def test_idle_network_no_penalty(self, tmp_path: Path):
+        """Total network volume = 0 → factor 1.0 for all crown earners."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
+        v = make_validator(tmp_path, hotkeys)
+        self.seed_tao_btc_crown(v, 'hk_a')
+        rewards, _ = calculate_miner_rewards(v)
+        # No swaps → factor = 1.0 → full crown reward.
+        np.testing.assert_allclose(rewards[0], POOL_TAO_BTC, atol=1e-6)
+        v.state_store.close()
+
+    def test_idle_crown_holder_loses_alpha(self, tmp_path: Path):
+        """A holds 100% crown, B serves 100% volume → A factor = (1 - α)."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a', 'hk_b'])
+        v = make_validator(tmp_path, hotkeys)
+        self.seed_tao_btc_crown(v, 'hk_a')
+        # B doesn't post a rate → never holds crown.
+        self.insert_volume(v, 'hk_b', tao_amount=1_000_000_000, swap_id=1)
+        rewards, _ = calculate_miner_rewards(v)
+        # A's vol_share = 0, crown_share = 1.0 → participation = 0 → factor = 0.5.
+        # B has crown_share = 0 → no crown reward to multiply.
+        np.testing.assert_allclose(rewards[0], POOL_TAO_BTC * 0.5, atol=1e-6)
+        assert rewards[1] == 0.0
+        v.state_store.close()
+
+    def test_matched_crown_and_volume_full_reward(self, tmp_path: Path):
+        """Equal crown + equal volume → factor 1.0 for both."""
+        from allways.constants import VOLUME_WEIGHT_ALPHA  # noqa: F401 — keep imports tidy
+
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a', 'hk_b'])
+        v = make_validator(tmp_path, hotkeys)
+        conn = v.state_store.require_connection()
+        for hk in ('hk_a', 'hk_b'):
+            conn.execute(
+                'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+                (hk, 'tao', 'btc', 0.00020, 0),
+            )
+        conn.commit()
+        self.insert_volume(v, 'hk_a', tao_amount=500_000_000, swap_id=1)
+        self.insert_volume(v, 'hk_b', tao_amount=500_000_000, swap_id=2)
+        rewards, _ = calculate_miner_rewards(v)
+        # Both 50/50 on crown and volume → participation 1.0 → factor 1.0 each.
+        np.testing.assert_allclose(rewards[0], POOL_TAO_BTC * 0.5, atol=1e-6)
+        np.testing.assert_allclose(rewards[1], POOL_TAO_BTC * 0.5, atol=1e-6)
+        v.state_store.close()
+
+    def test_over_serving_capped_no_bonus(self, tmp_path: Path):
+        """A holds 100% crown but B serves 9× more volume → A's factor still > 0,
+        B gets nothing (no crown). Verifies cap is one-sided: high volume can't
+        amplify a low crown holder."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a', 'hk_b'])
+        v = make_validator(tmp_path, hotkeys)
+        # btc→tao: higher rate wins (canonical direction). A wins, B loses.
+        conn = v.state_store.require_connection()
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_a', 'btc', 'tao', 200.0, 0),
+        )
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_b', 'btc', 'tao', 100.0, 0),
+        )
+        conn.commit()
+        self.insert_volume(v, 'hk_a', tao_amount=100_000_000, swap_id=1)
+        self.insert_volume(v, 'hk_b', tao_amount=900_000_000, swap_id=2)
+        rewards, _ = calculate_miner_rewards(v)
+        # A: crown_share = 1.0, vol_share = 0.1, participation = 0.1 → factor = 0.55
+        np.testing.assert_allclose(rewards[0], POOL_BTC_TAO * 0.55, atol=1e-6)
+        # B: crown_share = 0 → factor moot, no reward to multiply.
+        assert rewards[1] == 0.0
+        v.state_store.close()
+
+    def test_partial_mismatch_interpolates(self, tmp_path: Path):
+        """A holds 80% crown / 20% volume, B holds 20% crown / 80% volume.
+        Uses btc→tao (higher rate wins) so the rate-direction mapping is
+        self-evident in the test."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a', 'hk_b'])
+        v = make_validator(tmp_path, hotkeys)
+        conn = v.state_store.require_connection()
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_a', 'btc', 'tao', 200.0, 0),
+        )
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_b', 'btc', 'tao', 150.0, 0),
+        )
+        conn.commit()
+        # Window is (9400, 10000]. A busy block 9_500..9_620 (120 blocks within
+        # the window) so B holds crown 20% of window.
+        v.event_watcher.apply_event(9_500, 'SwapInitiated', {'swap_id': 1, 'miner': 'hk_a'})
+        v.event_watcher.apply_event(9_620, 'SwapCompleted', {'swap_id': 1, 'miner': 'hk_a', 'tao_amount': 200_000_000})
+        self.insert_volume(v, 'hk_b', tao_amount=800_000_000, swap_id=2)
+        rewards, _ = calculate_miner_rewards(v)
+        # Crown: A=480/600=0.8, B=120/600=0.2. Volume: A=0.2, B=0.8.
+        # A participation = 0.2/0.8 = 0.25 → factor 0.625.
+        # B participation = min(1.0, 0.8/0.2) = 1.0 → factor 1.0.
+        np.testing.assert_allclose(rewards[0], POOL_BTC_TAO * 0.8 * 0.625, atol=1e-6)
+        np.testing.assert_allclose(rewards[1], POOL_BTC_TAO * 0.2 * 1.0, atol=1e-6)
+        v.state_store.close()
+
+    def test_timed_out_swaps_dont_count_as_volume(self, tmp_path: Path):
+        """SwapTimedOut hits credibility, not volume."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
+        v = make_validator(tmp_path, hotkeys)
+        self.seed_tao_btc_crown(v, 'hk_a')
+        # Timed-out swap → completed=False → ignored by get_volume_since.
+        self.insert_volume(
+            v,
+            'hk_a',
+            tao_amount=1_000_000_000,
+            swap_id=1,
+            completed=False,
+        )
+        rewards, _ = calculate_miner_rewards(v)
+        # Volume aggregator returns 0 → idle network short-circuit → factor 1.0.
+        # But sr is also dropped by the failed swap: 0/(0+1) = 0 → factor 0³.
+        # So reward is zero — but for credibility reasons, not volume.
+        assert rewards[0] == 0.0
+        v.state_store.close()
+
+    def test_volume_aggregates_across_directions(self, tmp_path: Path):
+        """tao_amount is the canonical TAO side regardless of swap direction —
+        get_volume_since sums across both directions per miner."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
+        v = make_validator(tmp_path, hotkeys)
+        self.seed_tao_btc_crown(v, 'hk_a')
+        # Two completed swaps, both contribute to volume.
+        self.insert_volume(v, 'hk_a', tao_amount=300_000_000, swap_id=1)
+        self.insert_volume(v, 'hk_a', tao_amount=200_000_000, swap_id=2)
+        volumes = v.state_store.get_volume_since(0)
+        assert volumes == {'hk_a': 500_000_000}
+        v.state_store.close()
+
+    def test_legacy_rows_with_zero_tao_amount_tolerated(self, tmp_path: Path):
+        """Pre-migration rows have tao_amount = 0 in the schema default — they
+        just don't count toward future volume aggregation."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
+        v = make_validator(tmp_path, hotkeys)
+        # Direct insert simulating a row that predates the column.
+        conn = v.state_store.require_connection()
+        conn.execute(
+            'INSERT INTO swap_outcomes (swap_id, miner_hotkey, completed, resolved_block, tao_amount) VALUES (?, ?, ?, ?, ?)',
+            (1, 'hk_a', 1, 9_000, 0),
+        )
+        conn.commit()
+        # No volume seen → idle-network short-circuit applies.
+        volumes = v.state_store.get_volume_since(0)
+        assert volumes == {'hk_a': 0}
+        v.state_store.close()
+
+
+class TestCapacityVolumeInteraction:
+    """Capacity + volume are independent multipliers — verify they compose."""
+
+    def test_both_factors_compose_multiplicatively(self, tmp_path: Path):
+        """Single miner, capacity 0.5, idle on volume → reward = pool * 0.5 * 0.5."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a', 'hk_b'])
+        v = make_validator(
+            tmp_path,
+            hotkeys,
+            max_swap_amount=500_000_000,
+            collaterals={'hk_a': 250_000_000},
+        )
+        conn = v.state_store.require_connection()
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_a', 'tao', 'btc', 0.00020, 0),
+        )
+        conn.commit()
+        # B serves some volume so A's vol_share = 0.
+        v.state_store.insert_swap_outcome(
+            swap_id=1,
+            miner_hotkey='hk_b',
+            completed=True,
+            resolved_block=9_500,
+            tao_amount=500_000_000,
+        )
+        rewards, _ = calculate_miner_rewards(v)
+        # A: pool 0.5 × crown 1.0 × sr 1.0 × capacity 0.5 × volume_factor 0.5
+        np.testing.assert_allclose(rewards[0], 0.5 * 1.0 * 1.0 * 0.5 * 0.5, atol=1e-6)
+        v.state_store.close()
+
+    def test_full_pool_conservation_with_all_factors(self, tmp_path: Path):
+        """Reward sum + recycle = 1.0 always, regardless of capacity/volume shortfalls."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a', 'hk_b'])
+        v = make_validator(
+            tmp_path,
+            hotkeys,
+            max_swap_amount=500_000_000,
+            collaterals={'hk_a': 100_000_000, 'hk_b': 500_000_000},
+        )
+        conn = v.state_store.require_connection()
+        for hk, rate in (('hk_a', 0.00020), ('hk_b', 200.0)):
+            from_c, to_c = ('tao', 'btc') if rate < 1 else ('btc', 'tao')
+            conn.execute(
+                'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+                (hk, from_c, to_c, rate, 0),
+            )
+        conn.commit()
+        v.state_store.insert_swap_outcome(
+            swap_id=1,
+            miner_hotkey='hk_b',
+            completed=True,
+            resolved_block=9_500,
+            tao_amount=400_000_000,
+        )
+        rewards, _ = calculate_miner_rewards(v)
+        np.testing.assert_allclose(rewards.sum(), 1.0, atol=1e-6)
+        v.state_store.close()
+
+
+class TestStateStoreVolumeMigration:
+    """The tao_amount column was added in a schema migration. Ensure the
+    ALTER path is idempotent and aggregation tolerates legacy data."""
+
+    def test_idempotent_alter_on_reopen(self, tmp_path: Path):
+        """Opening the DB twice must not fail on duplicate ALTER."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        store.close()
+        # Re-open — init_db runs again, ALTER must be caught.
+        store2 = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        store2.close()
+
+    def test_insert_swap_outcome_persists_tao_amount(self, tmp_path: Path):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        store.insert_swap_outcome(
+            swap_id=42,
+            miner_hotkey='hk_a',
+            completed=True,
+            resolved_block=1_000,
+            tao_amount=123_456_789,
+        )
+        row = (
+            store.require_connection()
+            .execute(
+                'SELECT tao_amount FROM swap_outcomes WHERE swap_id = ?',
+                (42,),
+            )
+            .fetchone()
+        )
+        assert row['tao_amount'] == 123_456_789
+        store.close()
+
+    def test_get_volume_since_excludes_timed_out(self, tmp_path: Path):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        store.insert_swap_outcome(
+            swap_id=1,
+            miner_hotkey='hk_a',
+            completed=True,
+            resolved_block=1_000,
+            tao_amount=100_000_000,
+        )
+        store.insert_swap_outcome(
+            swap_id=2,
+            miner_hotkey='hk_a',
+            completed=False,
+            resolved_block=1_100,
+            tao_amount=999_999_999,
+        )
+        assert store.get_volume_since(0) == {'hk_a': 100_000_000}
+        store.close()
+
+    def test_get_volume_since_respects_cutoff(self, tmp_path: Path):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        store.insert_swap_outcome(
+            swap_id=1,
+            miner_hotkey='hk_a',
+            completed=True,
+            resolved_block=500,
+            tao_amount=100_000_000,
+        )
+        store.insert_swap_outcome(
+            swap_id=2,
+            miner_hotkey='hk_a',
+            completed=True,
+            resolved_block=1_500,
+            tao_amount=200_000_000,
+        )
+        # since=1_000 → only the later swap counts.
+        assert store.get_volume_since(1_000) == {'hk_a': 200_000_000}
+        store.close()
+
+
+class TestEventWatcherPassesTaoAmount:
+    """SwapCompleted events carry tao_amount; it must reach the state store."""
+
+    def test_swap_completed_persists_tao_amount(self, tmp_path: Path):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active={'hk_a'})
+        # Pre-arm with the matching SwapInitiated so the busy delta is consistent.
+        watcher.apply_event(100, 'SwapInitiated', {'swap_id': 7, 'miner': 'hk_a'})
+        watcher.apply_event(
+            200,
+            'SwapCompleted',
+            {'swap_id': 7, 'miner': 'hk_a', 'tao_amount': 250_000_000},
+        )
+        assert store.get_volume_since(0) == {'hk_a': 250_000_000}
+        store.close()
+
+    def test_swap_completed_without_tao_amount_defaults_to_zero(self, tmp_path: Path):
+        """Tests that don't set tao_amount still work (backwards compat with
+        the older test fixtures that didn't pass the field)."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active={'hk_a'})
+        watcher.apply_event(100, 'SwapInitiated', {'swap_id': 7, 'miner': 'hk_a'})
+        watcher.apply_event(200, 'SwapCompleted', {'swap_id': 7, 'miner': 'hk_a'})
+        # Row exists but tao_amount is 0 → excluded from any positive-volume
+        # network.
+        row = (
+            store.require_connection()
+            .execute(
+                'SELECT tao_amount FROM swap_outcomes WHERE swap_id = 7',
+            )
+            .fetchone()
+        )
+        assert row['tao_amount'] == 0
+        store.close()

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -68,6 +68,7 @@ def make_validator(
     *,
     max_swap_amount: int = 0,
     collaterals: dict[str, int] | None = None,
+    baseline_credibility: bool = True,
 ) -> SimpleNamespace:
     """Build a SimpleNamespace stand-in for the validator.
 
@@ -75,7 +76,14 @@ def make_validator(
     returns 1.0 fail-safe) and provide a zero-collateral stub. Tests that
     exercise capacity weighting pass explicit ``max_swap_amount`` and
     ``collaterals`` overrides.
+
+    ``baseline_credibility`` pre-seeds enough completed swap outcomes per
+    hotkey to keep the credibility ramp at 1.0 — every test that isn't
+    specifically exercising the ramp gets a "fully credible" miner by
+    default. Credibility tests pass ``False`` to start from zero.
     """
+    from allways.constants import CREDIBILITY_RAMP_OBSERVATIONS
+
     store = ValidatorStateStore(db_path=tmp_path / 'state.db')
     watcher = make_watcher(store, active=set(hotkeys))
     collaterals = collaterals or {}
@@ -83,6 +91,15 @@ def make_validator(
     bounds_cache.max_swap_amount.return_value = max_swap_amount
     contract_client = MagicMock()
     contract_client.get_miner_collateral.side_effect = lambda hk: collaterals.get(hk, 0)
+    if baseline_credibility:
+        for hk_idx, hk in enumerate(hotkeys):
+            for i in range(CREDIBILITY_RAMP_OBSERVATIONS):
+                store.insert_swap_outcome(
+                    swap_id=-(hk_idx * CREDIBILITY_RAMP_OBSERVATIONS + i + 1),
+                    miner_hotkey=hk,
+                    completed=True,
+                    resolved_block=0,
+                )
     return SimpleNamespace(
         block=block,
         metagraph=make_metagraph(hotkeys),
@@ -102,14 +119,35 @@ def pad_hotkeys_to_cover_recycle(seeds: list[str]) -> list[str]:
 
 
 class TestSuccessRateHelper:
-    def test_none_is_optimistic(self):
-        assert success_rate(None) == 1.0
+    def test_none_is_pessimistic(self):
+        """Zero observations earns no trust — the credibility hole closed."""
+        assert success_rate(None) == 0.0
 
-    def test_zero_total_is_optimistic(self):
-        assert success_rate((0, 0)) == 1.0
+    def test_zero_total_is_pessimistic(self):
+        assert success_rate((0, 0)) == 0.0
 
-    def test_ratio_is_completed_over_total(self):
+    def test_ratio_at_full_ramp_is_raw_rate(self):
+        """At >= CREDIBILITY_RAMP_OBSERVATIONS closed swaps the ramp is a no-op."""
         assert success_rate((8, 2)) == 0.8
+
+    def test_ramp_scales_below_threshold(self):
+        """1 closed swap → ramp 0.1; raw rate is 1.0 → sr = 0.1."""
+        assert success_rate((1, 0)) == 0.1
+
+    def test_ramp_half_at_half_observations(self):
+        """5/5 completed → ramp 0.5, raw 1.0 → sr = 0.5."""
+        assert success_rate((5, 0)) == 0.5
+
+    def test_timed_out_swaps_advance_ramp(self):
+        """A timeout still counts as a closed observation — moves the ramp,
+        drops the raw rate."""
+        # 5 completed + 5 timed_out: total=10, ramp=1.0, raw=0.5 → 0.5
+        assert success_rate((5, 5)) == 0.5
+
+    def test_full_ramp_with_mixed_outcomes(self):
+        """At the ramp cap, sr equals the raw success rate exactly."""
+        assert success_rate((8, 2)) == 0.8
+        assert success_rate((90, 10)) == 0.9
 
 
 class TestCrownHoldersHelper:
@@ -380,8 +418,10 @@ class TestCalculateMinerRewards:
         v.state_store.close()
 
     def test_partial_success_reduces_reward_by_cube(self, tmp_path: Path):
+        # Opt out of the fixture's baseline credibility seed so the test's
+        # explicit 8-completed-2-timed-out profile is the only credibility data.
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
-        v = make_validator(tmp_path, hotkeys=hotkeys)
+        v = make_validator(tmp_path, hotkeys=hotkeys, baseline_credibility=False)
         conn = v.state_store.require_connection()
         conn.execute(
             'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
@@ -1327,9 +1367,8 @@ class TestVolumeWeighting:
     def test_timed_out_swaps_dont_count_as_volume(self, tmp_path: Path):
         """SwapTimedOut hits credibility, not volume."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
-        v = make_validator(tmp_path, hotkeys)
+        v = make_validator(tmp_path, hotkeys, baseline_credibility=False)
         self.seed_tao_btc_crown(v, 'hk_a')
-        # Timed-out swap → completed=False → ignored by get_volume_since.
         self.insert_volume(
             v,
             'hk_a',
@@ -1339,8 +1378,9 @@ class TestVolumeWeighting:
         )
         rewards, _ = calculate_miner_rewards(v)
         # Volume aggregator returns 0 → idle network short-circuit → factor 1.0.
-        # But sr is also dropped by the failed swap: 0/(0+1) = 0 → factor 0³.
-        # So reward is zero — but for credibility reasons, not volume.
+        # sr from (0 completed, 1 timed_out) = 0 → cubed = 0 → reward 0 via
+        # credibility, confirming the timed-out swap didn't sneak through as
+        # volume credit.
         assert rewards[0] == 0.0
         v.state_store.close()
 
@@ -1348,9 +1388,8 @@ class TestVolumeWeighting:
         """tao_amount is the canonical TAO side regardless of swap direction —
         get_volume_since sums across both directions per miner."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
-        v = make_validator(tmp_path, hotkeys)
+        v = make_validator(tmp_path, hotkeys, baseline_credibility=False)
         self.seed_tao_btc_crown(v, 'hk_a')
-        # Two completed swaps, both contribute to volume.
         self.insert_volume(v, 'hk_a', tao_amount=300_000_000, swap_id=1)
         self.insert_volume(v, 'hk_a', tao_amount=200_000_000, swap_id=2)
         volumes = v.state_store.get_volume_since(0)
@@ -1361,15 +1400,13 @@ class TestVolumeWeighting:
         """Pre-migration rows have tao_amount = 0 in the schema default — they
         just don't count toward future volume aggregation."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
-        v = make_validator(tmp_path, hotkeys)
-        # Direct insert simulating a row that predates the column.
+        v = make_validator(tmp_path, hotkeys, baseline_credibility=False)
         conn = v.state_store.require_connection()
         conn.execute(
             'INSERT INTO swap_outcomes (swap_id, miner_hotkey, completed, resolved_block, tao_amount) VALUES (?, ?, ?, ?, ?)',
             (1, 'hk_a', 1, 9_000, 0),
         )
         conn.commit()
-        # No volume seen → idle-network short-circuit applies.
         volumes = v.state_store.get_volume_since(0)
         assert volumes == {'hk_a': 0}
         v.state_store.close()
@@ -1431,6 +1468,101 @@ class TestCapacityVolumeInteraction:
             tao_amount=400_000_000,
         )
         rewards, _ = calculate_miner_rewards(v)
+        np.testing.assert_allclose(rewards.sum(), 1.0, atol=1e-6)
+        v.state_store.close()
+
+
+class TestCredibilityRamp:
+    """End-to-end ramp behavior via calculate_miner_rewards.
+
+    Pessimistic-default + linear ramp closes the new-miner free-emission hole
+    without a hard cliff. A genuinely active miner crosses the ramp in 10
+    closed swaps and is then indistinguishable from a long-running miner with
+    the same raw success rate.
+    """
+
+    def seed_btc_tao_crown(self, v: SimpleNamespace, hotkey: str, rate: float = 200.0) -> None:
+        conn = v.state_store.require_connection()
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            (hotkey, 'btc', 'tao', rate, 0),
+        )
+        conn.commit()
+
+    def test_zero_observations_earns_nothing(self, tmp_path: Path):
+        """A brand-new miner with no closed swaps earns nothing even with
+        full crown — the old optimistic-default hole."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
+        v = make_validator(tmp_path, hotkeys, baseline_credibility=False)
+        self.seed_btc_tao_crown(v, 'hk_a')
+        rewards, _ = calculate_miner_rewards(v)
+        assert rewards[0] == 0.0
+        v.state_store.close()
+
+    def test_one_completed_earns_thousandth(self, tmp_path: Path):
+        """1/1 completed → sr = 0.1, cubed = 0.001 → effectively zero."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
+        v = make_validator(tmp_path, hotkeys, baseline_credibility=False)
+        self.seed_btc_tao_crown(v, 'hk_a')
+        v.state_store.insert_swap_outcome(swap_id=1, miner_hotkey='hk_a', completed=True, resolved_block=100)
+        rewards, _ = calculate_miner_rewards(v)
+        np.testing.assert_allclose(rewards[0], POOL_BTC_TAO * 0.1**3, atol=1e-6)
+        v.state_store.close()
+
+    def test_five_completed_quarter_of_pool(self, tmp_path: Path):
+        """5/5 completed → sr = 0.5, cubed = 0.125 → 1/8 of the direction pool."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
+        v = make_validator(tmp_path, hotkeys, baseline_credibility=False)
+        self.seed_btc_tao_crown(v, 'hk_a')
+        for i in range(5):
+            v.state_store.insert_swap_outcome(
+                swap_id=i + 1, miner_hotkey='hk_a', completed=True, resolved_block=100 + i
+            )
+        rewards, _ = calculate_miner_rewards(v)
+        np.testing.assert_allclose(rewards[0], POOL_BTC_TAO * 0.5**3, atol=1e-6)
+        v.state_store.close()
+
+    def test_full_ramp_at_threshold(self, tmp_path: Path):
+        """10/10 completed → sr = 1.0, full pool earned."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
+        v = make_validator(tmp_path, hotkeys, baseline_credibility=False)
+        self.seed_btc_tao_crown(v, 'hk_a')
+        for i in range(10):
+            v.state_store.insert_swap_outcome(
+                swap_id=i + 1, miner_hotkey='hk_a', completed=True, resolved_block=100 + i
+            )
+        rewards, _ = calculate_miner_rewards(v)
+        np.testing.assert_allclose(rewards[0], POOL_BTC_TAO, atol=1e-6)
+        v.state_store.close()
+
+    def test_timeouts_advance_ramp_but_hurt_raw_rate(self, tmp_path: Path):
+        """5 completed + 5 timed_out → ramp = 1.0, raw = 0.5 → cubed = 0.125."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
+        v = make_validator(tmp_path, hotkeys, baseline_credibility=False)
+        self.seed_btc_tao_crown(v, 'hk_a')
+        for i in range(5):
+            v.state_store.insert_swap_outcome(
+                swap_id=i + 1, miner_hotkey='hk_a', completed=True, resolved_block=100 + i
+            )
+        for i in range(5):
+            v.state_store.insert_swap_outcome(
+                swap_id=100 + i, miner_hotkey='hk_a', completed=False, resolved_block=200 + i
+            )
+        rewards, _ = calculate_miner_rewards(v)
+        np.testing.assert_allclose(rewards[0], POOL_BTC_TAO * 0.5**3, atol=1e-6)
+        v.state_store.close()
+
+    def test_unearned_ramp_portion_recycles(self, tmp_path: Path):
+        """Ramped-down reward doesn't transfer to other miners — it recycles."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
+        v = make_validator(tmp_path, hotkeys, baseline_credibility=False)
+        self.seed_btc_tao_crown(v, 'hk_a')
+        v.state_store.insert_swap_outcome(swap_id=1, miner_hotkey='hk_a', completed=True, resolved_block=100)
+        rewards, _ = calculate_miner_rewards(v)
+        recycle_uid = RECYCLE_UID if RECYCLE_UID < len(rewards) else 0
+        # tao→btc pool fully recycles (no holder), btc→tao gives A 0.001;
+        # the remaining 0.499 + 0.5 = 0.999 recycles.
+        np.testing.assert_allclose(rewards[recycle_uid], 1.0 - POOL_BTC_TAO * 0.1**3, atol=1e-6)
         np.testing.assert_allclose(rewards.sum(), 1.0, atol=1e-6)
         v.state_store.close()
 


### PR DESCRIPTION
## Problem → Solution

**Problem 1 — Idle crown farming.** A miner can post just-above-market rates, self-reserve to lock themselves out, and earn full emission for "being available" without ever serving swaps. We can't simply stop paying reserved miners (inverse exploit: attackers force-reserve real miners to zero their emissions).

→ **Capacity + volume weighting on per-direction rewards.** Independent multipliers on the existing crown-time × success_rate³ formula:

```
reward_i = Σ_dir [pool_d × crown_share_id × sr_i³ × capacity_i] × volume_factor_i
```

- `capacity_factor = min(1.0, collateral / max_swap_amount)`. A miner at the 0.1 TAO collateral floor with a 0.5 TAO max swap only covers 20% of the swap-size band, so they earn 20% of what they'd otherwise win. Cold-start fail-safe to 1.0 when bounds aren't readable.
- `volume_factor = (1 - α) + α × min(1.0, vol_share / crown_share)`, α=0.5. Idle crown holders lose half; over-serving is capped at 1.0 — the cap is the anti-wash-trade guarantee (no incentive to force volume past parity with your crown share). Quiet network (zero volume) → factor 1.0, no penalty.

Each shortfall recycles to `RECYCLE_UID`; nothing transfers between miners.

**Problem 2 — New-miner free emission.** `success_rate(stats)` defaulted to 1.0 for zero-outcome miners, so a fresh hotkey holding crown earned the full cubed multiplier (`1.0³ = 1.0`) before serving anything. Cheap sybil farming surface.

→ **Linear credibility ramp.**

```
success_rate = (completed / total) × min(1.0, total / CREDIBILITY_RAMP_OBSERVATIONS)
```

`CREDIBILITY_RAMP_OBSERVATIONS = 10`. Zero observations → zero credibility. Each closed swap (completed or timed-out) climbs the ramp by 10%. At ≥10 closed swaps the ramp is a no-op and the function returns the raw success rate exactly as before. A miner with 8/10 still gets `0.8³ = 0.512` — no behavior change at steady state, only the bootstrap window changes.

This is the right shape for the network: it incentivizes brand-new miners to actually compete for crown and serve swaps (each successful fulfillment is a measurable credibility gain), instead of dropping in and farming from day one.

## Recycling

All four shortfall sources flow to `RECYCLE_UID`:
- Success rate (`sr³` < 1)
- Capacity (`collateral / max_swap` < 1)
- Volume (`vol_share / crown_share` < 1)
- Crown unfilled (no qualifying miner)

None redirect to other miners. Pool conservation is invariant (`rewards.sum() == 1.0` always).

## Surfacing

The per-round scoring trace now reads per crown earner:

```
uid=12 hotkey=5C1a.. crown_blk=400 sr=0.500 (5/10 closed, ramp=0.50) cap=0.20 (col=0.1t) vol=0.000t vol_share=0.00 crown_share=1.00 vol_f=0.50 reward=0.013
```

A miner sees exactly which factor zeroed them: collateral too low → raise; volume too low → fulfill more; closed swaps too few → keep grinding.

## Test plan

- [x] `ruff check allways/ tests/` — clean
- [x] `ruff format --check` — all formatted
- [x] `pytest tests/` — 461/461 passing locally (97 in scoring, including 19 new for capacity/volume/credibility behavior)
- [x] Algebraic spot-checks on every new factor (helpers + integration)
- [x] Pool-conservation regression: `rewards.sum() == 1.0` across mixed-factor scenarios
- [x] Schema migration is idempotent (`duplicate column` caught)
- [x] Cold-start fail-safe verified: `bounds_cache.max_swap_amount()` returns 0 → capacity_factor = 1.0 (no zeroing on first pass post-restart)
- [ ] After merge: pull on lena, restart `aw-vali`, watch the scoring trace surface the new factors on the next pass