### PR TITLE
log: surface SwapReserve/SwapConfirm request details in validator axon

### DIFF
--- a/allways/miner/fulfillment.py
+++ b/allways/miner/fulfillment.py
@@ -192,14 +192,10 @@ class SwapFulfiller:
                 require_confirmed=True,
             )
             if tx_info is None:
-                # Log once per (swap, attempt) so a miner waiting on confirmations
-                # surfaces in the INFO stream rather than only DEBUG. The base
-                # helper rate-limits its own confs progress at debug; this is
-                # the chronological breadcrumb at INFO.
                 log_on_change(
                     f'src_waiting:{swap.id}',
                     True,
-                    f'Swap {swap.id}: source tx not yet ready (waiting on visibility/confirmations/sender) — will retry',
+                    f'Swap {swap.id}: source tx not yet ready, will retry',
                 )
                 return False
 
@@ -278,8 +274,7 @@ class SwapFulfiller:
 
         user_receives_amount, my_source_address = safety_result
 
-        # Step 2: Verify user sent source funds — verify_user_sent_funds logs
-        # confirmation progress via log_on_change, so no extra line here.
+        # Step 2: Verify user sent source funds
         if not self.verify_user_sent_funds(swap, my_source_address):
             return False
 

--- a/allways/miner/fulfillment.py
+++ b/allways/miner/fulfillment.py
@@ -172,11 +172,7 @@ class SwapFulfiller:
         return user_receives_amount, swap.miner_from_address
 
     def verify_user_sent_funds(self, swap: Swap, miner_from_address: str) -> bool:
-        """Verify that the user sent funds on the source chain.
-
-        Uses ``require_confirmed=False`` so we can log confirmation progress on
-        partial txs via ``log_on_change`` — without this, a miner waiting on
-        confirmations sees only a silent DEBUG line and looks stuck."""
+        """Verify that the user sent funds on the source chain."""
         provider = self.providers.get(swap.from_chain)
         if not provider:
             bt.logging.error(f'No provider for chain: {swap.from_chain}')
@@ -193,23 +189,17 @@ class SwapFulfiller:
                 expected_amount=swap.from_amount,
                 block_hint=swap.from_tx_block,
                 expected_sender=swap.user_from_address,
-                require_confirmed=False,
+                require_confirmed=True,
             )
             if tx_info is None:
+                # Log once per (swap, attempt) so a miner waiting on confirmations
+                # surfaces in the INFO stream rather than only DEBUG. The base
+                # helper rate-limits its own confs progress at debug; this is
+                # the chronological breadcrumb at INFO.
                 log_on_change(
-                    f'src_visible:{swap.id}',
-                    False,
-                    f'Swap {swap.id}: source tx not yet visible (or sender/amount mismatch) — will retry',
-                )
-                return False
-
-            min_confs = provider.get_chain().min_confirmations
-            if not tx_info.confirmed:
-                log_on_change(
-                    f'src_confs:{swap.id}',
-                    tx_info.confirmations,
-                    f'Swap {swap.id}: waiting for source funds '
-                    f'({tx_info.confirmations}/{min_confs} confs, from {tx_info.sender})',
+                    f'src_waiting:{swap.id}',
+                    True,
+                    f'Swap {swap.id}: source tx not yet ready (waiting on visibility/confirmations/sender) — will retry',
                 )
                 return False
 

--- a/allways/miner/fulfillment.py
+++ b/allways/miner/fulfillment.py
@@ -12,6 +12,7 @@ from allways.chain_providers.base import ChainProvider, ProviderUnreachableError
 from allways.classes import Swap
 from allways.constants import DEFAULT_MINER_TIMEOUT_CUSHION_BLOCKS
 from allways.contract_client import AllwaysContractClient, ContractError, is_contract_rejection
+from allways.utils.logging import log_on_change
 from allways.utils.rate import expected_swap_amounts
 
 
@@ -171,7 +172,11 @@ class SwapFulfiller:
         return user_receives_amount, swap.miner_from_address
 
     def verify_user_sent_funds(self, swap: Swap, miner_from_address: str) -> bool:
-        """Verify that the user sent funds on the source chain."""
+        """Verify that the user sent funds on the source chain.
+
+        Uses ``require_confirmed=False`` so we can log confirmation progress on
+        partial txs via ``log_on_change`` — without this, a miner waiting on
+        confirmations sees only a silent DEBUG line and looks stuck."""
         provider = self.providers.get(swap.from_chain)
         if not provider:
             bt.logging.error(f'No provider for chain: {swap.from_chain}')
@@ -188,10 +193,24 @@ class SwapFulfiller:
                 expected_amount=swap.from_amount,
                 block_hint=swap.from_tx_block,
                 expected_sender=swap.user_from_address,
-                require_confirmed=True,
+                require_confirmed=False,
             )
             if tx_info is None:
-                bt.logging.debug(f'Swap {swap.id}: source tx not ready (not found, unconfirmed, or sender mismatch)')
+                log_on_change(
+                    f'src_visible:{swap.id}',
+                    False,
+                    f'Swap {swap.id}: source tx not yet visible (or sender/amount mismatch) — will retry',
+                )
+                return False
+
+            min_confs = provider.get_chain().min_confirmations
+            if not tx_info.confirmed:
+                log_on_change(
+                    f'src_confs:{swap.id}',
+                    tx_info.confirmations,
+                    f'Swap {swap.id}: waiting for source funds '
+                    f'({tx_info.confirmations}/{min_confs} confs, from {tx_info.sender})',
+                )
                 return False
 
             bt.logging.info(f'Swap {swap.id}: source funds verified ({tx_info.amount} from {tx_info.sender})')
@@ -269,9 +288,9 @@ class SwapFulfiller:
 
         user_receives_amount, my_source_address = safety_result
 
-        # Step 2: Verify user sent source funds
+        # Step 2: Verify user sent source funds — verify_user_sent_funds logs
+        # confirmation progress via log_on_change, so no extra line here.
         if not self.verify_user_sent_funds(swap, my_source_address):
-            bt.logging.debug(f'Swap {swap.id}: waiting for source funds confirmation')
             return False
 
         # Step 3: Send destination funds — unless we already did on a previous

--- a/allways/utils/logging.py
+++ b/allways/utils/logging.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from logging.handlers import RotatingFileHandler
-from typing import Any
+from typing import Any, Optional
 
 import bittensor as bt
 
@@ -46,3 +46,26 @@ def log_on_change(key: str, value: Any, message: str) -> None:
     if _last_seen.get(key) != value:
         _last_seen[key] = value
         bt.logging.info(message)
+
+
+def miner_label(metagraph: Optional[Any], hotkey: str) -> str:
+    """Return ``UID N / hotkey[:8]`` so a glance at any log line ties it to a UID.
+
+    ``metagraph`` is optional so unit tests and offline tools can pass None
+    and fall back to the hotkey-only label."""
+    if not hotkey:
+        return 'UID ? / ????????'
+    uid: Any = '?'
+    if metagraph is not None:
+        try:
+            uid = metagraph.hotkeys.index(hotkey)
+        except (ValueError, IndexError, AttributeError):
+            uid = '?'
+    return f'UID {uid} / {hotkey[:8]}'
+
+
+def swap_label(swap: Any, metagraph: Optional[Any] = None) -> str:
+    """Format a swap log prefix: ``Swap #N [DIR UID … / hotkey]``."""
+    direction = f'{(swap.from_chain or "?").upper()}->{(swap.to_chain or "?").upper()}'
+    miner = miner_label(metagraph, getattr(swap, 'miner_hotkey', ''))
+    return f'Swap #{swap.id} [{direction} {miner}]'

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -143,6 +143,15 @@ def reject_synapse(synapse: bt.Synapse, reason: str, context: str = '') -> None:
         bt.logging.info(f'{context}: {reason}')
 
 
+def miner_label(validator: 'Validator', miner_hotkey: str) -> str:
+    """Return ``UID N (hotkey[:8])`` for logs — same shape forward.py uses."""
+    try:
+        uid = validator.metagraph.hotkeys.index(miner_hotkey)
+    except (ValueError, IndexError):
+        uid = '?'
+    return f'UID {uid} ({miner_hotkey[:8]})'
+
+
 # =============================================================================
 # MinerActivateSynapse handlers
 # =============================================================================
@@ -257,10 +266,16 @@ async def handle_swap_reserve(
 ) -> SwapReserveSynapse:
     """Validate swap reservation request and vote on contract."""
     contract: AllwaysContractClient = validator.axon_contract_client
-    bt.logging.info(f'SwapReserve request: miner={synapse.miner_hotkey}, tao={synapse.tao_amount}')
-
     miner = synapse.miner_hotkey
-    ctx = f'SwapReserve({miner})'
+    label = miner_label(validator, miner)
+    direction = f'{(synapse.from_chain or "?").upper()}->{(synapse.to_chain or "?").upper()}'
+    bt.logging.info(
+        f'SwapReserve REQUEST received: miner={label} dir={direction} '
+        f'tao={synapse.tao_amount} from_amount={synapse.from_amount} to_amount={synapse.to_amount} '
+        f'user_from_address={synapse.from_address} block_anchor={synapse.block_anchor}'
+    )
+
+    ctx = f'SwapReserve[{label} {direction}]'
 
     try:
         # Cheap, local checks BEFORE axon_lock — invalid signatures, missing fields,
@@ -320,10 +335,14 @@ async def handle_swap_reserve(
             if synapse.from_chain not in (commitment.from_chain, commitment.to_chain):
                 reject_synapse(synapse, 'Miner does not support this swap direction', ctx)
                 return synapse
-            reserve_rate, _ = commitment.get_rate_for_direction(synapse.from_chain)
+            reserve_rate, reserve_rate_str = commitment.get_rate_for_direction(synapse.from_chain)
             if reserve_rate <= 0:
                 reject_synapse(synapse, 'Miner does not support this swap direction', ctx)
                 return synapse
+            bt.logging.info(
+                f'{ctx}: commitment ok — miner_rate={reserve_rate_str or reserve_rate} '
+                f'miner_from={commitment.from_address} miner_to={commitment.to_address}'
+            )
 
             collateral, active, has_swap, reserved_until, _ = contract.get_miner_snapshot(miner)
             if not active:
@@ -370,7 +389,10 @@ async def handle_swap_reserve(
                     )
                     return synapse
 
-            bt.logging.info(f'{ctx} preflight ok, voting')
+            bt.logging.info(
+                f'{ctx}: preflight ok — collateral={collateral} reserved_until={reserved_until} '
+                f'cur_block={cur_block} → submitting vote_reserve'
+            )
             contract.vote_reserve(
                 wallet=validator.wallet,
                 request_hash=request_hash,
@@ -383,7 +405,10 @@ async def handle_swap_reserve(
                 to_amount=synapse.to_amount,
             )
             synapse.accepted = True
-            bt.logging.info(f'Voted to reserve miner {miner}')
+            bt.logging.info(
+                f'{ctx}: RESERVED — vote_reserve submitted for {label} '
+                f'(tao={synapse.tao_amount}, rate={reserve_rate_str or reserve_rate})'
+            )
 
     except ContractError as e:
         bt.logging.error(f'{ctx} failed: {e}')
@@ -425,10 +450,16 @@ async def handle_swap_confirm(
 ) -> SwapConfirmSynapse:
     """Verify source transaction and vote to initiate swap."""
     contract: AllwaysContractClient = validator.axon_contract_client
-    bt.logging.info(f'SwapConfirm request: miner={synapse.reservation_id}, tx={synapse.from_tx_hash}')
-
     miner = synapse.reservation_id  # reservation_id is miner_hotkey (reservation keyed by miner)
-    ctx = f'SwapConfirm({miner})'
+    label = miner_label(validator, miner)
+    direction = f'{(synapse.from_chain or "?").upper()}->{(synapse.to_chain or "?").upper()}'
+    bt.logging.info(
+        f'SwapConfirm REQUEST received (post-reserve, user claims source tx sent): '
+        f'miner={label} dir={direction} from_tx={synapse.from_tx_hash} '
+        f'user_from_address={synapse.from_address} user_to_address={synapse.to_address} '
+        f'from_tx_block_hint={synapse.from_tx_block}'
+    )
+    ctx = f'SwapConfirm[{label} {direction}]'
 
     try:
         if not synapse.from_address or not synapse.from_tx_proof:
@@ -586,7 +617,10 @@ async def handle_swap_confirm(
                 rate=selected_rate_str,
             )
             synapse.accepted = True
-            bt.logging.info(f'Voted to initiate swap for miner {miner}')
+            bt.logging.info(
+                f'{ctx}: INITIATED — vote_initiate submitted (tx={synapse.from_tx_hash[:16]}..., '
+                f'tao={res_tao_amount}, rate={selected_rate_str})'
+            )
 
     except ContractError as e:
         bt.logging.error(f'{ctx} failed: {e}')

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -144,12 +144,12 @@ def reject_synapse(synapse: bt.Synapse, reason: str, context: str = '') -> None:
 
 
 def miner_label(validator: 'Validator', miner_hotkey: str) -> str:
-    """Return ``UID N (hotkey[:8])`` for logs — same shape forward.py uses."""
+    """Return ``UID N / hotkey[:8]`` — leads every miner log line with the UID."""
     try:
         uid = validator.metagraph.hotkeys.index(miner_hotkey)
     except (ValueError, IndexError):
         uid = '?'
-    return f'UID {uid} ({miner_hotkey[:8]})'
+    return f'UID {uid} / {miner_hotkey[:8]}'
 
 
 # =============================================================================
@@ -189,9 +189,9 @@ async def handle_miner_activate(
     """Process miner activation: verify commitment + vote on contract."""
     miner_hotkey = synapse.dendrite.hotkey
     contract: AllwaysContractClient = validator.axon_contract_client
-    bt.logging.info(f'MinerActivate request from {miner_hotkey}')
-
-    ctx = f'MinerActivate({miner_hotkey})'
+    label = miner_label(validator, miner_hotkey)
+    ctx = f'[{label}] MinerActivate'
+    bt.logging.info(f'{ctx}: REQUEST received (full hotkey={miner_hotkey})')
 
     try:
         with validator.axon_lock:
@@ -225,7 +225,7 @@ async def handle_miner_activate(
 
             contract.vote_activate(wallet=validator.wallet, miner_hotkey=miner_hotkey)
             synapse.accepted = True
-            bt.logging.info(f'Voted to activate miner {miner_hotkey}')
+            bt.logging.info(f'{ctx}: ACTIVATED — vote_activate submitted')
 
     except Exception as e:
         bt.logging.error(f'{ctx} failed: {e}')
@@ -269,13 +269,12 @@ async def handle_swap_reserve(
     miner = synapse.miner_hotkey
     label = miner_label(validator, miner)
     direction = f'{(synapse.from_chain or "?").upper()}->{(synapse.to_chain or "?").upper()}'
+    ctx = f'[{label}] SwapReserve {direction}'
     bt.logging.info(
-        f'SwapReserve REQUEST received: miner={label} dir={direction} '
-        f'tao={synapse.tao_amount} from_amount={synapse.from_amount} to_amount={synapse.to_amount} '
+        f'{ctx}: REQUEST received — tao={synapse.tao_amount} '
+        f'from_amount={synapse.from_amount} to_amount={synapse.to_amount} '
         f'user_from_address={synapse.from_address} block_anchor={synapse.block_anchor}'
     )
-
-    ctx = f'SwapReserve[{label} {direction}]'
 
     try:
         # Cheap, local checks BEFORE axon_lock — invalid signatures, missing fields,
@@ -406,7 +405,7 @@ async def handle_swap_reserve(
             )
             synapse.accepted = True
             bt.logging.info(
-                f'{ctx}: RESERVED — vote_reserve submitted for {label} '
+                f'{ctx}: RESERVED — vote_reserve submitted '
                 f'(tao={synapse.tao_amount}, rate={reserve_rate_str or reserve_rate})'
             )
 
@@ -453,13 +452,12 @@ async def handle_swap_confirm(
     miner = synapse.reservation_id  # reservation_id is miner_hotkey (reservation keyed by miner)
     label = miner_label(validator, miner)
     direction = f'{(synapse.from_chain or "?").upper()}->{(synapse.to_chain or "?").upper()}'
+    ctx = f'[{label}] SwapConfirm {direction}'
     bt.logging.info(
-        f'SwapConfirm REQUEST received (post-reserve, user claims source tx sent): '
-        f'miner={label} dir={direction} from_tx={synapse.from_tx_hash} '
-        f'user_from_address={synapse.from_address} user_to_address={synapse.to_address} '
-        f'from_tx_block_hint={synapse.from_tx_block}'
+        f'{ctx}: REQUEST received (post-reserve, user claims source tx sent) — '
+        f'from_tx={synapse.from_tx_hash} user_from_address={synapse.from_address} '
+        f'user_to_address={synapse.to_address} from_tx_block_hint={synapse.from_tx_block}'
     )
-    ctx = f'SwapConfirm[{label} {direction}]'
 
     try:
         if not synapse.from_address or not synapse.from_tx_proof:

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -20,6 +20,7 @@ from allways.commitments import read_miner_commitment
 from allways.constants import RESERVATION_COOLDOWN_BLOCKS
 from allways.contract_client import AllwaysContractClient, ContractError
 from allways.synapses import MinerActivateSynapse, SwapConfirmSynapse, SwapReserveSynapse
+from allways.utils.logging import miner_label as _miner_label
 from allways.utils.proofs import reserve_proof_message, swap_proof_message
 from allways.utils.scale import encode_bytes, encode_str, encode_u128
 from allways.validator.state_store import PendingConfirm
@@ -145,11 +146,7 @@ def reject_synapse(synapse: bt.Synapse, reason: str, context: str = '') -> None:
 
 def miner_label(validator: 'Validator', miner_hotkey: str) -> str:
     """Return ``UID N / hotkey[:8]`` — leads every miner log line with the UID."""
-    try:
-        uid = validator.metagraph.hotkeys.index(miner_hotkey)
-    except (ValueError, IndexError):
-        uid = '?'
-    return f'UID {uid} / {miner_hotkey[:8]}'
+    return _miner_label(getattr(validator, 'metagraph', None), miner_hotkey)
 
 
 # =============================================================================

--- a/allways/validator/chain_verification.py
+++ b/allways/validator/chain_verification.py
@@ -1,13 +1,14 @@
 """Verifies both sides of a swap using chain providers and on-chain swap data."""
 
 import asyncio
-from typing import Dict, Set
+from typing import Any, Dict, Optional, Set
 
 import bittensor as bt
 
 from allways.chain_providers.base import ChainProvider, ProviderUnreachableError, TransactionInfo
 from allways.classes import Swap
 from allways.utils.logging import log_on_change
+from allways.utils.logging import swap_label as _swap_label
 from allways.utils.rate import expected_swap_amounts
 
 
@@ -22,11 +23,16 @@ class SwapVerifier:
         self,
         chain_providers: Dict[str, ChainProvider],
         fee_divisor: int = 100,
+        metagraph: Optional[Any] = None,
     ):
         self.providers = chain_providers
         self.fee_divisor = fee_divisor
+        self.metagraph = metagraph
         self.last_logged_confs: Dict[str, int] = {}  # swap_id:chain -> confs
         self.source_verified_ids: Set[int] = set()  # source tx is final once confirmed
+
+    def _label(self, swap: Swap) -> str:
+        return _swap_label(swap, self.metagraph)
 
     def verify_tx(
         self,
@@ -47,11 +53,11 @@ class SwapVerifier:
         """
         provider = self.providers.get(chain)
         if not provider:
-            bt.logging.warning(f'Swap {swap.id}: no provider for chain {chain}')
+            bt.logging.warning(f'{self._label(swap)}: no provider for chain {chain}')
             return False
 
         if not tx_hash:
-            bt.logging.debug(f'Swap {swap.id}: empty tx_hash for {chain}, skipping verification')
+            bt.logging.debug(f'{self._label(swap)}: empty tx_hash for {chain}, skipping verification')
             return False
 
         try:
@@ -64,23 +70,23 @@ class SwapVerifier:
             )
             if tx_info is None:
                 bt.logging.debug(
-                    f'Swap {swap.id}: verify_transaction returned None on {chain} '
+                    f'{self._label(swap)}: verify_transaction returned None on {chain} '
                     f'(tx={tx_hash[:16]}... block_hint={block_hint})'
                 )
                 return False
             if not tx_info.confirmed:
-                self.log_confs_progress(swap.id, chain, tx_hash, tx_info, expected_recipient, expected_amount)
+                self.log_confs_progress(swap, chain, tx_hash, tx_info, expected_recipient, expected_amount)
                 return False
             return True
         except ProviderUnreachableError:
             raise
         except Exception as e:
-            bt.logging.error(f'Swap {swap.id}: verification error on {chain}: {e}')
+            bt.logging.error(f'{self._label(swap)}: verification error on {chain}: {e}')
             return False
 
     def log_confs_progress(
         self,
-        swap_id: int,
+        swap: Swap,
         chain: str,
         tx_hash: str,
         tx_info: TransactionInfo,
@@ -88,12 +94,12 @@ class SwapVerifier:
         expected_amount: int,
     ) -> None:
         """Rate-limited debug log for confirmations progress on unconfirmed txs."""
-        log_key = f'{swap_id}:{chain}'
+        log_key = f'{swap.id}:{chain}'
         if self.last_logged_confs.get(log_key) == tx_info.confirmations:
             return
         self.last_logged_confs[log_key] = tx_info.confirmations
         bt.logging.debug(
-            f'Swap {swap_id}: tx found but not confirmed on {chain} '
+            f'{self._label(swap)}: tx found but not confirmed on {chain} '
             f'(confs={tx_info.confirmations} tx={tx_hash[:16]}... '
             f'addr={expected_recipient[:16]}... expected={expected_amount})'
         )
@@ -105,17 +111,18 @@ class SwapVerifier:
         (snapshotted at initiation), so this works regardless of miner registration.
         """
         if not swap.rate or not swap.miner_from_address:
-            bt.logging.warning(f'Swap {swap.id}: missing rate or miner_from_address on swap struct')
+            bt.logging.warning(f'{self._label(swap)}: missing rate or miner_from_address on swap struct')
             return False
 
         _, expected_user_receives = expected_swap_amounts(swap, self.fee_divisor)
         if expected_user_receives == 0:
-            bt.logging.warning(f'Swap {swap.id}: rate produces 0 to_amount after fees')
+            bt.logging.warning(f'{self._label(swap)}: rate produces 0 to_amount after fees')
             return False
 
         if int(swap.to_amount) != expected_user_receives:
             bt.logging.warning(
-                f'Swap {swap.id}: to_amount mismatch — expected {expected_user_receives}, contract has {swap.to_amount}'
+                f'{self._label(swap)}: to_amount mismatch — expected {expected_user_receives}, '
+                f'contract has {swap.to_amount}'
             )
             return False
 
@@ -150,7 +157,7 @@ class SwapVerifier:
             log_on_change(
                 f'partial:{swap.id}',
                 (source_ok, dest_ok),
-                f'Swap {swap.id}: partial verification (source={source_ok}, dest={dest_ok}) — '
+                f'{self._label(swap)}: partial verification (source={source_ok}, dest={dest_ok}) — '
                 f'{"dest" if source_ok else "source"} side blocking confirm',
             )
 

--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -413,8 +413,9 @@ class ContractEventWatcher:
             if not hotkey:
                 return
             active = bool(values.get('active'))
-            applied = self.record_active_transition(block_num, hotkey, active)
-            if applied:
+            state_changed = (hotkey in self.active_miners) != active
+            self.record_active_transition(block_num, hotkey, active)
+            if state_changed:
                 bt.logging.info(
                     f'EventWatcher: {self._label(hotkey)} MinerActivated(active={active}) @ block {block_num}'
                 )
@@ -493,16 +494,15 @@ class ContractEventWatcher:
     def _label(self, hotkey: str) -> str:
         return _miner_label(self.metagraph, hotkey)
 
-    def record_active_transition(self, block_num: int, hotkey: str, active: bool) -> bool:
+    def record_active_transition(self, block_num: int, hotkey: str, active: bool) -> None:
         """Apply an on-chain active-flag transition to both the current-state
         snapshot and the historical event log. A no-op if the flag already
-        matches — duplicate MinerActivated emissions don't pollute the log.
-        Returns True when the state actually changed."""
+        matches — duplicate MinerActivated emissions don't pollute the log."""
         if not hotkey:
-            return False
+            return
         currently_active = hotkey in self.active_miners
         if currently_active == active:
-            return False
+            return
         if active:
             self.active_miners.add(hotkey)
         else:
@@ -510,7 +510,6 @@ class ContractEventWatcher:
         event = ActiveEvent(hotkey=hotkey, active=active, block=block_num)
         self.active_events.append(event)
         self.active_events_by_hotkey.setdefault(hotkey, []).append(event)
-        return True
 
     def apply_busy_delta(self, block_num: int, hotkey: str, delta: int) -> None:
         """Apply a ±1 transition. Drops any -1 with no matching prior +1

--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -22,6 +22,7 @@ import bittensor as bt
 
 from allways.classes import SwapStatus
 from allways.constants import SCORING_WINDOW_BLOCKS
+from allways.utils.logging import miner_label as _miner_label
 from allways.utils.scale import (
     decode_account_id,
     decode_bool,
@@ -209,6 +210,7 @@ class ContractEventWatcher:
         metadata_path: Path,
         state_store: ValidatorStateStore,
         swap_tracker: Optional[SwapTracker] = None,
+        metagraph: Optional[Any] = None,
     ):
         self.substrate = substrate
         self.contract_address = contract_address
@@ -217,6 +219,8 @@ class ContractEventWatcher:
         # watcher (cycle in current init order). Timeout extension finalize
         # writes are skipped until this is set.
         self.swap_tracker = swap_tracker
+        # Optional — used purely for UID-resolved log labels.
+        self.metagraph = metagraph
         self.registry = load_event_registry(metadata_path)
         self.cursor: int = 0
         self.last_prune_block: int = 0
@@ -409,7 +413,11 @@ class ContractEventWatcher:
             if not hotkey:
                 return
             active = bool(values.get('active'))
-            self.record_active_transition(block_num, hotkey, active)
+            applied = self.record_active_transition(block_num, hotkey, active)
+            if applied:
+                bt.logging.info(
+                    f'EventWatcher: {self._label(hotkey)} MinerActivated(active={active}) @ block {block_num}'
+                )
         elif name == 'SwapInitiated':
             swap_id = values.get('swap_id')
             miner = values.get('miner', '')
@@ -421,21 +429,26 @@ class ContractEventWatcher:
                 if isinstance(swap_id, int) and swap_id in self.bootstrapped_swap_ids:
                     return
                 self.apply_busy_delta(block_num, miner, +1)
+                bt.logging.info(f'EventWatcher: {self._label(miner)} SwapInitiated swap=#{swap_id} @ block {block_num}')
         elif name == 'SwapCompleted':
             swap_id = values.get('swap_id')
             miner = values.get('miner', '')
             if isinstance(swap_id, int) and miner:
+                tao = int(values.get('tao_amount') or 0)
                 self.state_store.insert_swap_outcome(
                     swap_id=swap_id,
                     miner_hotkey=miner,
                     completed=True,
                     resolved_block=block_num,
-                    tao_amount=int(values.get('tao_amount') or 0),
+                    tao_amount=tao,
                 )
                 self.apply_busy_delta(block_num, miner, -1)
                 self.bootstrapped_swap_ids.discard(swap_id)
                 if self.swap_tracker is not None:
                     self.swap_tracker.resolve(swap_id, SwapStatus.COMPLETED, block_num)
+                bt.logging.info(
+                    f'EventWatcher: {self._label(miner)} SwapCompleted swap=#{swap_id} tao={tao} @ block {block_num}'
+                )
         elif name == 'SwapTimedOut':
             swap_id = values.get('swap_id')
             miner = values.get('miner', '')
@@ -450,6 +463,9 @@ class ContractEventWatcher:
                 self.bootstrapped_swap_ids.discard(swap_id)
                 if self.swap_tracker is not None:
                     self.swap_tracker.resolve(swap_id, SwapStatus.TIMED_OUT, block_num)
+                bt.logging.warning(
+                    f'EventWatcher: {self._label(miner)} SwapTimedOut swap=#{swap_id} @ block {block_num} (slash)'
+                )
         elif name == 'ReservationExtensionFinalized':
             # Event-driven cache update for the local pending_confirms row —
             # replaces the polling refresh that the legacy vote-extend flow
@@ -460,21 +476,33 @@ class ContractEventWatcher:
             applied_target = values.get('applied_target')
             if miner and isinstance(applied_target, int):
                 self.state_store.update_reserved_until(miner, applied_target)
+                bt.logging.info(
+                    f'EventWatcher: {self._label(miner)} ReservationExtensionFinalized '
+                    f'applied_target={applied_target} @ block {block_num}'
+                )
         elif name == 'TimeoutExtensionFinalized':
             swap_id = values.get('swap_id')
             applied_target = values.get('applied_target')
             if self.swap_tracker is not None and isinstance(swap_id, int) and isinstance(applied_target, int):
                 self.swap_tracker.update_timeout_block(swap_id, applied_target)
+                bt.logging.info(
+                    f'EventWatcher: TimeoutExtensionFinalized swap=#{swap_id} '
+                    f'applied_target={applied_target} @ block {block_num}'
+                )
 
-    def record_active_transition(self, block_num: int, hotkey: str, active: bool) -> None:
+    def _label(self, hotkey: str) -> str:
+        return _miner_label(self.metagraph, hotkey)
+
+    def record_active_transition(self, block_num: int, hotkey: str, active: bool) -> bool:
         """Apply an on-chain active-flag transition to both the current-state
         snapshot and the historical event log. A no-op if the flag already
-        matches — duplicate MinerActivated emissions don't pollute the log."""
+        matches — duplicate MinerActivated emissions don't pollute the log.
+        Returns True when the state actually changed."""
         if not hotkey:
-            return
+            return False
         currently_active = hotkey in self.active_miners
         if currently_active == active:
-            return
+            return False
         if active:
             self.active_miners.add(hotkey)
         else:
@@ -482,6 +510,7 @@ class ContractEventWatcher:
         event = ActiveEvent(hotkey=hotkey, active=active, block=block_num)
         self.active_events.append(event)
         self.active_events_by_hotkey.setdefault(hotkey, []).append(event)
+        return True
 
     def apply_busy_delta(self, block_num: int, hotkey: str, delta: int) -> None:
         """Apply a ±1 transition. Drops any -1 with no matching prior +1

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -17,6 +17,7 @@ from allways.constants import (
 )
 from allways.contract_client import ContractError, is_contract_rejection
 from allways.utils.logging import log_on_change
+from allways.utils.logging import swap_label as _swap_label
 from allways.utils.scale import strip_hex_prefix
 from allways.validator import voting
 from allways.validator.axon_handlers import (
@@ -39,6 +40,15 @@ async def forward(self: Validator) -> None:
     verifier: SwapVerifier = self.swap_verifier
 
     self.check_block_progress(self.reconnect_and_propagate)
+
+    pending_count = len(self.state_store.get_all())
+    active_count = len(tracker.active)
+    near_timeout = len(tracker.get_near_timeout_fulfilled(self.block))
+    bt.logging.info(
+        f'forward step #{self.step} @ block {self.block}: '
+        f'pending_confirms={pending_count} active_swaps={active_count} '
+        f'near_timeout_fulfilled={near_timeout}'
+    )
 
     clear_provider_caches(self)
 
@@ -395,22 +405,25 @@ async def confirm_miner_fulfillments(
         *[verifier.verify_miner_fulfillment(swap) for swap in fulfilled],
         return_exceptions=True,
     )
+    metagraph = getattr(self, 'metagraph', None)
     for swap, result in zip(fulfilled, results):
+        label = _swap_label(swap, metagraph)
         if isinstance(result, ProviderUnreachableError):
-            bt.logging.warning(f'Swap {swap.id}: provider unreachable, deferring verification')
+            bt.logging.warning(f'{label}: provider unreachable, deferring verification')
             uncertain.add(swap.id)
             continue
         if isinstance(result, Exception):
-            bt.logging.error(f'Swap {swap.id}: verification error: {result}')
+            bt.logging.error(f'{label}: verification error: {result}')
             continue
         if result:
-            if voting.confirm_swap(self.contract_client, self.wallet, swap.id):
+            bt.logging.info(f'{label}: verification ok → voting confirm_swap')
+            if voting.confirm_swap(self.contract_client, self.wallet, swap.id, label=label):
                 tracker.resolve(swap.id, SwapStatus.COMPLETED, current_block)
-                bt.logging.success(f'Swap {swap.id}: verified complete, confirmed')
+                bt.logging.success(f'{label}: verified complete, confirmed')
             # On vote failure, voting.confirm_swap already logs the error;
             # the entry stays in tracker and retries next step.
         else:
-            bt.logging.debug(f'Swap {swap.id}: verification incomplete this cycle, deferring confirm')
+            bt.logging.debug(f'{label}: verification incomplete this cycle, deferring confirm')
     return uncertain
 
 
@@ -423,9 +436,9 @@ def extend_fulfilled_near_timeout(self: Validator) -> None:
     tracker: SwapTracker = self.swap_tracker
     current_block = self.block
 
+    metagraph = getattr(self, 'metagraph', None)
     for swap in tracker.get_near_timeout_fulfilled(current_block):
-        swap_label = f'{swap.from_chain.upper()}->{swap.to_chain.upper()}'
-        ctx = f'Swap #{swap.id} [{swap_label}]'
+        ctx = _swap_label(swap, metagraph)
 
         # One pending-extension fetch shared across finalize/challenge/propose.
         pending = self.optimistic_extensions.fetch_pending_timeout(swap.id)
@@ -509,14 +522,17 @@ def extend_fulfilled_near_timeout(self: Validator) -> None:
 
 def enforce_swap_timeouts(self: Validator, tracker: SwapTracker, uncertain_swaps: Set[int]) -> None:
     """Timeout expired swaps, skipping uncertain_swaps where the provider was unreachable this cycle."""
+    metagraph = getattr(self, 'metagraph', None)
     for swap in tracker.get_timed_out(self.block):
         if tracker.is_voted(swap.id):
             continue
+        label = _swap_label(swap, metagraph)
         if swap.id in uncertain_swaps:
-            bt.logging.warning(f'Swap {swap.id}: deferring timeout, provider was unreachable')
+            bt.logging.warning(f'{label}: deferring timeout, provider was unreachable')
             continue
 
-        if voting.timeout_swap(self.contract_client, self.wallet, swap.id):
+        bt.logging.info(f'{label}: past timeout_block={swap.timeout_block} → voting timeout_swap')
+        if voting.timeout_swap(self.contract_client, self.wallet, swap.id, label=label):
             tracker.resolve(swap.id, SwapStatus.TIMED_OUT, self.block)
-            bt.logging.warning(f'Swap {swap.id}: timed out')
+            bt.logging.warning(f'{label}: timed out')
         # On vote failure, voting.timeout_swap already logs the error.

--- a/allways/validator/swap_tracker.py
+++ b/allways/validator/swap_tracker.py
@@ -3,13 +3,14 @@ so the forward loop knows what to verify, vote on, and time out. Swap
 outcomes (credibility ledger writes) are owned by ``ContractEventWatcher``."""
 
 import asyncio
-from typing import Dict, List, Set
+from typing import Any, Dict, List, Optional, Set
 
 import bittensor as bt
 
 from allways.classes import Swap, SwapStatus
 from allways.constants import EXTEND_THRESHOLD_BLOCKS
 from allways.contract_client import AllwaysContractClient
+from allways.utils.logging import swap_label as _swap_label_with_uid
 
 ACTIVE_STATUSES = (SwapStatus.ACTIVE, SwapStatus.FULFILLED)
 
@@ -35,11 +36,15 @@ class SwapTracker:
     """Discovery scans new swap IDs since the last poll; monitoring re-fetches
     all tracked ACTIVE/FULFILLED swaps each poll."""
 
-    def __init__(self, client: AllwaysContractClient):
+    def __init__(self, client: AllwaysContractClient, metagraph: Optional[Any] = None):
         self.client = client
+        self.metagraph = metagraph
         self.last_scanned_id = 0
         self.active: Dict[int, Swap] = {}
         self.voted_ids: Set[int] = set()
+
+    def _label(self, swap: Swap) -> str:
+        return _swap_label_with_uid(swap, self.metagraph)
 
     def initialize(self):
         """Cold start: scan backward from latest swap to seed active set.
@@ -84,7 +89,7 @@ class SwapTracker:
         swap.status = status
         swap.completed_block = block
         self.voted_ids.discard(swap_id)
-        bt.logging.info(f'Swap {swap_id}: dropped from active ({status.name} at block {block})')
+        bt.logging.info(f'{self._label(swap)}: dropped from active ({status.name} at block {block})')
 
     def mark_voted(self, swap_id: int):
         """Mark a swap as voted on to prevent redundant confirm/timeout extrinsics."""
@@ -133,7 +138,7 @@ class SwapTracker:
                 continue
             if swap.status in ACTIVE_STATUSES:
                 if swap.id not in self.active:
-                    bt.logging.info(f'Swap {swap.id} [{_swap_label(swap)}]: now {swap.status.name}, monitoring')
+                    bt.logging.info(f'{self._label(swap)}: now {swap.status.name}, monitoring')
                 self.active[swap.id] = swap
                 fresh.add(swap.id)
 
@@ -160,7 +165,7 @@ class SwapTracker:
             if result.status in ACTIVE_STATUSES:
                 prev = self.active.get(sid)
                 if prev is not None and prev.status != result.status:
-                    bt.logging.info(f'Swap {sid} [{_swap_label(result)}]: {prev.status.name} -> {result.status.name}')
+                    bt.logging.info(f'{self._label(result)}: {prev.status.name} -> {result.status.name}')
                 self.active[sid] = result
             else:
                 # Terminal status from chain — drop with reason for observability.

--- a/allways/validator/swap_tracker.py
+++ b/allways/validator/swap_tracker.py
@@ -28,10 +28,6 @@ MAX_INIT_GAP = 20
 RESCAN_WINDOW = 16
 
 
-def _swap_label(swap: Swap) -> str:
-    return f'{swap.from_chain.upper()}->{swap.to_chain.upper()}'
-
-
 class SwapTracker:
     """Discovery scans new swap IDs since the last poll; monitoring re-fetches
     all tracked ACTIVE/FULFILLED swaps each poll."""

--- a/allways/validator/voting.py
+++ b/allways/validator/voting.py
@@ -1,26 +1,40 @@
 """Thin wrappers around the swap-vote extrinsics. Both return False on any
 error; the caller decides whether to retry or escalate."""
 
+from typing import Optional
+
 import bittensor as bt
 
 from allways.contract_client import AllwaysContractClient
 
 
-def confirm_swap(client: AllwaysContractClient, wallet: bt.Wallet, swap_id: int) -> bool:
+def confirm_swap(
+    client: AllwaysContractClient,
+    wallet: bt.Wallet,
+    swap_id: int,
+    label: Optional[str] = None,
+) -> bool:
     """Vote to confirm a FULFILLED swap as COMPLETED. Caller logs the outcome."""
+    tag = label or f'Swap #{swap_id}'
     try:
         client.confirm_swap(wallet=wallet, swap_id=swap_id)
         return True
     except Exception as e:
-        bt.logging.error(f'Confirm swap failed for swap {swap_id}: {e}')
+        bt.logging.error(f'{tag}: confirm_swap vote failed: {e}')
         return False
 
 
-def timeout_swap(client: AllwaysContractClient, wallet: bt.Wallet, swap_id: int) -> bool:
+def timeout_swap(
+    client: AllwaysContractClient,
+    wallet: bt.Wallet,
+    swap_id: int,
+    label: Optional[str] = None,
+) -> bool:
     """Vote to time out a swap past its deadline. Caller logs the outcome."""
+    tag = label or f'Swap #{swap_id}'
     try:
         client.timeout_swap(wallet=wallet, swap_id=swap_id)
         return True
     except Exception as e:
-        bt.logging.error(f'Timeout swap failed for swap {swap_id}: {e}')
+        bt.logging.error(f'{tag}: timeout_swap vote failed: {e}')
         return False

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -108,6 +108,7 @@ class Validator(BaseValidatorNeuron):
             contract_address=self.contract_client.contract_address,
             metadata_path=metadata_path,
             state_store=self.state_store,
+            metagraph=self.metagraph,
         )
         self.event_watcher.initialize(
             current_block=self.block,
@@ -116,7 +117,7 @@ class Validator(BaseValidatorNeuron):
         )
         self.bootstrap_miner_rates()
 
-        self.swap_tracker = SwapTracker(client=self.contract_client)
+        self.swap_tracker = SwapTracker(client=self.contract_client, metagraph=self.metagraph)
         self.swap_tracker.initialize()
         # Late-bind the tracker so TimeoutExtensionFinalized events can write
         # the new timeout_block straight into the in-memory active swap.
@@ -126,6 +127,7 @@ class Validator(BaseValidatorNeuron):
         self.swap_verifier = SwapVerifier(
             chain_providers=self.chain_providers,
             fee_divisor=self.fee_divisor,
+            metagraph=self.metagraph,
         )
 
         # Separate subtensor/contract/providers for axon handlers (thread safety).


### PR DESCRIPTION
## Summary
- SwapReserve entry log now prints miner UID + hotkey, direction, tao/from/to amounts, user source address, and block anchor — so a reservation request is clearly distinguishable in the log instead of looking like a swap appeared out of nowhere.
- Once the commitment loads, log the miner's quoted rate and addresses for the requested direction.
- "Voting" / "Voted" lines now include collateral, reserved_until, cur_block (preflight) and rate + tao amount (post-vote).
- Same treatment on SwapConfirm so it's obvious from the log that the user is claiming a source tx (not initiating a new reservation), plus tx hash, addresses, and block hint.

## Test plan
- [x] `ruff check` / `ruff format` clean
- [x] `pytest tests/test_axon_handlers.py` (22 passed)
- [ ] Run a manual swap against dev env and confirm new log lines appear at each stage (REQUEST → preflight ok → RESERVED → CONFIRM REQUEST → INITIATED)