### PR TITLE
logging: tag serving Esplora host on success, not just failover

### DIFF
--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -471,6 +471,8 @@ class BitcoinProvider(ChainProvider):
                 bt.logging.warning(f'Esplora {pos} {tag}{path} → HTTP {resp.status_code}: {resp.text[:200].strip()}')
             elif i > 0:
                 bt.logging.info(f'Esplora {pos} {tag}{path} → {resp.status_code} (served after {i} fallback(s))')
+            else:
+                bt.logging.debug(f'Esplora {pos} {tag}{path} → {resp.status_code}')
             return resp
         raise last_err or RuntimeError('all BTC APIs failed')
 


### PR DESCRIPTION
## What

Adds one debug line in the Esplora request chokepoint (`btc_api_request`) so the **serving host is logged on the normal first-provider success**, not only on failover/error.

Before #364's narration, a healthy validator hitting its primary Esplora backend logged nothing — you couldn't confirm *which* backend was actually serving without waiting for a failover. This makes the active provider visible on the success path too.

## Change

```python
elif i > 0:
    bt.logging.info(... served after {i} fallback(s))
else:
    bt.logging.debug(f'Esplora {pos} {tag}{path} → {resp.status_code}')   # new
```

- Single additive branch, no behavior change.
- Logged at **debug** so it's visible on validators run with `--logging.debug` (where you actually want this confirmation) without spamming info-level deployments on every tip-height poll.
- Covers all critical reads, since swap verification, `tx_exists`, `find_recent_outgoing`, balance, and broadcast all route through `btc_api_request`.

Failover (`warning`) and fallback-served (`info`) lines are unchanged.