### PR TITLE
validator: tighten reserve slippage cap to 25% and log slippage_bps

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -65,7 +65,7 @@ RECYCLE_UID = 53  # Subnet owner UID
 
 # ─── Reservation ─────────────────────────────────────────
 RESERVE_SLIPPAGE_DEFAULT_BPS = 200  # 2% — applied when the synapse omits slippage
-RESERVE_SLIPPAGE_MAX_BPS = 100_000  # 1000% — clamp ceiling (mostly an integer/typo guard)
+RESERVE_SLIPPAGE_MAX_BPS = 2_500  # 25% — clamp ceiling; ≥10_000 turns the rate gate into a no-op
 RESERVATION_COOLDOWN_BLOCKS = 150  # ~30 min base cooldown on failed reservation
 RESERVATION_COOLDOWN_MULTIPLIER = 2  # 150 → 300 → 600 ...
 MAX_RESERVATIONS_PER_ADDRESS = 1

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -292,6 +292,7 @@ async def handle_swap_reserve(
     bt.logging.info(
         f'{ctx}: REQUEST received — tao={synapse.tao_amount} '
         f'from_amount={synapse.from_amount} to_amount={synapse.to_amount} '
+        f'slippage_bps={synapse.slippage_bps} '
         f'user_from_address={synapse.from_address} block_anchor={synapse.block_anchor}'
     )
 

--- a/tests/test_axon_handlers.py
+++ b/tests/test_axon_handlers.py
@@ -705,9 +705,7 @@ class TestReserveRateRecompute:
         """
         from allways.constants import RESERVE_SLIPPAGE_MAX_BPS
 
-        assert RESERVE_SLIPPAGE_MAX_BPS < 10_000, (
-            'cap ≥10_000 makes quote_within_slippage a no-op — see swap 550'
-        )
+        assert RESERVE_SLIPPAGE_MAX_BPS < 10_000, 'cap ≥10_000 makes quote_within_slippage a no-op — see swap 550'
 
         validator = make_reserve_validator()
         # Rate dropped 90% → recomputed = 10% of 345_000_000 = 34_500_000.

--- a/tests/test_axon_handlers.py
+++ b/tests/test_axon_handlers.py
@@ -694,25 +694,33 @@ class TestReserveRateRecompute:
         assert result.accepted is True
 
     def test_slippage_max_bps_clamp_applied(self):
-        """slippage_bps above RESERVE_SLIPPAGE_MAX_BPS is clamped, not errored.
+        """slippage_bps above RESERVE_SLIPPAGE_MAX_BPS is clamped, not errored,
+        and the cap is tight enough to still gate a wildly-off quote.
 
-        With the clamp applied, even a very large drift (rate dropped 90%)
-        passes the slippage gate because MAX_BPS >= 10_000 makes the threshold
-        non-positive.
+        MAX_BPS must stay below 10_000 (100%) — at ≥10_000 the threshold goes
+        non-positive and the gate becomes a no-op, which is what let swap-550's
+        operator-test traffic settle a 71%-off quote without rejection. The
+        clamp should accept the high request value but cap it to a band that
+        still bites real misquotes.
         """
         from allways.constants import RESERVE_SLIPPAGE_MAX_BPS
 
+        assert RESERVE_SLIPPAGE_MAX_BPS < 10_000, (
+            'cap ≥10_000 makes quote_within_slippage a no-op — see swap 550'
+        )
+
         validator = make_reserve_validator()
         # Rate dropped 90% → recomputed = 10% of 345_000_000 = 34_500_000.
-        # Default 2% band would reject this, but MAX_BPS uncaps it.
+        # With the cap at 25% (or anything <90%), this gap is still rejected
+        # even after the user-requested slippage gets clamped down.
         moved = make_commitment()
         moved.rate_str = str(345 * 0.10)
         moved.rate = 345 * 0.10
         synapse = make_reserve_synapse()
         synapse.slippage_bps = RESERVE_SLIPPAGE_MAX_BPS + 1_000_000  # absurdly large — clamped
         result = run_reserve_handler(validator, synapse, commitment=moved)
-        # With MAX_BPS applied, gate passes; default 2% would reject
-        assert result.accepted is True
+        assert result.accepted is False
+        assert 'slippage band' in result.rejection_reason
 
     # ------------------------------------------------------------------ #
     # tao_amount internal consistency                                      #


### PR DESCRIPTION
## Summary

- Cap `RESERVE_SLIPPAGE_MAX_BPS` from `100_000` (1000%) to `2_500` (25%). The old value sat above the `10_000` threshold where `quote_within_slippage` goes non-positive — anything ≥100% turned the gate into a no-op. A `SwapReserveSynapse` with `slippage_bps=10_000+` could land a quote arbitrarily far from the miner's commitment rate and still pass.
- Add `slippage_bps` to the `SwapReserve` REQUEST log line so the next swap-550-shape ticket is diagnosable from logs in a minute, not an afternoon of archive-node probes.
- Flip `test_slippage_max_bps_clamp_applied` to assert the new behavior (clamp now bites a wildly-off quote) and add an explicit `RESERVE_SLIPPAGE_MAX_BPS < 10_000` guard so a future bump can't silently disable the gate again.

## Why

Surfaced while diagnosing swap 550 (`btc→tao`, COMPLETED, `destAmount=98M rao` vs `deliveredAmount=28.2M rao` — 71% gap). Chain history showed the miner's commitment was stable at `rate=290.87` for ≥1000 blocks before init; the quote could only have settled if the synapse arrived with `slippage_bps ≥ 7091`. Validator logs from later that day showed the same operator running test traffic with deliberately-mismatched quotes through the same wallet pair (5HjnFE7Z / 5EqNSv84 / miner UID 14). So swap 550 itself is operator test traffic, not real user harm — but the underlying surface (any client can pass `slippage_bps=10_000` and disable the rate gate) is a footgun that's worth closing before a non-operator client trips it.

CLI default (`--slippage 2.0` → 200 bps) and user `--slippage` flow are unchanged. The CLI already warns above 10% and clamps to `MAX_BPS`, so the visible UX change is "explicit `--slippage 30` now clamps to 25% instead of 1000%."

## Test plan

- [x] `pytest tests/test_axon_handlers.py -k slippage` — 5/5 passing, including the flipped clamp test
- [x] `pytest tests/test_axon_handlers.py tests/test_rate.py` — 78/78 passing
- [ ] Spot-check on a live validator after deploy: confirm `REQUEST received — … slippage_bps=N …` shows up and that an explicit `--slippage 30` from the CLI now logs as `slippage_bps=2500` (clamped) and accepts within the 25% band.