### PR TITLE
Apply credibility ramp linearly, not cubed

### DIFF
--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -1,7 +1,8 @@
 """Crown-time scoring pipeline.
 
-Reward per miner is ``pool × crown_share × sr³ × capacity × volume_factor``;
-any shortfall recycles to ``RECYCLE_UID``. Entry point is
+Reward per miner is ``pool × crown_share × sr³ × ramp × capacity ×
+volume_factor``; the credibility ramp is applied linearly, not cubed. Any
+shortfall recycles to ``RECYCLE_UID``. Entry point is
 ``score_and_reward_miners(validator)``.
 """
 
@@ -89,7 +90,7 @@ def prune_swap_outcomes(self: Validator) -> None:
 
 def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
     """Replay the crown-time event stream, derive per-miner rewards
-    (pool × crown_share × sr³ × capacity × volume_factor), recycle the rest.
+    (pool × crown_share × sr³ × ramp × capacity × volume_factor), recycle the rest.
 
     Volume weighting is *per direction*: a miner earning crown on btc→tao is
     compared only to btc→tao volume on the network, not to the total of both
@@ -116,6 +117,7 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
     credibility_since = max(0, self.block - CREDIBILITY_WINDOW_BLOCKS)
     success_stats = self.state_store.get_success_rates_since(credibility_since)
     success_rates = {hk: success_rate(success_stats.get(hk)) for hk in rewardable_hotkeys}
+    credibility_ramps = {hk: credibility_ramp(success_stats.get(hk)) for hk in rewardable_hotkeys}
 
     direction_traces: Dict[Tuple[str, str], DirectionTrace] = {}
     weighting_traces: Dict[str, WeightingTrace] = {}
@@ -182,7 +184,9 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
             vol_dir = volumes_dir.get(hotkey, 0)
             vol_share_dir = (vol_dir / total_volume_dir) if total_volume_dir > 0 else 0.0
             vol_factor = volume_factor(vol_dir, total_volume_dir, crown_share_dir)
-            base = pool * crown_share_dir * (success_rates[hotkey] ** SUCCESS_EXPONENT) * cap
+            base = (
+                pool * crown_share_dir * (success_rates[hotkey] ** SUCCESS_EXPONENT) * credibility_ramps[hotkey] * cap
+            )
             unweighted_rewards[uid] += base
             rewards[uid] += base * vol_factor
             if vol_factor < 1.0:
@@ -279,13 +283,19 @@ def record_volume_traces(
 
 
 def success_rate(stats: Optional[Tuple[int, int]]) -> float:
-    """Raw success rate × linear ramp to full credibility at
-    CREDIBILITY_RAMP_OBSERVATIONS closed swaps. Zero observations → 0."""
+    """Raw completed / closed ratio. Cubed in the reward. Zero observations → 0."""
     if not stats or stats == (0, 0):
         return 0.0
     completed, timed_out = stats
-    total = completed + timed_out
-    return (completed / total) * min(1.0, total / CREDIBILITY_RAMP_OBSERVATIONS)
+    return completed / (completed + timed_out)
+
+
+def credibility_ramp(stats: Optional[Tuple[int, int]]) -> float:
+    """Linear ramp to full credibility at CREDIBILITY_RAMP_OBSERVATIONS closed
+    swaps. Applied linearly to the reward, not cubed. Zero observations → 0."""
+    if not stats or stats == (0, 0):
+        return 0.0
+    return min(1.0, sum(stats) / CREDIBILITY_RAMP_OBSERVATIONS)
 
 
 # ─── Crown-time replay ───────────────────────────────────────────────────

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -10,6 +10,7 @@ from allways.constants import RECYCLE_UID, SUCCESS_EXPONENT
 from allways.validator.event_watcher import ActiveEvent, ContractEventWatcher
 from allways.validator.scoring import (
     calculate_miner_rewards,
+    credibility_ramp,
     crown_holders_at_instant,
     replay_crown_time_window,
     score_and_reward_miners,
@@ -126,28 +127,32 @@ class TestSuccessRateHelper:
     def test_zero_total_is_pessimistic(self):
         assert success_rate((0, 0)) == 0.0
 
-    def test_ratio_at_full_ramp_is_raw_rate(self):
-        """At >= CREDIBILITY_RAMP_OBSERVATIONS closed swaps the ramp is a no-op."""
-        assert success_rate((8, 2)) == 0.8
-
-    def test_ramp_scales_below_threshold(self):
-        """1 closed swap → ramp 0.1; raw rate is 1.0 → sr = 0.1."""
-        assert success_rate((1, 0)) == 0.1
-
-    def test_ramp_half_at_half_observations(self):
-        """5/5 completed → ramp 0.5, raw 1.0 → sr = 0.5."""
-        assert success_rate((5, 0)) == 0.5
-
-    def test_timed_out_swaps_advance_ramp(self):
-        """A timeout still counts as a closed observation — moves the ramp,
-        drops the raw rate."""
-        # 5 completed + 5 timed_out: total=10, ramp=1.0, raw=0.5 → 0.5
-        assert success_rate((5, 5)) == 0.5
-
-    def test_full_ramp_with_mixed_outcomes(self):
-        """At the ramp cap, sr equals the raw success rate exactly."""
+    def test_raw_ratio_ignores_ramp(self):
+        """success_rate is the raw completed/closed ratio — no ramp folded in."""
+        assert success_rate((1, 0)) == 1.0
+        assert success_rate((5, 0)) == 1.0
         assert success_rate((8, 2)) == 0.8
         assert success_rate((90, 10)) == 0.9
+
+    def test_timed_out_swaps_drop_raw_rate(self):
+        # 5 completed + 5 timed_out → raw = 0.5
+        assert success_rate((5, 5)) == 0.5
+
+
+class TestCredibilityRampHelper:
+    def test_none_is_zero(self):
+        assert credibility_ramp(None) == 0.0
+        assert credibility_ramp((0, 0)) == 0.0
+
+    def test_scales_linearly_below_threshold(self):
+        """1 closed swap → ramp 0.1; 5 closed → 0.5. Counts timeouts too."""
+        assert credibility_ramp((1, 0)) == 0.1
+        assert credibility_ramp((5, 0)) == 0.5
+        assert credibility_ramp((2, 3)) == 0.5
+
+    def test_caps_at_full_ramp(self):
+        assert credibility_ramp((10, 0)) == 1.0
+        assert credibility_ramp((90, 10)) == 1.0
 
 
 class TestCrownHoldersHelper:
@@ -1622,18 +1627,18 @@ class TestCredibilityRamp:
         assert rewards[0] == 0.0
         v.state_store.close()
 
-    def test_one_completed_earns_thousandth(self, tmp_path: Path):
-        """1/1 completed → sr = 0.1, cubed = 0.001 → effectively zero."""
+    def test_one_completed_earns_tenth(self, tmp_path: Path):
+        """1/1 completed → raw 1.0, ramp 0.1 → 1.0³ × 0.1 = 0.1 of the pool."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
         v = make_validator(tmp_path, hotkeys, baseline_credibility=False)
         self.seed_btc_tao_crown(v, 'hk_a')
         v.state_store.insert_swap_outcome(swap_id=1, miner_hotkey='hk_a', completed=True, resolved_block=100)
         rewards, _ = calculate_miner_rewards(v)
-        np.testing.assert_allclose(rewards[0], POOL_BTC_TAO * 0.1**3, atol=1e-6)
+        np.testing.assert_allclose(rewards[0], POOL_BTC_TAO * 0.1, atol=1e-6)
         v.state_store.close()
 
-    def test_five_completed_quarter_of_pool(self, tmp_path: Path):
-        """5/5 completed → sr = 0.5, cubed = 0.125 → 1/8 of the direction pool."""
+    def test_five_completed_half_of_pool(self, tmp_path: Path):
+        """5/5 completed → raw 1.0, ramp 0.5 → 1.0³ × 0.5 = half the pool."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
         v = make_validator(tmp_path, hotkeys, baseline_credibility=False)
         self.seed_btc_tao_crown(v, 'hk_a')
@@ -1642,7 +1647,7 @@ class TestCredibilityRamp:
                 swap_id=i + 1, miner_hotkey='hk_a', completed=True, resolved_block=100 + i
             )
         rewards, _ = calculate_miner_rewards(v)
-        np.testing.assert_allclose(rewards[0], POOL_BTC_TAO * 0.5**3, atol=1e-6)
+        np.testing.assert_allclose(rewards[0], POOL_BTC_TAO * 0.5, atol=1e-6)
         v.state_store.close()
 
     def test_full_ramp_at_threshold(self, tmp_path: Path):
@@ -1659,7 +1664,7 @@ class TestCredibilityRamp:
         v.state_store.close()
 
     def test_timeouts_advance_ramp_but_hurt_raw_rate(self, tmp_path: Path):
-        """5 completed + 5 timed_out → ramp = 1.0, raw = 0.5 → cubed = 0.125."""
+        """5 completed + 5 timed_out → ramp = 1.0, raw = 0.5 → 0.5³ × 1.0 = 0.125."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
         v = make_validator(tmp_path, hotkeys, baseline_credibility=False)
         self.seed_btc_tao_crown(v, 'hk_a')
@@ -1683,9 +1688,9 @@ class TestCredibilityRamp:
         v.state_store.insert_swap_outcome(swap_id=1, miner_hotkey='hk_a', completed=True, resolved_block=100)
         rewards, _ = calculate_miner_rewards(v)
         recycle_uid = RECYCLE_UID if RECYCLE_UID < len(rewards) else 0
-        # tao→btc pool fully recycles (no holder), btc→tao gives A 0.001;
-        # the remaining 0.499 + 0.5 = 0.999 recycles.
-        np.testing.assert_allclose(rewards[recycle_uid], 1.0 - POOL_BTC_TAO * 0.1**3, atol=1e-6)
+        # tao→btc pool fully recycles (no holder), btc→tao gives A 0.05;
+        # the remaining 0.45 + 0.5 = 0.95 recycles.
+        np.testing.assert_allclose(rewards[recycle_uid], 1.0 - POOL_BTC_TAO * 0.1, atol=1e-6)
         np.testing.assert_allclose(rewards.sum(), 1.0, atol=1e-6)
         v.state_store.close()
 


### PR DESCRIPTION
## Problem

The credibility ramp was being cubed along with the raw success rate in the emission formula. `success_rate()` returned the *product* `raw_rate × ramp`, and `calculate_miner_rewards` then raised that whole value to `SUCCESS_EXPONENT` (3) — so the effective term was `raw_rate³ × ramp³` instead of `raw_rate³ × ramp`.

Impact (perfect raw rate, 6/10 closed swaps → ramp 0.6):
- Before: `(1.0 × 0.6)³ = 0.216` → 21.6% of pool
- After: `1.0³ × 0.6 = 0.6` → 60% of pool

Worst for new miners: `1/1` completed earned `0.1³ = 0.001` (≈0) instead of `0.1`. The intended linear on-ramp had become a near-cliff.

## Fix

- `success_rate()` now returns the raw `completed / closed` ratio (cubed in the reward).
- New `credibility_ramp()` returns the linear ramp multiplier, applied **once, uncubed**.
- Reward: `pool × crown_share × raw_rate³ × ramp × capacity × volume_factor`.

## Tests

- Split `TestSuccessRateHelper` into raw-rate and ramp helper tests.
- Updated end-to-end ramp expectations (`1/1 → 0.1×pool`, `5/5 → 0.5×pool`, recycle remainder). Full-ramp and timeout cases are numerically unchanged.
- Full suite: 528 passed.