### PR TITLE
Filter unexecutable rates from crown eligibility

### DIFF
--- a/allways/utils/rate.py
+++ b/allways/utils/rate.py
@@ -1,5 +1,6 @@
 """Shared rate calculation — single source of truth for to_amount math."""
 
+import math
 from decimal import Decimal
 from typing import Tuple
 
@@ -117,6 +118,59 @@ def quote_within_slippage(quoted: int, recomputed: int, slippage_bps: int) -> bo
     if recomputed >= quoted:
         return True
     return recomputed * 10_000 >= quoted * (10_000 - slippage_bps)
+
+
+def is_executable_rate(
+    rate: float,
+    from_chain: str,
+    to_chain: str,
+    min_swap_rao: int,
+    max_swap_rao: int,
+) -> bool:
+    """True iff some positive integer source amount yields a TAO leg within
+    ``[min_swap_rao, max_swap_rao]`` at the given rate and direction.
+
+    Crown-eligibility gate: sentinel rates like ``1e10`` TAO/BTC win the
+    rate sort but no positive integer satoshi maps to an in-bounds TAO
+    leg, so they're not routable by any user — they should not earn crown.
+
+    A bound at ``0`` is the contract's "unset" sentinel and disables that
+    side; both at 0 → permissive (no on-chain bounds yet).
+    """
+    if not math.isfinite(rate) or rate <= 0:
+        return False
+    if min_swap_rao <= 0 and max_swap_rao <= 0:
+        return True
+
+    if to_chain == 'tao':
+        # Forward into TAO: dest_rao = source_units × rate × 10**(tao_dec - src_dec).
+        src_decimals = get_chain(from_chain).decimals
+        decimal_factor = 10 ** (get_chain('tao').decimals - src_decimals)
+        denom = rate * decimal_factor
+        if not math.isfinite(denom) or denom <= 0:
+            # rate × decimal_factor overflowed (e.g. 1.797e308 × 10) → smallest
+            # positive integer source already maps above any finite max bound.
+            return False
+        min_source = max(1, math.ceil(max(1, min_swap_rao) / denom))
+        if max_swap_rao <= 0:
+            return True
+        max_source = math.floor(max_swap_rao / denom)
+        return min_source <= max_source
+
+    if from_chain == 'tao':
+        # Reverse out of TAO: TAO leg = source_rao itself. Any positive
+        # integer rao in [min, max] qualifies — rate doesn't gate the TAO
+        # side here. (The asymmetric griefing case — extremely low rate
+        # producing an unfulfillable BTC payout — is an economic-backing
+        # concern, not a granularity one, and is out of scope for this
+        # predicate.)
+        lo = max(1, min_swap_rao)
+        if max_swap_rao <= 0:
+            return True
+        return lo <= max_swap_rao
+
+    # Non-TAO pairs have no TAO-leg bound to enforce.
+    return True
 
 
 def check_swap_viability(

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import IntEnum
-from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Set, Tuple
 
 import bittensor as bt
 import numpy as np
@@ -25,6 +25,7 @@ from allways.constants import (
     SUCCESS_EXPONENT,
     VOLUME_WEIGHT_ALPHA,
 )
+from allways.utils.rate import is_executable_rate
 from allways.validator.event_watcher import ContractEventWatcher
 from allways.validator.scoring_trace import WeightingTrace, log_scoring_trace
 from allways.validator.state_store import ValidatorStateStore
@@ -126,6 +127,11 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
     except Exception as e:
         bt.logging.warning(f'max_swap_amount read failed: {e}')
         max_swap_amount = 0
+    try:
+        min_swap_amount = int(self.bounds_cache.min_swap_amount())
+    except Exception as e:
+        bt.logging.warning(f'min_swap_amount read failed: {e}')
+        min_swap_amount = 0
     collaterals: Dict[str, int] = {}
     miner_volume_total: Dict[str, int] = {}
     miner_crown_total: Dict[str, float] = {}
@@ -144,6 +150,8 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
             window_end=window_end,
             rewardable_hotkeys=rewardable_hotkeys,
             trace=trace,
+            min_swap_rao=min_swap_amount,
+            max_swap_rao=max_swap_amount,
         )
         total_crown_dir = sum(crown_blocks.values())
         volumes_dir = self.state_store.get_volume_by_direction_since(window_start, from_chain, to_chain)
@@ -391,15 +399,21 @@ def replay_crown_time_window(
     window_end: int,
     rewardable_hotkeys: Set[str],
     trace: Optional[DirectionTrace] = None,
+    min_swap_rao: int = 0,
+    max_swap_rao: int = 0,
 ) -> Dict[str, float]:
     """Walk the merged event stream, return ``{hotkey: crown_blocks_float}``.
     Ties at the same rate split credit evenly. A miner qualifies for crown
     at an instant iff they are on the current metagraph, were active at
-    that instant, not busy, and had a positive rate posted. Active/rate/busy
+    that instant, not busy, had a positive rate posted, and their rate is
+    executable under the current contract swap bounds. Active/rate/busy
     are evaluated per-block via the replay — a miner's status at scoring
     time is irrelevant other than metagraph membership (used to credit the
     UID). Collateral-floor invariants are trusted to the contract's active
-    flag; halt state is handled at ``score_and_reward_miners`` entry."""
+    flag; halt state is handled at ``score_and_reward_miners`` entry.
+
+    Bounds at 0 disable the executability filter (matches the contract's
+    "unset" sentinel); the rate-positive floor still applies."""
     rates, busy_count, active_set = reconstruct_window_start_state(
         store, event_watcher, from_chain, to_chain, window_start, rewardable_hotkeys
     )
@@ -410,6 +424,9 @@ def replay_crown_time_window(
     # direction (tao→btc) lower = better.
     canon_from, _ = canonical_pair(from_chain, to_chain)
     lower_rate_wins = from_chain != canon_from
+
+    def executable_check(rate: float) -> bool:
+        return is_executable_rate(rate, from_chain, to_chain, min_swap_rao, max_swap_rao)
 
     crown_blocks: Dict[str, float] = {}
     prev_block = window_start
@@ -425,6 +442,7 @@ def replay_crown_time_window(
             busy=busy_set,
             active=active_set,
             lower_rate_wins=lower_rate_wins,
+            executable_rate_check=executable_check,
         )
         if not holders:
             if trace is not None:
@@ -469,16 +487,25 @@ def crown_holders_at_instant(
     busy: Optional[Set[str]] = None,
     active: Optional[Set[str]] = None,
     lower_rate_wins: bool = False,
+    executable_rate_check: Optional[Callable[[float], bool]] = None,
 ) -> List[str]:
     """Take the miners posting the best rate, but only if they satisfy every
-    other condition (rewardable, active, not busy, rate > 0). If the best
-    rate has no qualified miner, fall through to the next-best rate.
+    other condition (rewardable, active, not busy, rate > 0, executable).
+    If the best rate has no qualified miner, fall through to the next-best
+    rate.
 
     ``lower_rate_wins`` flips the sort: rates are stored as canonical_dest
     per canonical_source (TAO per BTC), so higher-is-better only holds in
     the canonical direction (btc→tao). In the reverse direction (tao→btc)
     a smaller TAO/BTC quote means the miner is asking less TAO for 1 BTC —
     a better deal for the swapper, which earns them the crown.
+
+    ``executable_rate_check`` (optional) rejects rates that no user can
+    route under the current contract swap bounds. Sentinels like 1e10
+    TAO/BTC win the rate sort but map every positive integer satoshi to a
+    TAO leg outside ``[min_swap, max_swap]``, so they should not earn
+    crown. When None (tests that don't care about bounds; pre-bounds-aware
+    callers), no executability filter is applied.
 
     Collateral-floor gating is trusted to the contract's active flag —
     miners who drop below the floor get auto-deactivated on-chain (fee /
@@ -493,7 +520,12 @@ def crown_holders_at_instant(
     def qualifies(hotkey: str) -> bool:
         if active is not None and hotkey not in active:
             return False
-        return hotkey in rewardable and hotkey not in busy and rates.get(hotkey, 0) > 0
+        rate = rates.get(hotkey, 0)
+        if rate <= 0:
+            return False
+        if executable_rate_check is not None and not executable_rate_check(rate):
+            return False
+        return hotkey in rewardable and hotkey not in busy
 
     by_rate: Dict[float, List[str]] = {}
     for hotkey, rate in rates.items():

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -3,7 +3,7 @@
 from decimal import Decimal
 
 from allways.constants import BTC_TO_SAT, RATE_PRECISION, TAO_TO_RAO
-from allways.utils.rate import apply_fee_deduction, calculate_to_amount, normalize_rate
+from allways.utils.rate import apply_fee_deduction, calculate_to_amount, is_executable_rate, normalize_rate
 
 # Chain decimals
 TAO_DEC = 9
@@ -271,3 +271,68 @@ class TestNormalizeRate:
         """Pre-existing :g behavior — sub-1e-4 values switch to scientific.
         Documented so a future change to fixed-point doesn't silently break."""
         assert normalize_rate(1e-6) == '1e-06'
+
+
+class TestIsExecutableRate:
+    """Crown-eligibility gate against sentinel quotes that no user can route.
+
+    Bounds chosen to match live SN7 contract: ``min_swap=0.1 TAO``,
+    ``max_swap=0.5 TAO`` (in rao).
+    """
+
+    MIN = 100_000_000  # 0.1 TAO
+    MAX = 500_000_000  # 0.5 TAO
+
+    def test_sane_btc_to_tao_rate_executable(self):
+        assert is_executable_rate(326.0, 'btc', 'tao', self.MIN, self.MAX) is True
+
+    def test_sane_tao_to_btc_rate_executable(self):
+        assert is_executable_rate(326.0, 'tao', 'btc', self.MIN, self.MAX) is True
+
+    def test_huge_btc_to_tao_rate_rejected(self):
+        """1e10 TAO/BTC: 1 sat → 1e11 rao = 100 TAO, far above 0.5 TAO max.
+        No positive integer sat lands in [0.1, 0.5] TAO."""
+        assert is_executable_rate(1e10, 'btc', 'tao', self.MIN, self.MAX) is False
+
+    def test_float_max_btc_to_tao_rate_rejected(self):
+        """The other sentinel miners post: float-max wins the rate sort but
+        overflows the conversion math entirely."""
+        assert is_executable_rate(1.797e308, 'btc', 'tao', self.MIN, self.MAX) is False
+
+    def test_zero_rate_rejected(self):
+        assert is_executable_rate(0.0, 'btc', 'tao', self.MIN, self.MAX) is False
+
+    def test_negative_rate_rejected(self):
+        assert is_executable_rate(-1.0, 'btc', 'tao', self.MIN, self.MAX) is False
+
+    def test_non_finite_rate_rejected(self):
+        assert is_executable_rate(float('inf'), 'btc', 'tao', self.MIN, self.MAX) is False
+        assert is_executable_rate(float('nan'), 'btc', 'tao', self.MIN, self.MAX) is False
+
+    def test_bounds_unset_is_permissive(self):
+        """Both bounds at 0 → no on-chain limit configured → don't filter.
+        Matches the contract's unset-bounds sentinel."""
+        assert is_executable_rate(1e10, 'btc', 'tao', 0, 0) is True
+        assert is_executable_rate(1e-10, 'tao', 'btc', 0, 0) is True
+
+    def test_max_unset_only_lower_bound_enforced(self):
+        """If only min_swap is set, every rate above the floor is executable."""
+        assert is_executable_rate(1e10, 'btc', 'tao', self.MIN, 0) is True
+
+    def test_tao_to_btc_lowball_rate_passes_predicate(self):
+        """tao→btc with rate=1e-8: the TAO leg IS the source amount, which
+        is in bounds for any rao in [min, max]. The bug here is economic
+        (uncollateralized BTC payout) rather than granularity, and lives
+        outside this predicate — documented so reviewers know the gap."""
+        assert is_executable_rate(1e-8, 'tao', 'btc', self.MIN, self.MAX) is True
+
+    def test_boundary_rate_executable_at_one_sat(self):
+        """At max_swap/10 = 50_000_000 rao per sat, the smallest integer sat
+        produces exactly max_swap — should be executable."""
+        rate = self.MAX / 10  # TAO leg at 1 sat == max_swap
+        assert is_executable_rate(rate, 'btc', 'tao', self.MIN, self.MAX) is True
+
+    def test_just_past_boundary_rate_rejected(self):
+        """A rate that maps 1 sat just above max_swap → no executable sat."""
+        rate = (self.MAX / 10) * 1.0001
+        assert is_executable_rate(rate, 'btc', 'tao', self.MIN, self.MAX) is False

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -190,6 +190,23 @@ class TestCrownHoldersHelper:
         # Smallest miner is busy → next-smallest takes the crown.
         assert crown_holders_at_instant(rates, {'a', 'b'}, busy={'a'}, lower_rate_wins=True) == ['b']
 
+    def test_executable_check_drops_sentinel_and_falls_through(self):
+        """Regression for #392: a miner posting 1e10 TAO/BTC wins the rate
+        sort but is not routable, so the executability gate kicks them out
+        and the crown drops to the next-best sane rate."""
+        rates = {'sentinel': 1e10, 'sane': 326.0}
+        # Reject the sentinel rate, accept anything ≤ 1e6 (well above sane).
+        check = lambda r: r <= 1e6
+        assert crown_holders_at_instant(
+            rates, {'sentinel', 'sane'}, executable_rate_check=check
+        ) == ['sane']
+
+    def test_executable_check_none_preserves_legacy_behavior(self):
+        """When no check is supplied, the old qualification rules apply —
+        sentinel still wins. Ensures existing callers aren't surprised."""
+        rates = {'sentinel': 1e10, 'sane': 326.0}
+        assert crown_holders_at_instant(rates, {'sentinel', 'sane'}) == ['sentinel']
+
 
 class TestReplayCrownTime:
     def test_single_miner_holds_full_window(self, tmp_path: Path):
@@ -244,6 +261,67 @@ class TestReplayCrownTime:
         )
         # B leads blocks (100, 600] → 500 blocks, A leads (600, 1100] → 500 blocks
         assert crown == {'hk_b': 500.0, 'hk_a': 500.0}
+        store.close()
+
+    def test_sentinel_rate_earns_no_crown_when_bounds_set(self, tmp_path: Path):
+        """Regression for #392: a miner posting an unexecutable sentinel
+        rate (1e10 TAO/BTC) wins the rate sort but cannot route any
+        positive integer sat into ``[min_swap, max_swap]`` — they should
+        earn zero crown, and the sane miner takes the entire window."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active={'hk_sentinel', 'hk_sane'})
+        conn = store.require_connection()
+        for row in (
+            ('hk_sentinel', 'btc', 'tao', 1e10, 0),
+            ('hk_sane', 'btc', 'tao', 326.0, 0),
+        ):
+            conn.execute(
+                'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+                row,
+            )
+        conn.commit()
+
+        crown = replay_crown_time_window(
+            store=store,
+            event_watcher=watcher,
+            from_chain='btc',
+            to_chain='tao',
+            window_start=100,
+            window_end=1100,
+            rewardable_hotkeys={'hk_sentinel', 'hk_sane'},
+            min_swap_rao=100_000_000,  # 0.1 TAO
+            max_swap_rao=500_000_000,  # 0.5 TAO
+        )
+        assert crown == {'hk_sane': 1000.0}
+        store.close()
+
+    def test_sentinel_rate_still_wins_when_bounds_unset(self, tmp_path: Path):
+        """Without configured bounds the executability filter is permissive
+        — preserves legacy behavior on chains/networks that haven't yet
+        set ``min_swap_amount`` / ``max_swap_amount``."""
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active={'hk_sentinel', 'hk_sane'})
+        conn = store.require_connection()
+        for row in (
+            ('hk_sentinel', 'btc', 'tao', 1e10, 0),
+            ('hk_sane', 'btc', 'tao', 326.0, 0),
+        ):
+            conn.execute(
+                'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+                row,
+            )
+        conn.commit()
+
+        crown = replay_crown_time_window(
+            store=store,
+            event_watcher=watcher,
+            from_chain='btc',
+            to_chain='tao',
+            window_start=100,
+            window_end=1100,
+            rewardable_hotkeys={'hk_sentinel', 'hk_sane'},
+        )
+        assert crown == {'hk_sentinel': 1000.0}
         store.close()
 
     def test_zero_rate_optout_hands_crown_to_still_offering_miner(self, tmp_path: Path):

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -197,9 +197,7 @@ class TestCrownHoldersHelper:
         rates = {'sentinel': 1e10, 'sane': 326.0}
         # Reject the sentinel rate, accept anything ≤ 1e6 (well above sane).
         check = lambda r: r <= 1e6
-        assert crown_holders_at_instant(
-            rates, {'sentinel', 'sane'}, executable_rate_check=check
-        ) == ['sane']
+        assert crown_holders_at_instant(rates, {'sentinel', 'sane'}, executable_rate_check=check) == ['sane']
 
     def test_executable_check_none_preserves_legacy_behavior(self):
         """When no check is supplied, the old qualification rules apply —


### PR DESCRIPTION
## Summary

Closes #392.

`crown_holders_at_instant` previously qualified any rate with `rate > 0`, so sentinel quotes like `1e10` or `1.797e+308` TAO/BTC would win the rate sort despite being unroutable: no positive integer satoshi maps to a TAO leg inside the contract's `[min_swap_amount, max_swap_amount]` band. With the volume_factor's `(1-α) = 0.5` floor on idle miners, those sentinel posters were harvesting half-credit crown-time for free.

This change adds `is_executable_rate` in `utils/rate.py` and threads the contract's `min_swap_amount` / `max_swap_amount` (both already cached in `bounds_cache`) through `replay_crown_time_window` into `crown_holders_at_instant`. Miners failing the predicate at an instant are dropped from qualification; the crown sort falls through to the next-best executable rate. Net effect on the live exploit: sentinel posters get `crown_share = 0`, so `reward = pool × 0 × … = 0` — full removal, not a half-credit haircut.

## Scope notes

- **Bounds unset → no filter.** When `min_swap_amount` and `max_swap_amount` are both zero (the contract's "unset" sentinel), the predicate is permissive — preserves behavior on networks that haven't configured bounds yet.
- **Asymmetric tao→btc gap acknowledged.** The issue cites `1e-8` TAO/BTC on tao→btc as part of the same pattern. That direction is **contract-executable** (TAO leg = source amount, which sits in bounds for any user-chosen rao), so the granularity predicate from the issue's "expected direction" cannot catch it. It's an economic-backing problem (uncollateralized BTC payout), conceptually a different bug. Documented inline in `is_executable_rate` and called out in `test_tao_to_btc_lowball_rate_passes_predicate` so reviewers know the gap is intentional, not an oversight.
- **No data migration / on-chain action.** Existing sentinel commitments stay in the store; the parser still accepts them. They just stop earning crown the moment a validator runs the patched code. To re-enter the crown contest, miners post a sane commitment.

## Test plan

- [x] `pytest tests/test_rate.py` — new `TestIsExecutableRate` covers: sane rates in both directions accepted, `1e10` rejected, `1.797e+308` rejected, NaN/inf/negative/zero rejected, bounds-unset = permissive, boundary cases at `max_swap/10` (exactly executable at 1 sat) and just past (rejected), tao→btc lowball gap documented.
- [x] `pytest tests/test_scoring_v1.py` — new crown-filter tests: sentinel-vs-sane falls through to sane miner when bounds are set; sentinel still wins when bounds are unset (back-compat); legacy `crown_holders_at_instant` callers without `executable_rate_check` see no behavior change.
- [x] Full suite: 579 passed.