### PR TITLE
Crown calc uses pinned rate during the reserved-not-busy window

### DIFF
--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -33,7 +33,7 @@ from allways.utils.scale import (
     decode_u128,
     strip_hex_prefix,
 )
-from allways.validator.state_store import ReservationPin, ValidatorStateStore
+from allways.validator.state_store import ReservationPin, ReservationPinEvent, ValidatorStateStore
 from allways.validator.swap_tracker import SwapTracker
 
 DATA_DECODERS = {
@@ -241,6 +241,12 @@ class ContractEventWatcher:
         self.busy_events: List[BusyEvent] = []
         self.active_events: List[ActiveEvent] = []
         self.active_events_by_hotkey: Dict[str, List[ActiveEvent]] = {}
+        # Direction-keyed reservation pin lifecycle — feeds the scoring
+        # replay's pinned-rate overlay so a miner who pins at a moderate
+        # rate then bumps live to absurd cannot earn crown at the inflated
+        # value. Each entry's ``kind`` is 'start' (with the pinned rate) or
+        # 'end' (rate=0, clears the pin).
+        self.reservation_pin_events: List[ReservationPinEvent] = []
         # Swap IDs whose +1 was seeded directly from the contract's active-swap
         # list during initialize(). Replay must skip their SwapInitiated event
         # to avoid double-counting — the busy tick is already in open_swap_count.
@@ -296,6 +302,42 @@ class ContractEventWatcher:
                 break
             latest[ev.hotkey] = ev.active
         return {hk for hk, is_active in latest.items() if is_active}
+
+    def get_reservation_pin_events_in_range(
+        self, start_block: int, end_block: int, from_chain: str, to_chain: str
+    ) -> List[dict]:
+        """Reservation pin start/end transitions for one direction in
+        ``(start_block, end_block]``, oldest first."""
+        from_chain = (from_chain or '').lower()
+        to_chain = (to_chain or '').lower()
+        out: List[dict] = []
+        for ev in self.reservation_pin_events:
+            if ev.block_num <= start_block:
+                continue
+            if ev.block_num > end_block:
+                break
+            if ev.from_chain != from_chain or ev.to_chain != to_chain:
+                continue
+            out.append({'hotkey': ev.hotkey, 'kind': ev.kind, 'rate': ev.rate, 'block': ev.block_num})
+        return out
+
+    def get_reservation_pins_at(
+        self, block: int, from_chain: str, to_chain: str
+    ) -> Dict[str, float]:
+        """Pinned rate per hotkey active at ``block`` for the given direction,
+        reconstructed by replaying every pin transition at or before ``block``.
+        A hotkey is in the result iff its most recent transition for that
+        direction is a 'start'."""
+        from_chain = (from_chain or '').lower()
+        to_chain = (to_chain or '').lower()
+        latest: Dict[str, ReservationPinEvent] = {}
+        for ev in self.reservation_pin_events:
+            if ev.block_num > block:
+                break
+            if ev.from_chain != from_chain or ev.to_chain != to_chain:
+                continue
+            latest[ev.hotkey] = ev
+        return {hk: ev.rate for hk, ev in latest.items() if ev.kind == 'start'}
 
     # ─── Sync loop ──────────────────────────────────────────────────────
 
@@ -405,9 +447,23 @@ class ContractEventWatcher:
             counts[ev.hotkey] = counts.get(ev.hotkey, 0) + ev.delta
         self.open_swap_count = {hk: c for hk, c in counts.items() if c > 0}
 
+        pin_event_rows = self.state_store.load_all_reservation_pin_events()
+        self.reservation_pin_events = [
+            ReservationPinEvent(
+                block_num=r['block_num'],
+                hotkey=r['hotkey'],
+                from_chain=r['from_chain'],
+                to_chain=r['to_chain'],
+                kind=r['kind'],
+                rate=r['rate'],
+            )
+            for r in pin_event_rows
+        ]
+
         bt.logging.info(
             f'EventWatcher hydrated from DB: cursor={self.cursor}, '
-            f'{len(self.active_miners)} active, {sum(self.open_swap_count.values())} open swaps'
+            f'{len(self.active_miners)} active, {sum(self.open_swap_count.values())} open swaps, '
+            f'{len(self.reservation_pin_events)} pin events'
         )
 
     def sync_to(self, current_block: int) -> None:
@@ -533,6 +589,11 @@ class ContractEventWatcher:
                 # snapshot is captured in the on-chain swap struct, so the
                 # local pin is no longer needed.
                 self.state_store.remove_reservation_pin(miner)
+                # Close the scoring-overlay pins too; once busy, the miner
+                # earns no crown anyway, but emitting the 'end' keeps the
+                # in-memory state consistent and avoids stale pins lingering
+                # past a missed terminal event.
+                self._emit_reservation_pin_ends(block_num, miner)
                 # Skip if this swap's +1 was already seeded from the contract's
                 # live active-swap list at bootstrap — otherwise a restart
                 # whose replay window covers the original SwapInitiated would
@@ -557,6 +618,10 @@ class ContractEventWatcher:
                     to_chain=to_chain,
                 )
                 self.apply_busy_delta(block_num, miner, -1, swap_id)
+                # Defensive: if SwapInitiated was missed (out-of-order delivery,
+                # bootstrap), terminal SwapCompleted is the last chance to clear
+                # any lingering scoring pin for this miner.
+                self._emit_reservation_pin_ends(block_num, miner)
                 self.bootstrapped_swap_ids.discard(swap_id)
                 self.state_store.remove_bootstrapped_swap(swap_id)
                 if self.swap_tracker is not None:
@@ -580,6 +645,7 @@ class ContractEventWatcher:
                 # Defensive: a SwapInitiated this validator missed would leave
                 # a stale pin behind — clear it on the terminal event too.
                 self.state_store.remove_reservation_pin(miner)
+                self._emit_reservation_pin_ends(block_num, miner)
                 self.apply_busy_delta(block_num, miner, -1, swap_id)
                 self.bootstrapped_swap_ids.discard(swap_id)
                 self.state_store.remove_bootstrapped_swap(swap_id)
@@ -686,10 +752,99 @@ class ContractEventWatcher:
                 reserved_until=reserved_until,
             )
         )
+        # Emit pin lifecycle events into the scoring overlay. The reservation
+        # locks in BOTH offered directions for this miner (the contract takes
+        # the miner offline for any new swap until this reservation resolves),
+        # so we pin whichever directions the miner is currently quoting a
+        # positive rate for. A new MinerReserved later would emit fresh
+        # 'start' events that supersede these in the replay.
+        try:
+            primary_rate = float(commitment.rate_str) if commitment.rate_str else 0.0
+        except ValueError:
+            primary_rate = 0.0
+        try:
+            counter_rate = float(commitment.counter_rate_str) if commitment.counter_rate_str else 0.0
+        except ValueError:
+            counter_rate = 0.0
+        # Close any pin from a prior reservation that didn't terminate cleanly
+        # before laying down the new pin's 'start' rows.
+        self._emit_reservation_pin_ends(block_num, miner)
+        if primary_rate > 0:
+            self._record_reservation_pin_event(
+                block_num=block_num,
+                hotkey=miner,
+                from_chain=commitment.from_chain,
+                to_chain=commitment.to_chain,
+                kind='start',
+                rate=primary_rate,
+            )
+        if counter_rate > 0:
+            self._record_reservation_pin_event(
+                block_num=block_num,
+                hotkey=miner,
+                from_chain=commitment.to_chain,
+                to_chain=commitment.from_chain,
+                kind='start',
+                rate=counter_rate,
+            )
         bt.logging.info(
             f'EventWatcher: pinned reservation for {miner[:8]} at block {block_num} '
             f'({commitment.from_chain}->{commitment.to_chain})'
         )
+
+    def _record_reservation_pin_event(
+        self,
+        block_num: int,
+        hotkey: str,
+        from_chain: str,
+        to_chain: str,
+        kind: str,
+        rate: float,
+    ) -> None:
+        """Append to the in-memory pin event log and mirror to ``state_store``.
+        Mirrors the dual-write pattern used by ``apply_busy_delta``."""
+        from_chain = (from_chain or '').lower()
+        to_chain = (to_chain or '').lower()
+        ev = ReservationPinEvent(
+            block_num=block_num,
+            hotkey=hotkey,
+            from_chain=from_chain,
+            to_chain=to_chain,
+            kind=kind,
+            rate=float(rate),
+        )
+        self.reservation_pin_events.append(ev)
+        self.reservation_pin_events.sort(key=lambda e: e.block_num)
+        self.state_store.insert_reservation_pin_event(
+            block_num=block_num,
+            hotkey=hotkey,
+            from_chain=from_chain,
+            to_chain=to_chain,
+            kind=kind,
+            rate=rate,
+        )
+
+    def _emit_reservation_pin_ends(self, block_num: int, miner: str) -> None:
+        """Close any open pins for ``miner`` by emitting an 'end' event in each
+        direction whose latest event is a 'start'. Called when a reservation
+        terminates (SwapInitiated/SwapCompleted/SwapTimedOut) — the reservation
+        slot is consumed, so all directions it covered are released. Safe to
+        call when no pins are open."""
+        latest_by_dir: Dict[Tuple[str, str], ReservationPinEvent] = {}
+        for ev in self.reservation_pin_events:
+            if ev.hotkey != miner:
+                continue
+            latest_by_dir[(ev.from_chain, ev.to_chain)] = ev
+        for (from_chain, to_chain), ev in latest_by_dir.items():
+            if ev.kind == 'start':
+                self._record_reservation_pin_event(
+                    block_num=block_num,
+                    hotkey=miner,
+                    from_chain=from_chain,
+                    to_chain=to_chain,
+                    kind='end',
+                    rate=0.0,
+                )
 
     def record_active_transition(self, block_num: int, hotkey: str, active: bool) -> None:
         """Apply an on-chain active-flag transition to both the current-state
@@ -753,5 +908,16 @@ class ContractEventWatcher:
                     self.active_events_by_hotkey[hotkey] = pruned
                 else:
                     del self.active_events_by_hotkey[hotkey]
+        if self.reservation_pin_events:
+            latest_per_dir: Dict[Tuple[str, str, str], ReservationPinEvent] = {}
+            for ev in self.reservation_pin_events:
+                latest_per_dir[(ev.hotkey, ev.from_chain, ev.to_chain)] = ev
+            self.reservation_pin_events = [
+                ev
+                for ev in self.reservation_pin_events
+                if ev.block_num >= cutoff
+                or latest_per_dir.get((ev.hotkey, ev.from_chain, ev.to_chain)) is ev
+            ]
         self.state_store.prune_active_events(cutoff)
         self.state_store.prune_busy_events(cutoff)
+        self.state_store.prune_reservation_pin_events(cutoff)

--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -321,9 +321,7 @@ class ContractEventWatcher:
             out.append({'hotkey': ev.hotkey, 'kind': ev.kind, 'rate': ev.rate, 'block': ev.block_num})
         return out
 
-    def get_reservation_pins_at(
-        self, block: int, from_chain: str, to_chain: str
-    ) -> Dict[str, float]:
+    def get_reservation_pins_at(self, block: int, from_chain: str, to_chain: str) -> Dict[str, float]:
         """Pinned rate per hotkey active at ``block`` for the given direction,
         reconstructed by replaying every pin transition at or before ``block``.
         A hotkey is in the result iff its most recent transition for that
@@ -915,8 +913,7 @@ class ContractEventWatcher:
             self.reservation_pin_events = [
                 ev
                 for ev in self.reservation_pin_events
-                if ev.block_num >= cutoff
-                or latest_per_dir.get((ev.hotkey, ev.from_chain, ev.to_chain)) is ev
+                if ev.block_num >= cutoff or latest_per_dir.get((ev.hotkey, ev.from_chain, ev.to_chain)) is ev
             ]
         self.state_store.prune_active_events(cutoff)
         self.state_store.prune_busy_events(cutoff)

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -305,16 +305,21 @@ class EventKind(IntEnum):
     """Ordering of coincident-block transitions in the crown-time replay.
 
     ACTIVE applies first because the on-chain active flag is the per-miner
-    tell-all. Then BUSY (reservation ends crown for that miner), then
-    RATE. So if a user reserves a miner in the same block that miner's
-    best rate was posted, the reservation ends crown credit *before* the
-    rate attribution — matching the intent that a busy miner doesn't earn
-    a new interval.
+    tell-all. Then BUSY (busy ends crown for that miner). RESERVED_END is
+    next — once a reservation terminates, the pin overlay drops so the
+    miner's live rate takes effect again. RATE comes after that so a
+    same-block rate update lands cleanly on the now-unpinned series.
+    RESERVED_START is last so the pin captures whatever value RATE just
+    wrote: a miner who posts a rate change in the same block they get
+    reserved has the post-update value pinned, matching the contract's
+    block-end commitment read.
     """
 
     ACTIVE = 0
     BUSY = 1
-    RATE = 2
+    RESERVED_END = 2
+    RATE = 3
+    RESERVED_START = 4
 
 
 @dataclass
@@ -340,9 +345,9 @@ def reconstruct_window_start_state(
     to_chain: str,
     window_start: int,
     rewardable_hotkeys: Set[str],
-) -> Tuple[Dict[str, float], Dict[str, int], Set[str]]:
-    """Snapshot rates, busy counts, and the active set as they stood at
-    window_start."""
+) -> Tuple[Dict[str, float], Dict[str, int], Set[str], Dict[str, float]]:
+    """Snapshot rates, busy counts, active set, and reservation-pin overlay
+    as they stood at window_start."""
     rates: Dict[str, float] = {}
     busy_count: Dict[str, int] = dict(event_watcher.get_busy_miners_at(window_start))
     active_set: Set[str] = set(event_watcher.get_active_miners_at(window_start))
@@ -352,7 +357,13 @@ def reconstruct_window_start_state(
         if latest_rate is not None:
             rates[hotkey] = latest_rate[0]
 
-    return rates, busy_count, active_set
+    pinned_rates: Dict[str, float] = {
+        hk: rate
+        for hk, rate in event_watcher.get_reservation_pins_at(window_start, from_chain, to_chain).items()
+        if hk in rewardable_hotkeys and rate > 0
+    }
+
+    return rates, busy_count, active_set, pinned_rates
 
 
 def merge_replay_events(
@@ -363,8 +374,8 @@ def merge_replay_events(
     window_start: int,
     window_end: int,
 ) -> List[ReplayEvent]:
-    """Merge in-window active, busy, and rate transitions into one
-    chronologically-sorted stream."""
+    """Merge in-window active, busy, rate, and reservation-pin transitions
+    into one chronologically-sorted stream."""
     events: List[ReplayEvent] = []
 
     for e in event_watcher.get_active_events_in_range(window_start, window_end):
@@ -377,6 +388,10 @@ def merge_replay_events(
 
     for e in store.get_rate_events_in_range(from_chain, to_chain, window_start, window_end):
         events.append(ReplayEvent(block=e['block'], hotkey=e['hotkey'], kind=EventKind.RATE, value=float(e['rate'])))
+
+    for e in event_watcher.get_reservation_pin_events_in_range(window_start, window_end, from_chain, to_chain):
+        kind = EventKind.RESERVED_START if e['kind'] == 'start' else EventKind.RESERVED_END
+        events.append(ReplayEvent(block=e['block'], hotkey=e['hotkey'], kind=kind, value=float(e['rate'])))
 
     events.sort(key=lambda ev: ev.sort_key)
     return events
@@ -400,7 +415,7 @@ def replay_crown_time_window(
     time is irrelevant other than metagraph membership (used to credit the
     UID). Collateral-floor invariants are trusted to the contract's active
     flag; halt state is handled at ``score_and_reward_miners`` entry."""
-    rates, busy_count, active_set = reconstruct_window_start_state(
+    rates, busy_count, active_set, pinned_rates = reconstruct_window_start_state(
         store, event_watcher, from_chain, to_chain, window_start, rewardable_hotkeys
     )
     replay_events = merge_replay_events(store, event_watcher, from_chain, to_chain, window_start, window_end)
@@ -414,13 +429,25 @@ def replay_crown_time_window(
     crown_blocks: Dict[str, float] = {}
     prev_block = window_start
 
+    def effective_rates() -> Dict[str, float]:
+        """Live rates with pinned-during-reservation values overlaid. A miner
+        in ``pinned_rates`` earns crown at the value captured when they were
+        reserved, ignoring any subsequent live-rate updates until the
+        reservation terminates. Closes the bump-after-pin loophole."""
+        if not pinned_rates:
+            return rates
+        merged = dict(rates)
+        merged.update(pinned_rates)
+        return merged
+
     def credit_interval(interval_start: int, interval_end: int) -> None:
         duration = interval_end - interval_start
         if duration <= 0:
             return
         busy_set = {hk for hk, c in busy_count.items() if c > 0}
+        rates_for_instant = effective_rates()
         holders = crown_holders_at_instant(
-            rates,
+            rates_for_instant,
             rewardable_hotkeys,
             busy=busy_set,
             active=active_set,
@@ -430,7 +457,7 @@ def replay_crown_time_window(
             if trace is not None:
                 trace.unfilled_blocks += duration
             return
-        winner_rate = rates.get(holders[0], 0.0)
+        winner_rate = rates_for_instant.get(holders[0], 0.0)
         if trace is not None and winner_rate > 0:
             trace.best_rate = winner_rate
         split = duration / len(holders)
@@ -446,6 +473,11 @@ def replay_crown_time_window(
                 busy_count[event.hotkey] = new_count
             else:
                 busy_count.pop(event.hotkey, None)
+        elif event.kind is EventKind.RESERVED_START:
+            if event.value > 0:
+                pinned_rates[event.hotkey] = event.value
+        elif event.kind is EventKind.RESERVED_END:
+            pinned_rates.pop(event.hotkey, None)
         else:  # ACTIVE
             if event.value > 0:
                 active_set.add(event.hotkey)

--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -67,6 +67,29 @@ class ReservationPin:
     created_at: float = field(default_factory=time.time)
 
 
+@dataclass
+class ReservationPinEvent:
+    """One transition in the per-direction reservation-pin lifecycle, used by
+    the crown-time replay to freeze a miner's crown rate at the value pinned
+    when the reservation was created.
+
+    ``kind = 'start'`` carries the pinned rate (``rate`` field, canonical
+    units: TAO per BTC in the reservation's stated direction). ``kind = 'end'``
+    carries ``rate = 0`` and clears any active pin for that hotkey + direction.
+    The pin's lifetime spans (start block, end block]; the credit_interval
+    walker uses these events to overlay the pinned rate during the reserved-
+    not-busy window. Stored separately from ``rate_events`` so the live rate
+    series is unchanged by reservation lifecycle.
+    """
+
+    block_num: int
+    hotkey: str
+    from_chain: str
+    to_chain: str
+    kind: str  # 'start' or 'end'
+    rate: float
+
+
 class ValidatorStateStore:
     def __init__(
         self,
@@ -303,6 +326,112 @@ class ValidatorStateStore:
             reserved_until=row['reserved_until'],
             created_at=row['created_at'],
         )
+
+    # ─── reservation_pin_events ─────────────────────────────────────────
+    #
+    # Direction-keyed history of reservation pin start/end transitions.
+    # Used by ``replay_crown_time_window`` to overlay the pinned rate
+    # during the reserved-not-busy window, closing the bump-after-pin
+    # loophole where a miner pinned at a moderate rate could bump live
+    # rate to absurd and earn crown at the inflated value.
+
+    def insert_reservation_pin_event(
+        self,
+        block_num: int,
+        hotkey: str,
+        from_chain: str,
+        to_chain: str,
+        kind: str,
+        rate: float,
+    ) -> None:
+        with self.lock:
+            conn = self.require_connection()
+            conn.execute(
+                """
+                INSERT INTO reservation_pin_events
+                    (block_num, hotkey, from_chain, to_chain, kind, rate)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (block_num, hotkey, (from_chain or '').lower(), (to_chain or '').lower(), kind, float(rate)),
+            )
+            conn.commit()
+
+    def load_all_reservation_pin_events(self) -> List[dict]:
+        with self.lock:
+            conn = self.require_connection()
+            rows = conn.execute(
+                """
+                SELECT block_num, hotkey, from_chain, to_chain, kind, rate
+                FROM reservation_pin_events
+                ORDER BY block_num ASC, id ASC
+                """
+            ).fetchall()
+        return [
+            {
+                'block_num': r['block_num'],
+                'hotkey': r['hotkey'],
+                'from_chain': r['from_chain'],
+                'to_chain': r['to_chain'],
+                'kind': r['kind'],
+                'rate': r['rate'],
+            }
+            for r in rows
+        ]
+
+    def get_reservation_pin_events_in_range(
+        self,
+        from_chain: str,
+        to_chain: str,
+        start_block: int,
+        end_block: int,
+    ) -> List[dict]:
+        """Pin lifecycle events in ``(start_block, end_block]`` for a direction,
+        oldest first."""
+        with self.lock:
+            conn = self.require_connection()
+            rows = conn.execute(
+                """
+                SELECT id, block_num, hotkey, kind, rate
+                FROM reservation_pin_events
+                WHERE from_chain = ? AND to_chain = ?
+                  AND block_num > ? AND block_num <= ?
+                ORDER BY block_num ASC, id ASC
+                """,
+                ((from_chain or '').lower(), (to_chain or '').lower(), start_block, end_block),
+            ).fetchall()
+        return [
+            {
+                'id': r['id'],
+                'block': r['block_num'],
+                'hotkey': r['hotkey'],
+                'kind': r['kind'],
+                'rate': r['rate'],
+            }
+            for r in rows
+        ]
+
+    def prune_reservation_pin_events(self, cutoff_block: int) -> None:
+        """Drop pin events older than ``cutoff_block``, preserving each
+        (hotkey, from_chain, to_chain) tuple's most recent event so a still-
+        open pin retains its 'start' anchor for state reconstruction. Mirrors
+        the anchor-preservation rule used by ``prune_active_events``.
+        """
+        if cutoff_block <= 0:
+            return
+        with self.lock:
+            conn = self.require_connection()
+            conn.execute(
+                """
+                DELETE FROM reservation_pin_events
+                WHERE block_num < ?
+                  AND id NOT IN (
+                    SELECT MAX(id) FROM reservation_pin_events
+                    GROUP BY hotkey, from_chain, to_chain
+                  )
+                """,
+                (cutoff_block,),
+            )
+            conn.commit()
 
     # ─── rate_events ────────────────────────────────────────────────────
 
@@ -602,6 +731,7 @@ class ValidatorStateStore:
             conn = self.require_connection()
             conn.execute('DELETE FROM active_events')
             conn.execute('DELETE FROM busy_events')
+            conn.execute('DELETE FROM reservation_pin_events')
             conn.execute("DELETE FROM event_watcher_meta WHERE key = 'cursor'")
             conn.execute('DELETE FROM bootstrapped_swaps')
             conn.commit()
@@ -614,6 +744,7 @@ class ValidatorStateStore:
             conn.execute('DELETE FROM rate_events WHERE hotkey = ?', (hotkey,))
             conn.execute('DELETE FROM swap_outcomes WHERE miner_hotkey = ?', (hotkey,))
             conn.execute('DELETE FROM reservation_pins WHERE miner_hotkey = ?', (hotkey,))
+            conn.execute('DELETE FROM reservation_pin_events WHERE hotkey = ?', (hotkey,))
             conn.commit()
 
     def prune_events_older_than(self, cutoff_block: int) -> None:
@@ -735,6 +866,22 @@ class ValidatorStateStore:
                     ON busy_events(block_num);
                 CREATE INDEX IF NOT EXISTS idx_busy_events_hotkey
                     ON busy_events(hotkey);
+
+                CREATE TABLE IF NOT EXISTS reservation_pin_events (
+                    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                    block_num   INTEGER NOT NULL,
+                    hotkey      TEXT NOT NULL,
+                    from_chain  TEXT NOT NULL,
+                    to_chain    TEXT NOT NULL,
+                    kind        TEXT NOT NULL,
+                    rate        REAL NOT NULL DEFAULT 0
+                );
+                CREATE INDEX IF NOT EXISTS idx_reservation_pin_events_block
+                    ON reservation_pin_events(block_num);
+                CREATE INDEX IF NOT EXISTS idx_reservation_pin_events_hotkey
+                    ON reservation_pin_events(hotkey);
+                CREATE INDEX IF NOT EXISTS idx_reservation_pin_events_dir_block
+                    ON reservation_pin_events(from_chain, to_chain, block_num);
 
                 CREATE TABLE IF NOT EXISTS event_watcher_meta (
                     key     TEXT PRIMARY KEY,

--- a/tests/test_event_watcher.py
+++ b/tests/test_event_watcher.py
@@ -539,8 +539,7 @@ class TestReservationPin:
         w.apply_event(950, 'SwapInitiated', {'swap_id': 1, 'miner': 'hk_a'})
 
         end_events = [
-            ev for ev in w.reservation_pin_events
-            if ev.hotkey == 'hk_a' and ev.kind == 'end' and ev.block_num == 950
+            ev for ev in w.reservation_pin_events if ev.hotkey == 'hk_a' and ev.kind == 'end' and ev.block_num == 950
         ]
         # One 'end' per direction that had been pinned.
         assert {(ev.from_chain, ev.to_chain) for ev in end_events} == {('btc', 'tao'), ('tao', 'btc')}
@@ -591,8 +590,7 @@ class TestReservationPin:
         primary = w.get_reservation_pins_at(1150, 'btc', 'tao')
         assert primary == {'hk_a': 250.0}
         end_events = [
-            ev for ev in w.reservation_pin_events
-            if ev.hotkey == 'hk_a' and ev.kind == 'end' and ev.block_num == 1100
+            ev for ev in w.reservation_pin_events if ev.hotkey == 'hk_a' and ev.kind == 'end' and ev.block_num == 1100
         ]
         assert {(ev.from_chain, ev.to_chain) for ev in end_events} == {('btc', 'tao'), ('tao', 'btc')}
         w.state_store.close()

--- a/tests/test_event_watcher.py
+++ b/tests/test_event_watcher.py
@@ -504,6 +504,99 @@ class TestReservationPin:
         assert pin.reserved_until == 1400
         w.state_store.close()
 
+    def test_miner_reserved_emits_scoring_pin_events_for_both_directions(self, tmp_path: Path):
+        """The scoring overlay needs to see a 'start' event in each direction
+        the miner offers a positive rate for. ``MinerReserved`` reads the
+        commitment's primary + counter rate and emits one event per direction
+        with a positive quote."""
+        w = make_watcher(tmp_path, netuid=2, subtensor=MagicMock())
+        with patch(
+            'allways.validator.event_watcher.read_miner_commitment',
+            return_value=make_pinned_commitment(),
+        ):
+            w.apply_event(900, 'MinerReserved', {'miner': 'hk_a', 'reserved_until': 1000})
+
+        # commitment has rate_str=345 (btc→tao) and counter_rate_str=0.0029 (tao→btc).
+        starts = [ev for ev in w.reservation_pin_events if ev.hotkey == 'hk_a' and ev.kind == 'start']
+        assert len(starts) == 2
+        primary = next(ev for ev in starts if ev.from_chain == 'btc' and ev.to_chain == 'tao')
+        counter = next(ev for ev in starts if ev.from_chain == 'tao' and ev.to_chain == 'btc')
+        assert primary.rate == 345.0
+        assert counter.rate == 0.0029
+        assert primary.block_num == 900 and counter.block_num == 900
+        w.state_store.close()
+
+    def test_swap_initiated_emits_pin_end_events(self, tmp_path: Path):
+        """Open pins in any direction must close on SwapInitiated so the
+        scoring overlay drops to live rates once the swap consumes the
+        reservation slot."""
+        w = make_watcher(tmp_path, netuid=2, subtensor=MagicMock())
+        with patch(
+            'allways.validator.event_watcher.read_miner_commitment',
+            return_value=make_pinned_commitment(),
+        ):
+            w.apply_event(900, 'MinerReserved', {'miner': 'hk_a', 'reserved_until': 1000})
+        w.apply_event(950, 'SwapInitiated', {'swap_id': 1, 'miner': 'hk_a'})
+
+        end_events = [
+            ev for ev in w.reservation_pin_events
+            if ev.hotkey == 'hk_a' and ev.kind == 'end' and ev.block_num == 950
+        ]
+        # One 'end' per direction that had been pinned.
+        assert {(ev.from_chain, ev.to_chain) for ev in end_events} == {('btc', 'tao'), ('tao', 'btc')}
+        # After end, get_reservation_pins_at returns empty for both directions.
+        assert w.get_reservation_pins_at(950, 'btc', 'tao') == {}
+        assert w.get_reservation_pins_at(950, 'tao', 'btc') == {}
+        w.state_store.close()
+
+    def test_get_reservation_pins_at_filters_by_direction(self, tmp_path: Path):
+        """get_reservation_pins_at returns only pins active for the requested
+        direction. A miner pinned in both legs is visible in both calls."""
+        w = make_watcher(tmp_path, netuid=2, subtensor=MagicMock())
+        with patch(
+            'allways.validator.event_watcher.read_miner_commitment',
+            return_value=make_pinned_commitment(),
+        ):
+            w.apply_event(900, 'MinerReserved', {'miner': 'hk_a', 'reserved_until': 1000})
+
+        primary = w.get_reservation_pins_at(950, 'btc', 'tao')
+        counter = w.get_reservation_pins_at(950, 'tao', 'btc')
+        assert primary == {'hk_a': 345.0}
+        assert counter == {'hk_a': 0.0029}
+        # A direction the miner doesn't quote returns nothing.
+        assert w.get_reservation_pins_at(950, 'btc', 'eth') == {}
+        w.state_store.close()
+
+    def test_consecutive_miner_reserved_supersedes_prior_pin(self, tmp_path: Path):
+        """If a fresh MinerReserved arrives while a pin from a prior reservation
+        is still open (e.g. terminal event missed), the helper emits an end
+        for the stale pin before laying down the new 'start'."""
+        w = make_watcher(tmp_path, netuid=2, subtensor=MagicMock())
+        first = make_pinned_commitment(rate_str='200', counter_rate_str='0.005')
+        second = make_pinned_commitment(rate_str='250', counter_rate_str='0.004')
+        with patch(
+            'allways.validator.event_watcher.read_miner_commitment',
+            return_value=first,
+        ):
+            w.apply_event(900, 'MinerReserved', {'miner': 'hk_a', 'reserved_until': 1000})
+        with patch(
+            'allways.validator.event_watcher.read_miner_commitment',
+            return_value=second,
+        ):
+            w.apply_event(1100, 'MinerReserved', {'miner': 'hk_a', 'reserved_until': 1200})
+
+        # At block 1100 the active pin should be the second one's rate, not
+        # the first's. The first pin must have been closed by an 'end' before
+        # the second 'start'.
+        primary = w.get_reservation_pins_at(1150, 'btc', 'tao')
+        assert primary == {'hk_a': 250.0}
+        end_events = [
+            ev for ev in w.reservation_pin_events
+            if ev.hotkey == 'hk_a' and ev.kind == 'end' and ev.block_num == 1100
+        ]
+        assert {(ev.from_chain, ev.to_chain) for ev in end_events} == {('btc', 'tao'), ('tao', 'btc')}
+        w.state_store.close()
+
 
 class TestBootstrap:
     """initialize() snapshotting behavior — the M1 fix."""

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -195,8 +195,11 @@ class TestCrownHoldersHelper:
         sort but is not routable, so the executability gate kicks them out
         and the crown drops to the next-best sane rate."""
         rates = {'sentinel': 1e10, 'sane': 326.0}
+
         # Reject the sentinel rate, accept anything ≤ 1e6 (well above sane).
-        check = lambda r: r <= 1e6
+        def check(r):
+            return r <= 1e6
+
         assert crown_holders_at_instant(rates, {'sentinel', 'sane'}, executable_rate_check=check) == ['sane']
 
     def test_executable_check_none_preserves_legacy_behavior(self):

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -424,6 +424,220 @@ class TestReplayCrownTime:
         store.close()
 
 
+class TestPinnedRateDuringReservation:
+    """Crown calculation must use the pinned rate during the reserved-not-busy
+    window, not the live rate. Closes the bump-after-pin loophole."""
+
+    def test_live_rate_bump_after_pin_does_not_earn_crown(self, tmp_path: Path):
+        """A reserved miner who bumps their live rate to an outlier value
+        earns crown at the pinned rate they had at reservation time, not the
+        post-pin live rate."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active={'hk_a', 'hk_b'})
+        conn = store.require_connection()
+        # Pre-window rates: A and B both at 200.
+        for hk in ('hk_a', 'hk_b'):
+            conn.execute(
+                'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+                (hk, 'btc', 'tao', 200.0, 0),
+            )
+        conn.commit()
+
+        # A is reserved at block 300 — pin captures the live rate (200).
+        watcher._record_reservation_pin_event(
+            block_num=300,
+            hotkey='hk_a',
+            from_chain='btc',
+            to_chain='tao',
+            kind='start',
+            rate=200.0,
+        )
+        # A bumps live rate to 25004 at block 400 — would normally dominate
+        # the crown ranking. With the pinned-rate overlay, this update is
+        # ignored for crown purposes until the reservation ends.
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_a', 'btc', 'tao', 25004.0, 400),
+        )
+        conn.commit()
+
+        crown = replay_crown_time_window(
+            store=store,
+            event_watcher=watcher,
+            from_chain='btc',
+            to_chain='tao',
+            window_start=100,
+            window_end=1100,
+            rewardable_hotkeys={'hk_a', 'hk_b'},
+        )
+        # Without the fix, A's 25004 live rate would dominate from block 400
+        # and A would earn ~600 blocks of crown. With the fix, A's effective
+        # rate stays pinned at 200, tying with B. Both earn half of the
+        # 1000-block window.
+        assert crown == {'hk_a': 500.0, 'hk_b': 500.0}
+        store.close()
+
+    def test_pin_end_lets_live_rate_take_over(self, tmp_path: Path):
+        """Once the reservation ends (RESERVED_END), the live rate updates
+        that happened during the pin take effect for crown ranking."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active={'hk_a', 'hk_b'})
+        conn = store.require_connection()
+        for hk in ('hk_a', 'hk_b'):
+            conn.execute(
+                'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+                (hk, 'btc', 'tao', 200.0, 0),
+            )
+        # A bumps to 300 at block 400 — buffered behind the pin.
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_a', 'btc', 'tao', 300.0, 400),
+        )
+        conn.commit()
+
+        watcher._record_reservation_pin_event(
+            block_num=300, hotkey='hk_a', from_chain='btc', to_chain='tao', kind='start', rate=200.0,
+        )
+        # Reservation ends at block 600 — A's live rate of 300 takes over.
+        watcher._record_reservation_pin_event(
+            block_num=600, hotkey='hk_a', from_chain='btc', to_chain='tao', kind='end', rate=0.0,
+        )
+
+        crown = replay_crown_time_window(
+            store=store,
+            event_watcher=watcher,
+            from_chain='btc',
+            to_chain='tao',
+            window_start=100,
+            window_end=1100,
+            rewardable_hotkeys={'hk_a', 'hk_b'},
+        )
+        # (100, 600]: A pinned at 200, B at 200 — tie, each earns 250.
+        # (600, 1100]: A live at 300, B still 200 — A wins 500.
+        assert crown == {'hk_a': 750.0, 'hk_b': 250.0}
+        store.close()
+
+    def test_pin_only_applies_to_pinned_direction(self, tmp_path: Path):
+        """A reservation pin is direction-specific — pinning btc→tao must not
+        affect crown ranking in the tao→btc direction."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active={'hk_a', 'hk_b'})
+        conn = store.require_connection()
+        # Pre-window: both miners quote tao→btc at 0.005.
+        for hk in ('hk_a', 'hk_b'):
+            conn.execute(
+                'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+                (hk, 'tao', 'btc', 0.005, 0),
+            )
+        # Mid-window: A improves their tao→btc rate (lower wins).
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_a', 'tao', 'btc', 0.003, 400),
+        )
+        conn.commit()
+
+        # Pin A in the btc→tao direction only — should not affect tao→btc
+        # crown ranking.
+        watcher._record_reservation_pin_event(
+            block_num=300, hotkey='hk_a', from_chain='btc', to_chain='tao', kind='start', rate=200.0,
+        )
+
+        crown = replay_crown_time_window(
+            store=store,
+            event_watcher=watcher,
+            from_chain='tao',
+            to_chain='btc',
+            window_start=100,
+            window_end=1100,
+            rewardable_hotkeys={'hk_a', 'hk_b'},
+        )
+        # In tao→btc the pin is invisible. (100, 400]: tied at 0.005 → split.
+        # (400, 1100]: A wins at 0.003 (lower) → 700 to A.
+        assert crown == {'hk_a': 150.0 + 700.0, 'hk_b': 150.0}
+        store.close()
+
+    def test_pin_active_at_window_start_is_reconstructed(self, tmp_path: Path):
+        """A pin laid down before window_start must overlay the live rate from
+        the first interval — same anchor-reconstruction guarantee that
+        rates/busy/active have."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active={'hk_a', 'hk_b'})
+        conn = store.require_connection()
+        for hk in ('hk_a', 'hk_b'):
+            conn.execute(
+                'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+                (hk, 'btc', 'tao', 200.0, 0),
+            )
+        # A bumps to 25004 BEFORE the window opens (block 50). Without the
+        # pin, A would dominate from window_start.
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_a', 'btc', 'tao', 25004.0, 50),
+        )
+        conn.commit()
+
+        # Pin laid down at block 30 (also before window_start) captures
+        # the rate as of that block: 200. Pin remains open at window_start.
+        watcher._record_reservation_pin_event(
+            block_num=30, hotkey='hk_a', from_chain='btc', to_chain='tao', kind='start', rate=200.0,
+        )
+
+        crown = replay_crown_time_window(
+            store=store,
+            event_watcher=watcher,
+            from_chain='btc',
+            to_chain='tao',
+            window_start=100,
+            window_end=1100,
+            rewardable_hotkeys={'hk_a', 'hk_b'},
+        )
+        # A's effective rate stays pinned at 200 across the entire window;
+        # B is also at 200. They tie, each earns half.
+        assert crown == {'hk_a': 500.0, 'hk_b': 500.0}
+        store.close()
+
+    def test_busy_still_excludes_pinned_miner_from_crown(self, tmp_path: Path):
+        """The pinned-rate overlay does not override the busy gate — a pinned
+        miner whose SwapInitiated fires earns no crown while busy. Sanity
+        check that pinning and busy compose correctly."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active={'hk_a', 'hk_b'})
+        conn = store.require_connection()
+        for hk in ('hk_a', 'hk_b'):
+            conn.execute(
+                'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+                (hk, 'btc', 'tao', 200.0, 0),
+            )
+        conn.commit()
+
+        # A pinned at 200 at block 300. Then SwapInitiated at 500 → busy.
+        # Pin should end at SwapInitiated (event_watcher emits the 'end' in
+        # production); we simulate that here.
+        watcher._record_reservation_pin_event(
+            block_num=300, hotkey='hk_a', from_chain='btc', to_chain='tao', kind='start', rate=200.0,
+        )
+        watcher._record_reservation_pin_event(
+            block_num=500, hotkey='hk_a', from_chain='btc', to_chain='tao', kind='end', rate=0.0,
+        )
+        watcher.apply_busy_delta(500, 'hk_a', +1)
+        watcher.apply_busy_delta(900, 'hk_a', -1)
+
+        crown = replay_crown_time_window(
+            store=store,
+            event_watcher=watcher,
+            from_chain='btc',
+            to_chain='tao',
+            window_start=100,
+            window_end=1100,
+            rewardable_hotkeys={'hk_a', 'hk_b'},
+        )
+        # (100, 500]: A pinned, both at 200, tie → 200 each.
+        # (500, 900]: A busy → B alone → 400.
+        # (900, 1100]: A back at live 200, tie → 100 each.
+        assert crown == {'hk_a': 200.0 + 100.0, 'hk_b': 200.0 + 400.0 + 100.0}
+        store.close()
+
+
 class TestCalculateMinerRewards:
     def test_empty_direction_recycles_full_pool(self, tmp_path: Path):
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -496,11 +496,21 @@ class TestPinnedRateDuringReservation:
         conn.commit()
 
         watcher._record_reservation_pin_event(
-            block_num=300, hotkey='hk_a', from_chain='btc', to_chain='tao', kind='start', rate=200.0,
+            block_num=300,
+            hotkey='hk_a',
+            from_chain='btc',
+            to_chain='tao',
+            kind='start',
+            rate=200.0,
         )
         # Reservation ends at block 600 — A's live rate of 300 takes over.
         watcher._record_reservation_pin_event(
-            block_num=600, hotkey='hk_a', from_chain='btc', to_chain='tao', kind='end', rate=0.0,
+            block_num=600,
+            hotkey='hk_a',
+            from_chain='btc',
+            to_chain='tao',
+            kind='end',
+            rate=0.0,
         )
 
         crown = replay_crown_time_window(
@@ -539,7 +549,12 @@ class TestPinnedRateDuringReservation:
         # Pin A in the btc→tao direction only — should not affect tao→btc
         # crown ranking.
         watcher._record_reservation_pin_event(
-            block_num=300, hotkey='hk_a', from_chain='btc', to_chain='tao', kind='start', rate=200.0,
+            block_num=300,
+            hotkey='hk_a',
+            from_chain='btc',
+            to_chain='tao',
+            kind='start',
+            rate=200.0,
         )
 
         crown = replay_crown_time_window(
@@ -579,7 +594,12 @@ class TestPinnedRateDuringReservation:
         # Pin laid down at block 30 (also before window_start) captures
         # the rate as of that block: 200. Pin remains open at window_start.
         watcher._record_reservation_pin_event(
-            block_num=30, hotkey='hk_a', from_chain='btc', to_chain='tao', kind='start', rate=200.0,
+            block_num=30,
+            hotkey='hk_a',
+            from_chain='btc',
+            to_chain='tao',
+            kind='start',
+            rate=200.0,
         )
 
         crown = replay_crown_time_window(
@@ -614,10 +634,20 @@ class TestPinnedRateDuringReservation:
         # Pin should end at SwapInitiated (event_watcher emits the 'end' in
         # production); we simulate that here.
         watcher._record_reservation_pin_event(
-            block_num=300, hotkey='hk_a', from_chain='btc', to_chain='tao', kind='start', rate=200.0,
+            block_num=300,
+            hotkey='hk_a',
+            from_chain='btc',
+            to_chain='tao',
+            kind='start',
+            rate=200.0,
         )
         watcher._record_reservation_pin_event(
-            block_num=500, hotkey='hk_a', from_chain='btc', to_chain='tao', kind='end', rate=0.0,
+            block_num=500,
+            hotkey='hk_a',
+            from_chain='btc',
+            to_chain='tao',
+            kind='end',
+            rate=0.0,
         )
         watcher.apply_busy_delta(500, 'hk_a', +1)
         watcher.apply_busy_delta(900, 'hk_a', -1)


### PR DESCRIPTION
## What
During the window between `MinerReserved` and `SwapInitiated` (or `SwapCompleted` / `SwapTimedOut` / next `MinerReserved`), the crown-time scoring replay now uses the rate captured at the reservation block — *not* whatever the miner's live rate is at that moment.

## Why
Today a miner can hold a moderate live rate up to `MinerReserved`, then bump live rate to an outlier value (e.g. 100× market) while still reserved-not-busy and earn crown at the inflated value for the entire reservation window. The "bump after pin" lever is the per-cycle driver behind sustained wash-farming of the crown pool — observed in production with UID 193 posting 25004 TAO/BTC (88× market) and self-completing swaps to keep success rate clean.

The reservation pin already captures the canonical commitment at the reservation block for `handle_swap_confirm`'s anti-snipe path. This change feeds the same signal into crown-time scoring so the miner's effective rate for ranking is frozen at the pinned value until the reservation terminates.

## How
- New `reservation_pin_events` table records direction-specific `'start'` (with the pinned rate) and `'end'` events.
- `MinerReserved` emits `'start'` events in each direction the miner offers a positive rate for (primary + counter if both > 0).
- `SwapInitiated` / `SwapCompleted` / `SwapTimedOut` emit `'end'` events that close any open pins for that miner.
- The crown-time replay overlays the pinned rate on top of live rates inside `credit_interval` — live `rate_events` continue to flow normally, so the moment a pin lifts the live rate takes effect cleanly.
- New `EventKind.RESERVED_START` / `RESERVED_END` with documented same-block ordering: `ACTIVE → BUSY → RESERVED_END → RATE → RESERVED_START`, so a same-block rate change is captured by the pin (matching the contract's block-end commitment read).
- Warm-restart hydration and prune logic mirror what `busy_events` / `active_events` already have.

## Scope
- Scoring-side change only — no contract change, no synapse change, no protocol-level coordination.
- Behavioral effect is on crown attribution. Existing `busy` semantics, success rate, capacity factor, volume factor are untouched.
- Validators converge by running the same scoring code against the same on-chain pin lifecycle — same convergence story as every other scoring change.

## Test
- 9 new tests: `TestPinnedRateDuringReservation` (5) covers bump-after-pin ignored, pin-end lets live rate take over, direction filtering, pin-active-at-window-start reconstruction, busy+pin composition. New `TestReservationPin` tests (4) cover dual-direction start emission, end-on-`SwapInitiated`, direction-filtered query, consecutive `MinerReserved` supersedes a stale pin.
- Full suite: 539 passed (one unrelated `embit` optional-dep failure in `test_bitcoin_signing.py`).