### PR TITLE
Fix swap quote row selection and close TAO→BTC crown loophole

### DIFF
--- a/allways/cli/swap_commands/quote.py
+++ b/allways/cli/swap_commands/quote.py
@@ -16,7 +16,13 @@ from allways.cli.swap_commands.helpers import (
 )
 from allways.constants import FEE_DIVISOR
 from allways.contract_client import ContractError
-from allways.utils.rate import apply_fee_deduction, calculate_to_amount, check_swap_viability, derive_tao_leg
+from allways.utils.rate import (
+    apply_fee_deduction,
+    calculate_to_amount,
+    check_swap_viability,
+    derive_tao_leg,
+    is_executable_rate,
+)
 
 
 @click.command('quote')
@@ -104,8 +110,6 @@ def quote_command(from_chain: str, to_chain: str, amount: float):
         console.print('[yellow]No active miners with collateral for this pair[/yellow]\n')
         return
 
-    available.sort(key=lambda x: x[0].rate, reverse=True)
-
     # Calculate amounts per miner
     canon_from, canon_to = canonical_pair(from_chain, to_chain)
     is_reverse = from_chain != canon_from
@@ -113,41 +117,18 @@ def quote_command(from_chain: str, to_chain: str, amount: float):
     canon_from_decimals = get_chain(canon_from).decimals
     dst_chain_def = get_chain(to_chain)
 
-    # Contract-side bounds are global — check before per-miner viability so
-    # a user who requested an out-of-bounds amount gets one clear reason
-    # instead of N rows each blaming collateral. Bounds are enforced against
-    # the TAO leg (see vote_reserve in lib.rs).
+    # Rate is canonical_dest per canonical_source (e.g. TAO/BTC). For BTC→TAO
+    # higher is better for the user; for TAO→BTC lower is better. Match the
+    # direction-aware sort already used by `swap now` (swap.py) and validator
+    # crown (scoring.py) so the top row is the best available rate.
+    available.sort(key=lambda x: x[0].rate, reverse=not is_reverse)
+
     try:
         min_swap_rao = client.get_min_swap_amount()
         max_swap_rao = client.get_max_swap_amount()
     except ContractError:
         min_swap_rao = 0
         max_swap_rao = 0
-
-    # Global bounds (min/max swap) are the same for every miner — check once
-    # up front so a bounds-violating amount gets one clear reason instead of
-    # N rows each blaming collateral. Use any row's rate to derive the TAO
-    # leg; only the direction matters, not the miner.
-    sample_pair = available[0][0]
-    sample_to_amount = calculate_to_amount(
-        from_amount, sample_pair.rate_str, is_reverse, canon_to_decimals, canon_from_decimals
-    )
-    request_tao_rao = derive_tao_leg(from_chain, from_amount, to_chain, sample_to_amount)
-
-    if min_swap_rao > 0 and request_tao_rao < min_swap_rao:
-        console.print(
-            f'\n[red]Amount below contract minimum: {from_rao(request_tao_rao):.4f} TAO equivalent '
-            f'< {from_rao(min_swap_rao):.4f} TAO min.[/red]\n'
-            f'[dim]No miner can accept this — increase --amount.[/dim]\n'
-        )
-        return
-    if max_swap_rao > 0 and request_tao_rao > max_swap_rao:
-        console.print(
-            f'\n[red]Amount above contract maximum: {from_rao(request_tao_rao):.4f} TAO equivalent '
-            f'> {from_rao(max_swap_rao):.4f} TAO max.[/red]\n'
-            f'[dim]No miner can accept this — decrease --amount.[/dim]\n'
-        )
-        return
 
     src_up = from_chain.upper()
     dst_up = to_chain.upper()
@@ -166,6 +147,12 @@ def quote_command(from_chain: str, to_chain: str, amount: float):
 
     viable_count = 0
     busy_but_fits_count = 0
+    # Track bounds reasons so we can give a single actionable hint when every
+    # miner failed for the same reason (the previous up-front bounds check did
+    # this, but using available[0]'s rate to derive the TAO leg — wrong for
+    # BTC→TAO, where the TAO leg depends on the miner's rate).
+    above_max_count = 0
+    below_min_count = 0
     for idx, (pair, collateral, has_swap) in enumerate(available, 1):
         to_amount = calculate_to_amount(from_amount, pair.rate_str, is_reverse, canon_to_decimals, canon_from_decimals)
         user_receives = apply_fee_deduction(to_amount, fee_divisor)
@@ -173,18 +160,29 @@ def quote_command(from_chain: str, to_chain: str, amount: float):
 
         tao_amount_rao = derive_tao_leg(from_chain, from_amount, to_chain, to_amount)
         viable, reason = check_swap_viability(tao_amount_rao, collateral, min_swap_rao, max_swap_rao)
+        # Sentinel rates (e.g. 1.797e+308 TAO/BTC) win the rate sort but no
+        # positive integer source amount maps to an in-bounds TAO leg, so the
+        # miner can't actually accept any user-routable swap. Match the crown
+        # eligibility gate so they don't get labeled "available" here either.
+        routable = is_executable_rate(pair.rate, from_chain, to_chain, min_swap_rao, max_swap_rao)
         # "in swap" takes precedence over amount-viability: even if the amount
         # fits, the miner can't accept a new reservation until the current one
         # resolves. Shown yellow rather than red to signal "temporary".
         if has_swap:
             status = '[yellow]in swap[/yellow]'
-            if viable:
+            if viable and routable:
                 busy_but_fits_count += 1
+        elif not routable:
+            status = '[red]unexecutable rate[/red]'
         elif viable:
             status = '[green]available[/green]'
             viable_count += 1
         else:
             status = f'[red]{reason}[/red]'
+            if 'above max' in reason:
+                above_max_count += 1
+            elif 'below min' in reason:
+                below_min_count += 1
 
         table.add_row(
             str(idx),
@@ -201,10 +199,14 @@ def quote_command(from_chain: str, to_chain: str, amount: float):
     # Show the implied max-send amount at the best available rate so a user
     # who hit "insufficient collateral" knows the ceiling to retry under.
     # Prefer a miner that's not in-swap so the hint is actionable now; fall
-    # back to the top-rate row so the user still sees a ceiling figure.
-    reservable = [row for row in available if not row[2]]
-    if (reservable or available) and max_swap_rao > 0:
-        best_pair, best_collateral, best_has_swap = reservable[0] if reservable else available[0]
+    # back to the top-rate row so the user still sees a ceiling figure. Skip
+    # rows with unexecutable rates — citing a sentinel as "best" would mislead.
+    routable_rows = [
+        row for row in available if is_executable_rate(row[0].rate, from_chain, to_chain, min_swap_rao, max_swap_rao)
+    ]
+    reservable = [row for row in routable_rows if not row[2]]
+    if (reservable or routable_rows) and max_swap_rao > 0:
+        best_pair, best_collateral, best_has_swap = reservable[0] if reservable else routable_rows[0]
         # The TAO leg is capped by min(collateral, max_swap_rao).
         effective_tao_cap_rao = min(best_collateral, max_swap_rao)
         if from_chain == 'tao':
@@ -225,6 +227,16 @@ def quote_command(from_chain: str, to_chain: str, amount: float):
         if busy_but_fits_count > 0:
             console.print(
                 '  [yellow]All miners that can fulfill this amount are currently in a swap — retry shortly.[/yellow]\n'
+            )
+        elif above_max_count > 0 and below_min_count == 0 and max_swap_rao > 0:
+            console.print(
+                f'  [yellow]No miner can accept this — every routable miner exceeds the contract max '
+                f'({from_rao(max_swap_rao):.4f} TAO equivalent). Decrease --amount.[/yellow]\n'
+            )
+        elif below_min_count > 0 and above_max_count == 0 and min_swap_rao > 0:
+            console.print(
+                f'  [yellow]No miner can accept this — every routable miner is below the contract min '
+                f'({from_rao(min_swap_rao):.4f} TAO equivalent). Increase --amount.[/yellow]\n'
             )
         else:
             console.print(

--- a/allways/utils/rate.py
+++ b/allways/utils/rate.py
@@ -127,12 +127,19 @@ def is_executable_rate(
     min_swap_rao: int,
     max_swap_rao: int,
 ) -> bool:
-    """True iff some positive integer source amount yields a TAO leg within
-    ``[min_swap_rao, max_swap_rao]`` at the given rate and direction.
+    """True iff the rate is integer-routable in its declared direction.
 
-    Crown-eligibility gate: sentinel rates like ``1e10`` TAO/BTC win the
-    rate sort but no positive integer satoshi maps to an in-bounds TAO
-    leg, so they're not routable by any user — they should not earn crown.
+    Crown-eligibility gate against sentinel rates that no user can route:
+
+    * BTC→TAO: high-side sentinels (``1e10``, ``1.797e308`` TAO/BTC) — the
+      smallest positive sat already maps above ``max_swap_rao``, so no
+      positive integer source produces an in-bounds TAO leg.
+    * TAO→BTC: low-side sentinels (``1e-8`` TAO/BTC) — the TAO leg IS the
+      source amount, so it trivially fits any bounds, but the destination
+      payout implied by the rate is absurd. Catch this by the symmetric
+      check on the inverse rate: if treating ``1/rate`` as a BTC→TAO rate
+      has no integer-routable source either, the original rate is at an
+      extreme of the executable spectrum and a sentinel by symmetry.
 
     A bound at ``0`` is the contract's "unset" sentinel and disables that
     side; both at 0 → permissive (no on-chain bounds yet).
@@ -142,11 +149,12 @@ def is_executable_rate(
     if min_swap_rao <= 0 and max_swap_rao <= 0:
         return True
 
-    if to_chain == 'tao':
-        # Forward into TAO: dest_rao = source_units × rate × 10**(tao_dec - src_dec).
-        src_decimals = get_chain(from_chain).decimals
+    def _has_integer_routable_source(forward_rate: float, src_chain: str) -> bool:
+        # For a "src → tao" direction at ``forward_rate`` (tao per src), is
+        # there a positive integer src amount whose TAO leg lands in bounds?
+        src_decimals = get_chain(src_chain).decimals
         decimal_factor = 10 ** (get_chain('tao').decimals - src_decimals)
-        denom = rate * decimal_factor
+        denom = forward_rate * decimal_factor
         if not math.isfinite(denom) or denom <= 0:
             # rate × decimal_factor overflowed (e.g. 1.797e308 × 10) → smallest
             # positive integer source already maps above any finite max bound.
@@ -157,17 +165,25 @@ def is_executable_rate(
         max_source = math.floor(max_swap_rao / denom)
         return min_source <= max_source
 
-    if from_chain == 'tao':
-        # Reverse out of TAO: TAO leg = source_rao itself. Any positive
-        # integer rao in [min, max] qualifies — rate doesn't gate the TAO
-        # side here. (The asymmetric griefing case — extremely low rate
-        # producing an unfulfillable BTC payout — is an economic-backing
-        # concern, not a granularity one, and is out of scope for this
-        # predicate.)
-        lo = max(1, min_swap_rao)
-        if max_swap_rao <= 0:
-            return True
-        return lo <= max_swap_rao
+    if to_chain == 'tao':
+        # Forward into TAO: dest_rao = source_units × rate × 10**(tao_dec - src_dec).
+        return _has_integer_routable_source(rate, from_chain)
+
+    if from_chain == 'tao' and to_chain != 'tao':
+        # Reverse out of TAO: the TAO leg is the source itself, so any positive
+        # rao in [min, max] is trivially in bounds — but absurd-low rates
+        # (e.g. 1e-8 TAO/BTC) imply destinations so large no rational user
+        # would route, and the miner can post them just to win the
+        # lowest-rate-wins crown. Treat ``1/rate`` as a ``to_chain → tao`` rate
+        # and apply the same integer-routability check by symmetry: if the
+        # inverse direction has no routable source either, the original rate
+        # is at an extreme of the executable spectrum.
+        if rate <= 0:
+            return False
+        inverse = 1.0 / rate
+        if not math.isfinite(inverse) or inverse <= 0:
+            return False
+        return _has_integer_routable_source(inverse, to_chain)
 
     # Non-TAO pairs have no TAO-leg bound to enforce.
     return True
@@ -183,8 +199,11 @@ def check_swap_viability(
 
     Mirrors the guards in lib.rs::vote_reserve (bounds) and vote_initiate
     (collateral). Returns (viable, reason) — reason is empty on success.
-    Bounds are global and should be checked against any single rate before
-    the per-miner loop; collateral is per-miner.
+
+    The bounds are global, but the TAO leg they apply to is *not* — when the
+    source chain isn't TAO, the TAO leg = to_amount, which depends on the
+    miner's rate. Callers must derive ``tao_amount_rao`` per miner; sampling
+    one rate up front is only safe when ``from_chain == 'tao'``.
     """
     if min_swap_rao > 0 and tao_amount_rao < min_swap_rao:
         return False, f'below min swap ({min_swap_rao / 1_000_000_000:.4f} TAO)'

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -319,12 +319,12 @@ class TestIsExecutableRate:
         """If only min_swap is set, every rate above the floor is executable."""
         assert is_executable_rate(1e10, 'btc', 'tao', self.MIN, 0) is True
 
-    def test_tao_to_btc_lowball_rate_passes_predicate(self):
-        """tao→btc with rate=1e-8: the TAO leg IS the source amount, which
-        is in bounds for any rao in [min, max]. The bug here is economic
-        (uncollateralized BTC payout) rather than granularity, and lives
-        outside this predicate — documented so reviewers know the gap."""
-        assert is_executable_rate(1e-8, 'tao', 'btc', self.MIN, self.MAX) is True
+    def test_tao_to_btc_lowball_rate_rejected(self):
+        """tao→btc with rate=1e-8 implies 0.1 TAO buys 1e7 BTC — destination
+        absurdity, not a granularity miss. Caught by the symmetric check:
+        treating 1/r = 1e8 as a btc→tao rate, 1 sat already overshoots
+        max_swap on the TAO leg, so the original rate is sentinel-low."""
+        assert is_executable_rate(1e-8, 'tao', 'btc', self.MIN, self.MAX) is False
 
     def test_boundary_rate_executable_at_one_sat(self):
         """At max_swap/10 = 50_000_000 rao per sat, the smallest integer sat
@@ -336,3 +336,26 @@ class TestIsExecutableRate:
         """A rate that maps 1 sat just above max_swap → no executable sat."""
         rate = (self.MAX / 10) * 1.0001
         assert is_executable_rate(rate, 'btc', 'tao', self.MIN, self.MAX) is False
+
+    def test_tao_to_btc_boundary_rate_executable_at_one_sat(self):
+        """Symmetric boundary: at inverse=max_swap/10 (i.e. r = 10/max_swap),
+        treating 1/r as btc→tao maps 1 sat to exactly max_swap on the TAO leg.
+        Just executable."""
+        rate = 10 / self.MAX  # 1/r * 10 == max_swap; 1 sat at inverse hits max
+        assert is_executable_rate(rate, 'tao', 'btc', self.MIN, self.MAX) is True
+
+    def test_tao_to_btc_just_past_boundary_rate_rejected(self):
+        """One ULP below the boundary: the inverse rate's 1 sat overshoots
+        max_swap, so no integer source routes by symmetry."""
+        rate = (10 / self.MAX) * 0.9999
+        assert is_executable_rate(rate, 'tao', 'btc', self.MIN, self.MAX) is False
+
+    def test_tao_to_btc_sentinel_unset_bounds_still_permissive(self):
+        """Unset bounds disable the gate in both directions — keeps the
+        legacy "no on-chain bounds yet" path permissive."""
+        assert is_executable_rate(1e-8, 'tao', 'btc', 0, 0) is True
+
+    def test_tao_to_btc_zero_max_only_min_set_is_permissive(self):
+        """If only min_swap is set (max_swap=0), any rate above the floor
+        symmetry still passes. Mirrors test_max_unset_only_lower_bound_enforced."""
+        assert is_executable_rate(1e-8, 'tao', 'btc', self.MIN, 0) is True

--- a/tests/test_swap_quote.py
+++ b/tests/test_swap_quote.py
@@ -1,0 +1,157 @@
+"""Tests for `alw swap quote` row selection.
+
+Covers two correctness regressions fixed alongside this file:
+- BTC→TAO no longer aborts globally when the top sorted row is a sentinel
+  rate (e.g. 1.797e+308 TAO/BTC); a normal-rate miner still gets labeled
+  "available" when the per-miner TAO leg lands in bounds.
+- TAO→BTC sorts direction-aware: lower rate first (better user price),
+  matching `alw swap now` and the validator crown.
+"""
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from allways.classes import MinerPair
+from allways.cli.swap_commands import quote as quote_module
+from allways.cli.swap_commands.quote import quote_command
+
+MIN_SWAP_RAO = 100_000_000  # 0.1 TAO
+MAX_SWAP_RAO = 500_000_000  # 0.5 TAO
+
+
+def _pair(uid: int, from_chain: str, to_chain: str, rate: float, rate_str: str | None = None) -> MinerPair:
+    return MinerPair(
+        uid=uid,
+        hotkey=f'hk{uid}',
+        from_chain=from_chain,
+        from_address=f'addr{uid}',
+        to_chain=to_chain,
+        to_address=f'dst{uid}',
+        rate=rate,
+        rate_str=rate_str if rate_str is not None else repr(rate),
+    )
+
+
+class _FakeClient:
+    """Stub for AllwaysContractClient — drives the per-miner viability path."""
+
+    def __init__(self, collaterals: dict[str, int], in_swap: set[str] | None = None):
+        self._collaterals = collaterals
+        self._in_swap = in_swap or set()
+
+    def get_miner_active_flag(self, hotkey: str) -> bool:
+        return True
+
+    def get_miner_collateral(self, hotkey: str) -> int:
+        return self._collaterals.get(hotkey, 0)
+
+    def get_miner_has_active_swap(self, hotkey: str) -> bool:
+        return hotkey in self._in_swap
+
+    def get_min_swap_amount(self) -> int:
+        return MIN_SWAP_RAO
+
+    def get_max_swap_amount(self) -> int:
+        return MAX_SWAP_RAO
+
+
+def _invoke(pairs: list[MinerPair], collaterals: dict[str, int], args: list[str], in_swap: set[str] | None = None):
+    """Run quote_command with stubbed chain/client access."""
+    fake_client = _FakeClient(collaterals, in_swap)
+    config = {'netuid': 7}
+    with (
+        patch.object(quote_module, 'get_cli_context', return_value=(config, None, object(), fake_client)),
+        patch.object(quote_module, 'read_miner_commitments', return_value=pairs),
+        patch.object(quote_module, 'find_matching_miners', side_effect=lambda all_pairs, f, t: list(all_pairs)),
+    ):
+        runner = CliRunner()
+        return runner.invoke(quote_command, args, catch_exceptions=False)
+
+
+class TestBtcToTaoBoundsCheck:
+    """Regression: the up-front bounds check used available[0]'s rate to derive
+    the TAO leg, so a single sentinel row aborted with "No miner can accept this"
+    even when other miners would have accepted the same source amount."""
+
+    def test_sentinel_top_row_does_not_hide_viable_lower_row(self):
+        pairs = [
+            _pair(14, 'btc', 'tao', 1.797e308),  # overflow sentinel
+            _pair(189, 'btc', 'tao', 226.42),  # normal — 0.0005 BTC → ~0.113 TAO, in bounds
+        ]
+        collaterals = {'hk14': 1_000_000_000, 'hk189': 1_000_000_000}
+        result = _invoke(pairs, collaterals, ['--from', 'btc', '--to', 'tao', '--amount', '0.0005'])
+        assert result.exit_code == 0, result.output
+        # The bug emitted this exact line before; assert it doesn't anymore.
+        assert 'Amount above contract maximum' not in result.output
+        assert '189' in result.output
+        assert 'available' in result.output
+
+    def test_sentinel_row_labeled_unexecutable(self):
+        pairs = [_pair(14, 'btc', 'tao', 1.797e308)]
+        collaterals = {'hk14': 1_000_000_000}
+        result = _invoke(pairs, collaterals, ['--from', 'btc', '--to', 'tao', '--amount', '0.0005'])
+        assert result.exit_code == 0, result.output
+        assert 'unexecutable rate' in result.output
+        # Sentinel rows must NOT count as available.
+        assert 'available' not in result.output
+
+    def test_all_above_max_emits_decrease_amount_hint(self):
+        # Every routable miner's TAO leg exceeds max_swap. The aggregate end
+        # message replaces the old up-front abort and stays actionable.
+        pairs = [_pair(189, 'btc', 'tao', 1000.0)]  # 0.0005 BTC * 1000 = 0.5 TAO -> at max; bump amount past max
+        collaterals = {'hk189': 10_000_000_000}
+        result = _invoke(pairs, collaterals, ['--from', 'btc', '--to', 'tao', '--amount', '0.001'])
+        assert result.exit_code == 0, result.output
+        assert 'Decrease --amount' in result.output
+
+
+class TestTaoToBtcSort:
+    """Regression: quote.py sorted descending unconditionally; TAO→BTC needs
+    ascending (lower TAO/BTC = better user price)."""
+
+    def test_lower_rate_appears_first(self):
+        pairs = [
+            _pair(253, 'tao', 'btc', 1000.0),
+            _pair(14, 'tao', 'btc', 999.0),
+            _pair(189, 'tao', 'btc', 339.62),
+            _pair(65, 'tao', 'btc', 340.12),
+        ]
+        collaterals = {'hk253': 10**12, 'hk14': 10**12, 'hk189': 10**12, 'hk65': 10**12}
+        result = _invoke(pairs, collaterals, ['--from', 'tao', '--to', 'btc', '--amount', '0.1'])
+        assert result.exit_code == 0, result.output
+        uids_in_order = []
+        for token in ('189', '65', '14', '253'):
+            idx = result.output.find(token)
+            assert idx >= 0, f'expected UID {token} in output:\n{result.output}'
+            uids_in_order.append((idx, token))
+        ordered = [t for _, t in sorted(uids_in_order)]
+        assert ordered == ['189', '65', '14', '253'], (
+            f'expected ascending-by-rate order [189, 65, 14, 253]; got {ordered}\n{result.output}'
+        )
+
+
+class TestTaoToBtcAbsurdLowRate:
+    """Regression: a miner posting r=1e-08 TAO/BTC promises an impossible BTC
+    payout (e.g. 0.1 TAO → 1e7 BTC). The ascending-rate sort would normally
+    put it on top as "best price" — is_executable_rate's symmetric branch
+    must catch it so the CLI labels it unexecutable, and crown ineligibility
+    follows from the same predicate."""
+
+    def test_sentinel_low_rate_labeled_unexecutable(self):
+        pairs = [
+            _pair(189, 'tao', 'btc', 339.62),
+            _pair(193, 'tao', 'btc', 1e-08),
+        ]
+        collaterals = {'hk189': 10**12, 'hk193': 10**12}
+        result = _invoke(pairs, collaterals, ['--from', 'tao', '--to', 'btc', '--amount', '0.1'])
+        assert result.exit_code == 0, result.output
+        assert 'unexecutable rate' in result.output
+        # UID 189 still routable.
+        assert '189' in result.output
+        # The sentinel row's status must NOT be "available" — that was the
+        # original #396 trap (ascending sort + permissive predicate would
+        # have made UID 193 the default pick).
+        sentinel_line = next((line for line in result.output.splitlines() if '193' in line), '')
+        assert 'unexecutable' in sentinel_line, f'expected sentinel-row marked unexecutable; got: {sentinel_line!r}'
+        assert 'available' not in sentinel_line


### PR DESCRIPTION
Fixes #393 and #396.

## Summary

Two related fixes in the quote / scoring pipeline. Both were exploitable by miners posting sentinel rates that won't actually serve users.

### #393 — `alw swap quote` row selection

- **Direction-aware sort.** `quote.py` was sorting `reverse=True` unconditionally. Correct for BTC→TAO (higher rate = better user price); wrong for TAO→BTC, where lower TAO/BTC is the better price. The fix matches the pattern already used by `swap now` (`swap.py:773`) and validator crown (`scoring.py:567`).
- **False global bounds abort.** The up-front bounds check sampled `available[0]`'s rate to derive the TAO leg and aborted with "No miner can accept this" when it failed. For BTC→TAO the TAO leg depends on the miner's rate, so a single sentinel top row (e.g. `1.797e+308`) was hiding viable lower rows like UID 189. Per-miner viability already covers the bounds check; an aggregate end-of-table hint preserves the "Decrease/Increase `--amount`" cue when every routable miner fails the same bound.
- **Sentinel-rate rows mislabeled `available`.** `is_executable_rate` (the predicate from PR #395) is now consulted per row in the quote table so sentinel BTC→TAO rates render as `unexecutable rate`, not `available`.
- **Best-miner hint skips unexecutable rows** so the "Best miner UID X can fulfill up to Y" line doesn't cite a sentinel-rate row.

### #396 — TAO→BTC crown loophole

PR #395 closed BTC→TAO sentinel rates from earning crown but explicitly left TAO→BTC open. The code and tests documented this gap:

```python
# allways/utils/rate.py (before)
# The asymmetric griefing case — extremely low rate producing an
# unfulfillable BTC payout — is an economic-backing concern, not a
# granularity one, and is out of scope for this predicate.
```

```python
# tests/test_rate.py (before)
def test_tao_to_btc_lowball_rate_passes_predicate(self):
    """... outside this predicate — documented so reviewers know the gap."""
    assert is_executable_rate(1e-8, 'tao', 'btc', self.MIN, self.MAX) is True
```

A miner posting `r=1e-8` TAO/BTC was winning the lowest-rate-wins TAO→BTC crown every block without ever serving a swap.

This PR closes the gap with a **symmetric inverse check**: for TAO→BTC, treat `1/r` as if it were a BTC→TAO rate and apply the same integer-overshoot logic. If `1/r`'s smallest positive sat would overshoot `max_swap_rao`, the original rate is sentinel-low by symmetry. Concretely with current SN7 bounds (`min_swap=0.1 TAO`, `max_swap=0.5 TAO`):

| `r` (TAO/BTC) | inverse direction integer-routable? | predicate |
|---|---|---|
| 339.62 (sane) | yes (min_source=3.39e9 sat, max_source=1.7e10 sat) | ✓ executable |
| 1000 (sane) | yes (min=1e10, max=5e10 sat) | ✓ executable |
| 2e-8 (boundary) | yes (1 sat at inverse maps to exactly max_swap) | ✓ executable |
| **1e-8 (live evidence)** | no (1 sat overshoots max_swap on TAO leg) | ✗ rejected |
| 1.797e+308 (BTC→TAO sentinel) | n/a — caught by the existing BTC→TAO branch | ✗ rejected |

The check is **policy-free** — it uses only `min_swap` / `max_swap`, which validators already agree on — and **consistent with #395's posture**: it's the same kind of integer-overshoot guard, applied symmetrically to the other direction.

### What this does NOT change

- Contract / validator-reserve still accept reservations at these rates. Closing the protocol-level exposure asymmetry would need a destination-side cap or rate floor in the contract; that's out of scope.
- User funds were never directly at risk: on TAO→BTC timeout the slash returns the TAO source leg to the user, so they're whole on principal. The exploit was about crown gaming and CLI trap-laying, not direct theft.

## Files changed

- `allways/utils/rate.py` — `is_executable_rate` now gates both directions symmetrically; docstring rewritten; the gap-documenting comment block is gone.
- `allways/cli/swap_commands/quote.py` — direction-aware sort, removed `sample_pair` abort, per-row `is_executable_rate`, aggregate bounds hint, unexecutable-aware best-miner hint.
- `tests/test_rate.py` — flipped `test_tao_to_btc_lowball_rate_passes_predicate` → `test_tao_to_btc_lowball_rate_rejected`; added 4 new boundary tests for the symmetric TAO→BTC branch.
- `tests/test_swap_quote.py` (new) — `CliRunner`-driven regressions: sentinel top row doesn't hide a viable lower row; sentinel row labeled unexecutable; aggregate "decrease --amount" hint; TAO→BTC ascending sort; TAO→BTC sentinel-low labeled unexecutable.

## Test plan

- [x] `pytest tests/test_rate.py` — 52 passed (4 new TAO→BTC boundary tests)
- [x] `pytest tests/test_swap_quote.py` — 5 passed (new file)
- [x] `pytest tests/test_scoring_v1.py` — 117 passed (crown gating unaffected for sane rates)
- [x] Full suite (excluding pre-existing `embit`-module failures unrelated to this PR): 564 passed
- [x] `ruff check` clean