### PR TITLE
fix: retry event watcher blocks after RPC failures

### DIFF
--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -420,7 +420,13 @@ class ContractEventWatcher:
         self.pruned_block_last = None
         end = min(current_block, self.cursor + MAX_BLOCKS_PER_SYNC)
         for block_num in range(self.cursor + 1, end + 1):
-            self.process_block(block_num)
+            if not self.process_block(block_num):
+                break
+        if self.cursor < end:
+            bt.logging.warning(
+                f'EventWatcher: sync stopped at block {self.cursor} before requested block {end} '
+                f'(current_block={current_block}); will retry from block {self.cursor + 1}'
+            )
         if current_block - self.last_prune_block >= EVENT_PRUNE_INTERVAL_BLOCKS:
             self.prune_old_events(current_block)
             self.last_prune_block = current_block
@@ -431,11 +437,13 @@ class ContractEventWatcher:
                 'RPC node retains only recent state'
             )
 
-    def process_block(self, block_num: int) -> None:
+    def process_block(self, block_num: int) -> bool:
         try:
             block_hash = self.substrate.get_block_hash(block_num)
             if not block_hash:
-                return
+                self.cursor = block_num
+                self.state_store.set_event_cursor(block_num)
+                return True
             events = self.substrate.get_events(block_hash=block_hash)
         except Exception as e:
             msg = str(e).lower()
@@ -448,10 +456,11 @@ class ContractEventWatcher:
                 self.pruned_block_last = block_num
                 self.cursor = block_num
                 self.state_store.set_event_cursor(block_num)
+                return True
             else:
                 # Transient: hold the cursor so the block is retried next sync.
                 bt.logging.debug(f'EventWatcher: block {block_num} events unavailable: {e}')
-            return
+            return False
 
         for event_record in events:
             decoded = self.decode_contract_event(event_record)
@@ -467,6 +476,7 @@ class ContractEventWatcher:
                 bt.logging.warning(f'EventWatcher: apply_event {name}@{block_num} failed: {e}')
         self.cursor = block_num
         self.state_store.set_event_cursor(block_num)
+        return True
 
     def decode_contract_event(self, event_record: Any) -> Optional[Tuple[str, Dict[str, Any]]]:
         record = event_record.value if hasattr(event_record, 'value') else event_record

--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -441,9 +441,8 @@ class ContractEventWatcher:
         try:
             block_hash = self.substrate.get_block_hash(block_num)
             if not block_hash:
-                self.cursor = block_num
-                self.state_store.set_event_cursor(block_num)
-                return True
+                bt.logging.debug(f'EventWatcher: block {block_num} hash unavailable')
+                return False
             events = self.substrate.get_events(block_hash=block_hash)
         except Exception as e:
             msg = str(e).lower()

--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -437,6 +437,17 @@ class ContractEventWatcher:
                 'RPC node retains only recent state'
             )
 
+    @staticmethod
+    def _is_permanently_unavailable_historical_block_error(error: Exception) -> bool:
+        msg = str(error).lower()
+        if ('state' in msg and 'discarded' in msg) or 'pruned' in msg:
+            return True
+
+        has_historical_context = any(token in msg for token in ('historical', 'archive', 'old state'))
+        has_unavailable_marker = any(token in msg for token in ('unavailable', 'not available', 'not found', 'missing'))
+        has_block_or_state_context = any(token in msg for token in ('state', 'block', 'header'))
+        return has_historical_context and has_unavailable_marker and has_block_or_state_context
+
     def process_block(self, block_num: int) -> bool:
         try:
             block_hash = self.substrate.get_block_hash(block_num)
@@ -445,10 +456,9 @@ class ContractEventWatcher:
                 return False
             events = self.substrate.get_events(block_hash=block_hash)
         except Exception as e:
-            msg = str(e).lower()
-            if ('state' in msg and 'discarded' in msg) or 'pruned' in msg:
-                # Permanently pruned: advance past it, else cold start loops
-                # the first pruned block forever and never reaches live state.
+            if self._is_permanently_unavailable_historical_block_error(e):
+                # Permanently unavailable historical block: advance past it,
+                # else cold start loops forever and never reaches live state.
                 self.pruned_block_count += 1
                 if self.pruned_block_first is None:
                     self.pruned_block_first = block_num

--- a/tests/test_event_watcher.py
+++ b/tests/test_event_watcher.py
@@ -9,7 +9,7 @@ Covers three layers:
 
 import struct
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from bittensor.utils import ss58_decode
 
@@ -932,4 +932,59 @@ class TestSwapOutcomesIdempotency:
         rows = w.state_store.get_success_rates_since(0)
         # Two SwapCompleted apply()s, but swap_outcomes is keyed by swap_id (INSERT OR REPLACE).
         assert rows.get('hk_a') == (1, 0)
+        w.state_store.close()
+
+
+class TestSyncToRetryFailures:
+    def test_clean_sync_advances_cursor_to_end(self, tmp_path: Path):
+        w = make_watcher(tmp_path)
+        w.cursor = 10
+        w.substrate.get_block_hash.side_effect = lambda block_num: f'hash-{block_num}'
+        w.substrate.get_events.return_value = []
+
+        w.sync_to(13)
+
+        assert w.cursor == 13
+        assert w.substrate.get_block_hash.call_args_list == [call(11), call(12), call(13)]
+        w.state_store.close()
+
+    def test_transient_block_fetch_failure_stops_cursor_before_failed_block(self, tmp_path: Path):
+        w = make_watcher(tmp_path)
+        w.cursor = 10
+
+        def get_block_hash(block_num: int):
+            if block_num == 12:
+                raise RuntimeError('rpc timeout')
+            return f'hash-{block_num}'
+
+        w.substrate.get_block_hash.side_effect = get_block_hash
+        w.substrate.get_events.return_value = []
+
+        w.sync_to(14)
+
+        assert w.cursor == 11
+        assert w.substrate.get_block_hash.call_args_list == [call(11), call(12)]
+        w.state_store.close()
+
+    def test_failed_block_is_retried_on_next_sync(self, tmp_path: Path):
+        w = make_watcher(tmp_path)
+        w.cursor = 10
+
+        def flaky_get_block_hash(block_num: int):
+            if block_num == 12:
+                raise RuntimeError('rpc timeout')
+            return f'hash-{block_num}'
+
+        w.substrate.get_block_hash.side_effect = flaky_get_block_hash
+        w.substrate.get_events.return_value = []
+        w.sync_to(14)
+        assert w.cursor == 11
+
+        w.substrate.get_block_hash.reset_mock()
+        w.substrate.get_block_hash.side_effect = lambda block_num: f'hash-{block_num}'
+
+        w.sync_to(14)
+
+        assert w.cursor == 14
+        assert w.substrate.get_block_hash.call_args_list == [call(12), call(13), call(14)]
         w.state_store.close()

--- a/tests/test_event_watcher.py
+++ b/tests/test_event_watcher.py
@@ -11,6 +11,7 @@ import struct
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
+import pytest
 from bittensor.utils import ss58_decode
 
 from allways.validator.event_watcher import (
@@ -993,6 +994,40 @@ class TestSyncToRetryFailures:
 
         assert w.cursor == 14
         assert w.substrate.get_block_hash.call_args_list == [call(12), call(13), call(14)]
+        w.state_store.close()
+
+    @pytest.mark.parametrize('falsy_hash', [None, '', 0])
+    def test_falsy_block_hash_is_retried_on_next_sync(self, tmp_path: Path, falsy_hash):
+        w = make_watcher(tmp_path)
+        w.cursor = 10
+
+        def flaky_get_block_hash(block_num: int):
+            if block_num == 12:
+                return falsy_hash
+            return f'hash-{block_num}'
+
+        w.substrate.get_block_hash.side_effect = flaky_get_block_hash
+        w.substrate.get_events.return_value = []
+        w.sync_to(14)
+        assert w.cursor == 11
+        assert w.state_store.get_event_cursor() == 11
+        assert w.substrate.get_block_hash.call_args_list == [call(11), call(12)]
+        assert w.substrate.get_events.call_args_list == [call(block_hash='hash-11')]
+
+        w.substrate.get_block_hash.reset_mock()
+        w.substrate.get_events.reset_mock()
+        w.substrate.get_block_hash.side_effect = lambda block_num: f'hash-{block_num}'
+
+        w.sync_to(14)
+
+        assert w.cursor == 14
+        assert w.state_store.get_event_cursor() == 14
+        assert w.substrate.get_block_hash.call_args_list == [call(12), call(13), call(14)]
+        assert w.substrate.get_events.call_args_list == [
+            call(block_hash='hash-12'),
+            call(block_hash='hash-13'),
+            call(block_hash='hash-14'),
+        ]
         w.state_store.close()
 
     def test_failed_event_fetch_is_retried_on_next_sync(self, tmp_path: Path):

--- a/tests/test_event_watcher.py
+++ b/tests/test_event_watcher.py
@@ -948,9 +948,11 @@ class TestSyncToRetryFailures:
         assert w.substrate.get_block_hash.call_args_list == [call(11), call(12), call(13)]
         w.state_store.close()
 
-    def test_transient_block_fetch_failure_stops_cursor_before_failed_block(self, tmp_path: Path):
+    def test_transient_block_fetch_failure_stops_cursor_before_failed_block(self, tmp_path: Path, monkeypatch):
         w = make_watcher(tmp_path)
         w.cursor = 10
+        warning = MagicMock()
+        monkeypatch.setattr('allways.validator.event_watcher.bt.logging.warning', warning)
 
         def get_block_hash(block_num: int):
             if block_num == 12:
@@ -964,6 +966,10 @@ class TestSyncToRetryFailures:
 
         assert w.cursor == 11
         assert w.substrate.get_block_hash.call_args_list == [call(11), call(12)]
+        warning.assert_called_once_with(
+            'EventWatcher: sync stopped at block 11 before requested block 14 '
+            '(current_block=14); will retry from block 12'
+        )
         w.state_store.close()
 
     def test_failed_block_is_retried_on_next_sync(self, tmp_path: Path):
@@ -987,4 +993,34 @@ class TestSyncToRetryFailures:
 
         assert w.cursor == 14
         assert w.substrate.get_block_hash.call_args_list == [call(12), call(13), call(14)]
+        w.state_store.close()
+
+    def test_failed_event_fetch_is_retried_on_next_sync(self, tmp_path: Path):
+        w = make_watcher(tmp_path)
+        w.cursor = 10
+        w.substrate.get_block_hash.side_effect = lambda block_num: f'hash-{block_num}'
+
+        def flaky_get_events(block_hash: str):
+            if block_hash == 'hash-12':
+                raise RuntimeError('rpc timeout')
+            return []
+
+        w.substrate.get_events.side_effect = flaky_get_events
+        w.sync_to(14)
+        assert w.cursor == 11
+
+        w.substrate.get_block_hash.reset_mock()
+        w.substrate.get_events.reset_mock()
+        w.substrate.get_events.side_effect = None
+        w.substrate.get_events.return_value = []
+
+        w.sync_to(14)
+
+        assert w.cursor == 14
+        assert w.substrate.get_block_hash.call_args_list == [call(12), call(13), call(14)]
+        assert w.substrate.get_events.call_args_list == [
+            call(block_hash='hash-12'),
+            call(block_hash='hash-13'),
+            call(block_hash='hash-14'),
+        ]
         w.state_store.close()

--- a/tests/test_event_watcher.py
+++ b/tests/test_event_watcher.py
@@ -884,6 +884,37 @@ class TestEventWatcherLogHygiene:
             ew_module.MAX_BLOCKS_PER_SYNC = original_chunk
         w.state_store.close()
 
+    def test_non_archive_historical_error_from_get_block_hash_is_skipped(self, tmp_path: Path):
+        w = make_watcher(tmp_path)
+        w.substrate.get_block_hash.side_effect = RuntimeError(
+            'RPC error: block not found in historical state; archive node required'
+        )
+        w.cursor = 0
+
+        w.sync_to(3)
+
+        assert w.pruned_block_count == 3
+        assert w.pruned_block_first == 1
+        assert w.pruned_block_last == 3
+        assert w.cursor == 3
+        assert w.state_store.get_event_cursor() == 3
+        w.state_store.close()
+
+    def test_non_archive_historical_error_from_get_events_is_skipped(self, tmp_path: Path):
+        w = make_watcher(tmp_path)
+        w.substrate.get_block_hash.side_effect = lambda block: f'0x{block:064x}'
+        w.substrate.get_events.side_effect = RuntimeError('state unavailable for historical block; non-archive node')
+        w.cursor = 0
+
+        w.sync_to(3)
+
+        assert w.pruned_block_count == 3
+        assert w.pruned_block_first == 1
+        assert w.pruned_block_last == 3
+        assert w.cursor == 3
+        assert w.state_store.get_event_cursor() == 3
+        w.state_store.close()
+
     def test_unrelated_exception_holds_cursor_for_retry(self, tmp_path: Path):
         w = make_watcher(tmp_path)
         w.substrate.get_block_hash.side_effect = RuntimeError('connection refused')


### PR DESCRIPTION
## Summary
- make `process_block()` report whether block event retrieval succeeded
- keep the event watcher cursor at the last successfully processed block when a transient RPC failure occurs
- add regression coverage for clean sync, mid-window failure, and retry after recovery

Fixes #201

Note: #339 also touches `event_watcher.py` for state persistence, so this may need a small rebase if that lands first.

## Tests
- `uv run pytest tests/test_event_watcher.py -q`
- `uv run ruff check allways/validator/event_watcher.py tests/test_event_watcher.py`
- `uv run ruff format --check allways/validator/event_watcher.py tests/test_event_watcher.py`
- `git diff --check`