### PR TITLE
fix(miner): keep active swaps through transient poll misses

### DIFF
--- a/allways/miner/swap_poller.py
+++ b/allways/miner/swap_poller.py
@@ -8,6 +8,8 @@ from allways.classes import Swap, SwapStatus
 from allways.contract_client import AllwaysContractClient
 
 RESCAN_WINDOW = 16
+ACTIVE_STATUSES = (SwapStatus.ACTIVE, SwapStatus.FULFILLED)
+MAX_REFRESH_MISSES = 3
 
 
 class SwapPoller:
@@ -24,6 +26,7 @@ class SwapPoller:
         self.miner_hotkey = miner_hotkey
         self.last_scanned_id = 0
         self.active: Dict[int, Swap] = {}
+        self.active_miss_counts: Dict[int, int] = {}
         self.last_poll_ok: bool = True
 
     def poll(self) -> Tuple[List[Swap], List[Swap]]:
@@ -43,15 +46,20 @@ class SwapPoller:
         next_id = self.client.get_next_swap_id()
         start = max(1, min(self.last_scanned_id + 1, next_id - RESCAN_WINDOW))
         for swap_id in range(start, next_id):
-            swap = self.client.get_swap(swap_id)
+            try:
+                swap = self.client.get_swap(swap_id)
+            except Exception as e:
+                bt.logging.debug(f'SwapPoller discovery({swap_id}) failed, will retry: {e}')
+                continue
             if swap and swap.miner_hotkey == self.miner_hotkey:
-                if swap.status in (SwapStatus.ACTIVE, SwapStatus.FULFILLED):
+                if swap.status in ACTIVE_STATUSES:
                     if swap.id not in self.active:
                         bt.logging.info(
                             f'Discovered swap {swap.id}: {swap.from_chain} -> {swap.to_chain}, '
                             f'tao_amount={swap.tao_amount}, status={swap.status.name}'
                         )
                     self.active[swap.id] = swap
+                    self.active_miss_counts.pop(swap.id, None)
                     fresh.add(swap.id)
         if next_id > 1:
             self.last_scanned_id = next_id - 1
@@ -61,14 +69,26 @@ class SwapPoller:
         for swap_id in list(self.active):
             if swap_id in fresh:
                 continue
-            swap = self.client.get_swap(swap_id)
-            if swap is None or swap.status not in (SwapStatus.ACTIVE, SwapStatus.FULFILLED):
-                terminal = swap.status.name if swap is not None else 'GONE'
+            try:
+                swap = self.client.get_swap(swap_id)
+            except Exception as e:
+                bt.logging.debug(f'SwapPoller refresh({swap_id}) failed, will retry: {e}')
+                continue
+            if swap is None:
+                misses = self.active_miss_counts.get(swap_id, 0) + 1
+                self.active_miss_counts[swap_id] = misses
+                if misses >= MAX_REFRESH_MISSES:
+                    resolved.append((swap_id, f'GONE_AFTER_{misses}_MISSES'))
+                continue
+            if swap.status not in ACTIVE_STATUSES:
+                terminal = swap.status.name
                 resolved.append((swap_id, terminal))
             else:
                 self.active[swap_id] = swap
+                self.active_miss_counts.pop(swap_id, None)
         for sid, terminal in resolved:
             self.active.pop(sid, None)
+            self.active_miss_counts.pop(sid, None)
             bt.logging.info(f'Swap {sid}: dropped from active (status={terminal})')
 
         # 3. Return categorized by contract status

--- a/tests/test_swap_poller.py
+++ b/tests/test_swap_poller.py
@@ -1,0 +1,190 @@
+from unittest.mock import MagicMock
+
+from allways.classes import Swap, SwapStatus
+from allways.miner.swap_poller import ACTIVE_STATUSES, MAX_REFRESH_MISSES, RESCAN_WINDOW, SwapPoller
+
+
+def make_swap(swap_id: int = 1, status: SwapStatus = SwapStatus.ACTIVE, miner_hotkey: str = 'miner') -> Swap:
+    return Swap(
+        id=swap_id,
+        user_hotkey='user',
+        miner_hotkey=miner_hotkey,
+        from_chain='btc',
+        to_chain='tao',
+        from_amount=1_000,
+        to_amount=2_000,
+        tao_amount=2_000,
+        user_from_address='bc1q-user',
+        user_to_address='5user',
+        miner_from_address='bc1q-miner',
+        miner_to_address='5miner',
+        rate='2',
+        status=status,
+        initiated_block=10,
+        timeout_block=100,
+    )
+
+
+def make_poller(client: MagicMock | None = None) -> SwapPoller:
+    return SwapPoller(contract_client=client or MagicMock(), miner_hotkey='miner')
+
+
+def assert_poller_invariants(poller: SwapPoller):
+    assert set(poller.active_miss_counts) <= set(poller.active)
+    assert all(swap.status in ACTIVE_STATUSES for swap in poller.active.values())
+    assert all(0 < misses < MAX_REFRESH_MISSES for misses in poller.active_miss_counts.values())
+
+
+def test_active_swap_retained_when_refresh_returns_none():
+    client = MagicMock()
+    client.get_next_swap_id.return_value = 2
+    client.get_swap.return_value = None
+    poller = make_poller(client)
+    active_swap = make_swap()
+    poller.active[active_swap.id] = active_swap
+    poller.last_scanned_id = 1
+
+    active, fulfilled = poller.poll()
+
+    assert poller.last_poll_ok is True
+    assert poller.active == {1: active_swap}
+    assert poller.active_miss_counts == {1: 1}
+    assert active == [active_swap]
+    assert fulfilled == []
+
+
+def test_active_swap_retained_when_refresh_raises():
+    client = MagicMock()
+    client.get_next_swap_id.return_value = 2
+    client.get_swap.side_effect = TimeoutError('temporary substrate miss')
+    poller = make_poller(client)
+    active_swap = make_swap()
+    poller.active[active_swap.id] = active_swap
+    poller.last_scanned_id = 1
+
+    active, fulfilled = poller.poll()
+
+    assert poller.last_poll_ok is True
+    assert poller.active == {1: active_swap}
+    assert poller.active_miss_counts == {}
+    assert active == [active_swap]
+    assert fulfilled == []
+
+
+def test_active_swap_removed_after_repeated_refresh_misses():
+    client = MagicMock()
+    client.get_next_swap_id.return_value = 2
+    client.get_swap.return_value = None
+    poller = make_poller(client)
+    active_swap = make_swap()
+    poller.active[active_swap.id] = active_swap
+    poller.last_scanned_id = 1
+
+    for _ in range(2):
+        active, fulfilled = poller.poll()
+        assert active == [active_swap]
+        assert fulfilled == []
+
+    active, fulfilled = poller.poll()
+
+    assert poller.last_poll_ok is True
+    assert poller.active == {}
+    assert poller.active_miss_counts == {}
+    assert active == []
+    assert fulfilled == []
+
+
+def test_poll_sequence_preserves_active_state_invariants():
+    """Mixed refresh outcomes must keep poller bookkeeping internally coherent.
+
+    This covers the invariant the miner relies on after each poll: every miss
+    counter belongs to a still-active swap, terminal swaps are gone, and a valid
+    refresh clears prior transient-miss state before fulfillment cleanup sees it.
+    """
+    client = MagicMock()
+    client.get_next_swap_id.return_value = 200
+    poller = make_poller(client)
+    poller.last_scanned_id = 199
+    poller.active = {
+        100: make_swap(100),
+        101: make_swap(101, status=SwapStatus.FULFILLED),
+        102: make_swap(102),
+    }
+
+    client.get_swap.side_effect = [None] * RESCAN_WINDOW + [
+        None,
+        TimeoutError('temporary refresh miss'),
+        make_swap(102, status=SwapStatus.COMPLETED),
+    ]
+    active, fulfilled = poller.poll()
+
+    assert_poller_invariants(poller)
+    assert set(poller.active) == {100, 101}
+    assert poller.active_miss_counts == {100: 1}
+    assert active == [poller.active[100]]
+    assert fulfilled == [poller.active[101]]
+
+    client.get_swap.side_effect = [None] * RESCAN_WINDOW + [
+        make_swap(100),
+        make_swap(101, status=SwapStatus.FULFILLED),
+    ]
+    active, fulfilled = poller.poll()
+
+    assert_poller_invariants(poller)
+    assert set(poller.active) == {100, 101}
+    assert poller.active_miss_counts == {}
+    assert active == [poller.active[100]]
+    assert fulfilled == [poller.active[101]]
+
+
+def test_active_swap_removed_on_terminal_status():
+    terminal_swap = make_swap(status=SwapStatus.COMPLETED)
+    client = MagicMock()
+    client.get_next_swap_id.return_value = 2
+    client.get_swap.return_value = terminal_swap
+    poller = make_poller(client)
+    poller.active[terminal_swap.id] = make_swap()
+    poller.last_scanned_id = 1
+
+    active, fulfilled = poller.poll()
+
+    assert poller.last_poll_ok is True
+    assert poller.active == {}
+    assert active == []
+    assert fulfilled == []
+
+
+def test_active_swap_retained_when_discovery_raises():
+    client = MagicMock()
+    active_swap = make_swap()
+    client.get_next_swap_id.return_value = 3
+    client.get_swap.side_effect = [
+        RuntimeError('temporary discovery miss'),
+        None,
+        active_swap,
+    ]
+    poller = make_poller(client)
+    poller.active[active_swap.id] = active_swap
+
+    active, fulfilled = poller.poll()
+
+    assert poller.last_poll_ok is True
+    assert poller.active == {1: active_swap}
+    assert poller.active_miss_counts == {}
+    assert active == [active_swap]
+    assert fulfilled == []
+
+
+def test_discovers_new_active_swap():
+    active_swap = make_swap()
+    client = MagicMock()
+    client.get_next_swap_id.return_value = 2
+    client.get_swap.return_value = active_swap
+    poller = make_poller(client)
+
+    active, fulfilled = poller.poll()
+
+    assert poller.last_poll_ok is True
+    assert poller.active == {1: active_swap}
+    assert active == [active_swap]
+    assert fulfilled == []


### PR DESCRIPTION
## Summary
- keep miner-tracked active swaps through short transient `None` reads or per-swap read failures
- prune stale active entries after repeated missing refreshes so resolved/pruned swaps do not live forever locally
- mirror the validator tracker behavior for transient gaps while keeping miner cleanup bounded

## What changed
- `SwapPoller` treats per-swap discovery/refresh exceptions as retryable without aborting the whole poll
- active swaps survive short `None` refresh streaks, then drop after repeated misses
- terminal statuses still remove swaps from the active set immediately
- regression tests cover transient refresh misses, refresh exceptions, repeated stale misses, discovery exceptions, terminal cleanup, new active swap discovery, and mixed-sequence bookkeeping invariants

## Why
A miner should not drop an assigned active swap just because one `get_swap` refresh briefly returns no data. At the same time, a permanently pruned swap should not remain active forever. This keeps active swap tracking resilient without leaving stale miner state unbounded.

## Validation
- `uv run pytest tests/test_swap_poller.py tests/test_swap_tracker.py -q`
- `uv run pytest -q`
- `uv run ruff check allways/miner/swap_poller.py tests/test_swap_poller.py`
- CodeRabbit review: 0 issues
- Codex Security diff scan: no reportable findings

## Notes
- Checked for active upstream PR overlap before opening; no matching PR was found for this root cause.