### PR TITLE
docs: add open-item rate limit rule to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,3 +43,11 @@ uv run pre-commit run --all-files --hook-stage pre-push  # pre-push hooks
 2. Make your changes
 3. Ensure tests pass
 4. Submit a pull request
+
+## Automatic Closures
+
+The maintainer bot enforces these rules without manual review. Contributions that violate them are closed automatically.
+
+### Open item limits
+
+Each contributor may have at most **2 open PRs** and **2 open issues** in this repository at any time. Submitting a 3rd of either type while at the cap closes the new one on submission. The limits apply independently — you can have 2 open PRs and 2 open issues at the same time.


### PR DESCRIPTION
## Summary

Adds an "Automatic Closures" section documenting the bot-enforced open-item rate limit: each contributor capped at 2 open PRs and 2 open issues; a 3rd of either type is auto-closed on submission. Limits apply independently.

Companion to entrius/gittensor-ui#1265, entrius/gittensor#1349, entrius/das-github-mirror#122. The maintainer bot (agentic-maintainer) gets a follow-up change to make rate limits per-repo: 2 for allways/das-github-mirror/gittensor-ui/allways-ui, 3 for gittensor.