### PR TITLE
feat: support paid/private Esplora endpoints via BTC_ESPLORA_URLS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,10 @@ BTC_NETWORK=mainnet
 BTC_RPC_URL=
 BTC_RPC_USER=
 BTC_RPC_PASS=
+# Esplora endpoints (lightweight mode + node-mode fallback), tried in order.
+# Optional — unset uses public blockstream.info then mempool.space.
+# Each entry is URL or URL|API_KEY (key sends Authorization: Bearer <key> to that endpoint).
+# BTC_ESPLORA_URLS=https://blockstream.info/api|your_token_here,https://mempool.space/api
 
 # ─── Bitcoin signing (users + miners) ──────────────────────
 # WIF private key. Required for miners in lightweight mode. Optional for

--- a/.env.example
+++ b/.env.example
@@ -31,8 +31,11 @@ BTC_RPC_USER=
 BTC_RPC_PASS=
 # Esplora endpoints (lightweight mode + node-mode fallback), tried in order.
 # Optional — unset uses public blockstream.info then mempool.space.
-# Each entry is URL or URL|API_KEY (key sends Authorization: Bearer <key> to that endpoint).
-# BTC_ESPLORA_URLS=https://blockstream.info/api|your_token_here,https://mempool.space/api
+# Each entry is URL or URL|API_KEY; keyed entries send the key via the header
+# named below. Default Authorization carries a "Bearer " prefix; any other
+# header name sends the raw key (e.g. Maestro uses "api-key").
+# BTC_ESPLORA_API_KEY_HEADER=api-key
+# BTC_ESPLORA_URLS=https://xbt-mainnet.gomaestro-api.org/v0/esplora|your_maestro_key,https://mempool.space/api
 
 # ─── Bitcoin signing (users + miners) ──────────────────────
 # WIF private key. Required for miners in lightweight mode. Optional for

--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -65,11 +65,13 @@ def to_mainnet_address(address: str) -> str:
     return address
 
 
-def parse_esplora_urls(raw: str) -> list[tuple[str, Optional[dict]]]:
+def parse_esplora_urls(raw: str, auth_header: str = 'Authorization') -> list[tuple[str, Optional[dict]]]:
     """Parse BTC_ESPLORA_URLS into (base_url, headers) pairs, tried in order.
 
-    Comma-separated; each entry is ``url`` or ``url|api_key``. A key sends
-    ``Authorization: Bearer <key>`` to that endpoint only — others stay anonymous.
+    Comma-separated; each entry is ``url`` or ``url|api_key``. A keyed entry
+    sends the key via ``auth_header`` to that endpoint only — others stay
+    anonymous. The default ``Authorization`` header carries a ``Bearer`` prefix;
+    any other header (e.g. Maestro's ``api-key``) sends the raw key.
     """
     bases = []
     for entry in raw.split(','):
@@ -78,7 +80,12 @@ def parse_esplora_urls(raw: str) -> list[tuple[str, Optional[dict]]]:
         if not url:
             continue
         key = key.strip()
-        bases.append((url, {'Authorization': f'Bearer {key}'} if key else None))
+        if not key:
+            bases.append((url, None))
+        elif auth_header.lower() == 'authorization':
+            bases.append((url, {auth_header: f'Bearer {key}'}))
+        else:
+            bases.append((url, {auth_header: key}))
     return bases
 
 
@@ -130,7 +137,10 @@ class BitcoinProvider(ChainProvider):
 
         # Optional operator-supplied Esplora endpoints (paid/private), tried
         # before the public defaults. Empty → public blockstream → mempool.
-        self.esplora_bases = parse_esplora_urls(os.environ.get('BTC_ESPLORA_URLS', ''))
+        self.esplora_bases = parse_esplora_urls(
+            os.environ.get('BTC_ESPLORA_URLS', ''),
+            os.environ.get('BTC_ESPLORA_API_KEY_HEADER', 'Authorization'),
+        )
 
     def _send_error(self, msg: str) -> None:
         self.last_send_error = msg

--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -364,55 +364,58 @@ class BitcoinProvider(ChainProvider):
             defaults = ('https://blockstream.info/api', 'https://mempool.space/api')
         return [(url, None) for url in defaults]
 
-    def should_failover(self, resp: requests.Response, base: str, path: str) -> bool:
-        """Log the response status and return True if we should try the next base.
+    def failover_reason(self, resp: requests.Response) -> Optional[str]:
+        """Reason to fall through to the next provider, or None to use this response.
 
-        Retries on rate limits (429), bad/expired keys (401/403), and server
-        errors (5xx) so a throttled or misconfigured endpoint falls through to a
-        free one instead of failing the call. 404 (not found) is authoritative
-        and silent; other 4xx are logged but returned to the caller.
+        Retries past rate limits (429), bad/expired keys (401/403), and server
+        errors (5xx). 404 (not found) is authoritative; other 4xx are returned.
         """
         code = resp.status_code
         if code in (401, 403):
-            bt.logging.warning(f'Esplora {base}{path} auth failed ({code}); trying next endpoint')
-            return True
+            return f'auth failed ({code})'
         if code == 429:
-            bt.logging.warning(f'Esplora {base}{path} rate-limited (429); trying next endpoint')
-            return True
+            return f'rate-limited ({code})'
         if code >= 500:
-            bt.logging.warning(f'Esplora {base}{path} server error ({code}); trying next endpoint')
-            return True
-        if code >= 400 and code != 404:
-            bt.logging.warning(f'Esplora {base}{path} client error ({code}): {resp.text[:200].strip()}')
-        return False
+            return f'server error ({code})'
+        return None
+
+    def btc_api_request(self, method: str, path: str, timeout: int, **kwargs) -> requests.Response:
+        """Try each Esplora provider in order, narrating every failover.
+
+        Logs read as a sequence — which provider was tried, the response, and
+        which provider is next — so a debugging session reads top-to-bottom.
+        """
+        bases = self.btc_api_bases()
+        last_err: Optional[Exception] = None
+        for i, (base, headers) in enumerate(bases):
+            pos = f'[{i + 1}/{len(bases)}]'
+            nxt = bases[i + 1][0] if i + 1 < len(bases) else None
+            tail = f'falling back to next provider: {nxt}' if nxt else 'no providers left, giving up'
+            try:
+                resp = self.http.request(method, f'{base}{path}', timeout=timeout, headers=headers, **kwargs)
+            except Exception as e:
+                last_err = e
+                bt.logging.warning(f'Esplora {pos} {base}{path} → request error: {e}; {tail}')
+                continue
+
+            reason = self.failover_reason(resp)
+            if reason:
+                last_err = requests.HTTPError(f'{base}{path}: {resp.status_code}', response=resp)
+                bt.logging.warning(f'Esplora {pos} {base}{path} → {reason}; {tail}')
+                continue
+
+            if resp.status_code >= 400 and resp.status_code != 404:
+                bt.logging.warning(f'Esplora {pos} {base}{path} → HTTP {resp.status_code}: {resp.text[:200].strip()}')
+            elif i > 0:
+                bt.logging.info(f'Esplora {pos} {base}{path} → {resp.status_code} (served after {i} fallback(s))')
+            return resp
+        raise last_err or RuntimeError('all BTC APIs failed')
 
     def btc_api_get(self, path: str, timeout: int = 15) -> requests.Response:
-        last_err: Optional[Exception] = None
-        for base, headers in self.btc_api_bases():
-            try:
-                resp = self.http.get(f'{base}{path}', timeout=timeout, headers=headers)
-                if self.should_failover(resp, base, path):
-                    last_err = requests.HTTPError(f'{base}{path}: {resp.status_code}', response=resp)
-                    continue
-                return resp
-            except Exception as e:
-                bt.logging.debug(f'Esplora {base}{path} request failed: {e}; trying next endpoint')
-                last_err = e
-        raise last_err or RuntimeError('all BTC APIs failed')
+        return self.btc_api_request('GET', path, timeout)
 
     def btc_api_post(self, path: str, data, timeout: int = 30) -> requests.Response:
-        last_err: Optional[Exception] = None
-        for base, headers in self.btc_api_bases():
-            try:
-                resp = self.http.post(f'{base}{path}', data=data, timeout=timeout, headers=headers)
-                if self.should_failover(resp, base, path):
-                    last_err = requests.HTTPError(f'{base}{path}: {resp.status_code}', response=resp)
-                    continue
-                return resp
-            except Exception as e:
-                bt.logging.debug(f'Esplora {base}{path} request failed: {e}; trying next endpoint')
-                last_err = e
-        raise last_err or RuntimeError('all BTC APIs failed')
+        return self.btc_api_request('POST', path, timeout, data=data)
 
     def tx_exists(self, txid: str) -> bool:
         try:

--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -65,6 +65,23 @@ def to_mainnet_address(address: str) -> str:
     return address
 
 
+def parse_esplora_urls(raw: str) -> list[tuple[str, Optional[dict]]]:
+    """Parse BTC_ESPLORA_URLS into (base_url, headers) pairs, tried in order.
+
+    Comma-separated; each entry is ``url`` or ``url|api_key``. A key sends
+    ``Authorization: Bearer <key>`` to that endpoint only — others stay anonymous.
+    """
+    bases = []
+    for entry in raw.split(','):
+        url, _, key = entry.strip().partition('|')
+        url = url.strip().rstrip('/')
+        if not url:
+            continue
+        key = key.strip()
+        bases.append((url, {'Authorization': f'Bearer {key}'} if key else None))
+    return bases
+
+
 class BitcoinProvider(ChainProvider):
     """Bitcoin chain provider. Supports two modes:
 
@@ -110,6 +127,10 @@ class BitcoinProvider(ChainProvider):
         # Scopes find_recent_outgoing reuse to this process — a fresh `alw swap`
         # run can't return a tx hash already consumed by an earlier swap.
         self.broadcasted_txids: set[str] = set()
+
+        # Optional operator-supplied Esplora endpoints (paid/private), tried
+        # before the public defaults. Empty → public blockstream → mempool.
+        self.esplora_bases = parse_esplora_urls(os.environ.get('BTC_ESPLORA_URLS', ''))
 
     def _send_error(self, msg: str) -> None:
         self.last_send_error = msg
@@ -329,23 +350,25 @@ class BitcoinProvider(ChainProvider):
             return int(round(result * BTC_TO_SAT))
         return self.api_get_balance(address)
 
-    def btc_api_bases(self) -> Tuple[str, ...]:
-        """Esplora-compatible bases tried in order; mempool.space is the fallback when blockstream is flaky."""
+    def btc_api_bases(self) -> list[tuple[str, Optional[dict]]]:
+        """Esplora (base_url, headers) pairs tried in order.
+
+        Defaults to public blockstream → mempool. Override with BTC_ESPLORA_URLS
+        (comma-separated ``url`` or ``url|api_key``) to use paid/private endpoints.
+        """
+        if self.esplora_bases:
+            return self.esplora_bases
         if self.network == 'testnet':
-            return (
-                'https://blockstream.info/testnet/api',
-                'https://mempool.space/testnet/api',
-            )
-        return (
-            'https://blockstream.info/api',
-            'https://mempool.space/api',
-        )
+            defaults = ('https://blockstream.info/testnet/api', 'https://mempool.space/testnet/api')
+        else:
+            defaults = ('https://blockstream.info/api', 'https://mempool.space/api')
+        return [(url, None) for url in defaults]
 
     def btc_api_get(self, path: str, timeout: int = 15) -> requests.Response:
         last_err: Optional[Exception] = None
-        for base in self.btc_api_bases():
+        for base, headers in self.btc_api_bases():
             try:
-                resp = self.http.get(f'{base}{path}', timeout=timeout)
+                resp = self.http.get(f'{base}{path}', timeout=timeout, headers=headers)
                 if resp.status_code >= 500:
                     last_err = requests.HTTPError(f'{base}{path}: {resp.status_code}', response=resp)
                     continue
@@ -356,9 +379,9 @@ class BitcoinProvider(ChainProvider):
 
     def btc_api_post(self, path: str, data, timeout: int = 30) -> requests.Response:
         last_err: Optional[Exception] = None
-        for base in self.btc_api_bases():
+        for base, headers in self.btc_api_bases():
             try:
-                resp = self.http.post(f'{base}{path}', data=data, timeout=timeout)
+                resp = self.http.post(f'{base}{path}', data=data, timeout=timeout, headers=headers)
                 if resp.status_code >= 500:
                     last_err = requests.HTTPError(f'{base}{path}: {resp.status_code}', response=resp)
                     continue

--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -364,16 +364,39 @@ class BitcoinProvider(ChainProvider):
             defaults = ('https://blockstream.info/api', 'https://mempool.space/api')
         return [(url, None) for url in defaults]
 
+    def should_failover(self, resp: requests.Response, base: str, path: str) -> bool:
+        """Log the response status and return True if we should try the next base.
+
+        Retries on rate limits (429), bad/expired keys (401/403), and server
+        errors (5xx) so a throttled or misconfigured endpoint falls through to a
+        free one instead of failing the call. 404 (not found) is authoritative
+        and silent; other 4xx are logged but returned to the caller.
+        """
+        code = resp.status_code
+        if code in (401, 403):
+            bt.logging.warning(f'Esplora {base}{path} auth failed ({code}); trying next endpoint')
+            return True
+        if code == 429:
+            bt.logging.warning(f'Esplora {base}{path} rate-limited (429); trying next endpoint')
+            return True
+        if code >= 500:
+            bt.logging.warning(f'Esplora {base}{path} server error ({code}); trying next endpoint')
+            return True
+        if code >= 400 and code != 404:
+            bt.logging.warning(f'Esplora {base}{path} client error ({code}): {resp.text[:200].strip()}')
+        return False
+
     def btc_api_get(self, path: str, timeout: int = 15) -> requests.Response:
         last_err: Optional[Exception] = None
         for base, headers in self.btc_api_bases():
             try:
                 resp = self.http.get(f'{base}{path}', timeout=timeout, headers=headers)
-                if resp.status_code >= 500:
+                if self.should_failover(resp, base, path):
                     last_err = requests.HTTPError(f'{base}{path}: {resp.status_code}', response=resp)
                     continue
                 return resp
             except Exception as e:
+                bt.logging.debug(f'Esplora {base}{path} request failed: {e}; trying next endpoint')
                 last_err = e
         raise last_err or RuntimeError('all BTC APIs failed')
 
@@ -382,11 +405,12 @@ class BitcoinProvider(ChainProvider):
         for base, headers in self.btc_api_bases():
             try:
                 resp = self.http.post(f'{base}{path}', data=data, timeout=timeout, headers=headers)
-                if resp.status_code >= 500:
+                if self.should_failover(resp, base, path):
                     last_err = requests.HTTPError(f'{base}{path}: {resp.status_code}', response=resp)
                     continue
                 return resp
             except Exception as e:
+                bt.logging.debug(f'Esplora {base}{path} request failed: {e}; trying next endpoint')
                 last_err = e
         raise last_err or RuntimeError('all BTC APIs failed')
 


### PR DESCRIPTION
## What

Lets validators (and lightweight users) point the Esplora client at paid/private endpoints with per-endpoint API keys, via one optional env var. Default behavior is unchanged.

## Why

The BTC Esplora client is hardcoded to public `blockstream.info` → `mempool.space`. Validators leaning on Esplora for verification (see #351) hit public rate limits with no way to use a paid plan or self-hosted instance, and no way to add endpoints for redundancy.

## How

One env var, comma-separated, each entry `URL` or `URL|API_KEY`:

```
BTC_ESPLORA_URLS=https://blockstream.info/api|YOUR_TOKEN,https://mempool.space/api
```

- Tried left-to-right — the **existing** fallback loop (5xx/exception → next base), now with N bases instead of 2.
- `|KEY` → `Authorization: Bearer <key>` on that endpoint only; keyless entries stay anonymous.
- Header attaches **per-request** in `btc_api_get/post`, so the key never rides on the shared session's bitcoind RPC POSTs.
- **Unset → byte-for-byte current behavior** (public blockstream → mempool, network-aware testnet bases).

## Changes

- `parse_esplora_urls()` — pure helper turning the env string into `(url, headers)` pairs.
- `btc_api_bases()` returns `(url, headers)` pairs instead of bare strings; defaults preserved.
- `btc_api_get/post` unpack the pair and pass `headers`.
- `.env.example` documents the var with a Blockstream+mempool example.

Note: assumes Blockstream's token works as a static Bearer. If your plan requires the key→short-lived-token exchange, that's a small follow-up hooking the same env var. (To validate separately.)

## Test

- `ruff format` / `ruff check`: clean
- `pytest tests/test_bitcoin_signing.py`: 33 passed
- Parser + default/override bases verified manually (empty→[], whitespace/trailing-slash/empty-entry handling, per-endpoint key mapping)
