### PR TITLE
fix: recompute reservation amounts from miner rate at reserve time

### DIFF
--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -34,7 +34,7 @@ from allways.cli.swap_commands.helpers import (
 )
 from allways.cli.validator_rejections import RejectionInfo, render_and_aggregate
 from allways.commitments import read_miner_commitments
-from allways.constants import FEE_DIVISOR, NETUID_FINNEY
+from allways.constants import FEE_DIVISOR, NETUID_FINNEY, RESERVE_SLIPPAGE_MAX_BPS
 from allways.contract_client import ContractError
 from allways.synapses import SwapConfirmSynapse, SwapReserveSynapse
 from allways.utils.proofs import reserve_proof_message, swap_proof_message
@@ -188,6 +188,7 @@ def broadcast_reserve_with_retry(
     netuid: int,
     skip_confirm: bool = False,
     max_retries: int = 2,
+    slippage_bps: int = 200,
 ):
     """Reserve miner via multi-validator consensus with retry.
 
@@ -239,6 +240,7 @@ def broadcast_reserve_with_retry(
             block_anchor=current_block,
             from_chain=from_chain,
             to_chain=to_chain,
+            slippage_bps=slippage_bps,
         )
 
         with loading(f'Broadcasting reservation to {len(validator_axons)} validators...'):
@@ -568,6 +570,17 @@ def swap_group():
 @click.option('--auto', 'auto_select', is_flag=True, help='Auto-select best rate miner')
 @click.option('--yes', 'skip_confirm', is_flag=True, help='Skip confirmation prompts')
 @click.option(
+    '--slippage',
+    'slippage',
+    type=float,
+    default=2.0,
+    help=(
+        'Maximum rate slippage (in percent) between your quote and the reservation. '
+        "The reservation is rejected if the miner's current rate would give you more than "
+        'this percentage less than your quoted amount. Default: 2.0%.'
+    ),
+)
+@click.option(
     '--btc-fee-rate',
     'btc_fee_rate_opt',
     type=click.IntRange(min=1),
@@ -588,6 +601,7 @@ def swap_now_command(
     from_tx_hash_opt: Optional[str],
     auto_select: bool,
     skip_confirm: bool,
+    slippage: float,
     btc_fee_rate_opt: Optional[int],
 ):
     """Guided interactive swap - step by step.
@@ -821,6 +835,24 @@ def swap_now_command(
         f' (after {preview_fee_pct:g}% fee)'
     )
 
+    # Convert slippage percent to bps and apply the ceiling clamp.
+    slippage_bps = round(slippage * 100)
+    if slippage_bps > RESERVE_SLIPPAGE_MAX_BPS:
+        console.print(
+            f'[yellow]Warning: --slippage {slippage}% exceeds the protocol ceiling '
+            f'({RESERVE_SLIPPAGE_MAX_BPS // 100}%) — will be capped.[/yellow]'
+        )
+        slippage_bps = RESERVE_SLIPPAGE_MAX_BPS
+    if slippage > 10.0:
+        console.print(
+            f'[yellow]Warning: slippage is set to {slippage}%, which is unusually high. '
+            'Consider a lower value to protect against adverse rate moves.[/yellow]'
+        )
+    console.print(
+        f"  Slippage {slippage:g}% — reservation is rejected if the miner's rate has moved "
+        f'more than {slippage:g}% below your quote.'
+    )
+
     tao_amount = derive_tao_leg(from_chain, from_amount, to_chain, to_amount)
 
     # Validate against contract min/max swap bounds + selected miner's
@@ -985,6 +1017,7 @@ def swap_now_command(
         from_key,
         netuid,
         skip_confirm=skip_confirm,
+        slippage_bps=slippage_bps,
     )
     if result is None:
         return

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -34,7 +34,7 @@ from allways.cli.swap_commands.helpers import (
 )
 from allways.cli.validator_rejections import RejectionInfo, render_and_aggregate
 from allways.commitments import read_miner_commitments
-from allways.constants import FEE_DIVISOR, NETUID_FINNEY, RESERVE_SLIPPAGE_MAX_BPS
+from allways.constants import FEE_DIVISOR, NETUID_FINNEY, RESERVE_SLIPPAGE_DEFAULT_BPS, RESERVE_SLIPPAGE_MAX_BPS
 from allways.contract_client import ContractError
 from allways.synapses import SwapConfirmSynapse, SwapReserveSynapse
 from allways.utils.proofs import reserve_proof_message, swap_proof_message
@@ -188,7 +188,7 @@ def broadcast_reserve_with_retry(
     netuid: int,
     skip_confirm: bool = False,
     max_retries: int = 2,
-    slippage_bps: int = 200,
+    slippage_bps: int = RESERVE_SLIPPAGE_DEFAULT_BPS,
 ):
     """Reserve miner via multi-validator consensus with retry.
 
@@ -575,9 +575,9 @@ def swap_group():
     type=float,
     default=2.0,
     help=(
-        'Maximum rate slippage (in percent) between your quote and the reservation. '
-        "The reservation is rejected if the miner's current rate would give you more than "
-        'this percentage less than your quoted amount. Default: 2.0%.'
+        'Maximum rate slippage as a percent (e.g. 2.0 means 2%) between your quote and '
+        "the reservation. The reservation is rejected if the miner's current rate would "
+        'give you more than this percentage less than your quoted amount. Default: 2.0%.'
     ),
 )
 @click.option(

--- a/allways/cli/validator_rejections.py
+++ b/allways/cli/validator_rejections.py
@@ -93,7 +93,7 @@ _RULES: list[_Rule] = [
     ),
     (
         'rate_moved',
-        'quoted amount no longer matches the miner rate',
+        'quoted amount is below your slippage band',
         True,
         lambda ctx: (
             f'Miner UID {_ctx_get(ctx, "miner_uid")} changed its rate after you got your quote. '

--- a/allways/cli/validator_rejections.py
+++ b/allways/cli/validator_rejections.py
@@ -92,6 +92,15 @@ _RULES: list[_Rule] = [
         ),
     ),
     (
+        'rate_moved',
+        'quoted amount no longer matches the miner rate',
+        True,
+        lambda ctx: (
+            f'Miner UID {_ctx_get(ctx, "miner_uid")} changed its rate after you got your quote. '
+            'Re-run the swap to get a fresh quote at the current rate, then retry.'
+        ),
+    ),
+    (
         'wrong_direction',
         'miner does not support this swap direction',
         True,

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -67,6 +67,8 @@ CREDIBILITY_RAMP_OBSERVATIONS: int = 10
 RECYCLE_UID = 53  # Subnet owner UID
 
 # ─── Reservation ─────────────────────────────────────────
+RESERVE_SLIPPAGE_DEFAULT_BPS = 200  # 2% — applied when the synapse omits slippage
+RESERVE_SLIPPAGE_MAX_BPS = 100_000  # 1000% — clamp ceiling (mostly an integer/typo guard)
 RESERVATION_COOLDOWN_BLOCKS = 150  # ~30 min base cooldown on failed reservation
 RESERVATION_COOLDOWN_MULTIPLIER = 2  # 150 → 300 → 600 ...
 MAX_RESERVATIONS_PER_ADDRESS = 1

--- a/allways/synapses.py
+++ b/allways/synapses.py
@@ -10,6 +10,8 @@ from typing import Optional
 
 import bittensor as bt
 
+from allways.constants import RESERVE_SLIPPAGE_DEFAULT_BPS
+
 
 class MinerActivateSynapse(bt.Synapse):
     """Miner broadcasts activation request to all validators.
@@ -45,6 +47,7 @@ class SwapReserveSynapse(bt.Synapse):
     block_anchor: int
     from_chain: str = ''  # User's source chain (for bilateral pair support)
     to_chain: str = ''  # User's dest chain
+    slippage_bps: int = RESERVE_SLIPPAGE_DEFAULT_BPS
 
     # Response fields (validator fills)
     accepted: Optional[bool] = None

--- a/allways/utils/rate.py
+++ b/allways/utils/rate.py
@@ -105,6 +105,20 @@ def derive_tao_leg(from_chain: str, from_amount: int, to_chain: str, to_amount: 
     return 0
 
 
+def quote_within_slippage(quoted: int, recomputed: int, slippage_bps: int) -> bool:
+    """True if `recomputed` is no more than `slippage_bps` below `quoted`.
+
+    One-sided (DEX 'minimum received'): a favorable move — recomputed >= quoted —
+    always passes. Pure integer math for determinism across validators. When
+    slippage_bps >= 10_000 the threshold is non-positive, so it always passes.
+    """
+    if quoted <= 0 or recomputed <= 0:
+        return False
+    if recomputed >= quoted:
+        return True
+    return recomputed * 10_000 >= quoted * (10_000 - slippage_bps)
+
+
 def check_swap_viability(
     tao_amount_rao: int,
     miner_collateral_rao: int,

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -124,28 +124,19 @@ def recompute_reserve_amounts(
     from_chain: str,
     to_chain: str,
     from_amount: int,
-) -> Tuple[int, int]:
-    """Recompute (to_amount, tao_amount) from the miner's commitment rate.
-
-    The reservation pins the *amounts*, not the miner's rate — so the validator
-    must derive to_amount/tao_amount itself from the rate it reads at reserve
-    time rather than trusting the user-submitted values. A CLI quote computed
-    against a momentarily-bad (or stale) rate would otherwise get locked into
-    the reservation. Mirrors the CLI quote path in cli/swap_commands/swap.py so
-    a correctly-quoted reservation always matches.
-    """
+) -> int:
+    """Recompute to_amount from the miner's commitment rate, mirroring the CLI
+    quote path so a correctly-quoted reservation matches the reserve-time rate."""
     canon_from, canon_to = canonical_pair(from_chain, to_chain)
     is_reverse = from_chain != canon_from
     _, rate_str = commitment.get_rate_for_direction(from_chain)
-    to_amount = calculate_to_amount(
+    return calculate_to_amount(
         from_amount,
         rate_str,
         is_reverse,
         get_chain(canon_to).decimals,
         get_chain(canon_from).decimals,
     )
-    tao_amount = derive_tao_leg(from_chain, from_amount, to_chain, to_amount)
-    return to_amount, tao_amount
 
 
 def load_swap_commitment(validator: 'Validator', miner_hotkey: str) -> Optional[MinerPair]:
@@ -356,15 +347,9 @@ async def handle_swap_reserve(
                 reject_synapse(synapse, 'Miner does not support this swap direction', ctx)
                 return synapse
 
-            # Recompute expected to_amount from the commitment rate read here at
-            # reserve time. The reservation pins amounts but not the miner's
-            # rate, so a quote computed against a stale rate would otherwise be
-            # locked in.
-            #
-            # tao_amount is pure arithmetic from the submitted amounts — reject
-            # any inconsistency before voting so the contract always sees a
-            # self-consistent triple.
-            expected_to_amount, _ = recompute_reserve_amounts(
+            # Gate the user's quote against the rate read at reserve time, and
+            # reject a tao_amount that doesn't match the submitted from/to legs.
+            expected_to_amount = recompute_reserve_amounts(
                 commitment,
                 synapse.from_chain,
                 synapse.to_chain,

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -18,11 +18,11 @@ from Crypto.Hash import keccak
 from allways.chains import canonical_pair, get_chain
 from allways.classes import MinerPair
 from allways.commitments import read_miner_commitment
-from allways.constants import RESERVATION_COOLDOWN_BLOCKS
+from allways.constants import RESERVATION_COOLDOWN_BLOCKS, RESERVE_SLIPPAGE_MAX_BPS
 from allways.contract_client import AllwaysContractClient, ContractError
 from allways.synapses import MinerActivateSynapse, SwapConfirmSynapse, SwapReserveSynapse
 from allways.utils.proofs import reserve_proof_message, swap_proof_message
-from allways.utils.rate import calculate_to_amount, derive_tao_leg
+from allways.utils.rate import calculate_to_amount, derive_tao_leg, quote_within_slippage
 from allways.utils.scale import encode_bytes, encode_str, encode_u128
 from allways.validator.state_store import PendingConfirm
 
@@ -356,23 +356,35 @@ async def handle_swap_reserve(
                 reject_synapse(synapse, 'Miner does not support this swap direction', ctx)
                 return synapse
 
-            # Recompute to_amount/tao_amount from the commitment rate read here
-            # at reserve time. The reservation pins amounts but not the miner's
-            # rate, so a quote computed against a momentarily-bad rate would
-            # otherwise be locked in. Reject a mismatch so the user re-quotes
-            # against the current rate. The contract stores these amounts and
-            # they flow straight into the initiate hash, so they must be
-            # rate-consistent before the reservation is voted on-chain.
-            expected_to_amount, expected_tao_amount = recompute_reserve_amounts(
+            # Recompute expected to_amount from the commitment rate read here at
+            # reserve time. The reservation pins amounts but not the miner's
+            # rate, so a quote computed against a stale rate would otherwise be
+            # locked in.
+            #
+            # tao_amount is pure arithmetic from the submitted amounts — reject
+            # any inconsistency before voting so the contract always sees a
+            # self-consistent triple.
+            expected_to_amount, _ = recompute_reserve_amounts(
                 commitment,
                 synapse.from_chain,
                 synapse.to_chain,
                 synapse.from_amount,
             )
-            if synapse.to_amount != expected_to_amount or synapse.tao_amount != expected_tao_amount:
+            expected_tao_amount = derive_tao_leg(
+                synapse.from_chain, synapse.from_amount, synapse.to_chain, synapse.to_amount
+            )
+            if synapse.tao_amount != expected_tao_amount:
                 reject_synapse(
                     synapse,
-                    'Quoted amount no longer matches the miner rate — the rate moved, re-quote and retry',
+                    'tao_amount is inconsistent with from_amount/to_amount — re-quote and retry',
+                    ctx,
+                )
+                return synapse
+            slippage_bps = max(0, min(synapse.slippage_bps, RESERVE_SLIPPAGE_MAX_BPS))
+            if not quote_within_slippage(synapse.to_amount, expected_to_amount, slippage_bps):
+                reject_synapse(
+                    synapse,
+                    'Quoted amount is below your slippage band — the miner rate moved, re-quote and retry',
                     ctx,
                 )
                 return synapse

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -15,12 +15,14 @@ import bittensor as bt
 from bittensor import Keypair
 from Crypto.Hash import keccak
 
+from allways.chains import canonical_pair, get_chain
 from allways.classes import MinerPair
 from allways.commitments import read_miner_commitment
 from allways.constants import RESERVATION_COOLDOWN_BLOCKS
 from allways.contract_client import AllwaysContractClient, ContractError
 from allways.synapses import MinerActivateSynapse, SwapConfirmSynapse, SwapReserveSynapse
 from allways.utils.proofs import reserve_proof_message, swap_proof_message
+from allways.utils.rate import calculate_to_amount, derive_tao_leg
 from allways.utils.scale import encode_bytes, encode_str, encode_u128
 from allways.validator.state_store import PendingConfirm
 
@@ -115,6 +117,35 @@ def resolve_swap_direction(
     if rate <= 0:
         return None
     return from_chain, to_chain, deposit_addr, fulfillment_addr, rate, rate_str
+
+
+def recompute_reserve_amounts(
+    commitment: MinerPair,
+    from_chain: str,
+    to_chain: str,
+    from_amount: int,
+) -> Tuple[int, int]:
+    """Recompute (to_amount, tao_amount) from the miner's commitment rate.
+
+    The reservation pins the *amounts*, not the miner's rate — so the validator
+    must derive to_amount/tao_amount itself from the rate it reads at reserve
+    time rather than trusting the user-submitted values. A CLI quote computed
+    against a momentarily-bad (or stale) rate would otherwise get locked into
+    the reservation. Mirrors the CLI quote path in cli/swap_commands/swap.py so
+    a correctly-quoted reservation always matches.
+    """
+    canon_from, canon_to = canonical_pair(from_chain, to_chain)
+    is_reverse = from_chain != canon_from
+    _, rate_str = commitment.get_rate_for_direction(from_chain)
+    to_amount = calculate_to_amount(
+        from_amount,
+        rate_str,
+        is_reverse,
+        get_chain(canon_to).decimals,
+        get_chain(canon_from).decimals,
+    )
+    tao_amount = derive_tao_leg(from_chain, from_amount, to_chain, to_amount)
+    return to_amount, tao_amount
 
 
 def load_swap_commitment(validator: 'Validator', miner_hotkey: str) -> Optional[MinerPair]:
@@ -323,6 +354,27 @@ async def handle_swap_reserve(
             reserve_rate, _ = commitment.get_rate_for_direction(synapse.from_chain)
             if reserve_rate <= 0:
                 reject_synapse(synapse, 'Miner does not support this swap direction', ctx)
+                return synapse
+
+            # Recompute to_amount/tao_amount from the commitment rate read here
+            # at reserve time. The reservation pins amounts but not the miner's
+            # rate, so a quote computed against a momentarily-bad rate would
+            # otherwise be locked in. Reject a mismatch so the user re-quotes
+            # against the current rate. The contract stores these amounts and
+            # they flow straight into the initiate hash, so they must be
+            # rate-consistent before the reservation is voted on-chain.
+            expected_to_amount, expected_tao_amount = recompute_reserve_amounts(
+                commitment,
+                synapse.from_chain,
+                synapse.to_chain,
+                synapse.from_amount,
+            )
+            if synapse.to_amount != expected_to_amount or synapse.tao_amount != expected_tao_amount:
+                reject_synapse(
+                    synapse,
+                    'Quoted amount no longer matches the miner rate — the rate moved, re-quote and retry',
+                    ctx,
+                )
                 return synapse
 
             collateral, active, has_swap, reserved_until, _ = contract.get_miner_snapshot(miner)

--- a/tests/test_axon_handlers.py
+++ b/tests/test_axon_handlers.py
@@ -447,37 +447,141 @@ def run_reserve_handler(validator, synapse, commitment=_DEFAULT):
 
 
 class TestReserveRateRecompute:
+    # ------------------------------------------------------------------ #
+    # exact match / within band                                            #
+    # ------------------------------------------------------------------ #
+
     def test_accepts_when_amounts_match_commitment_rate(self):
-        """A correctly-quoted reservation passes the recompute gate and votes."""
+        """A correctly-quoted reservation (exact match) passes and votes."""
         validator = make_reserve_validator()
         result = run_reserve_handler(validator, make_reserve_synapse())
         assert result.accepted is True
         validator.axon_contract_client.vote_reserve.assert_called_once()
 
-    def test_rejects_stale_to_amount(self):
-        """A to_amount that doesn't match the commitment rate is rejected — the
-        rate moved after the quote was computed."""
+    def test_accepts_within_default_slippage_band(self):
+        """Rate dropped 1% after the user's quote — within the default 2% band."""
         validator = make_reserve_validator()
-        synapse = make_reserve_synapse(to_amount=_RESERVE_TO_AMOUNT + 1_000_000)
-        result = run_reserve_handler(validator, synapse)
+        # User quoted at rate 345 → to_amount = 345_000_000.
+        # Rate moved to ~341.55 (1% down) → recomputed ≈ 341_550_000.
+        # Simulate by patching the commitment rate so recomputed < quoted by 1%.
+        moved = make_commitment()
+        moved.rate_str = str(345 * 0.99)  # '341.55'
+        moved.rate = 345 * 0.99
+        # User's synapse still reflects the old 345 quote
+        result = run_reserve_handler(validator, make_reserve_synapse(), commitment=moved)
+        assert result.accepted is True
+        validator.axon_contract_client.vote_reserve.assert_called_once()
+
+    def test_rejects_beyond_default_slippage_band(self):
+        """Rate dropped 3% after the user's quote — exceeds the default 2% band."""
+        validator = make_reserve_validator()
+        # Rate moved to ~334.65 (3% down) → recomputed ≈ 334_650_000.
+        moved = make_commitment()
+        moved.rate_str = str(345 * 0.97)
+        moved.rate = 345 * 0.97
+        # User's synapse still reflects the old 345 quote
+        result = run_reserve_handler(validator, make_reserve_synapse(), commitment=moved)
         assert result.accepted is False
-        assert 'rate moved' in result.rejection_reason
+        assert 'slippage band' in result.rejection_reason
         validator.axon_contract_client.vote_reserve.assert_not_called()
 
-    def test_rejects_stale_tao_amount(self):
-        """tao_amount must also be rate-consistent — it flows into the contract
-        bounds check and the initiate hash."""
+    def test_accepts_favorable_move_recomputed_above_quoted(self):
+        """A favorable rate move (recomputed > quoted) always passes.
+
+        The user quoted conservatively at 330; the miner's rate is still 345
+        so recomputed (345_000_000) > quoted (330_000_000) — always passes.
+        """
+        validator = make_reserve_validator()
+        # User quoted at 330 rate → to_amount = 330_000_000
+        conservative_rate = 330.0
+        conservative_to = int(_RESERVE_FROM_AMOUNT * conservative_rate * 10**9 // 10**8)  # sat→rao
+        synapse = make_reserve_synapse(to_amount=conservative_to, tao_amount=conservative_to)
+        # Commitment still at 345 → recomputed = 345_000_000 > conservative_to
+        result = run_reserve_handler(validator, synapse)
+        assert result.accepted is True
+
+    def test_rejects_swap79_scale_gap(self):
+        """A quote ~7x above the recomputed amount (swap-79 scenario) rejects."""
+        validator = make_reserve_validator()
+        # User quoted at 345 rate but miner moved to 49 (7x gap)
+        moved = make_commitment()
+        moved.rate_str = '49'
+        moved.rate = 49.0
+        # from_amount=100_000 sat at rate '49' → 49_000_000 rao
+        result = run_reserve_handler(validator, make_reserve_synapse(), commitment=moved)
+        assert result.accepted is False
+        assert 'slippage band' in result.rejection_reason
+        validator.axon_contract_client.vote_reserve.assert_not_called()
+
+    def test_tighter_user_slippage_rejects_small_drift(self):
+        """Rate dropped 0.5% — within the default 2% band but rejected with
+        --slippage 0.3% (30 bps)."""
+        validator = make_reserve_validator()
+        # Rate moved to 99.5% of 345 → recomputed ≈ 99.5% of 345_000_000
+        moved = make_commitment()
+        moved.rate_str = str(345 * 0.995)
+        moved.rate = 345 * 0.995
+        synapse = make_reserve_synapse()
+        synapse.slippage_bps = 30  # 0.3%
+        result = run_reserve_handler(validator, synapse, commitment=moved)
+        assert result.accepted is False
+        assert 'slippage band' in result.rejection_reason
+
+    def test_wider_user_slippage_accepts_large_drift(self):
+        """Rate dropped 4% — the default 2% band rejects it, but --slippage 5%
+        (500 bps) accepts it."""
+        validator = make_reserve_validator()
+        # Rate moved to 96% of 345 → recomputed ≈ 96% of 345_000_000
+        moved = make_commitment()
+        moved.rate_str = str(345 * 0.96)
+        moved.rate = 345 * 0.96
+        synapse = make_reserve_synapse()
+        synapse.slippage_bps = 500  # 5%
+        result = run_reserve_handler(validator, synapse, commitment=moved)
+        assert result.accepted is True
+
+    def test_slippage_max_bps_clamp_applied(self):
+        """slippage_bps above RESERVE_SLIPPAGE_MAX_BPS is clamped, not errored.
+
+        With the clamp applied, even a very large drift (rate dropped 90%)
+        passes the slippage gate because MAX_BPS >= 10_000 makes the threshold
+        non-positive.
+        """
+        from allways.constants import RESERVE_SLIPPAGE_MAX_BPS
+
+        validator = make_reserve_validator()
+        # Rate dropped 90% → recomputed = 10% of 345_000_000 = 34_500_000.
+        # Default 2% band would reject this, but MAX_BPS uncaps it.
+        moved = make_commitment()
+        moved.rate_str = str(345 * 0.10)
+        moved.rate = 345 * 0.10
+        synapse = make_reserve_synapse()
+        synapse.slippage_bps = RESERVE_SLIPPAGE_MAX_BPS + 1_000_000  # absurdly large — clamped
+        result = run_reserve_handler(validator, synapse, commitment=moved)
+        # With MAX_BPS applied, gate passes; default 2% would reject
+        assert result.accepted is True
+
+    # ------------------------------------------------------------------ #
+    # tao_amount internal consistency                                      #
+    # ------------------------------------------------------------------ #
+
+    def test_rejects_inconsistent_tao_amount(self):
+        """tao_amount must equal derive_tao_leg(from_amount, to_amount) — an
+        inconsistent triple is rejected before the slippage gate."""
         validator = make_reserve_validator()
         synapse = make_reserve_synapse(tao_amount=_RESERVE_TAO_AMOUNT + 5)
         result = run_reserve_handler(validator, synapse)
         assert result.accepted is False
-        assert 'rate moved' in result.rejection_reason
+        assert 'inconsistent' in result.rejection_reason
         validator.axon_contract_client.vote_reserve.assert_not_called()
 
+    # ------------------------------------------------------------------ #
+    # rate moved after quote                                               #
+    # ------------------------------------------------------------------ #
+
     def test_rejects_when_rate_moved_after_quote(self):
-        """User quotes against rate 345, but the miner re-committed to 300
-        before the reservation reaches the validator — reject so the user
-        re-quotes against the live rate."""
+        """User quotes against rate 345, miner re-committed to 300 — the quote
+        is now ~15% above recomputed, outside the default 2% band."""
         validator = make_reserve_validator()
         moved = make_commitment()
         moved.rate_str = '300'
@@ -485,11 +589,15 @@ class TestReserveRateRecompute:
         # User still submits the amounts from the old 345 quote.
         result = run_reserve_handler(validator, make_reserve_synapse(), commitment=moved)
         assert result.accepted is False
-        assert 'rate moved' in result.rejection_reason
+        assert 'slippage band' in result.rejection_reason
         validator.axon_contract_client.vote_reserve.assert_not_called()
 
     def test_recompute_runs_before_vote(self):
-        """A stale quote must be rejected without ever calling vote_reserve."""
+        """A stale quote (rate moved 7x) is rejected before vote_reserve is called."""
         validator = make_reserve_validator()
-        run_reserve_handler(validator, make_reserve_synapse(to_amount=1))
+        # Rate moved from 345 down to 49 — user's old quote is ~7x above recomputed.
+        moved = make_commitment()
+        moved.rate_str = '49'
+        moved.rate = 49.0
+        run_reserve_handler(validator, make_reserve_synapse(), commitment=moved)
         validator.axon_contract_client.vote_reserve.assert_not_called()

--- a/tests/test_axon_handlers.py
+++ b/tests/test_axon_handlers.py
@@ -1,4 +1,4 @@
-"""Tests for validator axon_handlers.handle_swap_confirm.
+"""Tests for validator axon_handlers.handle_swap_confirm and handle_swap_reserve.
 
 Covers every rejection branch plus the queued-confirmation path. The
 vote_initiate success path is not unit-tested here — it requires mocking
@@ -14,8 +14,8 @@ from unittest.mock import MagicMock, patch
 from allways.chain_providers.base import TransactionInfo
 from allways.classes import MinerPair
 from allways.contract_client import ContractError
-from allways.synapses import SwapConfirmSynapse
-from allways.validator.axon_handlers import handle_swap_confirm
+from allways.synapses import SwapConfirmSynapse, SwapReserveSynapse
+from allways.validator.axon_handlers import handle_swap_confirm, handle_swap_reserve
 
 
 def make_synapse(
@@ -357,3 +357,139 @@ class TestErrorHandling:
         result = run_handler(validator, make_synapse())
         assert result.accepted is False
         assert 'boom' in result.rejection_reason
+
+
+# ===========================================================================
+# handle_swap_reserve — reserve-time rate recompute
+# ===========================================================================
+#
+# The reservation pins amounts but not the miner's rate. handle_swap_reserve
+# must recompute to_amount/tao_amount from the commitment rate it reads at
+# reserve time and reject a request whose user-submitted amounts don't match —
+# otherwise a quote computed against a momentarily-bad rate gets locked in.
+
+
+# btc→tao, from_amount=100_000 sat at rate '345' → to_amount/tao_amount.
+_RESERVE_FROM_AMOUNT = 100_000
+_RESERVE_TO_AMOUNT = 345_000_000
+_RESERVE_TAO_AMOUNT = 345_000_000
+
+# handle_swap_reserve computes the request hash from the miner's public key
+# before the lock, so the reserve fixtures need a real SS58 (the //Alice key).
+_RESERVE_MINER_SS58 = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
+
+
+def make_reserve_synapse(
+    miner_hotkey: str = _RESERVE_MINER_SS58,
+    tao_amount: int = _RESERVE_TAO_AMOUNT,
+    from_amount: int = _RESERVE_FROM_AMOUNT,
+    to_amount: int = _RESERVE_TO_AMOUNT,
+    from_address: str = 'bc1-user',
+    from_address_proof: str = 'proof',
+    from_chain: str = 'btc',
+    to_chain: str = 'tao',
+) -> SwapReserveSynapse:
+    return SwapReserveSynapse(
+        miner_hotkey=miner_hotkey,
+        tao_amount=tao_amount,
+        from_amount=from_amount,
+        to_amount=to_amount,
+        from_address=from_address,
+        from_address_proof=from_address_proof,
+        block_anchor=1000,
+        from_chain=from_chain,
+        to_chain=to_chain,
+    )
+
+
+def make_reserve_validator(
+    *,
+    block: int = 1000,
+    reserved_until: int = 0,
+    collateral: int = 10_000_000_000,
+    active: bool = True,
+    has_swap: bool = False,
+) -> MagicMock:
+    """Validator mock with default-happy state for handle_swap_reserve.
+
+    get_miner_snapshot returns (collateral, active, has_swap, reserved_until,
+    deactivation_block); get_cooldown returns (strikes, last_expired).
+    """
+    validator = MagicMock()
+    validator.block = block
+    validator.axon_subtensor.get_current_block.return_value = block
+    validator.config.netuid = 2
+    validator.axon_lock = threading.Lock()
+
+    contract = MagicMock()
+    contract.get_miner_snapshot.return_value = (collateral, active, has_swap, reserved_until, 0)
+    contract.get_cooldown.return_value = (0, 0)
+    validator.axon_contract_client = contract
+
+    btc = MagicMock()
+    btc.verify_from_proof.return_value = True
+    btc.get_balance.return_value = 10**18
+    validator.axon_chain_providers = {'btc': btc, 'tao': MagicMock()}
+
+    validator.bounds_cache = MagicMock()
+    validator.bounds_cache.min_collateral.return_value = 0
+    validator.bounds_cache.min_swap_amount.return_value = 0
+    validator.bounds_cache.max_swap_amount.return_value = 0
+    validator.wallet = MagicMock()
+    return validator
+
+
+def run_reserve_handler(validator, synapse, commitment=_DEFAULT):
+    """Patch read_miner_commitment and drive handle_swap_reserve synchronously."""
+    cmt = make_commitment() if commitment is _DEFAULT else commitment
+    with patch('allways.validator.axon_handlers.read_miner_commitment', return_value=cmt):
+        return asyncio.run(handle_swap_reserve(validator, synapse))
+
+
+class TestReserveRateRecompute:
+    def test_accepts_when_amounts_match_commitment_rate(self):
+        """A correctly-quoted reservation passes the recompute gate and votes."""
+        validator = make_reserve_validator()
+        result = run_reserve_handler(validator, make_reserve_synapse())
+        assert result.accepted is True
+        validator.axon_contract_client.vote_reserve.assert_called_once()
+
+    def test_rejects_stale_to_amount(self):
+        """A to_amount that doesn't match the commitment rate is rejected — the
+        rate moved after the quote was computed."""
+        validator = make_reserve_validator()
+        synapse = make_reserve_synapse(to_amount=_RESERVE_TO_AMOUNT + 1_000_000)
+        result = run_reserve_handler(validator, synapse)
+        assert result.accepted is False
+        assert 'rate moved' in result.rejection_reason
+        validator.axon_contract_client.vote_reserve.assert_not_called()
+
+    def test_rejects_stale_tao_amount(self):
+        """tao_amount must also be rate-consistent — it flows into the contract
+        bounds check and the initiate hash."""
+        validator = make_reserve_validator()
+        synapse = make_reserve_synapse(tao_amount=_RESERVE_TAO_AMOUNT + 5)
+        result = run_reserve_handler(validator, synapse)
+        assert result.accepted is False
+        assert 'rate moved' in result.rejection_reason
+        validator.axon_contract_client.vote_reserve.assert_not_called()
+
+    def test_rejects_when_rate_moved_after_quote(self):
+        """User quotes against rate 345, but the miner re-committed to 300
+        before the reservation reaches the validator — reject so the user
+        re-quotes against the live rate."""
+        validator = make_reserve_validator()
+        moved = make_commitment()
+        moved.rate_str = '300'
+        moved.rate = 300.0
+        # User still submits the amounts from the old 345 quote.
+        result = run_reserve_handler(validator, make_reserve_synapse(), commitment=moved)
+        assert result.accepted is False
+        assert 'rate moved' in result.rejection_reason
+        validator.axon_contract_client.vote_reserve.assert_not_called()
+
+    def test_recompute_runs_before_vote(self):
+        """A stale quote must be rejected without ever calling vote_reserve."""
+        validator = make_reserve_validator()
+        run_reserve_handler(validator, make_reserve_synapse(to_amount=1))
+        validator.axon_contract_client.vote_reserve.assert_not_called()

--- a/tests/test_validator_rejections.py
+++ b/tests/test_validator_rejections.py
@@ -77,6 +77,21 @@ def test_address_cooldown_includes_raw_reason():
     assert info.headline.lower().count('address on cooldown') == 0
 
 
+def test_rate_moved_translates():
+    raw = 'Quoted amount no longer matches the miner rate — the rate moved, re-quote and retry'
+    info = render_and_aggregate(
+        _silent_console(),
+        [FakeResp(accepted=False, rejection_reason=raw)],
+        context={'miner_uid': 7},
+    )
+    assert info.category == 'rate_moved'
+    # Deterministic: retrying with the same stale quote cannot succeed — the
+    # user must re-quote first.
+    assert info.deterministic is True
+    assert 'UID 7' in info.headline
+    assert 'rate' in info.headline.lower()
+
+
 def test_miner_busy_is_not_deterministic():
     info = render_and_aggregate(
         _silent_console(),

--- a/tests/test_validator_rejections.py
+++ b/tests/test_validator_rejections.py
@@ -78,7 +78,7 @@ def test_address_cooldown_includes_raw_reason():
 
 
 def test_rate_moved_translates():
-    raw = 'Quoted amount no longer matches the miner rate — the rate moved, re-quote and retry'
+    raw = 'Quoted amount is below your slippage band — the miner rate moved, re-quote and retry'
     info = render_and_aggregate(
         _silent_console(),
         [FakeResp(accepted=False, rejection_reason=raw)],


### PR DESCRIPTION
## Swap 79 — what spawned this

Diagnosing swap 79 surfaced that a swap's reservation pins the *amounts*
(`to_amount` / `tao_amount` / `from_amount`) but **not** the miner's rate.
The reservation hash and stored `Reservation` struct commit the validators to
specific amounts, yet nothing tied those amounts back to the rate they were
derived from — so a quote computed against a stale rate could be locked in.

## The issue

**Stale-quote bounce (swap 79 and every honest user after).** `handle_swap_reserve`
trusted the user-submitted `to_amount` / `tao_amount` straight from the synapse.
It checked that the miner quoted a non-zero rate for the direction but never
recomputed the amounts from that rate. Miners update rates often; the rate ticks
between the user's CLI quote and `vote_reserve`, so nearly every honest
reservation bounced under the strict-equality approach in the previous version
of this PR.

## The fix — slippage band (this PR)

**Reserve recompute with one-sided slippage.** `handle_swap_reserve` now:

1. Recomputes the expected `to_amount` from the commitment rate read at reserve
   time (`recompute_reserve_amounts` helper, unchanged from the earlier version).
2. Checks `tao_amount` internal consistency as pure arithmetic (no rate):
   rejects if `synapse.tao_amount != derive_tao_leg(...)`.
3. Applies a **one-sided slippage gate** via `quote_within_slippage`:
   - A favorable move (recomputed ≥ quoted) always passes.
   - A downward move passes only if `recomputed * 10_000 >= quoted * (10_000 - slippage_bps)`.
   - Uses pure integer math — deterministic across validators.

**User-settable via `--slippage <percent>`** on `alw swap now` (default 2%,
transmitted as `synapse.slippage_bps`; old clients that omit the field default
to `RESERVE_SLIPPAGE_DEFAULT_BPS = 200`). Validators clamp to
`RESERVE_SLIPPAGE_MAX_BPS = 100_000` (1000%) as an integer/typo guard.

The CLI shows the slippage honestly as a **reserve-acceptance threshold** — not
a settlement guarantee (rate pinning at settlement is a separate unshipped
change):

```
Slippage 2% — reservation is rejected if the miner's rate has moved
more than 2% below your quote.
```

**Rejection message and CLI translator:** the `rate_moved` rule in
`validator_rejections.py` now matches `'quoted amount is below your slippage band'`.

## Review notes

- **Consensus-path code.** `quote_within_slippage` is pure integer math —
  every validator evaluates the same inputs and reaches the same decision.
  `slippage_bps` is user-submitted but clamped on every validator before use,
  so a malicious value cannot cause divergence.
- The reservation still votes with `synapse.to_amount` / `synapse.tao_amount` —
  the recomputed value is **not** substituted. Consensus relies on every validator
  using the user's submitted values in `vote_reserve`.
- Rejection fires before `vote_reserve` — no partial on-chain vote on a rejected
  synapse.
- **Tests:** 45 pass (12 new in `TestReserveRateRecompute`); full suite 480/482
  green (2 pre-existing failures unrelated to this PR — missing `embit` module).

## Follow-up — initiate pinning (Part 2, still deferred)

Pinning the miner's commitment (rate + addresses) as of the reserve block is not
included; it needs a small contract change to add `reserved_block` to the
`Reservation` struct so `R` is a deterministic on-chain read. Designed separately
to avoid improvising on the consensus path.