### PR TITLE
logging: clearer chain-provider startup summary and backend tags

### DIFF
--- a/allways/chain_providers/__init__.py
+++ b/allways/chain_providers/__init__.py
@@ -42,4 +42,9 @@ def create_chain_providers(check: bool = False, require_send: bool = True, **kwa
                 raise RuntimeError(f'{cls.__name__} failed startup check: {e}') from e
             bt.logging.warning(f'{cls.__name__} not available: {e}')
 
+    if check and providers:
+        bt.logging.info('Chain providers ready:')
+        for chain_id, provider in providers.items():
+            bt.logging.info(f'  {chain_id} → {provider.describe()}')
+
     return providers

--- a/allways/chain_providers/base.py
+++ b/allways/chain_providers/base.py
@@ -34,6 +34,10 @@ class ChainProvider(ABC):
     @abstractmethod
     def get_chain(self) -> ChainDefinition: ...
 
+    def describe(self) -> str:
+        """One-line summary of the backend/API this provider talks to, for startup logs."""
+        return self.get_chain().name
+
     @abstractmethod
     def check_connection(self, **kwargs) -> None:
         """Verify the chain provider can reach its backend (RPC node, subtensor, etc).

--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -17,6 +17,9 @@ ADDR_TYPE_P2SH_P2WPKH = 'p2wpkh-p2sh'
 ADDR_TYPE_P2WPKH = 'p2wpkh'
 ADDR_TYPE_P2TR = 'p2tr'
 
+LOG_RPC = '[BTC-RPC]'
+LOG_ESPLORA = '[Esplora]'
+
 
 def detect_address_type(address: str) -> str:
     """Detect Bitcoin address type from its prefix."""
@@ -149,6 +152,11 @@ class BitcoinProvider(ChainProvider):
     def get_chain(self) -> ChainDefinition:
         return CHAIN_BTC
 
+    def describe(self) -> str:
+        if self.mode == 'lightweight':
+            return f'Esplora API ({self.network})'
+        return f'Core RPC {self.rpc_url} (primary) + Esplora (fallback)'
+
     def check_connection(self, require_send: bool = True) -> None:
         if self.mode == 'lightweight':
             if require_send and not os.environ.get('BTC_PRIVATE_KEY'):
@@ -161,7 +169,7 @@ class BitcoinProvider(ChainProvider):
                 resp = self.btc_api_get('/blocks/tip/height', timeout=10)
                 resp.raise_for_status()
                 tip = int(resp.text.strip())
-                bt.logging.success(f'BTC lightweight mode: network={self.network}, Esplora tip={tip}')
+                bt.logging.success(f'{LOG_ESPLORA} connected: network={self.network}, tip={tip}')
             except Exception as e:
                 raise ConnectionError(f'Cannot reach Esplora API: {e}') from e
             return
@@ -169,7 +177,7 @@ class BitcoinProvider(ChainProvider):
         result = self.rpc_call('getblockchaininfo', [])
         if result is None:
             raise ConnectionError(f'Cannot reach Bitcoin RPC at {self.rpc_url}')
-        bt.logging.success(f'BTC RPC connected: chain={result.get("chain")}, blocks={result.get("blocks")}')
+        bt.logging.success(f'{LOG_RPC} connected: chain={result.get("chain")}, blocks={result.get("blocks")}')
 
     def rpc_call(self, method: str, params: Optional[list] = None) -> Optional[dict]:
         """Generic JSON-RPC helper for BTC Core."""
@@ -187,11 +195,11 @@ class BitcoinProvider(ChainProvider):
             response.raise_for_status()
             result = response.json()
             if result.get('error'):
-                bt.logging.error(f'BTC RPC error ({method}): {result["error"]}')
+                bt.logging.error(f'{LOG_RPC} error ({method}): {result["error"]}')
                 return None
             return result.get('result')
         except Exception as e:
-            bt.logging.error(f'BTC RPC call failed ({method}): {e}')
+            bt.logging.error(f'{LOG_RPC} call failed ({method}): {e}')
             return None
 
     def fetch_matching_tx(
@@ -213,9 +221,9 @@ class BitcoinProvider(ChainProvider):
 
         result = self.rpc_verify_transaction(tx_hash, expected_recipient, expected_amount)
         if result is not None:
-            bt.logging.debug(f'BTC verify: served by local RPC (tx {tx_hash[:16]}...)')
+            bt.logging.debug(f'{LOG_RPC} served tx {tx_hash[:16]}...')
             return result
-        bt.logging.debug(f'BTC verify: local RPC had no match, falling back to Esplora (tx {tx_hash[:16]}...)')
+        bt.logging.debug(f'{LOG_RPC} no match for tx {tx_hash[:16]}..., falling back to Esplora')
         return self.api_verify_transaction(tx_hash, expected_recipient, expected_amount)
 
     def rpc_verify_transaction(
@@ -257,7 +265,7 @@ class BitcoinProvider(ChainProvider):
                 )
 
         bt.logging.warning(
-            f'BTC RPC: tx {tx_hash[:16]}... has no vout paying {expected_recipient} >= {expected_amount} sat'
+            f'{LOG_RPC} tx {tx_hash[:16]}... has no vout paying {expected_recipient} >= {expected_amount} sat'
         )
         return None
 
@@ -303,7 +311,7 @@ class BitcoinProvider(ChainProvider):
         try:
             resp = self.btc_api_get(f'/tx/{tx_hash}', timeout=15)
             if resp.status_code == 404:
-                bt.logging.debug(f'BTC Esplora: tx {tx_hash[:16]}... not found (404)')
+                bt.logging.debug(f'{LOG_ESPLORA} tx {tx_hash[:16]}... not found (404)')
                 return None
             resp.raise_for_status()
             data = resp.json()
@@ -329,7 +337,7 @@ class BitcoinProvider(ChainProvider):
                         if status_resp.ok and status_resp.json().get('in_best_chain') is False:
                             return None  # block was reorged out
                 except Exception as e:
-                    bt.logging.debug(f'canonical-chain check skipped for {tx_hash}: {e}')
+                    bt.logging.debug(f'{LOG_ESPLORA} canonical-chain check skipped for {tx_hash}: {e}')
 
             for vout in data.get('vout', []):
                 addr = vout.get('scriptpubkey_address', '')
@@ -351,7 +359,7 @@ class BitcoinProvider(ChainProvider):
                     )
 
             bt.logging.warning(
-                f'BTC Esplora: tx {tx_hash[:16]}... has no vout paying {expected_recipient} >= {expected_amount} sat'
+                f'{LOG_ESPLORA} tx {tx_hash[:16]}... has no vout paying {expected_recipient} >= {expected_amount} sat'
             )
             return None
         except (requests.ConnectionError, requests.Timeout) as e:

--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -1,6 +1,7 @@
 import os
 import time
 from typing import Any, Optional, Tuple
+from urllib.parse import urlparse
 
 import base58
 import bech32
@@ -153,9 +154,10 @@ class BitcoinProvider(ChainProvider):
         return CHAIN_BTC
 
     def describe(self) -> str:
+        hosts = ', '.join(urlparse(base).netloc or base for base, _ in self.btc_api_bases())
         if self.mode == 'lightweight':
-            return f'Esplora API ({self.network})'
-        return f'Core RPC {self.rpc_url} (primary) + Esplora (fallback)'
+            return f'Esplora API ({self.network}): {hosts}'
+        return f'Core RPC {self.rpc_url} (primary) + Esplora fallback: {hosts}'
 
     def check_connection(self, require_send: bool = True) -> None:
         if self.mode == 'lightweight':

--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -93,6 +93,13 @@ def parse_esplora_urls(raw: str, auth_header: str = 'Authorization') -> list[tup
     return bases
 
 
+def esplora_tag(base: str) -> str:
+    """Short, log-friendly host label for an Esplora endpoint (e.g. 'blockstream', 'gomaestro-api')."""
+    host = (urlparse(base).netloc or base).split(':')[0].removeprefix('www.')
+    parts = host.split('.')
+    return parts[-2] if len(parts) >= 2 else host
+
+
 class BitcoinProvider(ChainProvider):
     """Bitcoin chain provider. Supports two modes:
 
@@ -439,25 +446,26 @@ class BitcoinProvider(ChainProvider):
         last_err: Optional[Exception] = None
         for i, (base, headers) in enumerate(bases):
             pos = f'[{i + 1}/{len(bases)}]'
-            nxt = bases[i + 1][0] if i + 1 < len(bases) else None
-            tail = f'falling back to next provider: {nxt}' if nxt else 'no providers left, giving up'
+            tag = esplora_tag(base)
+            nxt = esplora_tag(bases[i + 1][0]) if i + 1 < len(bases) else None
+            tail = f'falling back to: {nxt}' if nxt else 'no providers left, giving up'
             try:
                 resp = self.http.request(method, f'{base}{path}', timeout=timeout, headers=headers, **kwargs)
             except Exception as e:
                 last_err = e
-                bt.logging.warning(f'Esplora {pos} {base}{path} → request error: {e}; {tail}')
+                bt.logging.warning(f'Esplora {pos} {tag}{path} → request error: {e}; {tail}')
                 continue
 
             reason = self.failover_reason(resp)
             if reason:
                 last_err = requests.HTTPError(f'{base}{path}: {resp.status_code}', response=resp)
-                bt.logging.warning(f'Esplora {pos} {base}{path} → {reason}; {tail}')
+                bt.logging.warning(f'Esplora {pos} {tag}{path} → {reason}; {tail}')
                 continue
 
             if resp.status_code >= 400 and resp.status_code != 404:
-                bt.logging.warning(f'Esplora {pos} {base}{path} → HTTP {resp.status_code}: {resp.text[:200].strip()}')
+                bt.logging.warning(f'Esplora {pos} {tag}{path} → HTTP {resp.status_code}: {resp.text[:200].strip()}')
             elif i > 0:
-                bt.logging.info(f'Esplora {pos} {base}{path} → {resp.status_code} (served after {i} fallback(s))')
+                bt.logging.info(f'Esplora {pos} {tag}{path} → {resp.status_code} (served after {i} fallback(s))')
             return resp
         raise last_err or RuntimeError('all BTC APIs failed')
 

--- a/allways/chain_providers/subtensor.py
+++ b/allways/chain_providers/subtensor.py
@@ -8,6 +8,8 @@ from bittensor.utils import is_valid_ss58_address, ss58_encode
 from allways.chain_providers.base import ChainProvider, ProviderUnreachableError, TransactionInfo
 from allways.chains import CHAIN_TAO, ChainDefinition
 
+LOG_SUB = '[Subtensor]'
+
 
 class SubtensorProvider(ChainProvider):
     """TAO chain provider using bt.Subtensor and substrate-interface.
@@ -30,10 +32,13 @@ class SubtensorProvider(ChainProvider):
     def get_chain(self) -> ChainDefinition:
         return CHAIN_TAO
 
+    def describe(self) -> str:
+        return f'Subtensor {self.subtensor.chain_endpoint}'
+
     def check_connection(self, **kwargs) -> None:
         try:
             block = self.subtensor.get_current_block()
-            bt.logging.success(f'Subtensor connected: block={block}')
+            bt.logging.success(f'{LOG_SUB} connected: block={block}')
         except Exception as e:
             raise ConnectionError(f'Cannot reach Subtensor: {e}') from e
 
@@ -222,10 +227,10 @@ class SubtensorProvider(ChainProvider):
 
             if tx_hash_seen:
                 bt.logging.warning(
-                    f'TAO scan: tx {tx_hash[:16]}... found but no transfer pays {expected_recipient} >= {expected_amount} rao'
+                    f'{LOG_SUB} scan: tx {tx_hash[:16]}... found but no transfer pays {expected_recipient} >= {expected_amount} rao'
                 )
             else:
-                bt.logging.debug(f'TAO scan: tx {tx_hash[:16]}... not found in scan window')
+                bt.logging.debug(f'{LOG_SUB} scan: tx {tx_hash[:16]}... not found in scan window')
             return None
         except ProviderUnreachableError:
             raise


### PR DESCRIPTION
## What

Make validator/miner chain-provider logging legible: a one-time startup summary of which API each provider talks to, and consistent backend tags on the RPC/verify path so it's clear who served a call.

## Why

Today the backend in use is scattered across ad-hoc inline prefixes (`BTC RPC ...`, `BTC Esplora: ...`, `TAO scan: ...`) and there's no single "here's the lineup" line at load. Hard to tell at a glance which API a node is using or which Esplora host served a given lookup.

## Changes

- **Startup summary** (`create_chain_providers`, on `check=True`): logs each provider and its backend once, e.g.
  ```
  Chain providers ready:
    btc → Core RPC http://localhost:8332 (primary) + Esplora fallback: blockstream.info, mempool.space
    tao → Subtensor wss://entrypoint-finney…:443
  ```
  Driven by a new `describe()` on `ChainProvider` (default = chain name; overridden by BTC/TAO).
- **Backend tags** on the verify + RPC-call path: `[BTC-RPC]`, `[Esplora]`, `[Subtensor]` (module constants, defined once).
- **Short host tags** in Esplora failover narration — full URLs replaced with a compact registrable label so repeated lines don't pollute:
  ```
  Esplora [1/2] gomaestro-api/tx/9f3a…0f1a → rate-limited (429); falling back to: blockstream
  Esplora [2/2] blockstream/tx/9f3a…0f1a → 200 (served after 1 fallback(s))
  ```

## Scope

Limited to the transaction-verification / RPC-call path — the "which API served this" story. Send/sign/address/fee log lines are intentionally untouched. No behavior changes; logging strings only. Full base URL is still preserved inside the raised `HTTPError` for deep debugging.

## Test

`ruff format` + `ruff check` pass; package compiles. No tests assert on the changed log strings.
