### PR TITLE
fix: gate timeout-extension re-propose on post-finalize deadline

### DIFF
--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -479,6 +479,15 @@ def extend_fulfilled_near_timeout(self: Validator) -> None:
         if tx_info is None:
             continue  # dest tx invisible — neither tier qualifies
 
+        # A finalize this step may have just pushed the deadline out. Mirror
+        # the reservation-side gate in try_extend_reservation: once the swap
+        # is no longer near timeout, skip challenge/propose so the next
+        # extension anchors on the new deadline, not this block. Without this,
+        # finalizing extension N and proposing extension N+1 in the same step
+        # collapses N+1's runway to a handful of blocks.
+        if swap.timeout_block >= current_block + EXTEND_THRESHOLD_BLOCKS:
+            continue
+
         try:
             extension_count = self.contract_client.get_swap_extension_count(swap.id)
         except Exception as e:

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -1,0 +1,97 @@
+"""Validator forward pass — timeout-extension orchestration.
+
+Covers ``extend_fulfilled_near_timeout``, the per-step loop that finalizes a
+pending timeout extension and may propose the next one. Regression: a propose
+fired in the same step as a finalize anchors the new extension on the current
+block instead of the freshly extended deadline, collapsing its runway. This
+reproduces the swap 206 timeout.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from allways.classes import Swap, SwapStatus
+from allways.validator.forward import extend_fulfilled_near_timeout
+from allways.validator.swap_tracker import SwapTracker
+
+# Real swap 206 numbers: extension 2 was proposed at this block, and a BTC
+# timeout extension targets current_block + 240.
+PROPOSE_BLOCK = 8_207_273
+EXT_TARGET = PROPOSE_BLOCK + 240
+
+
+def make_fulfilled_swap(swap_id: int = 206) -> Swap:
+    """A FULFILLED TAO->BTC swap with a visible dest tx, one block from timeout."""
+    return Swap(
+        id=swap_id,
+        user_hotkey='user',
+        miner_hotkey='miner',
+        from_chain='tao',
+        to_chain='btc',
+        from_amount=100_000_000,
+        to_amount=37_189,
+        tao_amount=100_000_000,
+        user_from_address='5user',
+        user_to_address='bc1q-user',
+        to_tx_hash='dest-tx-hash',
+        status=SwapStatus.FULFILLED,
+        timeout_block=PROPOSE_BLOCK + 1,
+    )
+
+
+def make_validator(swap: Swap, block: int, finalized_target):
+    """Stand-in Validator for ``extend_fulfilled_near_timeout``.
+
+    ``finalized_target``: what ``maybe_finalize_timeout`` returns — an int for
+    a finalize that lands this step, or ``None`` for no finalize.
+    """
+    tracker = SwapTracker(client=MagicMock())
+    tracker.active[swap.id] = swap
+
+    ext = MagicMock()
+    ext.fetch_pending_timeout.return_value = None
+    ext.maybe_finalize_timeout.return_value = finalized_target
+    ext.maybe_propose_timeout.return_value = False
+
+    provider = MagicMock()
+    provider.verify_transaction.return_value = SimpleNamespace(confirmations=1)
+
+    contract_client = MagicMock()
+    contract_client.get_swap_extension_count.return_value = 1
+
+    return SimpleNamespace(
+        swap_tracker=tracker,
+        block=block,
+        optimistic_extensions=ext,
+        chain_providers={'btc': provider},
+        contract_client=contract_client,
+    )
+
+
+class TestExtendFulfilledNearTimeout:
+    def test_skips_repropose_when_finalize_pushes_deadline_out(self):
+        # The swap is one block from its deadline, so it enters the loop. The
+        # finalize this step jumps the deadline to current_block + 240 — far
+        # past the near-timeout window — so the step must not propose again.
+        swap = make_fulfilled_swap()
+        v = make_validator(swap, block=PROPOSE_BLOCK, finalized_target=EXT_TARGET)
+
+        extend_fulfilled_near_timeout(v)
+
+        v.optimistic_extensions.maybe_finalize_timeout.assert_called_once()
+        assert swap.timeout_block == EXT_TARGET  # finalize applied
+        # No longer near timeout → no second extension this step.
+        v.optimistic_extensions.maybe_propose_timeout.assert_not_called()
+        v.optimistic_extensions.maybe_challenge_timeout.assert_not_called()
+        v.contract_client.get_swap_extension_count.assert_not_called()
+
+    def test_proposes_when_still_near_timeout(self):
+        # No finalize this step; the swap stays near its deadline, so the
+        # propose path must still run — the guard must not block a legitimate
+        # near-timeout extension.
+        swap = make_fulfilled_swap()
+        v = make_validator(swap, block=PROPOSE_BLOCK, finalized_target=None)
+
+        extend_fulfilled_near_timeout(v)
+
+        v.optimistic_extensions.maybe_propose_timeout.assert_called_once()


### PR DESCRIPTION
## What

`extend_fulfilled_near_timeout` finalizes a pending timeout extension and, in the same forward step, can propose the next one. The decision to propose relied only on the `get_near_timeout_fulfilled` loop filter — which is evaluated *before* the finalize runs. So once a finalize pushed the deadline far out, the swap was no longer near timeout, but the propose still fired.

This adds the guard the reservation-side flow (`try_extend_reservation`) already has: after the finalize, skip challenge/propose once the swap is no longer within `EXTEND_THRESHOLD_BLOCKS` of its refreshed deadline.

## The bug in simple terms — swap 206

Swap 206 (TAO→BTC) timed out and the miner was slashed even though it had broadcast a valid BTC payment within 67 seconds. From the on-chain events:

- Extension 1 was proposed and finalized normally — deadline pushed out to block 8207504.
- **In the same step** as extension 1's finalize, extension 2 was proposed — but anchored on the *current* block (~8207273), so its target landed at 8207513: only **+9 blocks past extension 1's deadline**.
- That spent the swap's last extension slot for almost no added runway. The BTC dest tx couldn't reach its 2nd confirmation before 8207513, and the swap timed out.

A timeout extension's target is `current_block + 240`. That math is correct *only if the propose fires when the swap is genuinely near its deadline*. Because extension 2's propose fired ~230 blocks early — right after extension 1's finalize, off a stale in-memory deadline — `current_block + 240` barely cleared the deadline that already existed.

The miner did nothing wrong. The lost runway was the validator's extension logic proposing a second extension far too early.

## Fix

After a finalize updates `swap.timeout_block`, re-check near-timeout before proposing/challenging — mirroring `try_extend_reservation` (`forward.py:296-297`). With correct timing, the existing `current_block + 240` anchor produces the full intended runway; no other change is needed.

## Test plan

- New `tests/test_forward.py` covering `extend_fulfilled_near_timeout`:
  - finalize that pushes the deadline past the near-timeout window → no re-propose this step
  - no finalize, swap still near timeout → propose still runs (guard does not over-block)
- Confirmed the first test fails without the guard — it reaches `maybe_propose_timeout` with the real swap-206 numbers (`current_block=8207273, timeout_block=8207513`).
- Full suite: 472 passed. `ruff check` + `ruff format --check` clean.