### PR TITLE
bump pyproject.toml to 1.0.4

### DIFF
--- a/allways/__init__.py
+++ b/allways/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '1.0.3'
+__version__ = '1.0.4'
 version_split = __version__.split('.')
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "allways"
-version = "1.0.3"
+version = "1.0.4"
 description = "Allways - Universal Transaction Layer: Trustless cross-chain swaps on Bittensor Subnet 7"
 license = "MIT"
 requires-python = ">=3.10,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "allways"
-version = "1.0.3"
+version = "1.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "base58" },


### PR DESCRIPTION
Release version bump to v1.0.4.

Updates `__version__`, `pyproject.toml`, and `uv.lock` from 1.0.3 → 1.0.4.