### PR TITLE
Warn when an eligible reservation finalize is rejected too late

### DIFF
--- a/allways/validator/optimistic_extensions.py
+++ b/allways/validator/optimistic_extensions.py
@@ -178,6 +178,13 @@ class OptimisticExtensionWatcher:
                 miner_hotkey=miner_hotkey,
             ),
         )
+        if not success:
+            # Window elapsed, so not a benign challenge-race loss — the reservation
+            # likely expired before finalize landed, stranding the user's source funds.
+            bt.logging.warning(
+                f'OptimisticExt: finalize_extend_reservation for {miner_hotkey[:8]} rejected after '
+                f'challenge window (target {pending.target_block}) — reservation likely expired before finalize landed'
+            )
         return pending.target_block if success else None
 
     # ─── Timeout side ────────────────────────────────────────────────────


### PR DESCRIPTION
## What
Add one WARNING when an **eligible** `finalize_extend_reservation` is rejected by the contract.

## Why
Today that rejection is only logged at DEBUG (in the shared `_try_call`), so in prod it's invisible. But once the challenge window has elapsed, a finalize rejection is **not** a benign challenge-race loss — it almost always means the reservation expired before the finalize tx landed, which strands the user's already-sent source funds. That's the exact terminal signal of the runway bug (see reservation [`0x7d44…`](https://all-ways.io/reservations/0x7d4412ef1765c2513e76e0444b8522a0dee47b00be372cd1ed0b8edd5e83160a)) and it was silent.

## Scope
- Fires only in `maybe_finalize_reservation` **after** the challenge window check passes — so normal challenge-race DEBUG noise is untouched and there are no false alarms on benign/abandoned reservations.
- Does not change `_try_call` (shared by propose/challenge/timeout) — no broad log-level change.
- Logging only; no behavior change.

## Test
`ruff` clean; 58 extension/finalize tests pass.
