### PR TITLE
refactor: reuse fee helper when hydrating pending swaps

### DIFF
--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -15,12 +15,14 @@ from allways.classes import MinerPair, Swap, SwapStatus
 from allways.commitments import parse_commitment_data, read_miner_commitment, read_miner_commitments  # noqa: F401
 from allways.constants import CONTRACT_ADDRESS as DEFAULT_CONTRACT_ADDRESS
 from allways.constants import (
+    FEE_DIVISOR,
     MAX_EXTENSION_BLOCKS,
     MAX_EXTENSIONS_PER_RESERVATION,
     NETUID_FINNEY,
     TAO_TO_RAO,
 )
 from allways.contract_client import AllwaysContractClient, ContractError, is_contract_rejection
+from allways.utils.rate import apply_fee_deduction
 
 ALLWAYS_DIR = Path.home() / '.allways'
 CONFIG_FILE = ALLWAYS_DIR / 'config.json'
@@ -404,9 +406,7 @@ def hydrate_pending_swap(state: PendingSwapState, client) -> bool:
         pass
     # User receives = gross dest amount minus 1% protocol fee.
     if state.to_amount and not state.user_receives:
-        from allways.constants import FEE_DIVISOR
-
-        state.user_receives = state.to_amount - state.to_amount // FEE_DIVISOR
+        state.user_receives = apply_fee_deduction(state.to_amount, FEE_DIVISOR)
     return True
 
 

--- a/tests/test_probe_pending_reservation.py
+++ b/tests/test_probe_pending_reservation.py
@@ -6,12 +6,14 @@ by another user, and stale local file shown as ACTIVE because the contract
 leaves expired rows in the reservation map until lazy clear.
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from allways.classes import Swap, SwapStatus
 from allways.cli.swap_commands.helpers import (
     PendingSwapState,
     ReservationStatus,
+    hydrate_pending_swap,
     probe_pending_reservation,
 )
 from allways.contract_client import ContractError
@@ -75,6 +77,28 @@ def make_client(*, active_swaps=(), reserved_until=0, reservation_data=None):
     client.get_miner_reserved_until.return_value = reserved_until
     client.get_reservation_data.return_value = reservation_data
     return client
+
+
+def test_hydrate_pending_swap_sets_fee_adjusted_user_receives(monkeypatch):
+    state = make_state(request_hash='req-hash', to_amount=0, tao_amount=0, user_receives=0)
+    client = MagicMock()
+    client.subtensor = None
+    client.get_reservation.return_value = SimpleNamespace(
+        hash='req-hash',
+        from_chain='btc',
+        to_chain='tao',
+        from_amount=100_000,
+        to_amount=101,
+        tao_amount=101,
+        from_addr='tb1quser',
+        reserved_until=1_000_100,
+    )
+    monkeypatch.setattr('allways.commitments.read_miner_commitment', lambda *args, **kwargs: None)
+
+    assert hydrate_pending_swap(state, client) is True
+
+    assert state.to_amount == 101
+    assert state.user_receives == 100
 
 
 def test_our_swap_when_active_swaps_match_user_addresses():


### PR DESCRIPTION
## Summary
- use `apply_fee_deduction(..., FEE_DIVISOR)` when hydrating `user_receives` from an on-chain reservation
- add regression coverage for a non-divisible destination amount

Fixes #334

## Tests
- `uv run pytest tests/test_probe_pending_reservation.py -q`
- `uv run pytest tests/test_rate.py -q`
- `uv run ruff check allways/cli/swap_commands/helpers.py tests/test_probe_pending_reservation.py`
- `git diff --check`