### PR TITLE
refactor: move to_rao/from_rao out of CLI helpers (#171)

### DIFF
--- a/allways/cli/swap_commands/admin.py
+++ b/allways/cli/swap_commands/admin.py
@@ -6,14 +6,13 @@ from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
     blocks_to_minutes_str,
     console,
-    from_rao,
     get_cli_context,
     is_valid_ss58,
     loading,
     print_contract_error,
-    to_rao,
 )
 from allways.contract_client import ContractError
+from allways.utils.misc import from_rao, to_rao
 
 
 def _run_setter(title, getter, setter, noun, format_current, new_display, success_msg):

--- a/allways/cli/swap_commands/claim.py
+++ b/allways/cli/swap_commands/claim.py
@@ -6,9 +6,10 @@ import click
 
 from allways.classes import SwapStatus
 from allways.cli.help import StyledCommand
-from allways.cli.swap_commands.helpers import console, from_rao, get_cli_context, loading, print_contract_error
+from allways.cli.swap_commands.helpers import console, get_cli_context, loading, print_contract_error
 from allways.cli.swap_commands.view import DEFAULT_DASHBOARD_URL
 from allways.contract_client import ContractError
+from allways.utils.misc import from_rao
 
 
 @click.command('claim', cls=StyledCommand, show_disclaimer=True)

--- a/allways/cli/swap_commands/collateral.py
+++ b/allways/cli/swap_commands/collateral.py
@@ -7,14 +7,13 @@ from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
     blocks_to_minutes_str,
     console,
-    from_rao,
     get_cli_context,
     loading,
     print_contract_error,
-    to_rao,
 )
 from allways.constants import MIN_BALANCE_FOR_TX_RAO, MIN_COLLATERAL_TAO
 from allways.contract_client import ContractError, is_contract_rejection
+from allways.utils.misc import from_rao, to_rao
 
 
 @click.group('collateral', cls=StyledGroup, show_disclaimer=True)

--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -18,7 +18,6 @@ from allways.constants import (
     MAX_EXTENSION_BLOCKS,
     MAX_EXTENSIONS_PER_RESERVATION,
     NETUID_FINNEY,
-    TAO_TO_RAO,
 )
 from allways.contract_client import AllwaysContractClient, ContractError, is_contract_rejection
 
@@ -159,16 +158,6 @@ def is_local_network(network: str) -> bool:
     if network == 'local':
         return True
     return any(host in network for host in ('127.0.0.1', 'localhost', '0.0.0.0'))
-
-
-def to_rao(amount_tao: float) -> int:
-    """Convert TAO to rao."""
-    return int(amount_tao * TAO_TO_RAO)
-
-
-def from_rao(amount_rao: int) -> float:
-    """Convert rao to TAO."""
-    return amount_rao / TAO_TO_RAO
 
 
 def load_cli_config() -> dict:

--- a/allways/cli/swap_commands/miner_commands.py
+++ b/allways/cli/swap_commands/miner_commands.py
@@ -15,7 +15,6 @@ from allways.cli.swap_commands.helpers import (
     SWAP_STATUS_COLORS,
     blocks_to_minutes_str,
     console,
-    from_rao,
     get_cli_context,
     loading,
     print_contract_error,
@@ -24,6 +23,7 @@ from allways.cli.swap_commands.helpers import (
 from allways.cli.validator_rejections import render_and_aggregate
 from allways.constants import FEE_DIVISOR
 from allways.contract_client import ContractError
+from allways.utils.misc import from_rao
 
 
 @click.group('miner', cls=StyledGroup)

--- a/allways/cli/swap_commands/quote.py
+++ b/allways/cli/swap_commands/quote.py
@@ -9,13 +9,13 @@ from allways.chains import SUPPORTED_CHAINS, canonical_pair, get_chain
 from allways.cli.swap_commands.helpers import (
     console,
     find_matching_miners,
-    from_rao,
     get_cli_context,
     loading,
     read_miner_commitments,
 )
 from allways.constants import FEE_DIVISOR
 from allways.contract_client import ContractError
+from allways.utils.misc import from_rao
 from allways.utils.rate import apply_fee_deduction, calculate_to_amount, check_swap_viability, derive_tao_leg
 
 

--- a/allways/cli/swap_commands/status.py
+++ b/allways/cli/swap_commands/status.py
@@ -7,7 +7,6 @@ from allways.cli.help import StyledCommand
 from allways.cli.swap_commands.helpers import (
     blocks_to_minutes_str,
     console,
-    from_rao,
     get_cli_context,
     hydrate_pending_swap,
     load_pending_swap,
@@ -17,6 +16,7 @@ from allways.cli.swap_commands.helpers import (
 )
 from allways.constants import NETUID_FINNEY
 from allways.contract_client import ContractError
+from allways.utils.misc import from_rao
 
 
 @click.command('status', cls=StyledCommand)

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -21,7 +21,6 @@ from allways.cli.swap_commands.helpers import (
     clear_pending_swap,
     console,
     find_matching_miners,
-    from_rao,
     get_cli_context,
     is_local_network,
     load_pending_swap,
@@ -37,6 +36,7 @@ from allways.commitments import read_miner_commitments
 from allways.constants import FEE_DIVISOR, NETUID_FINNEY
 from allways.contract_client import ContractError
 from allways.synapses import SwapConfirmSynapse, SwapReserveSynapse
+from allways.utils.misc import from_rao
 from allways.utils.proofs import reserve_proof_message, swap_proof_message
 from allways.utils.rate import apply_fee_deduction, calculate_to_amount, check_swap_viability, derive_tao_leg
 

--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -19,7 +19,6 @@ from allways.cli.swap_commands.helpers import (
     blocks_to_minutes_str,
     clear_pending_swap,
     console,
-    from_rao,
     get_cli_context,
     hydrate_pending_swap,
     load_pending_swap,
@@ -35,6 +34,7 @@ from allways.constants import (
     MAX_EXTENSIONS_PER_SWAP,
 )
 from allways.contract_client import ContractError
+from allways.utils.misc import from_rao
 
 DEFAULT_DASHBOARD_URL = 'https://test.all-ways.io'
 

--- a/allways/utils/misc.py
+++ b/allways/utils/misc.py
@@ -3,6 +3,18 @@ from functools import lru_cache, update_wrapper
 from math import floor
 from typing import Any, Callable
 
+from allways.constants import TAO_TO_RAO
+
+
+def to_rao(amount_tao: float) -> int:
+    """Convert TAO to rao."""
+    return int(amount_tao * TAO_TO_RAO)
+
+
+def from_rao(amount_rao: int) -> float:
+    """Convert rao to TAO."""
+    return amount_rao / TAO_TO_RAO
+
 
 # LRU Cache with TTL
 def ttl_cache(maxsize: int = 128, typed: bool = False, ttl: int = -1):


### PR DESCRIPTION
## Summary
- Move `to_rao` / `from_rao` from `allways/cli/swap_commands/helpers.py` to `allways/utils/misc.py` — these are unit conversions, not CLI concerns.
- Drop the now-unused `TAO_TO_RAO` import from `helpers.py`.
- Update imports in all 8 CLI modules that used these helpers: `status.py`, `collateral.py`, `view.py`, `miner_commands.py`, `swap.py`, `quote.py`, `admin.py`, `claim.py`.
- No backwards-compat re-export — direct move, callers updated in the same change.

Closes #171.

## Test plan
- [x] `ruff check` clean on changed files
- [x] Full test suite: 470 passed
- [x] Smoke import of every touched CLI module + `to_rao(1.5) == 1_500_000_000` / `from_rao(1_500_000_000) == 1.5`
- [x] Verified `helpers` module no longer exports `to_rao` / `from_rao`