### PR TITLE
Lower validator forward step block estimate to 5

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -86,7 +86,7 @@ CHALLENGE_WINDOW_BLOCKS = 8
 # whose finalize window opens past the original reservation deadline.
 # Default sized for mainnet; testnet validators with slower/jankier RPC can
 # override via VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE env var.
-DEFAULT_VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE = 10
+DEFAULT_VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE = 5
 VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE = max(
     1,
     int(


### PR DESCRIPTION
Lowers `DEFAULT_VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE` from 10 to 5.

This is the conservative upper bound on subtensor blocks elapsed per validator forward step, used to size extension targets (`EXTEND_THRESHOLD_BLOCKS = estimate + CHALLENGE_WINDOW_BLOCKS`). Still env-overridable via `VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE`.