### PR TITLE
Record zero-rate opt-outs in crown-time accounting

### DIFF
--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -371,9 +371,20 @@ def refresh_miner_rates(self: Validator) -> None:
             (pair.from_chain, pair.to_chain, pair.rate),
             (pair.to_chain, pair.from_chain, pair.counter_rate),
         ):
-            if r <= 0:
-                continue  # miner opted out of this direction
             key = (pair.hotkey, from_c, to_c)
+            if r <= 0:
+                # Persist a zero terminator only if the direction was previously offered.
+                latest = self.state_store.get_latest_rate_before(pair.hotkey, from_c, to_c, self.block)
+                if latest is not None and latest[0] > 0:
+                    self.state_store.insert_rate_event(
+                        hotkey=pair.hotkey,
+                        from_chain=from_c,
+                        to_chain=to_c,
+                        rate=0.0,
+                        block=self.block,
+                    )
+                    self.last_known_rates[key] = 0.0
+                continue
             if self.last_known_rates.get(key) == r:
                 continue
             self.state_store.insert_rate_event(

--- a/tests/test_poll_commitments.py
+++ b/tests/test_poll_commitments.py
@@ -125,6 +125,87 @@ class TestPollCommitmentsZeroRate:
         assert ('hk_a', 'btc', 'tao') not in v.last_known_rates
         v.state_store.close()
 
+    def test_zero_after_positive_records_optout(self, tmp_path: Path):
+        """A miner dropping a previously-offered direction to 0 must persist a
+        terminating zero so scoring stops crediting the stale positive rate."""
+        v = make_validator(tmp_path)
+
+        with patch(
+            'allways.validator.forward.read_miner_commitments',
+            return_value=[make_pair('hk_a', rate=0.00015, counter_rate=6500.0)],
+        ):
+            poll_commitments(v)
+
+        v.block += 1
+        with patch(
+            'allways.validator.forward.read_miner_commitments',
+            return_value=[make_pair('hk_a', rate=0.0, counter_rate=6500.0)],
+        ):
+            poll_commitments(v)
+
+        tao_btc = v.state_store.get_rate_events_in_range('tao', 'btc', 0, 10_000)
+        assert [e['rate'] for e in tao_btc] == [0.00015, 0.0]
+        assert v.last_known_rates[('hk_a', 'tao', 'btc')] == 0.0
+        v.state_store.close()
+
+    def test_zero_optout_is_recorded_once_not_every_poll(self, tmp_path: Path):
+        """Once the zero terminator lands, repeated zero polls add nothing."""
+        v = make_validator(tmp_path)
+        with patch(
+            'allways.validator.forward.read_miner_commitments',
+            return_value=[make_pair('hk_a', rate=0.00015, counter_rate=6500.0)],
+        ):
+            poll_commitments(v)
+
+        for _ in range(3):
+            v.block += 1
+            with patch(
+                'allways.validator.forward.read_miner_commitments',
+                return_value=[make_pair('hk_a', rate=0.0, counter_rate=6500.0)],
+            ):
+                poll_commitments(v)
+
+        tao_btc = v.state_store.get_rate_events_in_range('tao', 'btc', 0, 10_000)
+        assert [e['rate'] for e in tao_btc] == [0.00015, 0.0]
+        v.state_store.close()
+
+    def test_reenable_after_optout(self, tmp_path: Path):
+        """positive -> 0 -> positive yields [pos, 0, pos]: the direction
+        re-enables normally after an opt-out."""
+        v = make_validator(tmp_path)
+        sequence = [0.00015, 0.0, 0.00020]
+        for rate in sequence:
+            with patch(
+                'allways.validator.forward.read_miner_commitments',
+                return_value=[make_pair('hk_a', rate=rate, counter_rate=6500.0)],
+            ):
+                poll_commitments(v)
+            v.block += 1
+
+        tao_btc = v.state_store.get_rate_events_in_range('tao', 'btc', 0, 10_000)
+        assert [e['rate'] for e in tao_btc] == [0.00015, 0.0, 0.00020]
+        v.state_store.close()
+
+    def test_zero_during_downtime_reconciles_against_persisted_rate(self, tmp_path: Path):
+        """A zero posted while the validator was down (so last_known_rates is
+        empty on restart) still terminates the prior positive on the next poll,
+        because the check reads the persisted latest rate."""
+        v = make_validator(tmp_path)
+        v.state_store.insert_rate_event(
+            hotkey='hk_a', from_chain='tao', to_chain='btc', rate=0.00015, block=v.block - 50
+        )
+
+        assert v.last_known_rates == {}  # simulate fresh process after restart
+        with patch(
+            'allways.validator.forward.read_miner_commitments',
+            return_value=[make_pair('hk_a', rate=0.0, counter_rate=6500.0)],
+        ):
+            poll_commitments(v)
+
+        tao_btc = v.state_store.get_rate_events_in_range('tao', 'btc', 0, 10_000)
+        assert [e['rate'] for e in tao_btc] == [0.00015, 0.0]
+        v.state_store.close()
+
 
 class TestPollCommitmentsDereg:
     def test_dereg_removes_hotkey_from_store_and_cache(self, tmp_path: Path):

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -246,6 +246,39 @@ class TestReplayCrownTime:
         assert crown == {'hk_b': 500.0, 'hk_a': 500.0}
         store.close()
 
+    def test_zero_rate_optout_hands_crown_to_still_offering_miner(self, tmp_path: Path):
+        """Regression for #379: a recorded zero-rate opt-out ends crown credit
+        for the leaving miner and hands the rest of the window to the miner who
+        is still offering the direction — instead of the stale positive rate
+        holding the crown for the whole window."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active={'hk_a', 'hk_b'})
+        conn = store.require_connection()
+        for row in (
+            ('hk_a', 'btc', 'tao', 200.0, 0),
+            ('hk_b', 'btc', 'tao', 150.0, 0),
+            # hk_a opts out mid-window — the zero terminator scoring now sees.
+            ('hk_a', 'btc', 'tao', 0.0, 600),
+        ):
+            conn.execute(
+                'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+                row,
+            )
+        conn.commit()
+
+        crown = replay_crown_time_window(
+            store=store,
+            event_watcher=watcher,
+            from_chain='btc',
+            to_chain='tao',
+            window_start=100,
+            window_end=1100,
+            rewardable_hotkeys={'hk_a', 'hk_b'},
+        )
+        # A leads (100, 600] → 500 blocks; after opt-out B holds (600, 1100] → 500.
+        assert crown == {'hk_a': 500.0, 'hk_b': 500.0}
+        store.close()
+
     def test_tie_splits_credit_evenly(self, tmp_path: Path):
         store = ValidatorStateStore(db_path=tmp_path / 'state.db')
         watcher = make_watcher(store, active={'hk_a', 'hk_b'})


### PR DESCRIPTION
Closes #379.

## Problem
A miner posting rate `0` for a direction means "no longer offered" (#37 semantics, enforced by the `rate > 0` filter in `crown_holders_at_instant`). But `refresh_miner_rates` `continue`d on `r <= 0` **before** writing a rate event, so the opt-out never reached the persisted `rate_events` stream. Scoring's `get_latest_rate_before` kept returning the stale positive rate, and the leaving miner kept its crown — displacing miners still offering the direction.

## Fix
When a direction with a previously-positive rate drops to `0`, persist a terminating `0.0` rate event. The check reads the **persisted latest** rate (via `get_latest_rate_before`) rather than only the in-memory `last_known_rates`, so:
- a never-offered direction (`latest is None`) records nothing — unchanged behavior;
- a zero posted while the validator was down still reconciles on the first poll after restart (`poll_commitments` runs before `score_and_reward_miners` in the same forward step);
- the terminator is written once; repeat zero polls are no-ops.

Single-function change in `allways/validator/forward.py`. No schema, API, UI, or contract changes — the existing prune logic already preserves the latest row per `(hotkey, direction)` as an anchor, so the zero survives as the terminator.

## Tests
- `test_poll_commitments.py`: positive→zero records the opt-out; recorded once not per-poll; positive→zero→positive re-enables; zero-during-downtime reconciles against the persisted rate.
- `test_scoring_v1.py`: replay regression mirroring the issue — `{hk_a: 500, hk_b: 500}` after opt-out instead of `{hk_a: 1000}`.

Full suite: 563 passed. `ruff format` + `ruff check` clean.