### PR TITLE
bump pyproject.toml to 1.0.3

### DIFF
--- a/allways/__init__.py
+++ b/allways/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '1.0.2'
+__version__ = '1.0.3'
 version_split = __version__.split('.')
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "allways"
-version = "1.0.2"
+version = "1.0.3"
 description = "Allways - Universal Transaction Layer: Trustless cross-chain swaps on Bittensor Subnet 7"
 license = "MIT"
 requires-python = ">=3.10,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "allways"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "base58" },


### PR DESCRIPTION
## Summary
- bumps `pyproject.toml`, `allways/__init__.py`, `uv.lock` to v1.0.3
- pre-cuts release for capacity/volume/credibility scoring (#324) so watchtower auto-rolls validators on `test` → `main` promotion

## Test plan
- [x] `uv lock` regenerated cleanly
- [ ] verify `aw-vali` container restarts on lena box post-merge to `main`