### PR TITLE
Write reservation pin synchronously at reserve time

### DIFF
--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -25,7 +25,7 @@ from allways.utils.logging import miner_label as _miner_label
 from allways.utils.proofs import reserve_proof_message, swap_proof_message
 from allways.utils.rate import calculate_to_amount, derive_tao_leg, quote_within_slippage
 from allways.utils.scale import encode_bytes, encode_str, encode_u128
-from allways.validator.state_store import PendingConfirm
+from allways.validator.state_store import PendingConfirm, ReservationPin
 
 if TYPE_CHECKING:
     from neurons.validator import Validator
@@ -454,6 +454,24 @@ async def handle_swap_reserve(
                 f'{ctx}: RESERVED — vote_reserve submitted '
                 f'(tao={synapse.tao_amount}, rate={reserve_rate_str or reserve_rate})'
             )
+
+            # Pin now so a fast SwapConfirm finds it; on failure the watcher backfills, never rejects the reserve.
+            try:
+                validator.state_store.upsert_reservation_pin(
+                    ReservationPin(
+                        miner_hotkey=miner,
+                        reserve_block=cur_block,
+                        from_chain=commitment.from_chain,
+                        to_chain=commitment.to_chain,
+                        rate_str=commitment.rate_str,
+                        counter_rate_str=commitment.counter_rate_str,
+                        miner_from_address=commitment.from_address,
+                        miner_to_address=commitment.to_address,
+                        reserved_until=contract.get_miner_reserved_until(miner),
+                    )
+                )
+            except Exception as e:
+                bt.logging.warning(f'{ctx}: synchronous pin write failed: {e} — watcher will backfill')
 
     except ContractError as e:
         bt.logging.error(f'{ctx} failed: {e}')

--- a/tests/test_axon_handlers.py
+++ b/tests/test_axon_handlers.py
@@ -847,3 +847,18 @@ class TestReservationPin:
         validator.axon_contract_client.vote_initiate.assert_called_once()
         call = validator.axon_chain_providers['btc'].verify_transaction.call_args
         assert call.kwargs['expected_recipient'] == 'bc1-miner'
+
+    def test_successful_reserve_pins_synchronously(self):
+        """handle_swap_reserve writes the pin inline so a fast SwapConfirm finds it."""
+        validator = make_reserve_validator()
+        validator.axon_contract_client.get_miner_reserved_until.return_value = 1050
+
+        run_reserve_handler(validator, make_reserve_synapse())
+
+        validator.axon_contract_client.vote_reserve.assert_called_once()
+        validator.state_store.upsert_reservation_pin.assert_called_once()
+        pin = validator.state_store.upsert_reservation_pin.call_args[0][0]
+        assert pin.rate_str == '345'
+        assert pin.miner_from_address == 'bc1-miner'
+        assert pin.miner_to_address == '5miner'
+        assert pin.reserved_until == 1050


### PR DESCRIPTION
## Problem

A completed swap can settle at a **worse rate than the user reserved**, even with zero slippage. Swap #813 (BTC→TAO) reserved at miner rate 550 but settled at 502 — the user received 0.0845 TAO instead of the 0.0926 they locked in.

Root cause is a race. The reservation rate pin (which settlement keys off) is written **asynchronously** by the event watcher when it observes `MinerReserved` — ~15-20s after reserve. Clients send `SwapConfirm` ~4-6s after reserve, before the pin exists, so `handle_swap_confirm` hits the fallback (`axon_handlers.py`, `no reservation pin, falling back to live commitment`) and resolves the rate from the miner's **live** commitment. If the miner moved its rate in that window, the user eats the difference. Validator logs show this fallback is the dominant path, not an edge case — so the pin was largely ineffective against fast confirms.

## Fix

Write the pin **synchronously** in `handle_swap_reserve`, right after `vote_reserve` succeeds, reusing the commitment already loaded for the slippage gate. The confirm-side read is unchanged. The event-watcher pin stays as a backfill for the cross-validator case (reserve and confirm handled by different validators); `upsert` is idempotent.

This freezes the **reserve-time rate**, so settlement recomputes the obligation from the rate the miner actually committed at reserve — correct for both zero and non-zero slippage, with no need to persist `slippage_bps`.

The write is guarded: a pin-write failure degrades to the watcher backfill and never rejects an already-on-chain reserve.

## Test

`test_successful_reserve_pins_synchronously` asserts the reserve handler writes the pin inline with the reserve-time rate and addresses.

## Follow-ups (separate)

- Log `slippage_bps` on the `SwapReserve` request line.
- Dashboard: surface quote-rate vs fill-rate / slippage on the swap detail page.