### PR TITLE
Widen reservation extension runway so finalize lands in time

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -96,10 +96,9 @@ VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE = max(
         )
     ),
 )
-# Vote to extend when this many blocks remain. Sized for one forward step
-# to land the propose tx and the challenge window to elapse — without that
-# runway the propose is orphaned and the reservation expires anyway.
-EXTEND_THRESHOLD_BLOCKS = VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE + CHALLENGE_WINDOW_BLOCKS
+# Vote to extend when this many blocks remain: a forward step to land each of
+# the propose and finalize txs, plus the challenge window between them.
+EXTEND_THRESHOLD_BLOCKS = 2 * VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE + CHALLENGE_WINDOW_BLOCKS
 
 # Cushion the miner subtracts from each swap's timeout before agreeing to
 # fulfill. Pinned to EXTEND_THRESHOLD_BLOCKS so the miner won't start a


### PR DESCRIPTION
## What
One-line fix: `EXTEND_THRESHOLD_BLOCKS` **13 → 18**. No behavior/logging/contract changes.

## Why
A reservation extension is two txs — `propose`, then `finalize` after the challenge window. `EXTEND_THRESHOLD_BLOCKS` is how many blocks before expiry the validator *starts* proposing. It was `FORWARD_STEP(5) + CHALLENGE_WINDOW(8) = 13`, which budgets a forward step for the **propose** + the window, but **none for the finalize tx to land**. So finalize was eligible only at the deadline and always included after it; the contract rejects a finalize where `reserved_until < current` (`lib.rs:746`) → the reservation expires with the user's source funds already sent. (Regression: initial commit was `20`; `lib.rs:646` still asserts the old invariant.)

Real case — reservation [`0x7d44…`](https://all-ways.io/reservations/0x7d4412ef1765c2513e76e0444b8522a0dee47b00be372cd1ed0b8edd5e83160a) (BTC→TAO):
```
18:50:53  proposed reservation extension (11 blocks remaining)
18:53:17  ReservationExtensionFinalized @ block 8248676   # == expiry block
```
Propose fired with 11 blocks left for an ~18-block sequence → finalize landed on the expiry block → `extensions_used=0`, `EXPIRED`, `swapId=null`, BTC stranded.

## Fix
```
EXTEND_THRESHOLD_BLOCKS = 2 * VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE + CHALLENGE_WINDOW_BLOCKS   # 13 -> 18
```
A forward step to land *each* of the two txs plus the challenge window. Starts the extension ~5 blocks earlier so finalize lands before expiry. `MINER_TIMEOUT_CUSHION_BLOCKS` stays pinned to this (intended). No TTL/window change, no contract change.

## Test
`ruff` clean; `EXTEND_THRESHOLD_BLOCKS == 18`; full suite 563 passed.

## Follow-ups (not here)
Tighten the doomed-propose guard (`optimistic_extensions.py:97`) to the same runway; fix the stale `lib.rs:646` comment.
