### PR TITLE
Log validator console output to wandb on startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,3 +53,12 @@ MINER_BTC_ADDRESS=
 # fail and every fulfillment would error with "password invalid". Leave unset
 # to be prompted interactively at launch.
 MINER_BITTENSOR_COLDKEY_PASSWORD=
+
+# ─── Validator: Weights & Biases ───────────────────────────
+# The validator opens a wandb run at startup that captures its console output.
+# Set WANDB_API_KEY to log online; unset runs offline (./wandb/) or pass
+# --neuron.wandb_off to disable entirely.
+WANDB_API_KEY=
+WANDB_ENTITY=entrius-allways
+WANDB_PROJECT=allways-validators
+WANDB_VALIDATOR_NAME=vali

--- a/allways/utils/config.py
+++ b/allways/utils/config.py
@@ -107,6 +107,13 @@ def add_validator_args(cls, parser):
     )
 
     parser.add_argument(
+        '--neuron.wandb_off',
+        action='store_true',
+        help='Disables Weights & Biases logging. wandb captures the validator console output for the run.',
+        default=False,
+    )
+
+    parser.add_argument(
         '--validator.poll_interval',
         type=int,
         help='Polling interval in seconds for checking swaps.',

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -8,6 +8,7 @@ Usage:
     python neurons/validator.py --netuid 7 --wallet.name default --wallet.hotkey default
 """
 
+import os
 import sys
 import threading
 import time
@@ -15,8 +16,10 @@ from functools import partial
 from pathlib import Path
 
 import bittensor as bt
+import wandb
 from dotenv import load_dotenv
 
+from allways import __version__
 from allways.chain_providers import create_chain_providers
 from allways.commitments import read_miner_commitments
 from allways.constants import (
@@ -47,6 +50,10 @@ from allways.validator.swap_tracker import SwapTracker
 from neurons.base.validator import BaseValidatorNeuron
 
 load_dotenv()
+
+WANDB_ENTITY = os.getenv('WANDB_ENTITY', 'entrius-allways')
+WANDB_PROJECT = os.getenv('WANDB_PROJECT', 'allways-validators')
+WANDB_VALIDATOR_NAME = os.getenv('WANDB_VALIDATOR_NAME', 'vali')
 
 
 class Validator(BaseValidatorNeuron):
@@ -157,6 +164,20 @@ class Validator(BaseValidatorNeuron):
         self.attach_axon_handlers()
 
         bt.logging.info(f'Validator initialized: hotkey={self.wallet.hotkey.ss58_address}')
+
+        # wandb captures the validator's console output for the run; no per-step
+        # log calls needed. Wrapped so a wandb outage never takes down scoring.
+        if not self.config.neuron.wandb_off:
+            try:
+                wandb.init(
+                    entity=WANDB_ENTITY,
+                    project=WANDB_PROJECT,
+                    name=f'{WANDB_VALIDATOR_NAME}-{self.uid}-{__version__}',
+                    config=self.config,
+                    reinit=True,
+                )
+            except Exception as e:
+                bt.logging.error(f'Failed to initialize wandb run: {e}')
 
     def bootstrap_miner_rates(self) -> None:
         """Cold-start anchor for rate events. Without this, a validator with a


### PR DESCRIPTION
## What

Opens a Weights & Biases run when the validator starts. wandb automatically captures the process's stdout/stderr, so every `bt.logging` line the validator already emits (forward steps, scoring traces, swap verifications, errors) lands in the run's Logs tab — no per-line instrumentation. Mirrors the gittensor validator pattern.

## Changes

- `neurons/validator.py` — `wandb.init(...)` at the end of `__init__`, run name `vali-{uid}-{version}`, wrapped in try/except so a wandb outage logs an error but never crashes scoring. Entity/project/name read from env (defaults `entrius-allways` / `allways-validators` / `vali`).
- `allways/utils/config.py` — adds `--neuron.wandb_off` to disable.
- `.env.example` — documents `WANDB_API_KEY` and the three settings.

`wandb==0.21.3` was already a dependency, so no `pyproject.toml` change.

## Usage

- Online: set `WANDB_API_KEY` in `.env` → logs to `entrius-allways/allways-validators`.
- Offline (default, no key): runs write to `./wandb/`.
- Off: `--neuron.wandb_off`.

## Notes

- Requires the `entrius-allways` wandb entity to exist and the API key to have access, otherwise `wandb.init` fails (caught, logged, validator continues).
- Verified: `ruff format` + `ruff check` clean, syntax checked. Not yet run end-to-end against the dev environment.
