### PR TITLE
fix(contract): cancel in-flight rounds on vote_deactivate quorum (#186)

### DIFF
--- a/smart-contracts/ink/lib.rs
+++ b/smart-contracts/ink/lib.rs
@@ -867,6 +867,12 @@ mod allways_swap_manager {
             }
 
             self.consensus_vote(miner, REQ_INITIATE, request_hash, move |this| {
+                // Re-check at closure time. vote_deactivate clears in-flight
+                // REQ_INITIATE rounds on quorum, but guard the closure anyway
+                // so a same-block race can't slip through.
+                if !this.miner_active.get(miner).unwrap_or(false) {
+                    return Err(Error::MinerNotActive);
+                }
                 let miner_collateral = this.collateral.get(miner).unwrap_or(0);
                 if tao_amount > miner_collateral {
                     return Err(Error::InsufficientCollateral);
@@ -1282,6 +1288,12 @@ mod allways_swap_manager {
             self.consensus_vote(miner, REQ_DEACTIVATE, Hash::default(), move |this| {
                 this.miner_active.insert(miner, &false);
                 this.miner_deactivation_block.insert(miner, &this.env().block_number());
+                // Cancel any in-flight miner-keyed rounds so a later vote landing
+                // on a pending reserve/initiate/activate can't reach quorum and
+                // run its closure against a now-deactivated miner.
+                this.clear_request(miner, REQ_ACTIVATE);
+                this.clear_request(miner, REQ_RESERVE);
+                this.clear_request(miner, REQ_INITIATE);
                 this.env().emit_event(MinerActivated { miner, active: false });
                 Ok(())
             })


### PR DESCRIPTION
## Summary

When a miner is deactivated via quorum the closure only flips `miner_active` and emits the event. Any `REQ_ACTIVATE` / `REQ_RESERVE` / `REQ_INITIATE` round already in flight stays voteable, so a later vote reaching its own quorum can run its closure against a now-deactivated miner. `do_initiate` is the most consequential one — its closure did not re-read `miner_active`.

Two changes in `smart-contracts/ink/lib.rs`:

1. `vote_deactivate` quorum closure calls `clear_request(miner, REQ_*)` for each miner-keyed request type after deactivation, so any pending vote rounds for that miner stop being countable.
2. The `REQ_INITIATE` consensus closure re-checks `miner_active` at closure time and returns `Error::MinerNotActive` on miss. Belt and suspenders against a same-block race where a deactivation and an initiate-quorum vote land in the same block.

`REQ_RESERVE` already gates at entry; the entry-point check is sufficient given the new `clear_request` call in vote_deactivate.

## Test plan

- [ ] Existing contract tests pass
- [ ] Manual: vote_deactivate quorum followed by a delayed vote on a pre-existing REQ_INITIATE round — the late vote should not find the request (cleared) and the closure should never run.
- [ ] Manual: same-block race — a REQ_INITIATE quorum vote and a vote_deactivate quorum vote land in the same block — initiate closure returns `MinerNotActive` if deactivation lands first.

Closes #186
