### PR TITLE
fix: queue SwapConfirm on tx_not_found instead of rejecting

### DIFF
--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -183,6 +183,7 @@ class BitcoinProvider(ChainProvider):
         """Verify a Bitcoin transaction using getrawtransaction RPC."""
         raw_tx = self.rpc_call('getrawtransaction', [tx_hash, True])
         if not raw_tx:
+            bt.logging.debug(f'BTC RPC: tx {tx_hash[:16]}... not found')
             return None
 
         confirmations = raw_tx.get('confirmations', 0)
@@ -215,6 +216,9 @@ class BitcoinProvider(ChainProvider):
                     confirmations=confirmations,
                 )
 
+        bt.logging.warning(
+            f'BTC RPC: tx {tx_hash[:16]}... has no vout paying {expected_recipient} >= {expected_amount} sat'
+        )
         return None
 
     def rpc_resolve_sender(self, raw_tx: dict) -> str:
@@ -259,6 +263,7 @@ class BitcoinProvider(ChainProvider):
         try:
             resp = self.btc_api_get(f'/tx/{tx_hash}', timeout=15)
             if resp.status_code == 404:
+                bt.logging.debug(f'BTC Esplora: tx {tx_hash[:16]}... not found (404)')
                 return None
             resp.raise_for_status()
             data = resp.json()
@@ -305,6 +310,9 @@ class BitcoinProvider(ChainProvider):
                         confirmations=confirmations,
                     )
 
+            bt.logging.warning(
+                f'BTC Esplora: tx {tx_hash[:16]}... has no vout paying {expected_recipient} >= {expected_amount} sat'
+            )
             return None
         except (requests.ConnectionError, requests.Timeout) as e:
             raise ProviderUnreachableError(f'Esplora API unreachable: {e}') from e

--- a/allways/chain_providers/subtensor.py
+++ b/allways/chain_providers/subtensor.py
@@ -194,6 +194,7 @@ class SubtensorProvider(ChainProvider):
             blocks_to_check = [current_block - offset for offset in range(window) if current_block - offset >= 0]
 
         try:
+            tx_hash_seen = False
             for block_num in blocks_to_check:
                 block = self.get_block(block_num)
                 if not block or 'extrinsics' not in block:
@@ -206,6 +207,7 @@ class SubtensorProvider(ChainProvider):
                     if match is None:
                         continue
 
+                    tx_hash_seen = True
                     dest, amount, sender = match
                     confs = current_block - block_num
                     if dest == expected_recipient and amount >= expected_amount:
@@ -219,6 +221,12 @@ class SubtensorProvider(ChainProvider):
                             confirmations=confs,
                         )
 
+            if tx_hash_seen:
+                bt.logging.warning(
+                    f'TAO scan: tx {tx_hash[:16]}... found but no transfer pays {expected_recipient} >= {expected_amount} rao'
+                )
+            else:
+                bt.logging.debug(f'TAO scan: tx {tx_hash[:16]}... not found in scan window')
             return None
         except ProviderUnreachableError:
             raise

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -70,11 +70,6 @@ RECYCLE_UID = 53  # Subnet owner UID
 RESERVATION_COOLDOWN_BLOCKS = 150  # ~30 min base cooldown on failed reservation
 RESERVATION_COOLDOWN_MULTIPLIER = 2  # 150 → 300 → 600 ...
 MAX_RESERVATIONS_PER_ADDRESS = 1
-# A user's tx is often invisible to a validator's RPC for the first few seconds
-# after submission (mempool propagation lag, regional RPC differences). Treat
-# "not found" as transient until the same entry has polled null this many times.
-PENDING_CONFIRM_NULL_RETRY_LIMIT = 3
-
 # ─── Optimistic Extensions ───────────────────────────────
 # Tunables for the propose/challenge/finalize extension flow. Per-chain timing
 # (block time, confirmations) lives in allways/chains.py; the contract enforces

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -507,17 +507,13 @@ async def handle_swap_confirm(
                 block_hint=synapse.from_tx_block,
                 expected_sender=synapse.from_address,
             )
-            if tx_info is None:
-                reject_synapse(synapse, 'Source transaction not found, amount or sender mismatch', ctx)
-                return synapse
 
-            # Persist the discovered block even if the user didn't supply
-            # one — the queue drain can then re-verify with O(1) lookup
-            # instead of re-scanning the sliding window.
-            found_tx_block = tx_info.block_number or synapse.from_tx_block
-
-            if not tx_info.confirmed:
-                chain_def = provider.get_chain()
+            # tx_info=None means we couldn't see the tx (propagation lag) or
+            # amount/sender didn't match — queue both rather than rejecting,
+            # so the drain re-verifies and PENDING_CONFIRM_NULL_RETRY_LIMIT
+            # bounds the bogus case. Rejecting here races freshly-broadcast txs.
+            if tx_info is None or not tx_info.confirmed:
+                found_tx_block = (tx_info.block_number if tx_info else 0) or synapse.from_tx_block
                 pending = PendingConfirm(
                     miner_hotkey=miner,
                     from_tx_hash=synapse.from_tx_hash,
@@ -536,11 +532,21 @@ async def handle_swap_confirm(
                 )
                 validator.state_store.enqueue(pending)
                 synapse.accepted = True
-                synapse.rejection_reason = (
-                    f'Queued — {tx_info.confirmations}/{chain_def.min_confirmations} confirmations. '
-                    f'Validator will auto-initiate when confirmed.'
-                )
-                bt.logging.info(f'{ctx} queued: {tx_info.confirmations}/{chain_def.min_confirmations} confirmations')
+                if tx_info is None:
+                    synapse.rejection_reason = (
+                        'Queued — source tx not yet visible to validators (propagation lag '
+                        'or pending re-verify). Validator will auto-initiate once seen and confirmed.'
+                    )
+                    bt.logging.info(f'{ctx} queued: source tx not yet visible')
+                else:
+                    chain_def = provider.get_chain()
+                    synapse.rejection_reason = (
+                        f'Queued — {tx_info.confirmations}/{chain_def.min_confirmations} confirmations. '
+                        f'Validator will auto-initiate when confirmed.'
+                    )
+                    bt.logging.info(
+                        f'{ctx} queued: {tx_info.confirmations}/{chain_def.min_confirmations} confirmations'
+                    )
                 return synapse
 
             miner_bytes = bytes.fromhex(Keypair(ss58_address=miner).public_key.hex())

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -510,8 +510,8 @@ async def handle_swap_confirm(
 
             # tx_info=None means we couldn't see the tx (propagation lag) or
             # amount/sender didn't match — queue both rather than rejecting,
-            # so the drain re-verifies and PENDING_CONFIRM_NULL_RETRY_LIMIT
-            # bounds the bogus case. Rejecting here races freshly-broadcast txs.
+            # so the drain re-verifies until the reservation expires (purge
+            # bounds the bogus case). Rejecting here races freshly-broadcast txs.
             if tx_info is None or not tx_info.confirmed:
                 found_tx_block = (tx_info.block_number if tx_info else 0) or synapse.from_tx_block
                 pending = PendingConfirm(

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -13,7 +13,6 @@ from allways.commitments import read_miner_commitments
 from allways.constants import (
     CHALLENGE_WINDOW_BLOCKS,
     EXTEND_THRESHOLD_BLOCKS,
-    PENDING_CONFIRM_NULL_RETRY_LIMIT,
     SCORING_WINDOW_BLOCKS,
 )
 from allways.contract_client import ContractError, is_contract_rejection
@@ -99,12 +98,6 @@ def initialize_pending_user_reservations(self: Validator) -> None:
     from bittensor import Keypair
 
     items = self.state_store.get_all()
-    # Drop per-entry receipts whose pending_confirm has been removed
-    # (vote_initiate landed, tx not found, expired, etc.).
-    live_keys = {(item.miner_hotkey, item.from_tx_hash) for item in items}
-    for stale_key in [k for k in self.pending_confirm_null_polls if k not in live_keys]:
-        del self.pending_confirm_null_polls[stale_key]
-
     if not items:
         return
 
@@ -154,24 +147,14 @@ def initialize_pending_user_reservations(self: Validator) -> None:
             continue
 
         if tx_info is None:
-            null_key = (item.miner_hotkey, item.from_tx_hash)
-            attempts = self.pending_confirm_null_polls.get(null_key, 0) + 1
-            if attempts < PENDING_CONFIRM_NULL_RETRY_LIMIT:
-                self.pending_confirm_null_polls[null_key] = attempts
-                bt.logging.info(
-                    f'PendingConfirm [{swap_label} {miner_short}]: tx {item.from_tx_hash[:16]}... '
-                    f'not found (attempt {attempts}/{PENDING_CONFIRM_NULL_RETRY_LIMIT}), retrying'
-                )
-                try_extend_reservation(self, item, current_block, swap_label, miner_short, tx_info=None)
-                continue
-            self.state_store.remove(item.miner_hotkey)
-            bt.logging.warning(
+            log_on_change(
+                f'null:{item.miner_hotkey}:{item.from_tx_hash}',
+                'not_found',
                 f'PendingConfirm [{swap_label} {miner_short}]: tx {item.from_tx_hash[:16]}... '
-                f'not found after {PENDING_CONFIRM_NULL_RETRY_LIMIT} attempts, dropping'
+                f'not yet visible, will retry until reservation expires',
             )
+            try_extend_reservation(self, item, current_block, swap_label, miner_short, tx_info=None)
             continue
-
-        self.pending_confirm_null_polls.pop((item.miner_hotkey, item.from_tx_hash), None)
 
         log_on_change(
             f'confs:{item.miner_hotkey}',

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -85,9 +85,6 @@ class Validator(BaseValidatorNeuron):
             current_block_fn=lambda: self.block,
         )
         self.last_known_rates: dict[tuple[str, str, str], float] = {}
-        # (miner_hotkey, from_tx_hash) → consecutive "tx not found" poll count.
-        # Used to absorb mempool propagation lag before dropping a pending entry.
-        self.pending_confirm_null_polls: dict[tuple[str, str], int] = {}
         # Forces one scoring pass per fresh process so a mid-window restart
         # doesn't leave self.scores stale until the next 1200-step boundary
         # (which would route emissions to RECYCLE via the empty-norm fallback).

--- a/tests/test_axon_handlers.py
+++ b/tests/test_axon_handlers.py
@@ -286,12 +286,33 @@ class TestChainProviderValidation:
 
 
 class TestSourceTxVerification:
-    def test_rejects_when_source_tx_not_found(self):
+    def test_queues_when_source_tx_not_yet_visible(self):
+        """tx_info=None means we couldn't see the tx (propagation lag) or
+        amount/sender mismatch — queue and let the forward drain re-verify
+        instead of rejecting outright. The drain bounds bogus entries via
+        PENDING_CONFIRM_NULL_RETRY_LIMIT."""
         validator = make_validator()
         validator.axon_chain_providers['btc'].verify_transaction.return_value = None
         result = run_handler(validator, make_synapse())
-        assert result.accepted is False
-        assert 'Source transaction not found' in result.rejection_reason
+        assert result.accepted is True
+        assert 'Queued' in (result.rejection_reason or '')
+        assert 'not yet visible' in result.rejection_reason
+        validator.state_store.enqueue.assert_called_once()
+        queued = validator.state_store.enqueue.call_args[0][0]
+        assert queued.from_amount == 100_000  # res_source_amount, not user-supplied
+        assert queued.tao_amount == 345_000_000
+        assert queued.from_tx_hash == 'abc123'
+
+    def test_queued_not_yet_visible_persists_user_block_hint(self):
+        """When the user supplied a from_tx_block hint, persist it on the
+        queued entry so the drain can re-verify in O(1) once the tx lands."""
+        validator = make_validator()
+        validator.axon_chain_providers['btc'].verify_transaction.return_value = None
+        synapse = make_synapse()
+        synapse.from_tx_block = 12345
+        run_handler(validator, synapse)
+        queued = validator.state_store.enqueue.call_args[0][0]
+        assert queued.from_tx_block == 12345
 
     def test_queues_when_source_tx_unconfirmed(self):
         """Visible on-chain but below min_confirmations → accepted + queued."""

--- a/tests/test_axon_handlers.py
+++ b/tests/test_axon_handlers.py
@@ -289,8 +289,8 @@ class TestSourceTxVerification:
     def test_queues_when_source_tx_not_yet_visible(self):
         """tx_info=None means we couldn't see the tx (propagation lag) or
         amount/sender mismatch — queue and let the forward drain re-verify
-        instead of rejecting outright. The drain bounds bogus entries via
-        PENDING_CONFIRM_NULL_RETRY_LIMIT."""
+        instead of rejecting outright. Bogus entries are bounded by the
+        reservation expiry (purge_expired_pending_confirms)."""
         validator = make_validator()
         validator.axon_chain_providers['btc'].verify_transaction.return_value = None
         result = run_handler(validator, make_synapse())

--- a/tests/test_validator_rejections.py
+++ b/tests/test_validator_rejections.py
@@ -43,6 +43,25 @@ def test_all_queued_counted_separately():
     assert info.queued == 2
 
 
+def test_queued_not_yet_visible_counted_as_queued():
+    """Upgraded validators queue when the source tx isn't visible yet
+    (propagation lag) instead of rejecting — the CLI should treat the
+    new wording the same way it treats `Queued — N/M confirmations`."""
+    responses = [
+        FakeResp(
+            accepted=True,
+            rejection_reason=(
+                'Queued — source tx not yet visible to validators (propagation lag '
+                'or pending re-verify). Validator will auto-initiate once seen and confirmed.'
+            ),
+        ),
+    ]
+    info = render_and_aggregate(_silent_console(), responses)
+    assert info.accepted == 1
+    assert info.queued == 1
+    assert info.rejected == 0
+
+
 def test_insufficient_source_balance_translates():
     responses = [FakeResp(accepted=False, rejection_reason='Insufficient source balance')]
     info = render_and_aggregate(


### PR DESCRIPTION
## Summary

Validator hard-rejected `SwapConfirm` when the user's source tx wasn't yet visible to its local node + Esplora at axon time (mempool propagation lag). Honest users got bounced and forced to retry across a propagation race they didn't control. This PR queues that case the same way "found but not yet confirmed" is already queued, so the forward drain re-verifies on each step.

## The fix, in three modular commits

**`60f9f33` — queue SwapConfirm on tx_not_found instead of rejecting**
`handle_swap_confirm` no longer rejects when `tx_info=None`. It enqueues into `pending_confirms` (same path as unconfirmed-but-visible) and returns `accepted=True` with a "Queued — source tx not yet visible..." message the existing CLI already renders as queued. Also splits the silent-None paths in `BitcoinProvider` into `DEBUG` (tx not in RPC/Esplora) and `WARNING` (tx exists but no vout matches).

**`1ba2a8a` — mirror BTC silent-None logging split on TAO scan**
Same `DEBUG` vs `WARNING` distinction for `SubtensorProvider.fetch_matching_tx`: `DEBUG` when no extrinsic in the scan window matched the hash, `WARNING` when the hash matched but the transfer's dest/amount didn't. Useful when debugging dest-side verification.

**`d649649` — drop `PENDING_CONFIRM_NULL_RETRY_LIMIT`; rely on `reserved_until` purge**
First commit's retry counter capped honest-but-slow propagation at ~30–45s (3 forward steps × ~15s). The reservation itself already gives the user 50–100 blocks (~8–15 min). Removed the counter; `purge_expired_pending_confirms` runs every forward step and is the natural backstop — symmetric with how the miner-fulfillment side handles dest-tx invisibility (no retry counter, bounded by the swap's on-chain timeout). Per-step visibility kept via `log_on_change` so operators see one "not yet visible" line per state transition, not per step.

## Why no mirrored change on the miner→user (dest) side

The dest path already behaves this way implicitly. Miners post `MarkFulfilled` as an on-chain extrinsic, not via an axon synapse, so there's no synchronous handler to hard-reject from. The validator's forward loop polls `verify_miner_fulfillment` each step; `tx_info=None` returns False → `forward.py` defers confirm → retries next cycle until the swap's `timeout_block`. The asymmetry this PR closes is specific to the axon entry point.

## Trickle-through on reservation expiry

When the user's tx never propagates within the reservation window:
1. `purge_expired_pending_confirms` (`forward.py:64`) deletes the row at the first forward step where `reserved_until < current_block`
2. INFO log: `forward: purged N expired pending_confirms (reservations elapsed without tx confirmation)`
3. User UX is identical to today's "rejected" path — a fresh SwapConfirm needs a fresh reservation
4. No silent failures; no on-chain side-effects

## Dedupe note

`state_store.enqueue` uses `INSERT OR REPLACE` keyed on `miner_hotkey` (`state_store.py:69, 366`). Re-submission with the same hash replaces the row rather than stacking.

## Real incident this PR addresses

Reservation at `15:02:25Z` → `SwapConfirm` 20s later → rejected at `15:02:46Z` → tx confirmed in block at `15:58:36Z`. The tx was real and valid; the validator just couldn't see it yet. Same pattern reproduced on swap #83 in the lena validator log (`20:24:21Z` reject → `20:24:48Z` reject → `20:25:03Z` queue once the tx propagated, 42s lag).

## Test plan

- [x] `pytest tests/test_axon_handlers.py tests/test_validator_rejections.py tests/test_pending_confirm_queue.py` — 42 passed
- [x] `pytest` — full suite, 472 passed
- [x] `ruff format` + `ruff check` — clean
- [ ] E2E smoke (`./tests/run.sh --chains btc --suite 02`) on dev environment to confirm the queued path drains correctly when the tx eventually lands
- [ ] Manual: broadcast a BTC tx, immediately call `alw swap` with the matching reservation, confirm validator logs show `queued: source tx not yet visible` and the swap initiates once the tx propagates
- [ ] Manual: simulate propagation > reservation window; confirm `purged N expired pending_confirms` fires and the row is dropped cleanly
