### PR TITLE
fix(scoring): apply volume_factor per swap direction

### DIFF
--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -540,7 +540,7 @@ class ContractEventWatcher:
         swap = self.swap_tracker.active.get(swap_id)
         if swap is None:
             return '', ''
-        return swap.from_chain, swap.to_chain
+        return (swap.from_chain or '').lower(), (swap.to_chain or '').lower()
 
     def record_reservation_pin(self, block_num: int, miner: str, reserved_until: int) -> None:
         """Pin the miner's commitment as of the reservation block ``block_num``.

--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -456,12 +456,15 @@ class ContractEventWatcher:
             miner = values.get('miner', '')
             if isinstance(swap_id, int) and miner:
                 tao = int(values.get('tao_amount') or 0)
+                from_chain, to_chain = self._lookup_swap_direction(swap_id)
                 self.state_store.insert_swap_outcome(
                     swap_id=swap_id,
                     miner_hotkey=miner,
                     completed=True,
                     resolved_block=block_num,
                     tao_amount=tao,
+                    from_chain=from_chain,
+                    to_chain=to_chain,
                 )
                 self.apply_busy_delta(block_num, miner, -1)
                 self.bootstrapped_swap_ids.discard(swap_id)
@@ -474,11 +477,14 @@ class ContractEventWatcher:
             swap_id = values.get('swap_id')
             miner = values.get('miner', '')
             if isinstance(swap_id, int) and miner:
+                from_chain, to_chain = self._lookup_swap_direction(swap_id)
                 self.state_store.insert_swap_outcome(
                     swap_id=swap_id,
                     miner_hotkey=miner,
                     completed=False,
                     resolved_block=block_num,
+                    from_chain=from_chain,
+                    to_chain=to_chain,
                 )
                 # Defensive: a SwapInitiated this validator missed would leave
                 # a stale pin behind — clear it on the terminal event too.
@@ -519,6 +525,22 @@ class ContractEventWatcher:
 
     def _label(self, hotkey: str) -> str:
         return _miner_label(self.metagraph, hotkey)
+
+    def _lookup_swap_direction(self, swap_id: int) -> Tuple[str, str]:
+        """Resolve (from_chain, to_chain) for a swap that's just terminated.
+
+        SwapCompleted/SwapTimedOut events carry no direction. The tracker still
+        holds the Swap (resolve() runs after we record the outcome), so it's
+        the authoritative source. Returns ('', '') when the tracker is unset
+        or doesn't know the swap — e.g. a swap that completed/timed out before
+        the validator caught up. Empty direction means the outcome won't
+        contribute to per-direction volume sums, which is the safe default."""
+        if self.swap_tracker is None:
+            return '', ''
+        swap = self.swap_tracker.active.get(swap_id)
+        if swap is None:
+            return '', ''
+        return swap.from_chain, swap.to_chain
 
     def record_reservation_pin(self, block_num: int, miner: str, reserved_until: int) -> None:
         """Pin the miner's commitment as of the reservation block ``block_num``.

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -143,7 +143,7 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
             rewardable_hotkeys=rewardable_hotkeys,
             trace=trace,
         )
-        total_crown = sum(crown_blocks.values())
+        total_crown_dir = sum(crown_blocks.values())
         volumes_dir = self.state_store.get_volume_by_direction_since(window_start, from_chain, to_chain)
         total_volume_dir = sum(volumes_dir.values())
         for hk, v in volumes_dir.items():
@@ -151,9 +151,14 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
         network_volume_total += int(total_volume_dir)
         for hk, blk in crown_blocks.items():
             miner_crown_total[hk] = miner_crown_total.get(hk, 0.0) + blk
-        network_crown_total += total_crown
+        network_crown_total += total_crown_dir
 
-        if total_crown == 0:
+        bt.logging.debug(
+            f'V1 scoring [{from_chain}→{to_chain}]: '
+            f'total_crown={total_crown_dir:.1f} blk, total_volume_rao={total_volume_dir}'
+        )
+
+        if total_crown_dir == 0:
             continue  # empty bucket — pool recycles via the remainder below
 
         for hotkey, blocks in crown_blocks.items():
@@ -173,12 +178,19 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
                 closed_swaps=sum(success_stats.get(hotkey, (0, 0))),
                 ramp_target=CREDIBILITY_RAMP_OBSERVATIONS,
             )
-            crown_share_dir = blocks / total_crown
+            crown_share_dir = blocks / total_crown_dir
             vol_dir = volumes_dir.get(hotkey, 0)
+            vol_share_dir = (vol_dir / total_volume_dir) if total_volume_dir > 0 else 0.0
             vol_factor = volume_factor(vol_dir, total_volume_dir, crown_share_dir)
             base = pool * crown_share_dir * (success_rates[hotkey] ** SUCCESS_EXPONENT) * cap
             unweighted_rewards[uid] += base
             rewards[uid] += base * vol_factor
+            if vol_factor < 1.0:
+                bt.logging.debug(
+                    f'V1 scoring [{from_chain}→{to_chain}] {hotkey[:8]}: '
+                    f'crown_share={crown_share_dir:.3f} vol_share={vol_share_dir:.3f} '
+                    f'vol_factor={vol_factor:.3f}'
+                )
 
     record_volume_traces(
         weighting_traces=weighting_traces,

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -89,7 +89,12 @@ def prune_swap_outcomes(self: Validator) -> None:
 
 def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
     """Replay the crown-time event stream, derive per-miner rewards
-    (pool × crown_share × sr³ × capacity × volume_factor), recycle the rest."""
+    (pool × crown_share × sr³ × capacity × volume_factor), recycle the rest.
+
+    Volume weighting is *per direction*: a miner earning crown on btc→tao is
+    compared only to btc→tao volume on the network, not to the total of both
+    directions. Otherwise heavy tao→btc flow from other miners would dilute
+    a btc→tao earner's vol_share even though they own that direction."""
     n_uids = self.metagraph.n.item()
     if n_uids == 0:
         return np.array([], dtype=np.float32), set()
@@ -107,6 +112,7 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
     hotkey_to_uid: Dict[str, int] = {self.metagraph.hotkeys[uid]: uid for uid in range(n_uids)}
 
     rewards = np.zeros(n_uids, dtype=np.float32)
+    unweighted_rewards = np.zeros(n_uids, dtype=np.float32)
     credibility_since = max(0, self.block - CREDIBILITY_WINDOW_BLOCKS)
     success_stats = self.state_store.get_success_rates_since(credibility_since)
     success_rates = {hk: success_rate(success_stats.get(hk)) for hk in rewardable_hotkeys}
@@ -119,6 +125,10 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
         bt.logging.warning(f'max_swap_amount read failed: {e}')
         max_swap_amount = 0
     collaterals: Dict[str, int] = {}
+    miner_volume_total: Dict[str, int] = {}
+    miner_crown_total: Dict[str, float] = {}
+    network_volume_total: int = 0
+    network_crown_total: float = 0.0
 
     for (from_chain, to_chain), pool in DIRECTION_POOLS.items():
         trace = DirectionTrace(pool=pool)
@@ -133,8 +143,17 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
             rewardable_hotkeys=rewardable_hotkeys,
             trace=trace,
         )
-        total = sum(crown_blocks.values())
-        if total == 0:
+        total_crown = sum(crown_blocks.values())
+        volumes_dir = self.state_store.get_volume_by_direction_since(window_start, from_chain, to_chain)
+        total_volume_dir = sum(volumes_dir.values())
+        for hk, v in volumes_dir.items():
+            miner_volume_total[hk] = miner_volume_total.get(hk, 0) + int(v)
+        network_volume_total += int(total_volume_dir)
+        for hk, blk in crown_blocks.items():
+            miner_crown_total[hk] = miner_crown_total.get(hk, 0.0) + blk
+        network_crown_total += total_crown
+
+        if total_crown == 0:
             continue  # empty bucket — pool recycles via the remainder below
 
         for hotkey, blocks in crown_blocks.items():
@@ -154,16 +173,22 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
                 closed_swaps=sum(success_stats.get(hotkey, (0, 0))),
                 ramp_target=CREDIBILITY_RAMP_OBSERVATIONS,
             )
-            share = blocks / total
-            rewards[uid] += pool * share * (success_rates[hotkey] ** SUCCESS_EXPONENT) * cap
+            crown_share_dir = blocks / total_crown
+            vol_dir = volumes_dir.get(hotkey, 0)
+            vol_factor = volume_factor(vol_dir, total_volume_dir, crown_share_dir)
+            base = pool * crown_share_dir * (success_rates[hotkey] ** SUCCESS_EXPONENT) * cap
+            unweighted_rewards[uid] += base
+            rewards[uid] += base * vol_factor
 
-    apply_volume_weighting(
-        self,
-        rewards=rewards,
-        hotkey_to_uid=hotkey_to_uid,
-        direction_traces=direction_traces,
+    record_volume_traces(
         weighting_traces=weighting_traces,
-        window_start=window_start,
+        hotkey_to_uid=hotkey_to_uid,
+        rewards=rewards,
+        unweighted_rewards=unweighted_rewards,
+        miner_volume_total=miner_volume_total,
+        miner_crown_total=miner_crown_total,
+        network_volume_total=network_volume_total,
+        network_crown_total=network_crown_total,
     )
 
     recycle_uid = RECYCLE_UID if RECYCLE_UID < n_uids else 0
@@ -209,40 +234,35 @@ def volume_factor(
     return (1.0 - alpha) + alpha * participation
 
 
-def apply_volume_weighting(
-    self: Validator,
+def record_volume_traces(
     *,
-    rewards: np.ndarray,
-    hotkey_to_uid: Dict[str, int],
-    direction_traces: Dict[Tuple[str, str], DirectionTrace],
     weighting_traces: Dict[str, WeightingTrace],
-    window_start: int,
+    hotkey_to_uid: Dict[str, int],
+    rewards: np.ndarray,
+    unweighted_rewards: np.ndarray,
+    miner_volume_total: Dict[str, int],
+    miner_crown_total: Dict[str, float],
+    network_volume_total: int,
+    network_crown_total: float,
 ) -> None:
-    """Multiply each crown earner's reward by their volume_factor."""
-    volumes = self.state_store.get_volume_since(window_start)
-    crown_per_hotkey: Dict[str, float] = {}
-    for trace in direction_traces.values():
-        for hk, blk in trace.crown_blocks.items():
-            crown_per_hotkey[hk] = crown_per_hotkey.get(hk, 0.0) + blk
-
-    total_crown = sum(crown_per_hotkey.values())
-    total_volume = sum(volumes.values())
-    if total_crown <= 0:
-        return
-
-    for hotkey, crown in crown_per_hotkey.items():
+    """Populate the per-miner volume rows of the scoring log. Volume gating is
+    already applied inline in ``calculate_miner_rewards``; this only records
+    aggregate counters and the effective per-miner multiplier
+    (weighted / unweighted) for human-readable diagnosis."""
+    for hotkey, wt in weighting_traces.items():
         uid = hotkey_to_uid.get(hotkey)
-        if uid is None or rewards[uid] <= 0:
+        if uid is None:
             continue
-        crown_share = crown / total_crown
-        vol = volumes.get(hotkey, 0)
-        factor = volume_factor(vol, total_volume, crown_share)
-        rewards[uid] *= factor
-        weighting_traces.setdefault(hotkey, WeightingTrace()).record_volume(
-            vol_rao=vol,
-            total_volume_rao=total_volume,
+        unweighted = float(unweighted_rewards[uid])
+        weighted = float(rewards[uid])
+        effective = (weighted / unweighted) if unweighted > 0 else 1.0
+        crown = miner_crown_total.get(hotkey, 0.0)
+        crown_share = (crown / network_crown_total) if network_crown_total > 0 else 0.0
+        wt.record_volume(
+            vol_rao=miner_volume_total.get(hotkey, 0),
+            total_volume_rao=network_volume_total,
             crown_share=crown_share,
-            factor=factor,
+            factor=effective,
         )
 
 

--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -386,6 +386,10 @@ class ValidatorStateStore:
         from_chain: str = '',
         to_chain: str = '',
     ) -> None:
+        # Direction is normalized to lowercase on write so the per-direction
+        # volume query is robust to upstream case drift. SQLite text
+        # comparisons are case-sensitive and DIRECTION_POOLS keys are
+        # lowercase.
         with self.lock:
             conn = self.require_connection()
             conn.execute(
@@ -400,8 +404,8 @@ class ValidatorStateStore:
                     1 if completed else 0,
                     resolved_block,
                     int(tao_amount or 0),
-                    from_chain or '',
-                    to_chain or '',
+                    (from_chain or '').lower(),
+                    (to_chain or '').lower(),
                 ),
             )
             conn.commit()
@@ -448,7 +452,10 @@ class ValidatorStateStore:
     def get_volume_by_direction_since(self, since_block: int, from_chain: str, to_chain: str) -> Dict[str, int]:
         """Per-miner volume (rao) restricted to one swap direction. Outcomes
         missing direction (pre-migration legacy rows) are excluded — they
-        contribute no volume credit, same as legacy rows with tao_amount=0."""
+        contribute no volume credit, same as legacy rows with tao_amount=0.
+
+        Lookup is lowercased to match the normalization applied in
+        ``insert_swap_outcome``."""
         with self.lock:
             conn = self.require_connection()
             rows = conn.execute(
@@ -461,7 +468,7 @@ class ValidatorStateStore:
                   AND to_chain = ?
                 GROUP BY miner_hotkey
                 """,
-                (since_block, from_chain, to_chain),
+                (since_block, (from_chain or '').lower(), (to_chain or '').lower()),
             ).fetchall()
         return {r['miner_hotkey']: int(r['total'] or 0) for r in rows}
 

--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -445,9 +445,7 @@ class ValidatorStateStore:
             ).fetchall()
         return {r['miner_hotkey']: int(r['total'] or 0) for r in rows}
 
-    def get_volume_by_direction_since(
-        self, since_block: int, from_chain: str, to_chain: str
-    ) -> Dict[str, int]:
+    def get_volume_by_direction_since(self, since_block: int, from_chain: str, to_chain: str) -> Dict[str, int]:
         """Per-miner volume (rao) restricted to one swap direction. Outcomes
         missing direction (pre-migration legacy rows) are excluded — they
         contribute no volume credit, same as legacy rows with tao_amount=0."""

--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -383,16 +383,26 @@ class ValidatorStateStore:
         completed: bool,
         resolved_block: int,
         tao_amount: int = 0,
+        from_chain: str = '',
+        to_chain: str = '',
     ) -> None:
         with self.lock:
             conn = self.require_connection()
             conn.execute(
                 """
                 INSERT OR REPLACE INTO swap_outcomes
-                    (swap_id, miner_hotkey, completed, resolved_block, tao_amount)
-                VALUES (?, ?, ?, ?, ?)
+                    (swap_id, miner_hotkey, completed, resolved_block, tao_amount, from_chain, to_chain)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
                 """,
-                (swap_id, miner_hotkey, 1 if completed else 0, resolved_block, int(tao_amount or 0)),
+                (
+                    swap_id,
+                    miner_hotkey,
+                    1 if completed else 0,
+                    resolved_block,
+                    int(tao_amount or 0),
+                    from_chain or '',
+                    to_chain or '',
+                ),
             )
             conn.commit()
 
@@ -416,7 +426,12 @@ class ValidatorStateStore:
 
     def get_volume_since(self, since_block: int) -> Dict[str, int]:
         """Sum ``tao_amount`` of completed swaps per miner (rao) since
-        ``since_block``. Timed-out swaps don't count toward volume."""
+        ``since_block``. Timed-out swaps don't count toward volume.
+
+        Aggregates across directions — kept for callers that don't care about
+        direction breakdown. Volume-weighted scoring uses
+        ``get_volume_by_direction_since`` so a miner serving one direction
+        isn't diluted by network volume on the other direction."""
         with self.lock:
             conn = self.require_connection()
             rows = conn.execute(
@@ -427,6 +442,28 @@ class ValidatorStateStore:
                 GROUP BY miner_hotkey
                 """,
                 (since_block,),
+            ).fetchall()
+        return {r['miner_hotkey']: int(r['total'] or 0) for r in rows}
+
+    def get_volume_by_direction_since(
+        self, since_block: int, from_chain: str, to_chain: str
+    ) -> Dict[str, int]:
+        """Per-miner volume (rao) restricted to one swap direction. Outcomes
+        missing direction (pre-migration legacy rows) are excluded — they
+        contribute no volume credit, same as legacy rows with tao_amount=0."""
+        with self.lock:
+            conn = self.require_connection()
+            rows = conn.execute(
+                """
+                SELECT miner_hotkey, SUM(tao_amount) AS total
+                FROM swap_outcomes
+                WHERE resolved_block >= ?
+                  AND completed = 1
+                  AND from_chain = ?
+                  AND to_chain = ?
+                GROUP BY miner_hotkey
+                """,
+                (since_block, from_chain, to_chain),
             ).fetchall()
         return {r['miner_hotkey']: int(r['total'] or 0) for r in rows}
 
@@ -521,7 +558,9 @@ class ValidatorStateStore:
                     miner_hotkey    TEXT NOT NULL,
                     completed       INTEGER NOT NULL,
                     resolved_block  INTEGER NOT NULL,
-                    tao_amount      INTEGER NOT NULL DEFAULT 0
+                    tao_amount      INTEGER NOT NULL DEFAULT 0,
+                    from_chain      TEXT NOT NULL DEFAULT '',
+                    to_chain        TEXT NOT NULL DEFAULT ''
                 );
                 CREATE INDEX IF NOT EXISTS idx_swap_outcomes_hotkey
                     ON swap_outcomes(miner_hotkey);
@@ -552,6 +591,8 @@ class ValidatorStateStore:
             for table, column, ddl in (
                 ('pending_confirms', 'from_tx_block', 'INTEGER NOT NULL DEFAULT 0'),
                 ('swap_outcomes', 'tao_amount', 'INTEGER NOT NULL DEFAULT 0'),
+                ('swap_outcomes', 'from_chain', "TEXT NOT NULL DEFAULT ''"),
+                ('swap_outcomes', 'to_chain', "TEXT NOT NULL DEFAULT ''"),
             ):
                 try:
                     conn.execute(f'ALTER TABLE {table} ADD COLUMN {column} {ddl}')

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -1337,6 +1337,8 @@ class TestVolumeWeighting:
         swap_id: int = 1,
         resolved_block: int = 9_500,
         completed: bool = True,
+        from_chain: str = 'tao',
+        to_chain: str = 'btc',
     ) -> None:
         v.state_store.insert_swap_outcome(
             swap_id=swap_id,
@@ -1344,6 +1346,8 @@ class TestVolumeWeighting:
             completed=completed,
             resolved_block=resolved_block,
             tao_amount=tao_amount,
+            from_chain=from_chain,
+            to_chain=to_chain,
         )
 
     def test_idle_network_no_penalty(self, tmp_path: Path):
@@ -1408,8 +1412,8 @@ class TestVolumeWeighting:
             ('hk_b', 'btc', 'tao', 100.0, 0),
         )
         conn.commit()
-        self.insert_volume(v, 'hk_a', tao_amount=100_000_000, swap_id=1)
-        self.insert_volume(v, 'hk_b', tao_amount=900_000_000, swap_id=2)
+        self.insert_volume(v, 'hk_a', tao_amount=100_000_000, swap_id=1, from_chain='btc', to_chain='tao')
+        self.insert_volume(v, 'hk_b', tao_amount=900_000_000, swap_id=2, from_chain='btc', to_chain='tao')
         rewards, _ = calculate_miner_rewards(v)
         # A: crown_share = 1.0, vol_share = 0.1, participation = 0.1 → factor = 0.55
         np.testing.assert_allclose(rewards[0], POOL_BTC_TAO * 0.55, atol=1e-6)
@@ -1434,10 +1438,14 @@ class TestVolumeWeighting:
         )
         conn.commit()
         # Window is (9400, 10000]. A busy block 9_500..9_620 (120 blocks within
-        # the window) so B holds crown 20% of window.
-        v.event_watcher.apply_event(9_500, 'SwapInitiated', {'swap_id': 1, 'miner': 'hk_a'})
-        v.event_watcher.apply_event(9_620, 'SwapCompleted', {'swap_id': 1, 'miner': 'hk_a', 'tao_amount': 200_000_000})
-        self.insert_volume(v, 'hk_b', tao_amount=800_000_000, swap_id=2)
+        # the window) so B holds crown 20% of window. We can't use a
+        # SwapCompleted event here because the direction lookup needs an
+        # active swap entry in the tracker — easier to just record the
+        # outcome and the busy delta directly.
+        v.event_watcher.apply_busy_delta(9_500, 'hk_a', +1)
+        v.event_watcher.apply_busy_delta(9_620, 'hk_a', -1)
+        self.insert_volume(v, 'hk_a', tao_amount=200_000_000, swap_id=1, from_chain='btc', to_chain='tao')
+        self.insert_volume(v, 'hk_b', tao_amount=800_000_000, swap_id=2, from_chain='btc', to_chain='tao')
         rewards, _ = calculate_miner_rewards(v)
         # Crown: A=480/600=0.8, B=120/600=0.2. Volume: A=0.2, B=0.8.
         # A participation = 0.2/0.8 = 0.25 → factor 0.625.
@@ -1466,16 +1474,43 @@ class TestVolumeWeighting:
         assert rewards[0] == 0.0
         v.state_store.close()
 
-    def test_volume_aggregates_across_directions(self, tmp_path: Path):
-        """tao_amount is the canonical TAO side regardless of swap direction —
-        get_volume_since sums across both directions per miner."""
+    def test_volume_split_per_direction(self, tmp_path: Path):
+        """Per-direction volume queries isolate each market. A miner with
+        volume in both directions shows up in both per-direction sums but
+        each query only returns that direction's slice. The aggregate
+        ``get_volume_since`` still sums both, kept for non-scoring callers."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
         v = make_validator(tmp_path, hotkeys, baseline_credibility=False)
         self.seed_tao_btc_crown(v, 'hk_a')
-        self.insert_volume(v, 'hk_a', tao_amount=300_000_000, swap_id=1)
-        self.insert_volume(v, 'hk_a', tao_amount=200_000_000, swap_id=2)
-        volumes = v.state_store.get_volume_since(0)
-        assert volumes == {'hk_a': 500_000_000}
+        self.insert_volume(v, 'hk_a', tao_amount=300_000_000, swap_id=1, from_chain='tao', to_chain='btc')
+        self.insert_volume(v, 'hk_a', tao_amount=200_000_000, swap_id=2, from_chain='btc', to_chain='tao')
+        assert v.state_store.get_volume_by_direction_since(0, 'tao', 'btc') == {'hk_a': 300_000_000}
+        assert v.state_store.get_volume_by_direction_since(0, 'btc', 'tao') == {'hk_a': 200_000_000}
+        assert v.state_store.get_volume_since(0) == {'hk_a': 500_000_000}
+        v.state_store.close()
+
+    def test_per_direction_volume_isolates_markets(self, tmp_path: Path):
+        """A holds 100% of btc→tao crown and 100% of btc→tao volume. B has
+        no crown but serves heavy tao→btc volume. A's reward must not be
+        penalized for sitting out the tao→btc market — its denominator is
+        btc→tao only."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a', 'hk_b'])
+        v = make_validator(tmp_path, hotkeys)
+        conn = v.state_store.require_connection()
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_a', 'btc', 'tao', 200.0, 0),
+        )
+        conn.commit()
+        # A serves all of btc→tao. B floods tao→btc but earns no crown there.
+        self.insert_volume(v, 'hk_a', tao_amount=100_000_000, swap_id=1, from_chain='btc', to_chain='tao')
+        self.insert_volume(v, 'hk_b', tao_amount=9_000_000_000, swap_id=2, from_chain='tao', to_chain='btc')
+        rewards, _ = calculate_miner_rewards(v)
+        # Old direction-blind logic: A vol_share = 0.011 of total network,
+        # crown_share = 1.0 → factor 0.5055 → reward ≈ POOL_BTC_TAO * 0.5055.
+        # New per-direction logic: A is sole btc→tao server, factor = 1.0.
+        np.testing.assert_allclose(rewards[0], POOL_BTC_TAO, atol=1e-6)
+        assert rewards[1] == 0.0
         v.state_store.close()
 
     def test_legacy_rows_with_zero_tao_amount_tolerated(self, tmp_path: Path):
@@ -1491,6 +1526,8 @@ class TestVolumeWeighting:
         conn.commit()
         volumes = v.state_store.get_volume_since(0)
         assert volumes == {'hk_a': 0}
+        # Direction is empty → excluded from per-direction sums.
+        assert v.state_store.get_volume_by_direction_since(0, 'tao', 'btc') == {}
         v.state_store.close()
 
 
@@ -1512,13 +1549,15 @@ class TestCapacityVolumeInteraction:
             ('hk_a', 'tao', 'btc', 0.00020, 0),
         )
         conn.commit()
-        # B serves some volume so A's vol_share = 0.
+        # B serves some volume in A's market (tao→btc) so A's vol_share = 0.
         v.state_store.insert_swap_outcome(
             swap_id=1,
             miner_hotkey='hk_b',
             completed=True,
             resolved_block=9_500,
             tao_amount=500_000_000,
+            from_chain='tao',
+            to_chain='btc',
         )
         rewards, _ = calculate_miner_rewards(v)
         # A: pool 0.5 × crown 1.0 × sr 1.0 × capacity 0.5 × volume_factor 0.5
@@ -1548,6 +1587,8 @@ class TestCapacityVolumeInteraction:
             completed=True,
             resolved_block=9_500,
             tao_amount=400_000_000,
+            from_chain='btc',
+            to_chain='tao',
         )
         rewards, _ = calculate_miner_rewards(v)
         np.testing.assert_allclose(rewards.sum(), 1.0, atol=1e-6)


### PR DESCRIPTION
## Summary

The validator's volume-weighted scoring used **total network volume across all directions** as the denominator, so a miner owning 100% of `btc→tao` crown and delivering 100% of `btc→tao` volume was penalized whenever `tao→btc` had heavy flow from other miners — even though they weren't competing in that market. Per-direction crown computation was already correct; only the volume side was collapsing both markets into one ratio.

Fix: compute `volume_factor` inline within the existing per-`(from_chain, to_chain)` loop in `calculate_miner_rewards`, comparing each miner only against the volume of the direction they earned crown in.

## End-to-end flow

1. **Storage** — `swap_outcomes` gets `from_chain` / `to_chain` columns (schema + ALTER migration). `insert_swap_outcome` accepts direction. New query `get_volume_by_direction_since(window_start, from, to)`. Legacy `get_volume_since` kept for non-scoring callers.
2. **Capture point** — `SwapCompleted` / `SwapTimedOut` events don't carry direction and the contract removes the on-chain `Swap` struct on the same call, so we can't `get_swap` it. But `swap_tracker.active[swap_id]` still holds the `Swap` (with `from_chain`/`to_chain`) until `resolve()` runs, which is *after* `insert_swap_outcome`. A new `_lookup_swap_direction(swap_id)` reads it there and threads it into the outcome insert. If the tracker doesn't know the swap (validator was down during init), it returns `('', '')` — credibility still recorded, volume credit safely zero.
3. **Scoring** — `apply_volume_weighting` (which collapsed all directions) is removed. Inside the per-direction loop, `volume_factor(vol_dir, total_volume_dir, crown_share_dir)` multiplies the per-direction reward contribution. The scoring trace's `WeightingTrace` now records the effective combined multiplier (`weighted / unweighted`) so the per-miner log line is unchanged in shape.

## Tests

- New `test_per_direction_volume_isolates_markets` asserts the fix: A owns btc→tao, B floods tao→btc, A's reward is no longer diluted.
- `test_volume_aggregates_across_directions` (which asserted the buggy behavior on the aggregate path) replaced with `test_volume_split_per_direction`, covering both `get_volume_by_direction_since` and the legacy aggregate `get_volume_since`.
- Existing scoring tests updated to pass direction to `insert_volume` / `insert_swap_outcome`.
- 107 / 107 scoring tests pass; 516 / 518 overall (2 pre-existing failures in `test_bitcoin_signing.py` from missing `embit` module — unrelated).

## Known limit

If a validator restarts between `SwapInitiated` and `SwapCompleted` and never had the swap in its tracker, that outcome lands with empty direction strings and contributes zero per-direction volume credit. Credibility is still recorded correctly. Persisting `(swap_id → direction)` across restarts is out of scope for this change.

## Test plan

- [ ] Validator restart: cycle a running validator and confirm `swap_outcomes.from_chain/to_chain` populate for new swaps.
- [ ] Run scoring round in a dev env with skewed direction volume; confirm scoring log's per-miner `vol_f` reflects per-direction comparison.
- [ ] Smoke `pytest tests/test_scoring_v1.py tests/test_event_watcher.py tests/test_state_store.py`.