### PR TITLE
feat: per-miner success rate in view rates and swap now

### DIFF
--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -117,7 +117,7 @@ def fetch_miner_reliability(window_days: int = RELIABILITY_WINDOW_DAYS, use_cach
         resolved = _parse_iso(s.get('resolvedAt')) or _parse_iso(s.get('updatedAt'))
         if resolved is None or resolved < cutoff:
             continue
-        direction = f"{s.get('sourceChain')}->{s.get('destChain')}"
+        direction = f'{s.get("sourceChain")}->{s.get("destChain")}'
         comp, tot = stats.setdefault(hk, {}).get(direction, (0, 0))
         stats[hk][direction] = (comp + (status == 'COMPLETED'), tot + 1)
 

--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -4,7 +4,6 @@ import sys
 import tempfile
 import time
 from dataclasses import asdict, dataclass
-from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -37,37 +36,26 @@ console = Console()
 SECONDS_PER_BLOCK = 12
 
 # --- Miner reliability (swap success rate) -------------------------------
-# The CLI reads miner state from chain/contract, but per-miner success rate is
-# not on-chain. `view rates` and `swap now` fetch resolved-swap history from
-# this API and aggregate it. Override with ALLWAYS_API_URL for testnet or a
+# Per-miner success rate is not on-chain. `view rates` and `swap now` pull a
+# pre-aggregated per-direction completed/total map from the allways API and
+# color-code it. Override the host with ALLWAYS_API_URL for testnet or a
 # self-hosted indexer.
 DEFAULT_API_URL = 'https://api.all-ways.io'
-RELIABILITY_CACHE_TTL = 600  # seconds — stats move slowly; avoid re-paging every call
-RELIABILITY_WINDOW_DAYS = 30  # matches the subnet's 30-day credibility window
+RELIABILITY_CACHE_TTL = 600  # seconds — stats move slowly; avoid refetching every call
 
 
 def _api_url() -> str:
     return os.environ.get('ALLWAYS_API_URL', DEFAULT_API_URL).rstrip('/')
 
 
-def _parse_iso(ts: Optional[str]) -> Optional[datetime]:
-    """Parse an ISO-8601 timestamp (tolerating a trailing 'Z'); None on failure."""
-    if not ts:
-        return None
-    try:
-        return datetime.fromisoformat(ts.replace('Z', '+00:00'))
-    except (ValueError, AttributeError):
-        return None
-
-
-def fetch_miner_reliability(window_days: int = RELIABILITY_WINDOW_DAYS, use_cache: bool = True) -> Optional[dict]:
+def fetch_miner_reliability(use_cache: bool = True) -> Optional[dict]:
     """Per-miner, per-direction swap success counts from the allways API.
 
-    Returns ``{hotkey: {'btc->tao': (completed, total), ...}}`` over the last
-    ``window_days`` — counting only resolved swaps (COMPLETED + TIMED_OUT), the
-    same basis the subnet's success_rate uses. Returns ``None`` if the API is
-    unreachable: callers must degrade gracefully, since `view rates` and
-    `swap now` have to work whether or not the indexer is up.
+    Returns ``{hotkey: {'btc->tao': (completed, total), ...}}`` from
+    ``/miners/reliability`` — resolved swaps only (COMPLETED + TIMED_OUT) over
+    the API's credibility window. Returns ``None`` if the API is unreachable:
+    callers must degrade gracefully, since `view rates` and `swap now` have to
+    work whether or not the indexer is up.
     """
     cache_file = ALLWAYS_DIR / 'miner_reliability_cache.json'
     api_url = _api_url()
@@ -75,51 +63,32 @@ def fetch_miner_reliability(window_days: int = RELIABILITY_WINDOW_DAYS, use_cach
         try:
             cached = json.loads(cache_file.read_text())
             fresh = time.time() - cached.get('fetched_at', 0) < RELIABILITY_CACHE_TTL
-            # A cache from a different API host or window must not be reused.
-            same = cached.get('api_url') == api_url and cached.get('window_days') == window_days
-            if fresh and same:
+            # A cache from a different API host must not be reused.
+            if fresh and cached.get('api_url') == api_url:
                 return {hk: {d: tuple(v) for d, v in dirs.items()} for hk, dirs in cached['stats'].items()}
         except (json.JSONDecodeError, KeyError, OSError):
             pass  # stale/corrupt cache — fall through and refetch
 
-    cutoff = datetime.now(timezone.utc) - timedelta(days=window_days)
     # The API rejects unknown user agents; identify ourselves explicitly.
     headers = {'User-Agent': f'allways-cli/{__import__("allways").__version__}'}
-    swaps: list = []
     try:
-        for offset in range(0, 100_000, 50):
-            resp = requests.get(
-                f'{api_url}/swaps',
-                params={'limit': 50, 'offset': offset},
-                headers=headers,
-                timeout=10,
-            )
-            resp.raise_for_status()
-            page = resp.json()
-            # A JSON error object (dict) instead of a list must not be iterated.
-            if not isinstance(page, list) or not page:
-                break
-            swaps.extend(page)
-            # Swaps are newest-first; once the oldest on a page predates the
-            # window, every later page does too — stop paging.
-            oldest = _parse_iso(page[-1].get('createdAt'))
-            if oldest is not None and oldest < cutoff:
-                break
+        resp = requests.get(f'{api_url}/miners/reliability', headers=headers, timeout=10)
+        resp.raise_for_status()
+        rows = resp.json()
     except (requests.RequestException, ValueError):
         return None
+    # A JSON error object (dict) instead of a list means no usable data.
+    if not isinstance(rows, list):
+        return {}
 
     stats: dict = {}
-    for s in swaps:
-        hk = s.get('minerHotkey')
-        status = s.get('status')
-        if not hk or status not in ('COMPLETED', 'TIMED_OUT'):
+    for r in rows:
+        hk = r.get('minerHotkey')
+        src = r.get('sourceChain')
+        dst = r.get('destChain')
+        if not hk or not src or not dst:
             continue
-        resolved = _parse_iso(s.get('resolvedAt')) or _parse_iso(s.get('updatedAt'))
-        if resolved is None or resolved < cutoff:
-            continue
-        direction = f'{s.get("sourceChain")}->{s.get("destChain")}'
-        comp, tot = stats.setdefault(hk, {}).get(direction, (0, 0))
-        stats[hk][direction] = (comp + (status == 'COMPLETED'), tot + 1)
+        stats.setdefault(hk, {})[f'{src}->{dst}'] = (int(r.get('completed') or 0), int(r.get('total') or 0))
 
     try:
         ALLWAYS_DIR.mkdir(parents=True, exist_ok=True)
@@ -128,7 +97,6 @@ def fetch_miner_reliability(window_days: int = RELIABILITY_WINDOW_DAYS, use_cach
                 {
                     'fetched_at': int(time.time()),
                     'api_url': api_url,
-                    'window_days': window_days,
                     'stats': {hk: {d: list(v) for d, v in dirs.items()} for hk, dirs in stats.items()},
                 }
             )

--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -2,13 +2,17 @@ import json
 import os
 import sys
 import tempfile
+import time
 from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional, Tuple
 
 import bittensor as bt
 import click
+import requests
 from rich.console import Console
+from rich.text import Text
 
 from allways.chain_providers.base import ProviderUnreachableError
 from allways.classes import MinerPair, Swap, SwapStatus
@@ -31,6 +35,123 @@ PENDING_SWAP_FILE = ALLWAYS_DIR / 'pending_swap.json'
 console = Console()
 
 SECONDS_PER_BLOCK = 12
+
+# --- Miner reliability (swap success rate) -------------------------------
+# The CLI reads miner state from chain/contract, but per-miner success rate is
+# not on-chain. `view rates` and `swap now` fetch resolved-swap history from
+# this API and aggregate it. Override with ALLWAYS_API_URL for testnet or a
+# self-hosted indexer.
+DEFAULT_API_URL = 'https://api.all-ways.io'
+RELIABILITY_CACHE_TTL = 600  # seconds — stats move slowly; avoid re-paging every call
+RELIABILITY_WINDOW_DAYS = 30  # matches the subnet's 30-day credibility window
+
+
+def _api_url() -> str:
+    return os.environ.get('ALLWAYS_API_URL', DEFAULT_API_URL).rstrip('/')
+
+
+def _parse_iso(ts: Optional[str]) -> Optional[datetime]:
+    """Parse an ISO-8601 timestamp (tolerating a trailing 'Z'); None on failure."""
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace('Z', '+00:00'))
+    except (ValueError, AttributeError):
+        return None
+
+
+def fetch_miner_reliability(window_days: int = RELIABILITY_WINDOW_DAYS, use_cache: bool = True) -> Optional[dict]:
+    """Per-miner, per-direction swap success counts from the allways API.
+
+    Returns ``{hotkey: {'btc->tao': (completed, total), ...}}`` over the last
+    ``window_days`` — counting only resolved swaps (COMPLETED + TIMED_OUT), the
+    same basis the subnet's success_rate uses. Returns ``None`` if the API is
+    unreachable: callers must degrade gracefully, since `view rates` and
+    `swap now` have to work whether or not the indexer is up.
+    """
+    cache_file = ALLWAYS_DIR / 'miner_reliability_cache.json'
+    api_url = _api_url()
+    if use_cache and cache_file.exists():
+        try:
+            cached = json.loads(cache_file.read_text())
+            fresh = time.time() - cached.get('fetched_at', 0) < RELIABILITY_CACHE_TTL
+            # A cache from a different API host or window must not be reused.
+            same = cached.get('api_url') == api_url and cached.get('window_days') == window_days
+            if fresh and same:
+                return {hk: {d: tuple(v) for d, v in dirs.items()} for hk, dirs in cached['stats'].items()}
+        except (json.JSONDecodeError, KeyError, OSError):
+            pass  # stale/corrupt cache — fall through and refetch
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=window_days)
+    # The API rejects unknown user agents; identify ourselves explicitly.
+    headers = {'User-Agent': f'allways-cli/{__import__("allways").__version__}'}
+    swaps: list = []
+    try:
+        for offset in range(0, 100_000, 50):
+            resp = requests.get(
+                f'{api_url}/swaps',
+                params={'limit': 50, 'offset': offset},
+                headers=headers,
+                timeout=10,
+            )
+            resp.raise_for_status()
+            page = resp.json()
+            # A JSON error object (dict) instead of a list must not be iterated.
+            if not isinstance(page, list) or not page:
+                break
+            swaps.extend(page)
+            # Swaps are newest-first; once the oldest on a page predates the
+            # window, every later page does too — stop paging.
+            oldest = _parse_iso(page[-1].get('createdAt'))
+            if oldest is not None and oldest < cutoff:
+                break
+    except (requests.RequestException, ValueError):
+        return None
+
+    stats: dict = {}
+    for s in swaps:
+        hk = s.get('minerHotkey')
+        status = s.get('status')
+        if not hk or status not in ('COMPLETED', 'TIMED_OUT'):
+            continue
+        resolved = _parse_iso(s.get('resolvedAt')) or _parse_iso(s.get('updatedAt'))
+        if resolved is None or resolved < cutoff:
+            continue
+        direction = f"{s.get('sourceChain')}->{s.get('destChain')}"
+        comp, tot = stats.setdefault(hk, {}).get(direction, (0, 0))
+        stats[hk][direction] = (comp + (status == 'COMPLETED'), tot + 1)
+
+    try:
+        ALLWAYS_DIR.mkdir(parents=True, exist_ok=True)
+        cache_file.write_text(
+            json.dumps(
+                {
+                    'fetched_at': int(time.time()),
+                    'api_url': api_url,
+                    'window_days': window_days,
+                    'stats': {hk: {d: list(v) for d, v in dirs.items()} for hk, dirs in stats.items()},
+                }
+            )
+        )
+    except OSError:
+        pass  # cache write is best-effort
+    return stats
+
+
+def reliability_text(hotkey: str, src: str, dst: str, reliability: Optional[dict]) -> Text:
+    """Colored ``completed/total`` for one swap direction.
+
+    Green ≥90%, yellow ≥50%, red below; dim ``—`` when reliability is
+    unavailable or the miner has no resolved swap in that direction.
+    """
+    if reliability is None:
+        return Text('—', style='dim')
+    comp, tot = reliability.get(hotkey, {}).get(f'{src}->{dst}', (0, 0))
+    if tot == 0:
+        return Text('—', style='dim')
+    pct = comp / tot
+    style = 'green' if pct >= 0.9 else 'yellow' if pct >= 0.5 else 'red'
+    return Text(f'{comp}/{tot}', style=style)
 
 
 def blocks_to_minutes_str(blocks: int) -> str:

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -21,6 +21,7 @@ from allways.cli.swap_commands.helpers import (
     clear_pending_swap,
     console,
     dashboard_url,
+    fetch_miner_reliability,
     find_matching_miners,
     from_rao,
     get_cli_context,
@@ -29,6 +30,7 @@ from allways.cli.swap_commands.helpers import (
     loading,
     mark_pending_swap_tx_sent,
     probe_pending_reservation,
+    reliability_text,
     resolve_source_tx_block,
     save_pending_swap,
     sign_or_prompt_external,
@@ -770,17 +772,35 @@ def swap_now_command(
     canon_is_reverse = from_chain != canon_from
     available_miners.sort(key=lambda x: x[0].rate, reverse=not canon_is_reverse)
 
+    # Per-miner success rate for this direction (None if the API is down).
+    with loading('Checking miner reliability...'):
+        reliability = fetch_miner_reliability()
+
     # Show miners table
     table = Table(title='Available Miners', show_header=True)
     table.add_column('#', style='dim')
     table.add_column('UID', style='cyan')
     table.add_column('Rate (TAO)', style='green')
+    table.add_column('Reliability', no_wrap=True)
     table.add_column('Collateral (TAO)', style='yellow')
 
     for idx, (pair, collateral) in enumerate(available_miners, 1):
-        table.add_row(str(idx), str(pair.uid), f'{pair.rate:g}', f'{from_rao(collateral):.4f}')
+        table.add_row(
+            str(idx),
+            str(pair.uid),
+            f'{pair.rate:g}',
+            reliability_text(pair.hotkey, from_chain, to_chain, reliability),
+            f'{from_rao(collateral):.4f}',
+        )
 
     console.print(table)
+    if reliability is None:
+        console.print('[dim]Reliability unavailable — swap-history API unreachable.[/dim]')
+    else:
+        console.print(
+            f'[dim]Reliability = {from_chain.upper()}→{to_chain.upper()} swaps completed/resolved '
+            'over the last 30 days; green ≥90%, yellow ≥50%, red <50%.[/dim]'
+        )
 
     # Step 3: Select miner (default to best rate)
     best_pair = available_miners[0][0]

--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -19,6 +19,7 @@ from allways.cli.swap_commands.helpers import (
     clear_pending_swap,
     console,
     dashboard_url,
+    fetch_miner_reliability,
     from_rao,
     get_cli_context,
     hydrate_pending_swap,
@@ -26,6 +27,7 @@ from allways.cli.swap_commands.helpers import (
     loading,
     probe_pending_reservation,
     read_miner_commitments,
+    reliability_text,
 )
 from allways.constants import (
     CHALLENGE_WINDOW_BLOCKS,
@@ -39,6 +41,23 @@ from allways.contract_client import ContractError
 
 def _dashboard_url() -> str:
     return dashboard_url()
+
+
+def _reliability_cell(hotkey: str, src: str, dst: str, reliability: dict | None) -> Text:
+    """Combined two-direction success cell for one `view rates` row.
+
+    ``S→D c/t · D→S c/t`` — each side colored by `reliability_text`; the
+    whole cell is a dim ``—`` when reliability is unavailable.
+    """
+    if reliability is None:
+        return Text('—', style='dim')
+    cell = Text()
+    cell.append(f'{src.upper()[0]}→{dst.upper()[0]} ', style='dim')
+    cell.append_text(reliability_text(hotkey, src, dst, reliability))
+    cell.append('  ·  ', style='dim')
+    cell.append(f'{dst.upper()[0]}→{src.upper()[0]} ', style='dim')
+    cell.append_text(reliability_text(hotkey, dst, src, reliability))
+    return cell
 
 
 @click.group('view', cls=StyledGroup)
@@ -349,7 +368,11 @@ def view_rates(
       TAO→BTC N  reads:  N TAO → 1 BTC
 
     Capacity (TAO) is the miner's posted collateral — the hard cap on the
-    TAO leg of any single swap.[/dim]
+    TAO leg of any single swap.
+
+    Reliability shows completed/resolved swaps per direction over the last
+    30 days (green ≥90%, yellow ≥50%, red below), from the swap-history
+    API — '—' if that API is unreachable.[/dim]
 
     [dim]Examples:
         $ alw view rates
@@ -385,6 +408,10 @@ def view_rates(
         except ContractError:
             min_swap_rao = 0
             max_swap_rao = 0
+
+        # Per-miner success rate — fetched from the swap-history API and
+        # aggregated. None if the API is unreachable; the table still renders.
+        reliability = fetch_miner_reliability()
 
     if pair:
         parts = pair.lower().split('-')
@@ -450,6 +477,7 @@ def view_rates(
         table.add_column('UID', style='cyan')
         table.add_column(f'{src_up}→{dst_up}', style='green')
         table.add_column(f'{dst_up}→{src_up}', style='green')
+        table.add_column('Reliability', no_wrap=True)
         table.add_column('Capacity (TAO)', style='yellow')
         table.add_column(f'{src_up} Addr', style='dim')
         table.add_column(f'{dst_up} Addr', style='dim')
@@ -478,6 +506,7 @@ def view_rates(
                 str(p.uid),
                 fwd,
                 rev,
+                _reliability_cell(p.hotkey, src, dst, reliability),
                 f'{from_rao(collateral):.4f}',
                 _trunc(p.from_address),
                 _trunc(p.to_address),
@@ -530,6 +559,14 @@ def view_rates(
     shown = len(pairs_with_collateral)
     if shown != total_before_filter:
         console.print(f'[dim]Showing {shown} of {total_before_filter} miners after filters.[/dim]')
+    if reliability is None:
+        console.print('[yellow]Reliability unavailable — swap-history API unreachable.[/yellow]')
+    else:
+        console.print(
+            '[dim]Reliability = completed/resolved swaps per direction; '
+            'green ≥90%, yellow ≥50%, red <50%. A small sample (e.g. 1/1) is '
+            'noisy — prefer miners with a track record.[/dim]'
+        )
     console.print(f'[dim]Sorted by: {sort_by}[/dim]')
     if not full:
         console.print('[dim]Use --full to show untruncated addresses.[/dim]')

--- a/tests/test_miner_reliability.py
+++ b/tests/test_miner_reliability.py
@@ -1,12 +1,11 @@
 """fetch_miner_reliability / reliability_text: per-miner swap success aggregation.
 
-Pins the aggregation behind the Reliability column in `alw view rates` and the
-`swap now` miner picker: per-direction completed/total over a 30-day window,
-unresolved statuses excluded, a graceful None when the API is down, and the
-page-shape guard against a JSON error object served instead of a list.
+Pins the Reliability column in `alw view rates` and the `swap now` miner picker:
+per-direction completed/total reshaped from the API's pre-aggregated
+`/miners/reliability` response, a graceful None when the API is down, and the
+shape guard against a JSON error object served instead of a list.
 """
 
-from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import requests
@@ -15,72 +14,46 @@ from allways.cli.swap_commands import helpers
 from allways.cli.swap_commands.helpers import fetch_miner_reliability, reliability_text
 
 
-def _iso(dt: datetime) -> str:
-    return dt.strftime('%Y-%m-%dT%H:%M:%S.000Z')
+def _row(miner: str, src: str, dst: str, completed: int, total: int) -> dict:
+    return {'minerHotkey': miner, 'sourceChain': src, 'destChain': dst, 'completed': completed, 'total': total}
 
 
-def _swap(miner: str, src: str, dst: str, status: str, age_days: float = 1) -> dict:
-    ts = _iso(datetime.now(timezone.utc) - timedelta(days=age_days))
-    return {
-        'minerHotkey': miner,
-        'sourceChain': src,
-        'destChain': dst,
-        'status': status,
-        'createdAt': ts,
-        'resolvedAt': ts,
-    }
-
-
-def _mock_get(pages: list):
-    """Fake requests.get that serves `pages` by offset, then empty pages."""
+def _mock_get(payload):
+    """Fake requests.get serving a fixed JSON payload from /miners/reliability."""
 
     def _get(url, params=None, headers=None, timeout=None):
-        idx = (params or {}).get('offset', 0) // 50
         resp = MagicMock()
-        resp.json.return_value = pages[idx] if idx < len(pages) else []
+        resp.json.return_value = payload
         resp.raise_for_status.return_value = None
         return resp
 
     return _get
 
 
-def test_aggregates_per_miner_per_direction(tmp_path, monkeypatch):
+def test_reshapes_per_miner_per_direction(tmp_path, monkeypatch):
     monkeypatch.setattr(helpers, 'ALLWAYS_DIR', tmp_path)
-    page = [
-        _swap('5A', 'tao', 'btc', 'COMPLETED'),
-        _swap('5A', 'tao', 'btc', 'COMPLETED'),
-        _swap('5A', 'tao', 'btc', 'TIMED_OUT'),
-        _swap('5A', 'btc', 'tao', 'COMPLETED'),
-        _swap('5B', 'tao', 'btc', 'TIMED_OUT'),
+    payload = [
+        _row('5A', 'tao', 'btc', 2, 3),
+        _row('5A', 'btc', 'tao', 1, 1),
+        _row('5B', 'tao', 'btc', 0, 1),
     ]
-    with patch.object(helpers.requests, 'get', _mock_get([page])):
+    with patch.object(helpers.requests, 'get', _mock_get(payload)):
         stats = fetch_miner_reliability(use_cache=False)
     assert stats['5A']['tao->btc'] == (2, 3)
     assert stats['5A']['btc->tao'] == (1, 1)
     assert stats['5B']['tao->btc'] == (0, 1)
 
 
-def test_excludes_swaps_outside_window(tmp_path, monkeypatch):
+def test_skips_rows_missing_hotkey_or_direction(tmp_path, monkeypatch):
     monkeypatch.setattr(helpers, 'ALLWAYS_DIR', tmp_path)
-    page = [
-        _swap('5A', 'tao', 'btc', 'COMPLETED', age_days=2),
-        _swap('5A', 'tao', 'btc', 'TIMED_OUT', age_days=40),  # older than the 30d window
+    payload = [
+        _row('5A', 'tao', 'btc', 1, 1),
+        {'minerHotkey': None, 'sourceChain': 'tao', 'destChain': 'btc', 'completed': 1, 'total': 1},
+        {'minerHotkey': '5B', 'sourceChain': 'tao', 'completed': 1, 'total': 1},  # no destChain
     ]
-    with patch.object(helpers.requests, 'get', _mock_get([page])):
-        stats = fetch_miner_reliability(window_days=30, use_cache=False)
-    assert stats['5A']['tao->btc'] == (1, 1)  # the 40-day-old swap is dropped
-
-
-def test_ignores_unresolved_statuses(tmp_path, monkeypatch):
-    monkeypatch.setattr(helpers, 'ALLWAYS_DIR', tmp_path)
-    page = [
-        _swap('5A', 'tao', 'btc', 'COMPLETED'),
-        _swap('5A', 'tao', 'btc', 'ACTIVE'),
-        _swap('5A', 'tao', 'btc', 'REFUNDED'),
-    ]
-    with patch.object(helpers.requests, 'get', _mock_get([page])):
+    with patch.object(helpers.requests, 'get', _mock_get(payload)):
         stats = fetch_miner_reliability(use_cache=False)
-    assert stats['5A']['tao->btc'] == (1, 1)  # only COMPLETED/TIMED_OUT count
+    assert stats == {'5A': {'tao->btc': (1, 1)}}
 
 
 def test_returns_none_when_api_unreachable(tmp_path, monkeypatch):
@@ -96,14 +69,7 @@ def test_returns_none_when_api_unreachable(tmp_path, monkeypatch):
 def test_json_error_object_does_not_crash(tmp_path, monkeypatch):
     """A dict error body instead of a list must be treated as no data, not iterated."""
     monkeypatch.setattr(helpers, 'ALLWAYS_DIR', tmp_path)
-
-    def _get(url, params=None, headers=None, timeout=None):
-        resp = MagicMock()
-        resp.json.return_value = {'error': 'Not Found', 'statusCode': 404}
-        resp.raise_for_status.return_value = None
-        return resp
-
-    with patch.object(helpers.requests, 'get', _get):
+    with patch.object(helpers.requests, 'get', _mock_get({'error': 'Not Found', 'statusCode': 404})):
         assert fetch_miner_reliability(use_cache=False) == {}
 
 

--- a/tests/test_miner_reliability.py
+++ b/tests/test_miner_reliability.py
@@ -1,0 +1,124 @@
+"""fetch_miner_reliability / reliability_text: per-miner swap success aggregation.
+
+Pins the aggregation behind the Reliability column in `alw view rates` and the
+`swap now` miner picker: per-direction completed/total over a 30-day window,
+unresolved statuses excluded, a graceful None when the API is down, and the
+page-shape guard against a JSON error object served instead of a list.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from allways.cli.swap_commands import helpers
+from allways.cli.swap_commands.helpers import fetch_miner_reliability, reliability_text
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime('%Y-%m-%dT%H:%M:%S.000Z')
+
+
+def _swap(miner: str, src: str, dst: str, status: str, age_days: float = 1) -> dict:
+    ts = _iso(datetime.now(timezone.utc) - timedelta(days=age_days))
+    return {
+        'minerHotkey': miner,
+        'sourceChain': src,
+        'destChain': dst,
+        'status': status,
+        'createdAt': ts,
+        'resolvedAt': ts,
+    }
+
+
+def _mock_get(pages: list):
+    """Fake requests.get that serves `pages` by offset, then empty pages."""
+
+    def _get(url, params=None, headers=None, timeout=None):
+        idx = (params or {}).get('offset', 0) // 50
+        resp = MagicMock()
+        resp.json.return_value = pages[idx] if idx < len(pages) else []
+        resp.raise_for_status.return_value = None
+        return resp
+
+    return _get
+
+
+def test_aggregates_per_miner_per_direction(tmp_path, monkeypatch):
+    monkeypatch.setattr(helpers, 'ALLWAYS_DIR', tmp_path)
+    page = [
+        _swap('5A', 'tao', 'btc', 'COMPLETED'),
+        _swap('5A', 'tao', 'btc', 'COMPLETED'),
+        _swap('5A', 'tao', 'btc', 'TIMED_OUT'),
+        _swap('5A', 'btc', 'tao', 'COMPLETED'),
+        _swap('5B', 'tao', 'btc', 'TIMED_OUT'),
+    ]
+    with patch.object(helpers.requests, 'get', _mock_get([page])):
+        stats = fetch_miner_reliability(use_cache=False)
+    assert stats['5A']['tao->btc'] == (2, 3)
+    assert stats['5A']['btc->tao'] == (1, 1)
+    assert stats['5B']['tao->btc'] == (0, 1)
+
+
+def test_excludes_swaps_outside_window(tmp_path, monkeypatch):
+    monkeypatch.setattr(helpers, 'ALLWAYS_DIR', tmp_path)
+    page = [
+        _swap('5A', 'tao', 'btc', 'COMPLETED', age_days=2),
+        _swap('5A', 'tao', 'btc', 'TIMED_OUT', age_days=40),  # older than the 30d window
+    ]
+    with patch.object(helpers.requests, 'get', _mock_get([page])):
+        stats = fetch_miner_reliability(window_days=30, use_cache=False)
+    assert stats['5A']['tao->btc'] == (1, 1)  # the 40-day-old swap is dropped
+
+
+def test_ignores_unresolved_statuses(tmp_path, monkeypatch):
+    monkeypatch.setattr(helpers, 'ALLWAYS_DIR', tmp_path)
+    page = [
+        _swap('5A', 'tao', 'btc', 'COMPLETED'),
+        _swap('5A', 'tao', 'btc', 'ACTIVE'),
+        _swap('5A', 'tao', 'btc', 'REFUNDED'),
+    ]
+    with patch.object(helpers.requests, 'get', _mock_get([page])):
+        stats = fetch_miner_reliability(use_cache=False)
+    assert stats['5A']['tao->btc'] == (1, 1)  # only COMPLETED/TIMED_OUT count
+
+
+def test_returns_none_when_api_unreachable(tmp_path, monkeypatch):
+    monkeypatch.setattr(helpers, 'ALLWAYS_DIR', tmp_path)
+
+    def _boom(*args, **kwargs):
+        raise requests.ConnectionError('indexer down')
+
+    with patch.object(helpers.requests, 'get', _boom):
+        assert fetch_miner_reliability(use_cache=False) is None
+
+
+def test_json_error_object_does_not_crash(tmp_path, monkeypatch):
+    """A dict error body instead of a list must be treated as no data, not iterated."""
+    monkeypatch.setattr(helpers, 'ALLWAYS_DIR', tmp_path)
+
+    def _get(url, params=None, headers=None, timeout=None):
+        resp = MagicMock()
+        resp.json.return_value = {'error': 'Not Found', 'statusCode': 404}
+        resp.raise_for_status.return_value = None
+        return resp
+
+    with patch.object(helpers.requests, 'get', _get):
+        assert fetch_miner_reliability(use_cache=False) == {}
+
+
+def test_reliability_text_colors_and_formats():
+    rel = {'5A': {'tao->btc': (9, 10), 'btc->tao': (1, 4)}}
+
+    high = reliability_text('5A', 'tao', 'btc', rel)
+    assert high.plain == '9/10'
+    assert high.style == 'green'
+
+    low = reliability_text('5A', 'btc', 'tao', rel)
+    assert low.plain == '1/4'
+    assert low.style == 'red'
+
+    # no resolved swap for this miner/direction → dim dash
+    assert reliability_text('5Z', 'tao', 'btc', rel).plain == '—'
+    # API unavailable → dim dash
+    assert reliability_text('5A', 'tao', 'btc', None).plain == '—'


### PR DESCRIPTION
## What

Adds a `Reliability` column to `alw view rates` (the user-shopping table) and the `alw swap now` miner picker — per-miner, per-direction swap success rate, shown as `completed/resolved` and color-coded (green ≥90%, yellow ≥50%, red below).

## Why

Today a user picks a miner by posted rate alone. A miner can quote the best rate and still fail most of its swaps, with no signal in the CLI to catch it before reserving. The column surfaces it — e.g. a miner showing `T→B 1/17` has timed out 16 of its last 17 tao→btc swaps.

## How

- `fetch_miner_reliability()` (helpers.py) aggregates resolved swaps (`COMPLETED` + `TIMED_OUT` — the same basis as the subnet's `success_rate`) from the public swap-history API.
- 30-day window, matching the subnet's credibility window.
- Cached 10 min, keyed by API host + window; paging stops once swaps predate the window.
- Degrades gracefully — returns `None` / renders `—` if the API is unreachable, so `view rates` and `swap now` still work offline of the indexer.
- `ALLWAYS_API_URL` env override.

## Tests

`tests/test_miner_reliability.py` — aggregation, 30-day windowing, unresolved-status exclusion, API-unreachable, and a JSON-error-body guard.

## Docs

Companion docs PR in `allways-docs-ui` updates `cli.md`.

## Deferred (follow-ups)

- `--sort reliability` on `view rates`
- the same column on `alw view miners`
- making `--auto` reliability-aware