### PR TITLE
Support BTC testnet4 in lightweight provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ CONTRACT_ADDRESS=
 # ─── Chain: Bitcoin (env_prefix=BTC) ───────────────────────
 # node = local Bitcoin node | lightweight = Blockstream API (no node required)
 BTC_MODE=lightweight
-# mainnet | testnet (auto-detected from RPC URL in node mode)
+# mainnet | testnet | testnet4 (auto-detected from RPC URL in node mode)
 BTC_NETWORK=mainnet
 # Required for BTC_MODE=node only
 BTC_RPC_URL=

--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -110,7 +110,9 @@ class BitcoinProvider(ChainProvider):
             self.rpc_user = os.environ.get('BTC_RPC_USER', '')
             self.rpc_pass = os.environ.get('BTC_RPC_PASS', '')
             if not self.network:
-                if any(p in self.rpc_url for p in [':18332', ':18443', 'testnet']):
+                if ':48332' in self.rpc_url:
+                    self.network = 'testnet4'
+                elif any(p in self.rpc_url for p in [':18332', ':18443', 'testnet']):
                     self.network = 'testnet'
                 else:
                     self.network = 'mainnet'
@@ -398,7 +400,10 @@ class BitcoinProvider(ChainProvider):
         """
         if self.esplora_bases:
             return self.esplora_bases
-        if self.network == 'testnet':
+        if self.network == 'testnet4':
+            # Blockstream serves no testnet4 API; mempool.space is the only public Esplora.
+            defaults = ('https://mempool.space/testnet4/api',)
+        elif self.network == 'testnet':
             defaults = ('https://blockstream.info/testnet/api', 'https://mempool.space/testnet/api')
         else:
             defaults = ('https://blockstream.info/api', 'https://mempool.space/api')
@@ -620,7 +625,7 @@ class BitcoinProvider(ChainProvider):
             return None
 
         try:
-            network = NETWORKS['test'] if self.network == 'testnet' else NETWORKS['main']
+            network = NETWORKS['test'] if self.network in ('testnet', 'testnet4') else NETWORKS['main']
             privkey = EmbitPrivateKey.from_wif(wif)
             pubkey = privkey.get_public_key()
             segwit_script = p2wpkh(pubkey)


### PR DESCRIPTION
The testnet system now runs on Bitcoin **testnet4** for BTC swaps. The lightweight provider only knew `testnet` (testnet3) and pointed Esplora at Blockstream — which serves no testnet4 API.

## Changes
- `btc_api_bases`: `BTC_NETWORK=testnet4` selects `https://mempool.space/testnet4/api` (the only public testnet4 Esplora; Blockstream returns an SPA shell, not API data).
- embit signing recognizes `testnet4` as a test network (`NETWORKS['test']` — testnet3/testnet4 share address + WIF params).
- Node-mode auto-detect maps the testnet4 RPC port `:48332` to `testnet4`.
- `.env.example` documents `testnet4` as a valid `BTC_NETWORK` value.

Legacy `BTC_NETWORK=testnet` is untouched — still resolves to the testnet3 Blockstream/mempool bases, so existing `.env` files keep working.

## Verification
- `https://mempool.space/testnet4/api/blocks/tip/height` → live (tip 135865).
- `https://blockstream.info/testnet4/api/...` → SPA HTML, no API (confirmed dropped from defaults).
- `ruff check` / `ruff format` clean.

Docs PRs follow in allways-ui (agents page) and allways-docs-ui.