### PR TITLE
wandb: default entity to entrius-gittensor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,6 @@ MINER_BITTENSOR_COLDKEY_PASSWORD=
 # Set WANDB_API_KEY to log online; unset runs offline (./wandb/) or pass
 # --neuron.wandb_off to disable entirely.
 WANDB_API_KEY=
-WANDB_ENTITY=entrius-allways
+WANDB_ENTITY=entrius-gittensor
 WANDB_PROJECT=allways-validators
 WANDB_VALIDATOR_NAME=vali

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -51,7 +51,7 @@ from neurons.base.validator import BaseValidatorNeuron
 
 load_dotenv()
 
-WANDB_ENTITY = os.getenv('WANDB_ENTITY', 'entrius-allways')
+WANDB_ENTITY = os.getenv('WANDB_ENTITY', 'entrius-gittensor')
 WANDB_PROJECT = os.getenv('WANDB_PROJECT', 'allways-validators')
 WANDB_VALIDATOR_NAME = os.getenv('WANDB_VALIDATOR_NAME', 'vali')
 


### PR DESCRIPTION
## Summary
- Switches the default `WANDB_ENTITY` from `entrius-allways` to the existing `entrius-gittensor` team so we don't have to stand up (and pay ~$50/mo for) a new wandb team.
- Updates both the runtime default in `neurons/validator.py` and the documented value in `.env.example`. Project remains `allways-validators`.

## Test plan
- [ ] Start a validator with `WANDB_API_KEY` set and no `WANDB_ENTITY` override; confirm the run lands under `entrius-gittensor/allways-validators` in wandb.
- [ ] Confirm `WANDB_ENTITY=...` env override still wins over the new default.