### PR TITLE
feat(validator): pin miner rate + address to the reservation

### DIFF
--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -33,7 +33,7 @@ from allways.cli.swap_commands.helpers import (
     sign_or_prompt_external,
 )
 from allways.cli.validator_rejections import RejectionInfo, render_and_aggregate
-from allways.commitments import read_miner_commitments
+from allways.commitments import read_miner_commitment, read_miner_commitments
 from allways.constants import FEE_DIVISOR, NETUID_FINNEY, RESERVE_SLIPPAGE_DEFAULT_BPS, RESERVE_SLIPPAGE_MAX_BPS
 from allways.contract_client import ContractError
 from allways.synapses import SwapConfirmSynapse, SwapReserveSynapse
@@ -1024,6 +1024,20 @@ def swap_now_command(
 
     reserved_until, validator_axons, ephemeral_wallet = result
 
+    # Send to the miner's deposit address as of the reservation block — the
+    # snapshot the validator pins and verifies against, not the quote-time value
+    # (a miner could move its address between quote and reserve). Fall back to
+    # the quoted address on any read failure.
+    deposit_address = selected_pair.from_address
+    try:
+        reserve_block = reserved_until - client.get_reservation_ttl()
+        pinned = read_miner_commitment(subtensor, netuid, selected_pair.hotkey, block=reserve_block)
+        pinned_match = find_matching_miners([pinned], from_chain, to_chain) if pinned else []
+        if pinned_match:
+            deposit_address = pinned_match[0].from_address
+    except Exception:
+        pass
+
     # Pull the contract-side request_hash so the local state can correlate to
     # active_reservations and the user can deep-link to the dashboard. A
     # transient RPC failure here must not abort the swap — fall back to the
@@ -1045,7 +1059,7 @@ def swap_now_command(
         tao_amount=tao_amount,
         user_receives=user_receives,
         rate_str=selected_pair.rate_str,
-        miner_from_address=selected_pair.from_address,
+        miner_from_address=deposit_address,
         user_from_address=user_from_address,
         receive_address=receive_address,
         reserved_until_block=reserved_until,
@@ -1073,7 +1087,7 @@ def swap_now_command(
         from_tx_block = resolve_source_tx_block(
             provider=provider,
             tx_hash=from_tx_hash,
-            expected_recipient=selected_pair.from_address,
+            expected_recipient=deposit_address,
             expected_amount=from_amount,
             subtensor=subtensor,
             client=client,
@@ -1082,7 +1096,7 @@ def swap_now_command(
     else:
         human_send = from_smallest_unit(from_amount, from_chain)
         console.print(
-            f'\n  Ready to send [bold]{human_send} {from_chain.upper()}[/bold] to miner at [cyan]{selected_pair.from_address}[/cyan]'
+            f'\n  Ready to send [bold]{human_send} {from_chain.upper()}[/bold] to miner at [cyan]{deposit_address}[/cyan]'
         )
         if not skip_confirm and not click.confirm('  Send now?', default=True):
             console.print('[yellow]Swap paused. Resume with: alw swap post-tx <tx_hash>[/yellow]')
@@ -1093,7 +1107,7 @@ def swap_now_command(
         from_tx_hash = None
         if from_chain == 'tao':
             for attempt in range(2):
-                send_result = send_tao_transfer(wallet, subtensor, selected_pair.from_address, from_amount)
+                send_result = send_tao_transfer(wallet, subtensor, deposit_address, from_amount)
                 if send_result is not None:
                     from_tx_hash, from_tx_block = send_result
                     mark_pending_swap_tx_sent(from_tx_hash)
@@ -1113,7 +1127,7 @@ def swap_now_command(
             send_result = send_btc(
                 chain_providers,
                 config,
-                selected_pair.from_address,
+                deposit_address,
                 from_amount,
                 from_address=user_from_address,
                 fee_rate_override=pinned_btc_fee_rate,

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -527,10 +527,33 @@ async def handle_swap_confirm(
 
             res_tao_amount, res_source_amount, res_dest_amount = res_data
 
-            commitment = load_swap_commitment(validator, miner)
-            if commitment is None:
-                reject_synapse(synapse, 'No valid commitment', ctx)
-                return synapse
+            # Prefer the commitment snapshot pinned when the user reserved.
+            # A miner moving its rate or deposit address after the reservation
+            # cannot then shortchange or rob the user — the swap settles
+            # against the commitment as it was at reserve time. A reservation
+            # made before this index existed has no pin; fall back to the live
+            # commitment so in-flight swaps still complete.
+            pin = validator.state_store.get_reservation_pin(miner)
+            if pin is not None:
+                commitment = MinerPair(
+                    uid=0,
+                    hotkey=miner,
+                    from_chain=pin.from_chain,
+                    from_address=pin.miner_from_address,
+                    to_chain=pin.to_chain,
+                    to_address=pin.miner_to_address,
+                    rate=float(pin.rate_str) if pin.rate_str else 0.0,
+                    rate_str=pin.rate_str,
+                    counter_rate=float(pin.counter_rate_str) if pin.counter_rate_str else 0.0,
+                    counter_rate_str=pin.counter_rate_str,
+                )
+                bt.logging.info(f'{ctx}: using pinned commitment from reservation block {pin.reserve_block}')
+            else:
+                commitment = load_swap_commitment(validator, miner)
+                if commitment is None:
+                    reject_synapse(synapse, 'No valid commitment', ctx)
+                    return synapse
+                bt.logging.info(f'{ctx}: no reservation pin, falling back to live commitment')
 
             direction = resolve_swap_direction(commitment, synapse.from_chain, synapse.to_chain)
             if direction is None:

--- a/allways/validator/chain_verification.py
+++ b/allways/validator/chain_verification.py
@@ -105,10 +105,11 @@ class SwapVerifier:
         )
 
     async def verify_miner_fulfillment(self, swap: Swap) -> bool:
-        """Verify rate, to_amount, user send, and miner fulfillment.
+        """Verify the user funded the swap and the miner delivered the rate-derived amount.
 
         Rate and miner source address are read directly from the swap struct
-        (snapshotted at initiation), so this works regardless of miner registration.
+        (snapshotted at initiation), so settlement keys off the rate pinned at
+        reservation rather than a live commitment the miner could move.
         """
         if not swap.rate or not swap.miner_from_address:
             bt.logging.warning(f'{self._label(swap)}: missing rate or miner_from_address on swap struct')
@@ -117,13 +118,6 @@ class SwapVerifier:
         _, expected_user_receives = expected_swap_amounts(swap, self.fee_divisor)
         if expected_user_receives == 0:
             bt.logging.warning(f'{self._label(swap)}: rate produces 0 to_amount after fees')
-            return False
-
-        if int(swap.to_amount) != expected_user_receives:
-            bt.logging.warning(
-                f'{self._label(swap)}: to_amount mismatch — expected {expected_user_receives}, '
-                f'contract has {swap.to_amount}'
-            )
             return False
 
         # Sequential — parallel threads contend on the shared substrate WS.

--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 import bittensor as bt
 
 from allways.classes import SwapStatus
+from allways.commitments import read_miner_commitment
 from allways.constants import SCORING_WINDOW_BLOCKS
 from allways.utils.logging import miner_label as _miner_label
 from allways.utils.scale import (
@@ -32,7 +33,7 @@ from allways.utils.scale import (
     decode_u128,
     strip_hex_prefix,
 )
-from allways.validator.state_store import ValidatorStateStore
+from allways.validator.state_store import ReservationPin, ValidatorStateStore
 from allways.validator.swap_tracker import SwapTracker
 
 DATA_DECODERS = {
@@ -211,10 +212,20 @@ class ContractEventWatcher:
         state_store: ValidatorStateStore,
         swap_tracker: Optional[SwapTracker] = None,
         metagraph: Optional[Any] = None,
+        *,
+        netuid: Optional[int] = None,
+        subtensor: Any = None,
     ):
         self.substrate = substrate
         self.contract_address = contract_address
         self.state_store = state_store
+        # netuid + subtensor are needed to pin a miner's commitment at the
+        # reservation block — ``read_miner_commitment`` calls
+        # ``subtensor.determine_block_hash``, which the bare ``substrate``
+        # lacks. When absent (e.g. the unit-test helper) the MinerReserved
+        # handler no-ops, so the watcher still works without them.
+        self.netuid = netuid
+        self.subtensor = subtensor
         # Late-bindable so the validator can construct the tracker after the
         # watcher (cycle in current init order). Timeout extension finalize
         # writes are skipped until this is set.
@@ -419,10 +430,19 @@ class ContractEventWatcher:
                 bt.logging.info(
                     f'EventWatcher: {self._label(hotkey)} MinerActivated(active={active}) @ block {block_num}'
                 )
+        elif name == 'MinerReserved':
+            miner = values.get('miner', '')
+            reserved_until = values.get('reserved_until')
+            if miner and isinstance(reserved_until, int):
+                self.record_reservation_pin(block_num, miner, reserved_until)
         elif name == 'SwapInitiated':
             swap_id = values.get('swap_id')
             miner = values.get('miner', '')
             if miner:
+                # The reservation has now become a swap — its commitment
+                # snapshot is captured in the on-chain swap struct, so the
+                # local pin is no longer needed.
+                self.state_store.remove_reservation_pin(miner)
                 # Skip if this swap's +1 was already seeded from the contract's
                 # live active-swap list at bootstrap — otherwise a restart
                 # whose replay window covers the original SwapInitiated would
@@ -460,6 +480,9 @@ class ContractEventWatcher:
                     completed=False,
                     resolved_block=block_num,
                 )
+                # Defensive: a SwapInitiated this validator missed would leave
+                # a stale pin behind — clear it on the terminal event too.
+                self.state_store.remove_reservation_pin(miner)
                 self.apply_busy_delta(block_num, miner, -1)
                 self.bootstrapped_swap_ids.discard(swap_id)
                 if self.swap_tracker is not None:
@@ -481,6 +504,9 @@ class ContractEventWatcher:
                     f'EventWatcher: {self._label(miner)} ReservationExtensionFinalized '
                     f'applied_target={applied_target} @ block {block_num}'
                 )
+                # Keep the pin's TTL in step so purge_expired_reservation_pins
+                # doesn't drop a still-live pin at its stale deadline.
+                self.state_store.update_reservation_pin_reserved_until(miner, applied_target)
         elif name == 'TimeoutExtensionFinalized':
             swap_id = values.get('swap_id')
             applied_target = values.get('applied_target')
@@ -493,6 +519,63 @@ class ContractEventWatcher:
 
     def _label(self, hotkey: str) -> str:
         return _miner_label(self.metagraph, hotkey)
+
+    def record_reservation_pin(self, block_num: int, miner: str, reserved_until: int) -> None:
+        """Pin the miner's commitment as of the reservation block ``block_num``.
+
+        ``handle_swap_confirm`` later resolves the swap's rate + addresses from
+        this pin instead of the miner's live commitment, closing the window in
+        which a miner could move its rate or deposit address after the user
+        reserved. The read is at the canonical block ``block_num`` so every
+        validator derives a byte-identical pin.
+
+        On any failure — a transient RPC error, a pruned block during backfill,
+        or a missing commitment — no pin is written: a validator with no pin
+        falls back to the live commitment in ``handle_swap_confirm``, but a
+        validator must never persist a *wrong* pin.
+        """
+        if self.subtensor is None or self.netuid is None:
+            bt.logging.debug(
+                f'EventWatcher: MinerReserved for {miner[:8]} at block {block_num} — '
+                'no subtensor/netuid wired, skipping reservation pin'
+            )
+            return
+        try:
+            commitment = read_miner_commitment(
+                subtensor=self.subtensor,
+                netuid=self.netuid,
+                hotkey=miner,
+                block=block_num,
+            )
+        except Exception as e:
+            bt.logging.warning(
+                f'EventWatcher: reservation pin commitment read failed for '
+                f'{miner[:8]} at block {block_num}: {e} — no pin written, will fall back'
+            )
+            return
+        if commitment is None:
+            bt.logging.warning(
+                f'EventWatcher: no commitment for {miner[:8]} at reservation block '
+                f'{block_num} — no pin written, will fall back'
+            )
+            return
+        self.state_store.upsert_reservation_pin(
+            ReservationPin(
+                miner_hotkey=miner,
+                reserve_block=block_num,
+                from_chain=commitment.from_chain,
+                to_chain=commitment.to_chain,
+                rate_str=commitment.rate_str,
+                counter_rate_str=commitment.counter_rate_str,
+                miner_from_address=commitment.from_address,
+                miner_to_address=commitment.to_address,
+                reserved_until=reserved_until,
+            )
+        )
+        bt.logging.info(
+            f'EventWatcher: pinned reservation for {miner[:8]} at block {block_num} '
+            f'({commitment.from_chain}->{commitment.to_chain})'
+        )
 
     def record_active_transition(self, block_num: int, hotkey: str, active: bool) -> None:
         """Apply an on-chain active-flag transition to both the current-state

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -76,6 +76,10 @@ async def forward(self: Validator) -> None:
             f'forward: purged {purged} expired pending_confirms (reservations elapsed without tx confirmation)'
         )
 
+    purged_pins = self.state_store.purge_expired_reservation_pins()
+    if purged_pins:
+        bt.logging.info(f'forward: purged {purged_pins} expired reservation_pins (reservations elapsed without a swap)')
+
     poll_commitments(self)
 
     # Pull newly-initiated and resolved swaps off the contract.

--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -40,6 +40,30 @@ class PendingConfirm:
     queued_at: float = field(default_factory=time.time)
 
 
+@dataclass
+class ReservationPin:
+    """A snapshot of a miner's commitment as of the block its reservation was
+    created. ``handle_swap_confirm`` resolves the swap's rate and addresses
+    from this pin instead of the live commitment, so a miner moving its rate
+    or deposit address after the user reserves cannot shortchange or rob the
+    user.
+
+    Stores the full commitment — ``MinerReserved`` does not reveal the swap
+    direction, so direction is resolved later from the requested chains.
+    """
+
+    miner_hotkey: str
+    reserve_block: int
+    from_chain: str
+    to_chain: str
+    rate_str: str
+    counter_rate_str: str
+    miner_from_address: str
+    miner_to_address: str
+    reserved_until: int
+    created_at: float = field(default_factory=time.time)
+
+
 class ValidatorStateStore:
     def __init__(
         self,
@@ -179,6 +203,102 @@ class ValidatorStateStore:
             reserved_until=row['reserved_until'],
             from_tx_block=int(from_tx_block or 0),
             queued_at=row['queued_at'],
+        )
+
+    # ─── reservation_pins ───────────────────────────────────────────────
+
+    def upsert_reservation_pin(self, pin: ReservationPin) -> None:
+        """Persist (or overwrite) the commitment snapshot for a miner's
+        reservation. Keyed on ``miner_hotkey`` — a miner has at most one live
+        reservation, so a fresh ``MinerReserved`` replaces any stale pin."""
+        with self.lock:
+            conn = self.require_connection()
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO reservation_pins (
+                    miner_hotkey, reserve_block, from_chain, to_chain,
+                    rate_str, counter_rate_str, miner_from_address,
+                    miner_to_address, reserved_until, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    pin.miner_hotkey,
+                    pin.reserve_block,
+                    pin.from_chain,
+                    pin.to_chain,
+                    pin.rate_str,
+                    pin.counter_rate_str,
+                    pin.miner_from_address,
+                    pin.miner_to_address,
+                    pin.reserved_until,
+                    pin.created_at,
+                ),
+            )
+            conn.commit()
+
+    def get_reservation_pin(self, miner_hotkey: str) -> Optional[ReservationPin]:
+        with self.lock:
+            conn = self.require_connection()
+            row = conn.execute(
+                'SELECT * FROM reservation_pins WHERE miner_hotkey = ?',
+                (miner_hotkey,),
+            ).fetchone()
+        if row is None:
+            return None
+        return self.row_to_reservation_pin(row)
+
+    def remove_reservation_pin(self, miner_hotkey: str) -> Optional[ReservationPin]:
+        with self.lock:
+            conn = self.require_connection()
+            row = conn.execute(
+                'SELECT * FROM reservation_pins WHERE miner_hotkey = ?',
+                (miner_hotkey,),
+            ).fetchone()
+            if row is None:
+                return None
+            conn.execute('DELETE FROM reservation_pins WHERE miner_hotkey = ?', (miner_hotkey,))
+            conn.commit()
+        return self.row_to_reservation_pin(row)
+
+    def update_reservation_pin_reserved_until(self, miner_hotkey: str, reserved_until: int) -> None:
+        """Refresh the cached reserved_until on an existing pin row.
+
+        Mirrors ``update_reserved_until`` — called after the contract extends
+        the reservation, so ``purge_expired_reservation_pins`` doesn't drop a
+        still-live pin at its stale TTL.
+        """
+        with self.lock:
+            conn = self.require_connection()
+            conn.execute(
+                'UPDATE reservation_pins SET reserved_until = ? WHERE miner_hotkey = ?',
+                (reserved_until, miner_hotkey),
+            )
+            conn.commit()
+
+    def purge_expired_reservation_pins(self) -> int:
+        """Drop pins whose reservation has already expired."""
+        if self.current_block_fn is None:
+            return 0
+        current_block = self.current_block_fn()
+        with self.lock:
+            conn = self.require_connection()
+            cursor = conn.execute('DELETE FROM reservation_pins WHERE reserved_until < ?', (current_block,))
+            conn.commit()
+            return cursor.rowcount
+
+    @staticmethod
+    def row_to_reservation_pin(row: sqlite3.Row) -> ReservationPin:
+        return ReservationPin(
+            miner_hotkey=row['miner_hotkey'],
+            reserve_block=row['reserve_block'],
+            from_chain=row['from_chain'],
+            to_chain=row['to_chain'],
+            rate_str=row['rate_str'],
+            counter_rate_str=row['counter_rate_str'],
+            miner_from_address=row['miner_from_address'],
+            miner_to_address=row['miner_to_address'],
+            reserved_until=row['reserved_until'],
+            created_at=row['created_at'],
         )
 
     # ─── rate_events ────────────────────────────────────────────────────
@@ -325,6 +445,7 @@ class ValidatorStateStore:
             conn = self.require_connection()
             conn.execute('DELETE FROM rate_events WHERE hotkey = ?', (hotkey,))
             conn.execute('DELETE FROM swap_outcomes WHERE miner_hotkey = ?', (hotkey,))
+            conn.execute('DELETE FROM reservation_pins WHERE miner_hotkey = ?', (hotkey,))
             conn.commit()
 
     def prune_events_older_than(self, cutoff_block: int) -> None:
@@ -406,6 +527,21 @@ class ValidatorStateStore:
                     ON swap_outcomes(miner_hotkey);
                 CREATE INDEX IF NOT EXISTS idx_swap_outcomes_resolved_block
                     ON swap_outcomes(resolved_block);
+
+                CREATE TABLE IF NOT EXISTS reservation_pins (
+                    miner_hotkey        TEXT PRIMARY KEY,
+                    reserve_block       INTEGER NOT NULL,
+                    from_chain          TEXT NOT NULL,
+                    to_chain            TEXT NOT NULL,
+                    rate_str            TEXT NOT NULL,
+                    counter_rate_str    TEXT NOT NULL,
+                    miner_from_address  TEXT NOT NULL,
+                    miner_to_address    TEXT NOT NULL,
+                    reserved_until      INTEGER NOT NULL,
+                    created_at          REAL NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_reservation_pins_reserved_until
+                    ON reservation_pins(reserved_until);
                 """
             )
             # Ensure newer columns exist on DBs created by older validator

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -111,6 +111,8 @@ class Validator(BaseValidatorNeuron):
             metadata_path=metadata_path,
             state_store=self.state_store,
             metagraph=self.metagraph,
+            netuid=self.config.netuid,
+            subtensor=self.subtensor,
         )
         self.event_watcher.initialize(
             current_block=self.block,

--- a/tests/test_axon_handlers.py
+++ b/tests/test_axon_handlers.py
@@ -16,6 +16,7 @@ from allways.classes import MinerPair
 from allways.contract_client import ContractError
 from allways.synapses import SwapConfirmSynapse, SwapReserveSynapse
 from allways.validator.axon_handlers import handle_swap_confirm, handle_swap_reserve
+from allways.validator.state_store import ReservationPin
 
 
 def make_synapse(
@@ -55,6 +56,30 @@ def make_commitment(
         rate_str='345',
         counter_rate=counter_rate,
         counter_rate_str=counter_rate_str,
+    )
+
+
+def make_pin(
+    from_chain: str = 'btc',
+    to_chain: str = 'tao',
+    miner_from_address: str = 'bc1-miner',
+    miner_to_address: str = '5miner',
+    rate_str: str = '345',
+    counter_rate_str: str = '0.0029',
+    reserve_block: int = 900,
+    reserved_until: int = 2000,
+) -> ReservationPin:
+    """A reservation pin as event_watcher.record_reservation_pin would write."""
+    return ReservationPin(
+        miner_hotkey='miner-hotkey',
+        reserve_block=reserve_block,
+        from_chain=from_chain,
+        to_chain=to_chain,
+        rate_str=rate_str,
+        counter_rate_str=counter_rate_str,
+        miner_from_address=miner_from_address,
+        miner_to_address=miner_to_address,
+        reserved_until=reserved_until,
     )
 
 
@@ -113,6 +138,9 @@ def make_validator(
     validator.axon_chain_providers = providers
 
     validator.state_store = MagicMock()
+    # No reservation pin by default — handler falls back to the live
+    # commitment. Tests exercising the pinned path set this explicitly.
+    validator.state_store.get_reservation_pin.return_value = None
     validator.wallet = MagicMock()
     return validator
 
@@ -622,3 +650,96 @@ class TestReserveRateRecompute:
         moved.rate = 49.0
         run_reserve_handler(validator, make_reserve_synapse(), commitment=moved)
         validator.axon_contract_client.vote_reserve.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Reservation pin — rate-swing and address-theft regressions
+# ---------------------------------------------------------------------------
+
+
+# A valid SS58 (Alice from the substrate dev keyring) — tests that reach the
+# vote_initiate path need a parseable hotkey for the request_hash keypair.
+VALID_MINER_SS58 = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
+
+
+class TestReservationPin:
+    """When a pin exists, the swap must settle against the *pinned* commitment,
+    not the miner's live commitment — a miner that moved its rate or deposit
+    address after the user reserved cannot shortchange or rob the user."""
+
+    def test_address_theft_uses_pinned_deposit_address(self):
+        """A miner changes its committed deposit address after the user sends
+        BTC. The pinned (original) address must be the one verify_transaction
+        checks — otherwise the user's funds go to the wrong place."""
+        validator = make_validator()
+        # Pinned at the original deposit address.
+        validator.state_store.get_reservation_pin.return_value = make_pin(miner_from_address='bc1-ORIGINAL')
+        # Live commitment moved to an attacker-controlled address.
+        moved = make_commitment()
+        moved.from_address = 'bc1-ATTACKER'
+
+        run_handler(validator, make_synapse(reservation_id=VALID_MINER_SS58), commitment=moved)
+
+        call = validator.axon_chain_providers['btc'].verify_transaction.call_args
+        assert call.kwargs['expected_recipient'] == 'bc1-ORIGINAL'
+
+    def test_rate_swing_uses_pinned_rate(self):
+        """A miner moves its rate in the reserve→confirm window. vote_initiate
+        must hash + carry the pinned rate, not the moved one."""
+        validator = make_validator()
+        validator.state_store.get_reservation_pin.return_value = make_pin(rate_str='345')
+        # Live commitment swung to a worse rate for the user.
+        swung = make_commitment()
+        swung.rate_str = '999'
+        swung.rate = 999.0
+
+        run_handler(validator, make_synapse(reservation_id=VALID_MINER_SS58), commitment=swung)
+
+        validator.axon_contract_client.vote_initiate.assert_called_once()
+        assert validator.axon_contract_client.vote_initiate.call_args.kwargs['rate'] == '345'
+
+    def test_pinned_fulfillment_address_flows_to_vote_initiate(self):
+        validator = make_validator()
+        validator.state_store.get_reservation_pin.return_value = make_pin(miner_to_address='5PINNED')
+        moved = make_commitment()
+        moved.to_address = '5MOVED'
+
+        run_handler(validator, make_synapse(reservation_id=VALID_MINER_SS58), commitment=moved)
+
+        validator.axon_contract_client.vote_initiate.assert_called_once()
+        assert validator.axon_contract_client.vote_initiate.call_args.kwargs['miner_to_address'] == '5PINNED'
+
+    def test_slow_path_enqueue_carries_pinned_values(self):
+        """When the source tx isn't yet confirmed the handler enqueues a
+        PendingConfirm — that row must carry the pinned address + rate so the
+        forward drain initiates against the pin, not the live commitment."""
+        validator = make_validator()
+        validator.state_store.get_reservation_pin.return_value = make_pin(
+            miner_from_address='bc1-ORIGINAL', rate_str='345'
+        )
+        validator.axon_chain_providers['btc'].verify_transaction.return_value = make_tx_info(
+            confirmed=False, confirmations=2
+        )
+        moved = make_commitment()
+        moved.from_address = 'bc1-ATTACKER'
+        moved.rate_str = '999'
+        moved.rate = 999.0
+
+        run_handler(validator, make_synapse(), commitment=moved)
+
+        validator.state_store.enqueue.assert_called_once()
+        queued = validator.state_store.enqueue.call_args[0][0]
+        assert queued.miner_from_address == 'bc1-ORIGINAL'
+        assert queued.rate_str == '345'
+
+    def test_no_pin_falls_back_to_live_commitment(self):
+        """A reservation made before the pin index existed has no pin — the
+        handler falls back to the live commitment, unchanged from prior behavior."""
+        validator = make_validator()
+        validator.state_store.get_reservation_pin.return_value = None
+
+        run_handler(validator, make_synapse(reservation_id=VALID_MINER_SS58), commitment=make_commitment())
+
+        validator.axon_contract_client.vote_initiate.assert_called_once()
+        call = validator.axon_chain_providers['btc'].verify_transaction.call_args
+        assert call.kwargs['expected_recipient'] == 'bc1-miner'

--- a/tests/test_event_watcher.py
+++ b/tests/test_event_watcher.py
@@ -9,7 +9,7 @@ Covers three layers:
 
 import struct
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from bittensor.utils import ss58_decode
 
@@ -31,13 +31,15 @@ METADATA_PATH = Path(__file__).parent.parent / 'allways' / 'metadata' / 'allways
 TEST_CONTRACT_ADDRESS = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
 
 
-def make_watcher(tmp_path: Path) -> ContractEventWatcher:
+def make_watcher(tmp_path: Path, *, netuid=None, subtensor=None) -> ContractEventWatcher:
     store = ValidatorStateStore(db_path=tmp_path / 'state.db')
     return ContractEventWatcher(
         substrate=MagicMock(),
         contract_address=TEST_CONTRACT_ADDRESS,
         metadata_path=METADATA_PATH,
         state_store=store,
+        netuid=netuid,
+        subtensor=subtensor,
     )
 
 
@@ -372,6 +374,135 @@ class TestSCALEDecoder:
         assert 'first' in values
         assert 'second' not in values
         assert 'third' not in values
+
+
+def make_pinned_commitment(
+    from_chain: str = 'btc',
+    to_chain: str = 'tao',
+    from_address: str = 'bc1-miner',
+    to_address: str = '5miner',
+    rate_str: str = '345',
+    counter_rate_str: str = '0.0029',
+):
+    """A MinerPair as read_miner_commitment would return it."""
+    from allways.classes import MinerPair
+
+    return MinerPair(
+        uid=1,
+        hotkey='hk_a',
+        from_chain=from_chain,
+        from_address=from_address,
+        to_chain=to_chain,
+        to_address=to_address,
+        rate=float(rate_str),
+        rate_str=rate_str,
+        counter_rate=float(counter_rate_str) if counter_rate_str else 0.0,
+        counter_rate_str=counter_rate_str,
+    )
+
+
+class TestReservationPin:
+    """MinerReserved → reservation pin index, plus the lifecycle clears that
+    drop or refresh the pin."""
+
+    def test_miner_reserved_writes_expected_pin(self, tmp_path: Path):
+        w = make_watcher(tmp_path, netuid=2, subtensor=MagicMock())
+        commitment = make_pinned_commitment()
+        with patch(
+            'allways.validator.event_watcher.read_miner_commitment',
+            return_value=commitment,
+        ) as mock_read:
+            w.apply_event(900, 'MinerReserved', {'miner': 'hk_a', 'reserved_until': 1000})
+
+        # Commitment read pinned to the reservation block so every validator
+        # derives a byte-identical pin.
+        assert mock_read.call_args.kwargs['block'] == 900
+
+        pin = w.state_store.get_reservation_pin('hk_a')
+        assert pin is not None
+        assert pin.reserve_block == 900
+        assert pin.reserved_until == 1000
+        assert pin.from_chain == 'btc'
+        assert pin.to_chain == 'tao'
+        assert pin.rate_str == '345'
+        assert pin.counter_rate_str == '0.0029'
+        assert pin.miner_from_address == 'bc1-miner'
+        assert pin.miner_to_address == '5miner'
+        w.state_store.close()
+
+    def test_commitment_read_raising_writes_no_pin(self, tmp_path: Path):
+        """A transient RPC error or a pruned block must not write a pin and
+        must not let the exception escape apply_event."""
+        w = make_watcher(tmp_path, netuid=2, subtensor=MagicMock())
+        with patch(
+            'allways.validator.event_watcher.read_miner_commitment',
+            side_effect=RuntimeError('rpc down'),
+        ):
+            w.apply_event(900, 'MinerReserved', {'miner': 'hk_a', 'reserved_until': 1000})
+
+        assert w.state_store.get_reservation_pin('hk_a') is None
+        w.state_store.close()
+
+    def test_none_commitment_writes_no_pin(self, tmp_path: Path):
+        w = make_watcher(tmp_path, netuid=2, subtensor=MagicMock())
+        with patch(
+            'allways.validator.event_watcher.read_miner_commitment',
+            return_value=None,
+        ):
+            w.apply_event(900, 'MinerReserved', {'miner': 'hk_a', 'reserved_until': 1000})
+
+        assert w.state_store.get_reservation_pin('hk_a') is None
+        w.state_store.close()
+
+    def test_watcher_without_subtensor_is_noop(self, tmp_path: Path):
+        """The test helper (and any watcher built without subtensor/netuid)
+        must no-op the MinerReserved handler rather than crash."""
+        w = make_watcher(tmp_path)  # no netuid/subtensor
+        with patch('allways.validator.event_watcher.read_miner_commitment') as mock_read:
+            w.apply_event(900, 'MinerReserved', {'miner': 'hk_a', 'reserved_until': 1000})
+
+        mock_read.assert_not_called()
+        assert w.state_store.get_reservation_pin('hk_a') is None
+        w.state_store.close()
+
+    def test_swap_initiated_clears_pin(self, tmp_path: Path):
+        w = make_watcher(tmp_path, netuid=2, subtensor=MagicMock())
+        with patch(
+            'allways.validator.event_watcher.read_miner_commitment',
+            return_value=make_pinned_commitment(),
+        ):
+            w.apply_event(900, 'MinerReserved', {'miner': 'hk_a', 'reserved_until': 1000})
+        assert w.state_store.get_reservation_pin('hk_a') is not None
+
+        w.apply_event(950, 'SwapInitiated', {'swap_id': 1, 'miner': 'hk_a'})
+        assert w.state_store.get_reservation_pin('hk_a') is None
+        w.state_store.close()
+
+    def test_swap_timed_out_clears_pin(self, tmp_path: Path):
+        w = make_watcher(tmp_path, netuid=2, subtensor=MagicMock())
+        with patch(
+            'allways.validator.event_watcher.read_miner_commitment',
+            return_value=make_pinned_commitment(),
+        ):
+            w.apply_event(900, 'MinerReserved', {'miner': 'hk_a', 'reserved_until': 1000})
+
+        w.apply_event(1100, 'SwapTimedOut', {'swap_id': 1, 'miner': 'hk_a'})
+        assert w.state_store.get_reservation_pin('hk_a') is None
+        w.state_store.close()
+
+    def test_reservation_extension_finalized_bumps_pin_ttl(self, tmp_path: Path):
+        w = make_watcher(tmp_path, netuid=2, subtensor=MagicMock())
+        with patch(
+            'allways.validator.event_watcher.read_miner_commitment',
+            return_value=make_pinned_commitment(),
+        ):
+            w.apply_event(900, 'MinerReserved', {'miner': 'hk_a', 'reserved_until': 1000})
+
+        w.apply_event(990, 'ReservationExtensionFinalized', {'miner': 'hk_a', 'applied_target': 1400})
+        pin = w.state_store.get_reservation_pin('hk_a')
+        assert pin is not None
+        assert pin.reserved_until == 1400
+        w.state_store.close()
 
 
 class TestBootstrap:

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -1,0 +1,155 @@
+"""Unit tests for the ``reservation_pins`` table in ValidatorStateStore.
+
+The pin table snapshots a miner's commitment as of the reservation block so a
+swap settles against the miner's rate + addresses as they were when the user
+reserved — closing the rate-swing and address-theft windows. Coverage:
+round-trip, overwrite, expiry purge, TTL refresh, delete_hotkey cleanup, and a
+fresh ``init_db()`` creating the table.
+"""
+
+from dataclasses import replace
+from pathlib import Path
+
+from allways.validator.state_store import ReservationPin, ValidatorStateStore
+
+PIN_SAMPLE1 = ReservationPin(
+    miner_hotkey='miner-1',
+    reserve_block=900,
+    from_chain='btc',
+    to_chain='tao',
+    rate_str='345',
+    counter_rate_str='0.0029',
+    miner_from_address='bc1-miner',
+    miner_to_address='5miner',
+    reserved_until=1000,
+    created_at=1.0,
+)
+
+PIN_SAMPLE2 = ReservationPin(
+    miner_hotkey='miner-2',
+    reserve_block=905,
+    from_chain='btc',
+    to_chain='tao',
+    rate_str='350',
+    counter_rate_str='0.0028',
+    miner_from_address='bc1-miner-2',
+    miner_to_address='5miner2',
+    reserved_until=1005,
+    created_at=2.0,
+)
+
+
+class TestReservationPinRoundTrip:
+    def test_upsert_and_get_round_trip(self, tmp_path: Path):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        store.upsert_reservation_pin(PIN_SAMPLE1)
+
+        pin = store.get_reservation_pin('miner-1')
+        assert pin == PIN_SAMPLE1
+        store.close()
+
+    def test_persists_across_store_instances(self, tmp_path: Path):
+        db_path = tmp_path / 'state.db'
+        store1 = ValidatorStateStore(db_path=db_path)
+        store1.upsert_reservation_pin(PIN_SAMPLE1)
+        store1.close()
+
+        store2 = ValidatorStateStore(db_path=db_path)
+        assert store2.get_reservation_pin('miner-1') == PIN_SAMPLE1
+        store2.close()
+
+    def test_get_unknown_hotkey_returns_none(self, tmp_path: Path):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        assert store.get_reservation_pin('miner-unknown') is None
+        store.close()
+
+    def test_upsert_overwrites_existing_row(self, tmp_path: Path):
+        """A fresh MinerReserved for a miner replaces any stale pin —
+        INSERT OR REPLACE keyed on miner_hotkey, so exactly one row remains."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        store.upsert_reservation_pin(PIN_SAMPLE1)
+        store.upsert_reservation_pin(replace(PIN_SAMPLE1, reserve_block=1500, rate_str='999', reserved_until=1600))
+
+        pin = store.get_reservation_pin('miner-1')
+        assert pin.reserve_block == 1500
+        assert pin.rate_str == '999'
+        assert pin.reserved_until == 1600
+        store.close()
+
+    def test_remove_returns_and_deletes(self, tmp_path: Path):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        store.upsert_reservation_pin(PIN_SAMPLE1)
+
+        removed = store.remove_reservation_pin('miner-1')
+        assert removed == PIN_SAMPLE1
+        assert store.get_reservation_pin('miner-1') is None
+        store.close()
+
+    def test_remove_unknown_hotkey_is_noop(self, tmp_path: Path):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        assert store.remove_reservation_pin('miner-unknown') is None
+        store.close()
+
+
+class TestReservationPinPurge:
+    def test_purge_drops_only_expired_rows(self, tmp_path: Path):
+        store = ValidatorStateStore(
+            db_path=tmp_path / 'state.db',
+            current_block_fn=lambda: 1001,
+        )
+        store.upsert_reservation_pin(PIN_SAMPLE1)  # reserved_until=1000 → expired at 1001
+        store.upsert_reservation_pin(PIN_SAMPLE2)  # reserved_until=1005 → still live
+
+        purged = store.purge_expired_reservation_pins()
+        assert purged == 1
+        assert store.get_reservation_pin('miner-1') is None
+        assert store.get_reservation_pin('miner-2') == PIN_SAMPLE2
+        store.close()
+
+    def test_purge_without_current_block_fn_is_noop(self, tmp_path: Path):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        store.upsert_reservation_pin(PIN_SAMPLE1)
+        assert store.purge_expired_reservation_pins() == 0
+        assert store.get_reservation_pin('miner-1') == PIN_SAMPLE1
+        store.close()
+
+    def test_update_reserved_until_keeps_row_a_purge_would_drop(self, tmp_path: Path):
+        """Regression: after the contract extends a reservation, refreshing the
+        pin's reserved_until must keep it alive past its original TTL — exactly
+        as update_reserved_until does for pending_confirms."""
+        store = ValidatorStateStore(
+            db_path=tmp_path / 'state.db',
+            current_block_fn=lambda: 1003,
+        )
+        store.upsert_reservation_pin(PIN_SAMPLE1)  # reserved_until=1000, would be purged at 1003
+        store.update_reservation_pin_reserved_until('miner-1', 1300)
+
+        pin = store.get_reservation_pin('miner-1')
+        assert pin.reserved_until == 1300
+
+        assert store.purge_expired_reservation_pins() == 0
+        assert store.get_reservation_pin('miner-1') is not None
+        store.close()
+
+    def test_update_reserved_until_unknown_hotkey_is_noop(self, tmp_path: Path):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        store.update_reservation_pin_reserved_until('miner-unknown', 9999)
+        assert store.get_reservation_pin('miner-unknown') is None
+        store.close()
+
+
+class TestReservationPinCrossTable:
+    def test_delete_hotkey_clears_the_pin(self, tmp_path: Path):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        store.upsert_reservation_pin(PIN_SAMPLE1)
+
+        store.delete_hotkey('miner-1')
+        assert store.get_reservation_pin('miner-1') is None
+        store.close()
+
+    def test_fresh_init_db_has_reservation_pins_table(self, tmp_path: Path):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        conn = store.require_connection()
+        row = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='reservation_pins'").fetchone()
+        assert row is not None
+        store.close()


### PR DESCRIPTION
## Swap 79 — what spawned this

Diagnosing allways swap 79 surfaced that a reservation pins the swap **amounts**
(`to_amount`/`tao_amount`/`from_amount`) but **not** the miner's **rate** or its
**deposit/fulfillment addresses**. At `initiate` (~20 min after reserve, gated by
BTC confirmation) the validator re-reads the miner's **live** commitment — so a
miner can move its commitment in the reserve→initiate window and the swap still
settles against the moved values.

## The issue

Two exploits follow from `handle_swap_confirm` re-reading the live commitment
(`allways/validator/axon_handlers.py` — `load_swap_commitment` at the
`commitment = ...` call inside the `axon_lock` block):

- **Rate-swing** — a miner moves its rate between reserve and confirm; the
  `selected_rate_str` flowing into `scale_encode_initiate_hash_input` and
  `vote_initiate` is the *moved* rate, shortchanging the user.
- **Address theft (total loss)** — a miner changes its committed deposit address
  after the user has sent BTC. `verify_transaction` is then called with the new
  `miner_from_address` (`axon_handlers.py`, the `provider.verify_transaction(...)`
  call), `vote_initiate` fails verification, no swap is created, no slash fires —
  the miner keeps the BTC.

## The fix

A validator-side, event-driven **pin index** — no contract change, consensus-safe:

- `state_store.py` — new `ReservationPin` dataclass + `reservation_pins` table
  (purely additive, no migration) with `upsert`/`get`/`remove`/`purge`/`update`
  methods and `delete_hotkey` cleanup.
- `event_watcher.py` — the watcher gains `netuid`/`subtensor`; a new
  `MinerReserved` branch reads `read_miner_commitment(..., block=R)` at the
  canonical reservation block `R` and persists the commitment snapshot.
  `SwapInitiated`/`SwapTimedOut` clear the pin; `ReservationExtensionFinalized`
  bumps its TTL.
- `axon_handlers.py` — `handle_swap_confirm` resolves rate + addresses from the
  pin (synthesizing a `MinerPair` and feeding the existing
  `resolve_swap_direction`), falling back to the live commitment when no pin
  exists.
- `forward.py` — `purge_expired_reservation_pins()` beside the existing
  pending-confirm purge.
- `neurons/validator.py` — wires `netuid`/`subtensor` into the watcher.

The index is keyed on the canonical block `R` and a canonical commitment read,
so every validator derives a byte-identical pin → an identical `request_hash`.
A validator with no pin falls back; it never produces a *wrong* pin. On any
failure (transient RPC, pruned block) no pin is written.

## Review notes

- This is **consensus-path** code — it changes the provenance of the
  `vote_initiate` hash inputs.
- Needs a **coordinated validator upgrade**: mid-rollout, un-upgraded validators
  hash from the live commitment and upgraded ones from the pin; if a miner moved
  its rate/address the fleet can split on `vote_initiate`. The exploit closes
  only once a quorum runs the pin.
- **Not yet testnet-tested** — unit-tested only (state-store round-trip/purge,
  watcher `MinerReserved`/lifecycle, axon address-theft + rate-swing
  regressions). The plan's integration test (reserve, move the miner's
  commitment, confirm) still needs a testnet run.
- **Pre-existing reservations** made before this deploys have no pin and fall
  back to the live commitment — chosen over rejecting so in-flight swaps aren't
  broken. The exploit window stays open only for reservations straddling the
  deploy.
