### PR TITLE
fix: refuse BTC source send when reservation TTL is too short to extend (#315)

### DIFF
--- a/allways/chains.py
+++ b/allways/chains.py
@@ -95,3 +95,49 @@ def compute_extension_target(
     # at MAX_EXTENSION_BLOCKS (lib.rs:670, :1090), so a deadline anchor blows
     # the cap whenever propose fires before the deadline.
     return current_subnet_block + blocks_needed
+
+
+# Status returned by ``classify_send_runway`` — see that function for semantics.
+RUNWAY_OK = 'ok'
+RUNWAY_EXTENSION_REQUIRED = 'extension_required'
+RUNWAY_TOO_SHORT = 'too_short'
+
+# Subtensor blocks set aside for the user's source tx to propagate to
+# validators' RPC view before the extension propose flow can pick it up.
+# ~1 minute covers typical Blockstream/Esplora indexing lag.
+SEND_PROPAGATION_BUFFER_BLOCKS = 5
+
+
+def classify_send_runway(
+    from_chain_id: str,
+    current_subnet_block: int,
+    reserved_until_block: int,
+    extend_threshold_blocks: int,
+) -> tuple[str, int]:
+    """Classify whether broadcasting the source tx now is safe.
+
+    The validator extension flow (optimistic_extensions.py) needs at least
+    ``extend_threshold_blocks`` of runway before the deadline to land a
+    propose tx and let its challenge window elapse — without that, the
+    propose is mechanically doomed and the reservation will expire. The
+    user's tx also needs a ~1 min propagation buffer so the validator can
+    actually see it before proposing.
+
+    Returns ``(status, remaining_blocks)`` where status is one of:
+      * ``RUNWAY_OK`` — full confirmation window fits in remaining TTL.
+        No validator extension needed; broadcast freely.
+      * ``RUNWAY_EXTENSION_REQUIRED`` — confirmations won't fit in TTL,
+        but there is enough runway for validators to auto-extend once
+        the tx is visible. Caller should warn but may proceed.
+      * ``RUNWAY_TOO_SHORT`` — TTL is below the extension floor; even
+        the auto-extension cannot rescue this broadcast. Caller should
+        refuse to send.
+    """
+    remaining = reserved_until_block - current_subnet_block
+    confirmation_subnet_blocks = confirmations_to_subtensor_blocks(from_chain_id)
+
+    if remaining < extend_threshold_blocks + SEND_PROPAGATION_BUFFER_BLOCKS:
+        return (RUNWAY_TOO_SHORT, remaining)
+    if remaining < confirmation_subnet_blocks + SEND_PROPAGATION_BUFFER_BLOCKS:
+        return (RUNWAY_EXTENSION_REQUIRED, remaining)
+    return (RUNWAY_OK, remaining)

--- a/allways/cli/preflight.py
+++ b/allways/cli/preflight.py
@@ -1,0 +1,79 @@
+"""Pre-broadcast safety gate for source funds.
+
+Sits outside ``swap_commands/`` so importing it does not trigger that
+package's eager command-registration ``__init__.py`` (which pulls in
+bittensor via helpers). That keeps the wiring unit-testable without the
+whole CLI stack. swap.py and resume.py both import the public
+``preflight_send_runway`` and call it after the user has approved the
+send but before any funds leave the wallet.
+"""
+
+import click
+from rich.console import Console
+
+from allways.chains import (
+    RUNWAY_EXTENSION_REQUIRED,
+    RUNWAY_TOO_SHORT,
+    classify_send_runway,
+    get_chain,
+)
+from allways.constants import EXTEND_THRESHOLD_BLOCKS
+
+# Local Console rather than helpers.console: helpers.py imports bittensor at
+# module load and would defeat the whole point of keeping this module light.
+# Both Consoles target stdout — output ordering is unaffected.
+_console = Console()
+
+_SECONDS_PER_BLOCK = 12
+
+
+def _blocks_to_minutes_str(blocks: int) -> str:
+    return f'~{blocks * _SECONDS_PER_BLOCK / 60:.0f} min'
+
+
+def preflight_send_runway(
+    subtensor,
+    from_chain: str,
+    reserved_until_block: int,
+    skip_confirm: bool,
+) -> bool:
+    """Refuse / hard-warn before broadcasting source funds into a doomed reservation.
+
+    Re-reads the current subtensor block (the user may have idled at the
+    summary panel) and classifies the remaining TTL against the validator
+    auto-extension floor. Returns True if the caller should proceed with
+    the broadcast, False if the caller should abort. See
+    ``classify_send_runway`` in allways/chains.py for the categories.
+    """
+    current_block = subtensor.get_current_block()
+    status, remaining = classify_send_runway(
+        from_chain, current_block, reserved_until_block, EXTEND_THRESHOLD_BLOCKS
+    )
+    if status == RUNWAY_TOO_SHORT:
+        chain = get_chain(from_chain)
+        confs_min = chain.min_confirmations * chain.seconds_per_block // 60
+        _console.print(
+            f'\n[red]Refusing to send: only {_blocks_to_minutes_str(max(0, remaining))} '
+            f'left on the reservation — below the {EXTEND_THRESHOLD_BLOCKS}-block '
+            f'floor needed for validators to auto-extend. {chain.min_confirmations} '
+            f'{from_chain.upper()} confirmation(s) take ~{confs_min} min, so the '
+            f'reservation will expire before your tx confirms and the swap will fail.[/red]'
+        )
+        _console.print(
+            '[yellow]Start fresh with a new reservation: [cyan]alw swap now[/cyan][/yellow]'
+        )
+        return False
+    if status == RUNWAY_EXTENSION_REQUIRED:
+        chain = get_chain(from_chain)
+        confs_min = chain.min_confirmations * chain.seconds_per_block // 60
+        _console.print(
+            f'\n[yellow]Reservation has {_blocks_to_minutes_str(remaining)} left, less '
+            f'than the ~{confs_min} min needed for {chain.min_confirmations} '
+            f'{from_chain.upper()} confirmation(s). Validators will auto-extend once '
+            f"your tx is visible — but if they miss the window, the swap will expire "
+            f'before confirmation and your funds may be stranded.[/yellow]'
+        )
+        if not skip_confirm and not click.confirm('  Send anyway?', default=False):
+            _console.print('[yellow]Cancelled. Start fresh with: alw swap now[/yellow]')
+            return False
+    return True

--- a/allways/cli/preflight.py
+++ b/allways/cli/preflight.py
@@ -46,9 +46,7 @@ def preflight_send_runway(
     ``classify_send_runway`` in allways/chains.py for the categories.
     """
     current_block = subtensor.get_current_block()
-    status, remaining = classify_send_runway(
-        from_chain, current_block, reserved_until_block, EXTEND_THRESHOLD_BLOCKS
-    )
+    status, remaining = classify_send_runway(from_chain, current_block, reserved_until_block, EXTEND_THRESHOLD_BLOCKS)
     if status == RUNWAY_TOO_SHORT:
         chain = get_chain(from_chain)
         confs_min = chain.min_confirmations * chain.seconds_per_block // 60
@@ -59,9 +57,7 @@ def preflight_send_runway(
             f'{from_chain.upper()} confirmation(s) take ~{confs_min} min, so the '
             f'reservation will expire before your tx confirms and the swap will fail.[/red]'
         )
-        _console.print(
-            '[yellow]Start fresh with a new reservation: [cyan]alw swap now[/cyan][/yellow]'
-        )
+        _console.print('[yellow]Start fresh with a new reservation: [cyan]alw swap now[/cyan][/yellow]')
         return False
     if status == RUNWAY_EXTENSION_REQUIRED:
         chain = get_chain(from_chain)
@@ -70,7 +66,7 @@ def preflight_send_runway(
             f'\n[yellow]Reservation has {_blocks_to_minutes_str(remaining)} left, less '
             f'than the ~{confs_min} min needed for {chain.min_confirmations} '
             f'{from_chain.upper()} confirmation(s). Validators will auto-extend once '
-            f"your tx is visible — but if they miss the window, the swap will expire "
+            f'your tx is visible — but if they miss the window, the swap will expire '
             f'before confirmation and your funds may be stranded.[/yellow]'
         )
         if not skip_confirm and not click.confirm('  Send anyway?', default=False):

--- a/allways/cli/swap_commands/resume.py
+++ b/allways/cli/swap_commands/resume.py
@@ -25,6 +25,7 @@ from allways.cli.swap_commands.helpers import (
 from allways.cli.swap_commands.swap import (
     from_smallest_unit,
     poll_for_swap_with_progress,
+    preflight_send_runway,
     resolve_recent_swap_id,
     send_btc,
     send_tao_transfer,
@@ -187,6 +188,8 @@ def resume_reservation_command(from_tx_hash_opt: Optional[str], auto_send: bool,
             from_tx_hash_opt = saved_tx
             used_saved_tx = True
         elif auto_send:
+            if not preflight_send_runway(subtensor, state.from_chain, reserved_until, skip_confirm):
+                return
             console.print(f'\n[dim]Sending {send_label} to {state.miner_from_address}...[/dim]')
             if state.from_chain == 'tao':
                 send_result = send_tao_transfer(wallet, subtensor, state.miner_from_address, state.from_amount)

--- a/allways/cli/swap_commands/resume.py
+++ b/allways/cli/swap_commands/resume.py
@@ -11,6 +11,7 @@ from allways.chain_providers import create_chain_providers
 from allways.chains import get_chain
 from allways.classes import SwapStatus
 from allways.cli.dendrite_lite import discover_validators, get_ephemeral_wallet
+from allways.cli.preflight import preflight_send_runway
 from allways.cli.swap_commands.helpers import (
     blocks_to_minutes_str,
     clear_pending_swap,
@@ -22,7 +23,6 @@ from allways.cli.swap_commands.helpers import (
     mark_pending_swap_tx_sent,
     resolve_source_tx_block,
 )
-from allways.cli.preflight import preflight_send_runway
 from allways.cli.swap_commands.swap import (
     from_smallest_unit,
     poll_for_swap_with_progress,

--- a/allways/cli/swap_commands/resume.py
+++ b/allways/cli/swap_commands/resume.py
@@ -22,10 +22,10 @@ from allways.cli.swap_commands.helpers import (
     mark_pending_swap_tx_sent,
     resolve_source_tx_block,
 )
+from allways.cli.preflight import preflight_send_runway
 from allways.cli.swap_commands.swap import (
     from_smallest_unit,
     poll_for_swap_with_progress,
-    preflight_send_runway,
     resolve_recent_swap_id,
     send_btc,
     send_tao_transfer,

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -11,7 +11,14 @@ from rich.panel import Panel
 from rich.table import Table
 
 from allways.chain_providers import create_chain_providers
-from allways.chains import SUPPORTED_CHAINS, canonical_pair, get_chain
+from allways.chains import (
+    RUNWAY_EXTENSION_REQUIRED,
+    RUNWAY_TOO_SHORT,
+    SUPPORTED_CHAINS,
+    canonical_pair,
+    classify_send_runway,
+    get_chain,
+)
 from allways.classes import SwapStatus
 from allways.cli.dendrite_lite import broadcast_synapse, discover_validators, get_ephemeral_wallet
 from allways.cli.help import StyledGroup
@@ -34,7 +41,7 @@ from allways.cli.swap_commands.helpers import (
 )
 from allways.cli.validator_rejections import RejectionInfo, render_and_aggregate
 from allways.commitments import read_miner_commitments
-from allways.constants import FEE_DIVISOR, NETUID_FINNEY
+from allways.constants import EXTEND_THRESHOLD_BLOCKS, FEE_DIVISOR, NETUID_FINNEY
 from allways.contract_client import ContractError
 from allways.synapses import SwapConfirmSynapse, SwapReserveSynapse
 from allways.utils.proofs import reserve_proof_message, swap_proof_message
@@ -337,6 +344,54 @@ def broadcast_reserve_with_retry(
 # =========================================================================
 # Swap-specific helpers
 # =========================================================================
+
+
+def preflight_send_runway(
+    subtensor,
+    from_chain: str,
+    reserved_until_block: int,
+    skip_confirm: bool,
+) -> bool:
+    """Refuse / hard-warn before broadcasting source funds into a doomed reservation.
+
+    Re-reads the current subtensor block (the user may have idled at the
+    summary panel) and classifies the remaining TTL against the validator
+    auto-extension floor. Returns True if the caller should proceed with
+    the broadcast, False if the caller should abort. See
+    ``classify_send_runway`` in allways/chains.py for the categories.
+    """
+    current_block = subtensor.get_current_block()
+    status, remaining = classify_send_runway(
+        from_chain, current_block, reserved_until_block, EXTEND_THRESHOLD_BLOCKS
+    )
+    if status == RUNWAY_TOO_SHORT:
+        chain = get_chain(from_chain)
+        confs_min = chain.min_confirmations * chain.seconds_per_block // 60
+        console.print(
+            f'\n[red]Refusing to send: only {blocks_to_minutes_str(max(0, remaining))} '
+            f'left on the reservation — below the {EXTEND_THRESHOLD_BLOCKS}-block '
+            f'floor needed for validators to auto-extend. {chain.min_confirmations} '
+            f'{from_chain.upper()} confirmation(s) take ~{confs_min} min, so the '
+            f'reservation will expire before your tx confirms and the swap will fail.[/red]'
+        )
+        console.print(
+            '[yellow]Start fresh with a new reservation: [cyan]alw swap now[/cyan][/yellow]'
+        )
+        return False
+    if status == RUNWAY_EXTENSION_REQUIRED:
+        chain = get_chain(from_chain)
+        confs_min = chain.min_confirmations * chain.seconds_per_block // 60
+        console.print(
+            f'\n[yellow]Reservation has {blocks_to_minutes_str(remaining)} left, less '
+            f'than the ~{confs_min} min needed for {chain.min_confirmations} '
+            f'{from_chain.upper()} confirmation(s). Validators will auto-extend once '
+            f"your tx is visible — but if they miss the window, the swap will expire "
+            f'before confirmation and your funds may be stranded.[/yellow]'
+        )
+        if not skip_confirm and not click.confirm('  Send anyway?', default=False):
+            console.print('[yellow]Cancelled. Start fresh with: alw swap now[/yellow]')
+            return False
+    return True
 
 
 def display_timeout_notice(swap, dashboard_url: str):
@@ -1053,6 +1108,9 @@ def swap_now_command(
         )
         if not skip_confirm and not click.confirm('  Send now?', default=True):
             console.print('[yellow]Swap paused. Resume with: alw swap post-tx <tx_hash>[/yellow]')
+            return
+
+        if not preflight_send_runway(subtensor, from_chain, reserved_until, skip_confirm):
             return
 
         console.print(f'\n[dim]Step 2/3: Sending {from_chain.upper()}...[/dim]')

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -11,14 +11,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from allways.chain_providers import create_chain_providers
-from allways.chains import (
-    RUNWAY_EXTENSION_REQUIRED,
-    RUNWAY_TOO_SHORT,
-    SUPPORTED_CHAINS,
-    canonical_pair,
-    classify_send_runway,
-    get_chain,
-)
+from allways.chains import SUPPORTED_CHAINS, canonical_pair, get_chain
 from allways.classes import SwapStatus
 from allways.cli.dendrite_lite import broadcast_synapse, discover_validators, get_ephemeral_wallet
 from allways.cli.help import StyledGroup
@@ -39,9 +32,10 @@ from allways.cli.swap_commands.helpers import (
     save_pending_swap,
     sign_or_prompt_external,
 )
+from allways.cli.preflight import preflight_send_runway
 from allways.cli.validator_rejections import RejectionInfo, render_and_aggregate
 from allways.commitments import read_miner_commitments
-from allways.constants import EXTEND_THRESHOLD_BLOCKS, FEE_DIVISOR, NETUID_FINNEY
+from allways.constants import FEE_DIVISOR, NETUID_FINNEY
 from allways.contract_client import ContractError
 from allways.synapses import SwapConfirmSynapse, SwapReserveSynapse
 from allways.utils.proofs import reserve_proof_message, swap_proof_message
@@ -344,54 +338,6 @@ def broadcast_reserve_with_retry(
 # =========================================================================
 # Swap-specific helpers
 # =========================================================================
-
-
-def preflight_send_runway(
-    subtensor,
-    from_chain: str,
-    reserved_until_block: int,
-    skip_confirm: bool,
-) -> bool:
-    """Refuse / hard-warn before broadcasting source funds into a doomed reservation.
-
-    Re-reads the current subtensor block (the user may have idled at the
-    summary panel) and classifies the remaining TTL against the validator
-    auto-extension floor. Returns True if the caller should proceed with
-    the broadcast, False if the caller should abort. See
-    ``classify_send_runway`` in allways/chains.py for the categories.
-    """
-    current_block = subtensor.get_current_block()
-    status, remaining = classify_send_runway(
-        from_chain, current_block, reserved_until_block, EXTEND_THRESHOLD_BLOCKS
-    )
-    if status == RUNWAY_TOO_SHORT:
-        chain = get_chain(from_chain)
-        confs_min = chain.min_confirmations * chain.seconds_per_block // 60
-        console.print(
-            f'\n[red]Refusing to send: only {blocks_to_minutes_str(max(0, remaining))} '
-            f'left on the reservation — below the {EXTEND_THRESHOLD_BLOCKS}-block '
-            f'floor needed for validators to auto-extend. {chain.min_confirmations} '
-            f'{from_chain.upper()} confirmation(s) take ~{confs_min} min, so the '
-            f'reservation will expire before your tx confirms and the swap will fail.[/red]'
-        )
-        console.print(
-            '[yellow]Start fresh with a new reservation: [cyan]alw swap now[/cyan][/yellow]'
-        )
-        return False
-    if status == RUNWAY_EXTENSION_REQUIRED:
-        chain = get_chain(from_chain)
-        confs_min = chain.min_confirmations * chain.seconds_per_block // 60
-        console.print(
-            f'\n[yellow]Reservation has {blocks_to_minutes_str(remaining)} left, less '
-            f'than the ~{confs_min} min needed for {chain.min_confirmations} '
-            f'{from_chain.upper()} confirmation(s). Validators will auto-extend once '
-            f"your tx is visible — but if they miss the window, the swap will expire "
-            f'before confirmation and your funds may be stranded.[/yellow]'
-        )
-        if not skip_confirm and not click.confirm('  Send anyway?', default=False):
-            console.print('[yellow]Cancelled. Start fresh with: alw swap now[/yellow]')
-            return False
-    return True
 
 
 def display_timeout_notice(swap, dashboard_url: str):

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -15,6 +15,7 @@ from allways.chains import SUPPORTED_CHAINS, canonical_pair, get_chain
 from allways.classes import SwapStatus
 from allways.cli.dendrite_lite import broadcast_synapse, discover_validators, get_ephemeral_wallet
 from allways.cli.help import StyledGroup
+from allways.cli.preflight import preflight_send_runway
 from allways.cli.swap_commands.helpers import (
     PendingSwapState,
     blocks_to_minutes_str,
@@ -32,7 +33,6 @@ from allways.cli.swap_commands.helpers import (
     save_pending_swap,
     sign_or_prompt_external,
 )
-from allways.cli.preflight import preflight_send_runway
 from allways.cli.validator_rejections import RejectionInfo, render_and_aggregate
 from allways.commitments import read_miner_commitments
 from allways.constants import FEE_DIVISOR, NETUID_FINNEY

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -5,12 +5,18 @@ import pytest
 from allways.chains import (
     CHAIN_BTC,
     CHAIN_TAO,
+    RUNWAY_EXTENSION_REQUIRED,
+    RUNWAY_OK,
+    RUNWAY_TOO_SHORT,
+    SEND_PROPAGATION_BUFFER_BLOCKS,
     canonical_pair,
+    classify_send_runway,
     compute_extension_target,
     confirmations_to_subtensor_blocks,
     get_chain,
 )
 from allways.constants import (
+    EXTEND_THRESHOLD_BLOCKS,
     EXTENSION_BUCKET_BLOCKS,
     MAX_EXTENSION_BLOCKS,
 )
@@ -103,3 +109,53 @@ class TestComputeExtensionTarget:
     def test_unsupported_chain_raises(self):
         with pytest.raises(KeyError):
             compute_extension_target('eth', 0, 1000)
+
+
+class TestClassifySendRunway:
+    # BTC: 2 confs * 600s/12 = 100 subtensor blocks needed for confirmation.
+    # EXTEND_THRESHOLD_BLOCKS is sized for one validator forward step plus the
+    # challenge window — below that, the auto-extension propose tx is doomed.
+
+    def test_full_ttl_is_ok(self):
+        # Fresh 50-block reservation against BTC's 100-block confirmation window:
+        # confirmation can't fit, so EXTENSION_REQUIRED is expected — not OK.
+        status, remaining = classify_send_runway('btc', 0, 50, EXTEND_THRESHOLD_BLOCKS)
+        assert status == RUNWAY_EXTENSION_REQUIRED
+        assert remaining == 50
+
+    def test_tao_full_ttl_is_ok(self):
+        # TAO needs only 6 subtensor blocks for confirmation. A 50-block
+        # reservation comfortably fits — this is the OK path.
+        status, remaining = classify_send_runway('tao', 0, 50, EXTEND_THRESHOLD_BLOCKS)
+        assert status == RUNWAY_OK
+        assert remaining == 50
+
+    def test_below_extension_floor_is_too_short(self):
+        # Remaining = floor - 1: validators can't propose+challenge before deadline.
+        floor = EXTEND_THRESHOLD_BLOCKS + SEND_PROPAGATION_BUFFER_BLOCKS
+        status, remaining = classify_send_runway('btc', 0, floor - 1, EXTEND_THRESHOLD_BLOCKS)
+        assert status == RUNWAY_TOO_SHORT
+        assert remaining == floor - 1
+
+    def test_at_extension_floor_is_extension_required(self):
+        # Exactly at the floor: extension can fire, but confirmation won't fit.
+        floor = EXTEND_THRESHOLD_BLOCKS + SEND_PROPAGATION_BUFFER_BLOCKS
+        status, _ = classify_send_runway('btc', 0, floor, EXTEND_THRESHOLD_BLOCKS)
+        assert status == RUNWAY_EXTENSION_REQUIRED
+
+    def test_zero_remaining_is_too_short(self):
+        status, remaining = classify_send_runway('btc', 100, 100, EXTEND_THRESHOLD_BLOCKS)
+        assert status == RUNWAY_TOO_SHORT
+        assert remaining == 0
+
+    def test_negative_remaining_is_too_short(self):
+        # Reservation already expired — must hard-refuse.
+        status, remaining = classify_send_runway('btc', 200, 150, EXTEND_THRESHOLD_BLOCKS)
+        assert status == RUNWAY_TOO_SHORT
+        assert remaining == -50
+
+    def test_btc_with_long_ttl_is_ok(self):
+        # BTC needs ~100 subtensor blocks for 2 confs + 5-block propagation buffer:
+        # a 200-block reservation clears that easily.
+        status, _ = classify_send_runway('btc', 0, 200, EXTEND_THRESHOLD_BLOCKS)
+        assert status == RUNWAY_OK

--- a/tests/test_preflight_send_runway.py
+++ b/tests/test_preflight_send_runway.py
@@ -1,0 +1,120 @@
+"""Tests for ``preflight_send_runway`` — the CLI gate that refuses to broadcast
+source funds into a reservation that's already too short for confirmations to
+land (with or without the validator auto-extension flow).
+
+The classifier itself is unit-tested in test_chains.py; these tests cover the
+wiring: re-reading current_block at send time, branch routing
+(too_short / extension_required / ok), and the skip_confirm contract.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from allways.cli.preflight import preflight_send_runway
+
+
+def make_subtensor(current_block: int) -> MagicMock:
+    """Mock subtensor whose ``get_current_block`` returns the given height."""
+    sub = MagicMock()
+    sub.get_current_block.return_value = current_block
+    return sub
+
+
+class TestPreflightSendRunway:
+    def test_ok_runway_passes_silently(self):
+        # TAO needs ~6 subtensor blocks for confirmation; 200 blocks left is
+        # comfortably in the OK band — should return True without prompting.
+        sub = make_subtensor(current_block=1000)
+        with patch('allways.cli.preflight.click.confirm') as confirm:
+            result = preflight_send_runway(
+                subtensor=sub,
+                from_chain='tao',
+                reserved_until_block=1200,
+                skip_confirm=False,
+            )
+        assert result is True
+        confirm.assert_not_called()
+
+    def test_too_short_hard_refuses_without_prompt(self):
+        # Reservation only 5 blocks out — well below the extension floor.
+        # Must return False AND must not have asked the user anything.
+        sub = make_subtensor(current_block=1000)
+        with patch('allways.cli.preflight.click.confirm') as confirm:
+            result = preflight_send_runway(
+                subtensor=sub,
+                from_chain='btc',
+                reserved_until_block=1005,
+                skip_confirm=False,
+            )
+        assert result is False
+        confirm.assert_not_called()
+
+    def test_too_short_refuses_in_skip_confirm_mode_too(self):
+        # --yes must not silently override a doomed broadcast.
+        sub = make_subtensor(current_block=1000)
+        result = preflight_send_runway(
+            subtensor=sub,
+            from_chain='btc',
+            reserved_until_block=1005,
+            skip_confirm=True,
+        )
+        assert result is False
+
+    def test_extension_required_prompts_user_in_interactive_mode(self):
+        # BTC needs ~100 subtensor blocks for confirmation. 40 blocks left is
+        # above the extension floor but below the confirmation window — should
+        # warn and ask. Confirming yes returns True.
+        sub = make_subtensor(current_block=1000)
+        with patch(
+            'allways.cli.preflight.click.confirm', return_value=True
+        ) as confirm:
+            result = preflight_send_runway(
+                subtensor=sub,
+                from_chain='btc',
+                reserved_until_block=1040,
+                skip_confirm=False,
+            )
+        assert result is True
+        confirm.assert_called_once()
+
+    def test_extension_required_user_declines(self):
+        # Same band, user says no — must abort.
+        sub = make_subtensor(current_block=1000)
+        with patch(
+            'allways.cli.preflight.click.confirm', return_value=False
+        ) as confirm:
+            result = preflight_send_runway(
+                subtensor=sub,
+                from_chain='btc',
+                reserved_until_block=1040,
+                skip_confirm=False,
+            )
+        assert result is False
+        confirm.assert_called_once()
+
+    def test_extension_required_skip_confirm_passes_through(self):
+        # In --yes mode the extension-required band must not block — the
+        # validator auto-extension can still rescue this and scripted callers
+        # need a deterministic exit, not a hung prompt.
+        sub = make_subtensor(current_block=1000)
+        with patch('allways.cli.preflight.click.confirm') as confirm:
+            result = preflight_send_runway(
+                subtensor=sub,
+                from_chain='btc',
+                reserved_until_block=1040,
+                skip_confirm=True,
+            )
+        assert result is True
+        confirm.assert_not_called()
+
+    def test_reads_current_block_at_send_time(self):
+        # The user may idle at the summary panel — the gate must re-read
+        # current_block instead of trusting whatever was captured at reserve
+        # time. Verifies subtensor is actually queried.
+        sub = make_subtensor(current_block=1000)
+        preflight_send_runway(
+            subtensor=sub,
+            from_chain='tao',
+            reserved_until_block=1200,
+            skip_confirm=True,
+        )
+        sub.get_current_block.assert_called_once()

--- a/tests/test_preflight_send_runway.py
+++ b/tests/test_preflight_send_runway.py
@@ -22,9 +22,13 @@ def make_subtensor(current_block: int) -> MagicMock:
 class TestPreflightSendRunway:
     def test_ok_runway_passes_silently(self):
         # TAO needs ~6 subtensor blocks for confirmation; 200 blocks left is
-        # comfortably in the OK band — should return True without prompting.
+        # comfortably in the OK band — should return True without prompting
+        # AND without printing anything (covers "no new friction on the
+        # happy-path swap" — equivalent to the manual smoke test).
         sub = make_subtensor(current_block=1000)
-        with patch('allways.cli.preflight.click.confirm') as confirm:
+        with patch('allways.cli.preflight.click.confirm') as confirm, patch(
+            'allways.cli.preflight._console'
+        ) as console_mock:
             result = preflight_send_runway(
                 subtensor=sub,
                 from_chain='tao',
@@ -33,6 +37,7 @@ class TestPreflightSendRunway:
             )
         assert result is True
         confirm.assert_not_called()
+        console_mock.print.assert_not_called()
 
     def test_too_short_hard_refuses_without_prompt(self):
         # Reservation only 5 blocks out — well below the extension floor.

--- a/tests/test_preflight_send_runway.py
+++ b/tests/test_preflight_send_runway.py
@@ -26,9 +26,10 @@ class TestPreflightSendRunway:
         # AND without printing anything (covers "no new friction on the
         # happy-path swap" — equivalent to the manual smoke test).
         sub = make_subtensor(current_block=1000)
-        with patch('allways.cli.preflight.click.confirm') as confirm, patch(
-            'allways.cli.preflight._console'
-        ) as console_mock:
+        with (
+            patch('allways.cli.preflight.click.confirm') as confirm,
+            patch('allways.cli.preflight._console') as console_mock,
+        ):
             result = preflight_send_runway(
                 subtensor=sub,
                 from_chain='tao',
@@ -69,9 +70,7 @@ class TestPreflightSendRunway:
         # above the extension floor but below the confirmation window — should
         # warn and ask. Confirming yes returns True.
         sub = make_subtensor(current_block=1000)
-        with patch(
-            'allways.cli.preflight.click.confirm', return_value=True
-        ) as confirm:
+        with patch('allways.cli.preflight.click.confirm', return_value=True) as confirm:
             result = preflight_send_runway(
                 subtensor=sub,
                 from_chain='btc',
@@ -84,9 +83,7 @@ class TestPreflightSendRunway:
     def test_extension_required_user_declines(self):
         # Same band, user says no — must abort.
         sub = make_subtensor(current_block=1000)
-        with patch(
-            'allways.cli.preflight.click.confirm', return_value=False
-        ) as confirm:
+        with patch('allways.cli.preflight.click.confirm', return_value=False) as confirm:
             result = preflight_send_runway(
                 subtensor=sub,
                 from_chain='btc',


### PR DESCRIPTION
## Summary

Add a CLI-side preflight that classifies remaining reservation TTL at send time and refuses to broadcast source funds into a reservation the validator auto-extension flow cannot rescue. Closes #315.


## Problem
`alw swap now --from btc --to tao` could successfully reserve a miner and broadcast the BTC source transaction, then fail to initiate any on-chain swap because the reservation expired before the required BTC confirmations arrived. Per #315, a user sent 0.00018 BTC against a 50-block (~10 min) reservation — BTC needs 2 confirmations (~20 min), so the reservation expired before the tx confirmed and no TAO was delivered.

#316 addressed two of the five proposed mitigations: it dropped BTC `min_confirmations` from 3 → 2 and added validator-side auto-extension that fires when the source tx becomes visible. But the auto-extension has a hard prerequisite — validators need at least `EXTEND_THRESHOLD_BLOCKS` (~18 blocks ≈ 3.6 min) of runway to land their propose tx and let its challenge window close (`allways/validator/optimistic_extensions.py:97`). Below that the propose is mechanically doomed and the reservation expires anyway. The CLI never checked this, so users could broadcast into a reservation no validator could rescue.


## What Changed
- Added `classify_send_runway()` in `allways/chains.py` — pure classifier returning `ok` / `extension_required` / `too_short` based on remaining TTL vs `EXTEND_THRESHOLD_BLOCKS` plus a 5-block (~1 min) propagation buffer.
- Added `preflight_send_runway()` in a new `allways/cli/preflight.py` module (placed outside `swap_commands/` so importing it doesn't trigger that package's eager command-registration `__init__.py` chain, which pulls in `bittensor` via `helpers`).
- Wired the gate into both `alw swap now` (after the "Send now?" confirmation) and `alw swap resume-reservation --send`, re-reading `current_block` at send time so an idle user at the summary panel doesn't bypass the check.
- Behavior by band:
  - `too_short`: hard refusal, suggests starting fresh — overrides `--yes` to avoid scripted callers silently losing funds.
  - `extension_required`: warns the validator auto-extension will need to kick in, requires explicit re-confirm (default no) in interactive mode, passes through in `--yes`.
  - `ok`: silent passthrough (no prompt, no print).

Implements solutions #3 ("prevent auto-send when required confirmations cannot fit inside reservation TTL") and #5 ("surface a hard preflight error instead of a warning") from #315.


## Tests
- `tests/test_chains.py::TestClassifySendRunway` — 7 cases covering the classifier's three bands, the BTC vs TAO confirmation-window difference, exact-floor boundary, zero remaining, and already-expired (negative remaining).
- `tests/test_preflight_send_runway.py` — 7 cases covering the wiring: subtensor re-read at send time, branch routing per band, and the `skip_confirm` contract (refuses on `too_short` even in `--yes`; passes through `extension_required` in `--yes`). The OK band asserts both `click.confirm` *and* `console.print` are untouched, so any future regression that adds chatter to the happy-path swap fails the test.

Verification:
```
pytest -q tests/test_chains.py tests/test_preflight_send_runway.py
```