### PR TITLE
fix: harden neuron forward loop against reconnect crashes

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -14,6 +14,9 @@ MINER_POLL_INTERVAL_SECONDS = 12
 VALIDATOR_POLL_INTERVAL_SECONDS = 12
 # Consecutive polls of zero block progress before we force a substrate reconnect.
 STALE_BLOCK_POLL_THRESHOLD = 30
+# Seconds without a completed forward step before the supervisor declares the
+# loop dead/hung and exits non-zero for the process manager to restart.
+FORWARD_STALL_THRESHOLD_SECONDS = 600
 
 # ─── Commitment Format ────────────────────────────────────
 COMMITMENT_VERSION = 1

--- a/neurons/base/miner.py
+++ b/neurons/base/miner.py
@@ -50,12 +50,16 @@ class BaseMinerNeuron(BaseNeuron):
                         self.sync()
 
                     consecutive_errors = 0
+                    self.last_forward_time = time.time()
                 except KeyboardInterrupt:
                     raise
                 except Exception as step_err:
                     consecutive_errors += 1
                     bt.logging.error(f'Step {self.step} error ({consecutive_errors} consecutive): {step_err}')
-                    self.reconnect_subtensor()
+                    try:
+                        self.reconnect_subtensor()
+                    except Exception as reconnect_err:
+                        bt.logging.error(f'Reconnect failed during error recovery: {reconnect_err}')
                     time.sleep(min(2**consecutive_errors, 30))
 
                 self.step += 1
@@ -64,6 +68,9 @@ class BaseMinerNeuron(BaseNeuron):
         except KeyboardInterrupt:
             bt.logging.success('Miner killed by keyboard interrupt.')
             self.should_exit = True
+        except Exception as fatal_err:
+            bt.logging.critical(f'Forward loop exited unexpectedly: {fatal_err}', exc_info=True)
+            raise
 
     def run_in_background_thread(self):
         """Starts the miner's operations in a separate background thread."""

--- a/neurons/base/neuron.py
+++ b/neurons/base/neuron.py
@@ -69,6 +69,7 @@ class BaseNeuron(ABC):
             f'using network: {self.subtensor.chain_endpoint}'
         )
         self.step = 0
+        self.last_forward_time = time.time()
         self.last_seen_block = 0
         self.stale_block_polls = 0
 

--- a/neurons/base/validator.py
+++ b/neurons/base/validator.py
@@ -107,12 +107,16 @@ class BaseValidatorNeuron(BaseNeuron):
                     self.loop.run_until_complete(self.concurrent_forward())
                     self.sync()
                     consecutive_errors = 0
+                    self.last_forward_time = time.time()
                 except KeyboardInterrupt:
                     raise
                 except Exception as step_err:
                     consecutive_errors += 1
                     bt.logging.error(f'Step {self.step} error ({consecutive_errors} consecutive): {step_err}')
-                    self.reconnect_subtensor()
+                    try:
+                        self.reconnect_subtensor()
+                    except Exception as reconnect_err:
+                        bt.logging.error(f'Reconnect failed during error recovery: {reconnect_err}')
                     time.sleep(min(2**consecutive_errors, 30))
 
                 if self.should_exit:
@@ -132,6 +136,9 @@ class BaseValidatorNeuron(BaseNeuron):
                 self.axon.stop()
             bt.logging.success('Validator killed by keyboard interrupt.')
             self.should_exit = True
+        except Exception as fatal_err:
+            bt.logging.critical(f'Forward loop exited unexpectedly: {fatal_err}', exc_info=True)
+            raise
 
     def run_in_background_thread(self):
         """Starts the validator's operations in a background thread."""

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -7,6 +7,7 @@ Usage:
 """
 
 import os
+import sys
 import time
 from pathlib import Path
 from typing import Dict
@@ -16,7 +17,7 @@ from dotenv import load_dotenv
 
 from allways.chain_providers import create_chain_providers
 from allways.commitments import read_miner_commitment
-from allways.constants import FEE_DIVISOR
+from allways.constants import FEE_DIVISOR, FORWARD_STALL_THRESHOLD_SECONDS
 from allways.contract_client import AllwaysContractClient
 from allways.miner.fulfillment import SwapFulfiller
 from allways.miner.swap_poller import SwapPoller
@@ -183,5 +184,15 @@ class Miner(BaseMinerNeuron):
 if __name__ == '__main__':
     with Miner() as miner:
         while True:
-            bt.logging.info(f'Miner running... step={miner.step}')
+            forward_age = time.time() - miner.last_forward_time
+            if not miner.thread.is_alive():
+                bt.logging.error(f'Forward thread is dead (last forward {forward_age:.0f}s ago) — exiting for restart')
+                sys.exit(1)
+            if forward_age > FORWARD_STALL_THRESHOLD_SECONDS:
+                bt.logging.error(
+                    f'Forward progress stalled for {forward_age:.0f}s '
+                    f'(>{FORWARD_STALL_THRESHOLD_SECONDS}s) — exiting for restart'
+                )
+                sys.exit(1)
+            bt.logging.info(f'Miner running... step={miner.step} (last forward {forward_age:.0f}s ago)')
             time.sleep(60)

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -8,6 +8,7 @@ Usage:
     python neurons/validator.py --netuid 7 --wallet.name default --wallet.hotkey default
 """
 
+import sys
 import threading
 import time
 from functools import partial
@@ -21,6 +22,7 @@ from allways.commitments import read_miner_commitments
 from allways.constants import (
     DEFAULT_FULFILLMENT_TIMEOUT_BLOCKS,
     FEE_DIVISOR,
+    FORWARD_STALL_THRESHOLD_SECONDS,
     SCORING_WINDOW_BLOCKS,
 )
 from allways.contract_client import AllwaysContractClient
@@ -245,5 +247,15 @@ class Validator(BaseValidatorNeuron):
 if __name__ == '__main__':
     with Validator() as validator:
         while True:
-            bt.logging.info(f'Validator running... step={validator.step}')
+            forward_age = time.time() - validator.last_forward_time
+            if not validator.thread.is_alive():
+                bt.logging.error(f'Forward thread is dead (last forward {forward_age:.0f}s ago) — exiting for restart')
+                sys.exit(1)
+            if forward_age > FORWARD_STALL_THRESHOLD_SECONDS:
+                bt.logging.error(
+                    f'Forward progress stalled for {forward_age:.0f}s '
+                    f'(>{FORWARD_STALL_THRESHOLD_SECONDS}s) — exiting for restart'
+                )
+                sys.exit(1)
+            bt.logging.info(f'Validator running... step={validator.step} (last forward {forward_age:.0f}s ago)')
             time.sleep(60)


### PR DESCRIPTION
## Problem
- Validator froze: heartbeat printing, axon answering, but `step` stuck and no scoring.
- Transient finney `HTTP 503` failed an RPC mid-forward.
- Error handler called `reconnect_subtensor()` unguarded; reconnect hit the same 503.
- That exception escaped the loop and killed the forward daemon thread.
- Main thread never checks thread liveness, so process zombied ~6h until manual restart.

## Fix
- Guard `reconnect_subtensor()` in the error handler — transient blips no longer kill the loop.
- Log `CRITICAL` + traceback if the loop ever exits unexpectedly.
- Track `last_forward_time`; supervisor `sys.exit(1)`s on dead or stalled (>600s) thread.
- Docker `restart: unless-stopped` then restarts cleanly (`exec python` = PID 1).
- Heartbeat now logs forward age, so a growing value is alertable.

## Result
- Common 503 case: loop survives, no restart needed.
- Death/hang case: auto-recovers in ≤60s instead of multi-hour zombie.

## Scope note
- Mirrored into reference miner — same loop, same crash. Droppable if validator-only preferred.

## Testing
- `ruff format` / `ruff check` clean; `pytest` 474 passed.