### PR TITLE
Tighten timeout-extension evidence + persist dest-tip snapshot

### DIFF
--- a/allways/validator/chain_verification.py
+++ b/allways/validator/chain_verification.py
@@ -28,17 +28,29 @@ class SwapVerifier:
         chain_providers: Dict[str, ChainProvider],
         fee_divisor: int = 100,
         metagraph: Optional[Any] = None,
+        state_store: Optional[Any] = None,
     ):
         self.providers = chain_providers
         self.fee_divisor = fee_divisor
         self.metagraph = metagraph
+        self.state_store = state_store
         self.last_logged_confs: Dict[str, int] = {}  # swap_id:chain -> confs
         self.source_verified_ids: Set[int] = set()  # source tx is final once confirmed
-        self.dest_tip_at_init: Dict[int, int] = {}  # swap_id -> dest tip at first sighting (non-TAO only)
+        # Hydrate from sqlite so a validator restart mid-swap keeps the
+        # original (early) snapshot — a fresh snapshot taken after the honest
+        # dest tx already landed would reject the payout as a replay.
+        if state_store is not None:
+            self.dest_tip_at_init: Dict[int, int] = state_store.load_dest_tip_snapshots()
+        else:
+            self.dest_tip_at_init = {}  # swap_id -> dest tip at first sighting (non-TAO only)
 
-    def observe_initiation(self, swap: Swap) -> None:
+    def observe_initiation(self, swap: Swap, current_block: int = 0) -> None:
         """Snapshot the dest chain's tip on first sighting of a non-TAO swap.
-        Idempotent; fails open with a one-time warning on RPC error."""
+        Idempotent; fails open with a one-time warning on RPC error.
+
+        ``current_block`` is the substrate block at the moment of snapshot;
+        recorded on disk only, for debugging late-snapshot incidents.
+        """
         if swap.to_chain == 'tao' or swap.id in self.dest_tip_at_init:
             return
         provider = self.providers.get(swap.to_chain)
@@ -52,6 +64,22 @@ class SwapVerifier:
             tip = None
         if tip and tip > 0:
             self.dest_tip_at_init[swap.id] = tip
+            if self.state_store is not None:
+                # Same fail-open discipline as the RPC call above: a sqlite
+                # write failure must not break the forward loop. Persistence
+                # is best-effort; the in-memory snapshot remains the source
+                # of truth for this validator run.
+                try:
+                    self.state_store.upsert_dest_tip_snapshot(
+                        swap_id=swap.id,
+                        dest_chain=swap.to_chain,
+                        tip=tip,
+                        recorded_at=current_block,
+                    )
+                except Exception as e:
+                    bt.logging.warning(
+                        f'{self._label(swap)}: failed to persist dest-tip snapshot: {e}'
+                    )
         else:
             log_on_change(
                 f'snapshot_unavailable:{swap.id}',
@@ -63,6 +91,11 @@ class SwapVerifier:
         """Drop per-swap state for swaps no longer being tracked."""
         self.dest_tip_at_init = {sid: v for sid, v in self.dest_tip_at_init.items() if sid in active_ids}
         self.source_verified_ids &= active_ids
+        if self.state_store is not None:
+            try:
+                self.state_store.prune_dest_tip_snapshots(active_ids)
+            except Exception as e:
+                bt.logging.warning(f'failed to prune persisted dest-tip snapshots: {e}')
 
     def _label(self, swap: Swap) -> str:
         return _swap_label(swap, self.metagraph)
@@ -125,9 +158,14 @@ class SwapVerifier:
         if lower is None:
             return True  # fail-open; observe_initiation already logged
         if dest_info.block_number < lower:
+            # TAO lower bound is the swap's initiated_block; non-TAO is the
+            # dest-chain tip snapshot taken at first sighting. The label
+            # matters when debugging late-snapshot incidents — the bound
+            # crossed is not always the initiation block.
+            bound_label = 'initiated_block' if swap.to_chain == 'tao' else 'dest_tip_at_init'
             bt.logging.warning(
-                f'{self._label(swap)}: dest tx at block {dest_info.block_number} < initiated {lower} — '
-                f'rejecting as replay (tx={swap.to_tx_hash[:16]}...)'
+                f'{self._label(swap)}: dest tx at block {dest_info.block_number} < '
+                f'{bound_label} {lower} — rejecting as replay (tx={swap.to_tx_hash[:16]}...)'
             )
             return False
         return True

--- a/allways/validator/chain_verification.py
+++ b/allways/validator/chain_verification.py
@@ -77,9 +77,7 @@ class SwapVerifier:
                         recorded_at=current_block,
                     )
                 except Exception as e:
-                    bt.logging.warning(
-                        f'{self._label(swap)}: failed to persist dest-tip snapshot: {e}'
-                    )
+                    bt.logging.warning(f'{self._label(swap)}: failed to persist dest-tip snapshot: {e}')
         else:
             log_on_change(
                 f'snapshot_unavailable:{swap.id}',

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -18,6 +18,7 @@ from allways.constants import (
 from allways.contract_client import ContractError, is_contract_rejection
 from allways.utils.logging import log_on_change
 from allways.utils.logging import swap_label as _swap_label
+from allways.utils.rate import expected_swap_amounts
 from allways.utils.scale import strip_hex_prefix
 from allways.validator import voting
 from allways.validator.axon_handlers import (
@@ -481,19 +482,33 @@ def extend_fulfilled_near_timeout(self: Validator) -> None:
         if not provider or not swap.to_tx_hash:
             continue
 
+        # Mirror final-confirm evidence: extension verification must use the
+        # canonical payout derived from swap.rate, not the miner-controlled
+        # swap.to_amount. Otherwise a dust mark_fulfilled buys timeout
+        # protection that final-confirm itself would reject.
+        if not swap.rate or not swap.miner_to_address:
+            bt.logging.warning(f'{ctx}: missing rate or miner_to_address on Fulfilled swap')
+            continue
+
+        _, expected_user_receives = expected_swap_amounts(swap, self.swap_verifier.fee_divisor)
+        if expected_user_receives == 0:
+            bt.logging.warning(f'{ctx}: rate produces 0 to_amount after fees; skipping extension')
+            continue
+
         try:
             tx_info = provider.verify_transaction(
                 tx_hash=swap.to_tx_hash,
                 expected_recipient=swap.user_to_address,
-                expected_amount=swap.to_amount,
+                expected_amount=expected_user_receives,
                 block_hint=swap.to_tx_block,
+                expected_sender=swap.miner_to_address,
             )
         except Exception as e:
             bt.logging.debug(f'{ctx}: extend check verify_transaction error: {e}')
             continue
 
         if tx_info is None:
-            continue  # dest tx invisible — neither tier qualifies
+            continue  # dest tx invisible or below canonical payout — neither tier qualifies
 
         # A finalize this step may have just pushed the deadline out. Mirror
         # the reservation-side gate in try_extend_reservation: once the swap

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -89,7 +89,7 @@ async def forward(self: Validator) -> None:
 
     # Snapshot dest-chain tip on first sighting for the dest-tx replay defense.
     for swap in tracker.active.values():
-        verifier.observe_initiation(swap)
+        verifier.observe_initiation(swap, self.block)
     verifier.prune_to_active(set(tracker.active.keys()))
 
     # Verify FULFILLED swaps end-to-end and vote confirm_swap. The returned

--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -723,6 +723,59 @@ class ValidatorStateStore:
             )
             conn.commit()
 
+    # ─── dest_tip_snapshots ─────────────────────────────────────────────
+
+    def upsert_dest_tip_snapshot(
+        self,
+        swap_id: int,
+        dest_chain: str,
+        tip: int,
+        recorded_at: int,
+    ) -> None:
+        """Persist the dest-chain tip captured at first sighting of a swap.
+
+        INSERT OR IGNORE: only the first sighting matters for the replay-
+        defense lower bound, so a re-observation must not overwrite the
+        original (earlier) snapshot.
+        """
+        with self.lock:
+            conn = self.require_connection()
+            conn.execute(
+                """
+                INSERT OR IGNORE INTO dest_tip_snapshots (
+                    swap_id, dest_chain, tip, recorded_at
+                ) VALUES (?, ?, ?, ?)
+                """,
+                (swap_id, dest_chain, tip, recorded_at),
+            )
+            conn.commit()
+
+    def load_dest_tip_snapshots(self) -> Dict[int, int]:
+        """Repopulate the in-memory snapshot map at SwapVerifier init.
+
+        Returned as ``{swap_id: tip}`` — the in-memory check only needs the
+        tip; ``dest_chain``/``recorded_at`` are kept on disk for debugging.
+        """
+        with self.lock:
+            conn = self.require_connection()
+            rows = conn.execute('SELECT swap_id, tip FROM dest_tip_snapshots').fetchall()
+        return {int(r['swap_id']): int(r['tip']) for r in rows}
+
+    def prune_dest_tip_snapshots(self, active_ids: Set[int]) -> None:
+        """Mirror the in-memory prune: drop snapshots for swaps no longer
+        tracked so the table doesn't accumulate forever."""
+        with self.lock:
+            conn = self.require_connection()
+            if not active_ids:
+                conn.execute('DELETE FROM dest_tip_snapshots')
+            else:
+                placeholders = ','.join('?' * len(active_ids))
+                conn.execute(
+                    f'DELETE FROM dest_tip_snapshots WHERE swap_id NOT IN ({placeholders})',
+                    tuple(int(sid) for sid in active_ids),
+                )
+            conn.commit()
+
     def reset_event_watcher_state(self) -> None:
         """Wipe all event-watcher persistence. Used when the cursor is more than
         a scoring window behind current — the chain has moved past replayable
@@ -890,6 +943,13 @@ class ValidatorStateStore:
 
                 CREATE TABLE IF NOT EXISTS bootstrapped_swaps (
                     swap_id INTEGER PRIMARY KEY
+                );
+
+                CREATE TABLE IF NOT EXISTS dest_tip_snapshots (
+                    swap_id     INTEGER PRIMARY KEY,
+                    dest_chain  TEXT NOT NULL,
+                    tip         INTEGER NOT NULL,
+                    recorded_at INTEGER NOT NULL
                 );
                 """
             )

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -139,6 +139,7 @@ class Validator(BaseValidatorNeuron):
             chain_providers=self.chain_providers,
             fee_divisor=self.fee_divisor,
             metagraph=self.metagraph,
+            state_store=self.state_store,
         )
 
         # Separate subtensor/contract/providers for axon handlers (thread safety).

--- a/tests/test_chain_verification.py
+++ b/tests/test_chain_verification.py
@@ -6,11 +6,13 @@ initiated. Closes the gap left by the contract enforcing ``used_from_tx``
 only on the source side.
 """
 
+from pathlib import Path
 from unittest.mock import MagicMock
 
 from allways.chain_providers.base import TransactionInfo
 from allways.classes import Swap, SwapStatus
 from allways.validator.chain_verification import SwapVerifier
+from allways.validator.state_store import ValidatorStateStore
 
 
 def make_swap(swap_id: int = 1, to_chain: str = 'btc', initiated_block: int = 100) -> Swap:
@@ -140,3 +142,81 @@ class TestPruneToActive:
 
         assert v.dest_tip_at_init == {2: 200}
         assert v.source_verified_ids == {2}
+
+
+class TestSnapshotPersistence:
+    """A validator restart mid-swap must keep the original (early) snapshot;
+    re-snapshotting on warm start would capture a tip past the honest payout
+    block and reject the miner's tx as a replay."""
+
+    def test_restart_hydrates_snapshot_from_state_store(self, tmp_path: Path):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        btc = MagicMock()
+        btc.get_current_block_height.return_value = 850_000
+
+        # First validator run observes the swap and persists the tip.
+        v1 = SwapVerifier(chain_providers={'btc': btc}, state_store=store)
+        v1.observe_initiation(make_swap(swap_id=1, to_chain='btc'), current_block=500)
+        assert v1.dest_tip_at_init[1] == 850_000
+
+        # Simulate restart: a fresh verifier sharing the same state_store.
+        # The dest-chain tip is now well past the honest payout block (e.g.
+        # honest payout at 850_100, current tip 850_500). If the new verifier
+        # re-snapshotted, the tip-at-init would be 850_500 and a valid payout
+        # at block 850_100 would be rejected as a replay.
+        btc.get_current_block_height.return_value = 850_500
+        v2 = SwapVerifier(chain_providers={'btc': btc}, state_store=store)
+
+        assert v2.dest_tip_at_init == {1: 850_000}
+
+        # Subsequent observe_initiation for the same swap is a no-op because
+        # the hydrated entry already exists — the late tip is never recorded.
+        v2.observe_initiation(make_swap(swap_id=1, to_chain='btc'), current_block=600)
+        assert v2.dest_tip_at_init[1] == 850_000
+
+        # Honest dest tx at block 850_100 (after init, before restart tip)
+        # still passes the freshness check.
+        swap = make_swap(swap_id=1, to_chain='btc')
+        assert v2.is_dest_tx_fresh(swap, tx_at(850_100)) is True
+        store.close()
+
+    def test_observe_initiation_persists_first_snapshot(self, tmp_path: Path):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        btc = MagicMock()
+        btc.get_current_block_height.return_value = 850_000
+
+        v = SwapVerifier(chain_providers={'btc': btc}, state_store=store)
+        v.observe_initiation(make_swap(swap_id=1, to_chain='btc'), current_block=500)
+
+        assert store.load_dest_tip_snapshots() == {1: 850_000}
+        store.close()
+
+    def test_prune_to_active_removes_persisted_snapshot(self, tmp_path: Path):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        btc = MagicMock()
+        btc.get_current_block_height.return_value = 850_000
+
+        v = SwapVerifier(chain_providers={'btc': btc}, state_store=store)
+        v.observe_initiation(make_swap(swap_id=1, to_chain='btc'), current_block=500)
+        v.observe_initiation(make_swap(swap_id=2, to_chain='btc'), current_block=501)
+
+        v.prune_to_active({2})
+
+        assert store.load_dest_tip_snapshots() == {2: 850_000}
+        store.close()
+
+    def test_persistence_failure_does_not_break_in_memory_snapshot(self):
+        # Forward-loop discipline: a sqlite write failure must not interrupt
+        # the snapshot path. The in-memory entry must still be present so the
+        # current run keeps a working replay defense.
+        failing_store = MagicMock()
+        failing_store.load_dest_tip_snapshots.return_value = {}
+        failing_store.upsert_dest_tip_snapshot.side_effect = RuntimeError('disk full')
+
+        btc = MagicMock()
+        btc.get_current_block_height.return_value = 850_000
+        v = SwapVerifier(chain_providers={'btc': btc}, state_store=failing_store)
+
+        v.observe_initiation(make_swap(swap_id=1, to_chain='btc'), current_block=500)
+
+        assert v.dest_tip_at_init == {1: 850_000}

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -62,9 +62,7 @@ def make_validator(swap: Swap, block: int, finalized_target, tx_info=_UNSET):
     ext.maybe_propose_timeout.return_value = False
 
     provider = MagicMock()
-    provider.verify_transaction.return_value = (
-        SimpleNamespace(confirmations=1) if tx_info is _UNSET else tx_info
-    )
+    provider.verify_transaction.return_value = SimpleNamespace(confirmations=1) if tx_info is _UNSET else tx_info
     provider.get_chain.return_value = SimpleNamespace(min_confirmations=3)
 
     contract_client = MagicMock()

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -20,7 +20,7 @@ PROPOSE_BLOCK = 8_207_273
 EXT_TARGET = PROPOSE_BLOCK + 240
 
 
-def make_fulfilled_swap(swap_id: int = 206) -> Swap:
+def make_fulfilled_swap(swap_id: int = 206, to_amount: int = 37_189) -> Swap:
     """A FULFILLED TAO->BTC swap with a visible dest tx, one block from timeout."""
     return Swap(
         id=swap_id,
@@ -29,21 +29,29 @@ def make_fulfilled_swap(swap_id: int = 206) -> Swap:
         from_chain='tao',
         to_chain='btc',
         from_amount=100_000_000,
-        to_amount=37_189,
+        to_amount=to_amount,
         tao_amount=100_000_000,
         user_from_address='5user',
         user_to_address='bc1q-user',
+        miner_to_address='bc1q-miner',
+        rate='268',
         to_tx_hash='dest-tx-hash',
         status=SwapStatus.FULFILLED,
         timeout_block=PROPOSE_BLOCK + 1,
     )
 
 
-def make_validator(swap: Swap, block: int, finalized_target):
+_UNSET = object()
+
+
+def make_validator(swap: Swap, block: int, finalized_target, tx_info=_UNSET):
     """Stand-in Validator for ``extend_fulfilled_near_timeout``.
 
     ``finalized_target``: what ``maybe_finalize_timeout`` returns — an int for
     a finalize that lands this step, or ``None`` for no finalize.
+    ``tx_info``: what the provider's ``verify_transaction`` returns. Default
+    is a success namespace; pass ``None`` to simulate the provider rejecting
+    the dest tx (e.g. amount below canonical payout or sender mismatch).
     """
     tracker = SwapTracker(client=MagicMock())
     tracker.active[swap.id] = swap
@@ -54,7 +62,10 @@ def make_validator(swap: Swap, block: int, finalized_target):
     ext.maybe_propose_timeout.return_value = False
 
     provider = MagicMock()
-    provider.verify_transaction.return_value = SimpleNamespace(confirmations=1)
+    provider.verify_transaction.return_value = (
+        SimpleNamespace(confirmations=1) if tx_info is _UNSET else tx_info
+    )
+    provider.get_chain.return_value = SimpleNamespace(min_confirmations=3)
 
     contract_client = MagicMock()
     contract_client.get_swap_extension_count.return_value = 1
@@ -65,6 +76,7 @@ def make_validator(swap: Swap, block: int, finalized_target):
         optimistic_extensions=ext,
         chain_providers={'btc': provider},
         contract_client=contract_client,
+        swap_verifier=SimpleNamespace(fee_divisor=100),
     )
 
 
@@ -95,3 +107,34 @@ class TestExtendFulfilledNearTimeout:
         extend_fulfilled_near_timeout(v)
 
         v.optimistic_extensions.maybe_propose_timeout.assert_called_once()
+
+    def test_verifies_canonical_payout_and_miner_sender(self):
+        # Extension evidence must mirror final-confirm: expected_amount is the
+        # canonical payout from swap.rate (not the miner-controlled
+        # swap.to_amount), and expected_sender is pinned to miner_to_address.
+        # Without this, a dust mark_fulfilled buys timeout protection that
+        # final-confirm itself would reject.
+        swap = make_fulfilled_swap(to_amount=1)  # miner posted dust
+        v = make_validator(swap, block=PROPOSE_BLOCK, finalized_target=None)
+
+        extend_fulfilled_near_timeout(v)
+
+        provider = v.chain_providers['btc']
+        call = provider.verify_transaction.call_args
+        assert call.kwargs['expected_sender'] == 'bc1q-miner'
+        # Canonical payout derived from rate, not the dust to_amount the miner posted.
+        assert call.kwargs['expected_amount'] != 1
+        assert call.kwargs['expected_amount'] > 0
+
+    def test_skips_extension_when_dest_tx_fails_canonical_check(self):
+        # Provider returns None when the dest tx doesn't match the canonical
+        # amount or expected sender. The extension path must then skip propose
+        # so the swap proceeds to timeout naturally instead of being protected
+        # by a fraudulent mark_fulfilled.
+        swap = make_fulfilled_swap(to_amount=1)
+        v = make_validator(swap, block=PROPOSE_BLOCK, finalized_target=None, tx_info=None)
+
+        extend_fulfilled_near_timeout(v)
+
+        v.optimistic_extensions.maybe_propose_timeout.assert_not_called()
+        v.optimistic_extensions.maybe_challenge_timeout.assert_not_called()

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -153,3 +153,63 @@ class TestReservationPinCrossTable:
         row = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='reservation_pins'").fetchone()
         assert row is not None
         store.close()
+
+
+class TestDestTipSnapshots:
+    def test_upsert_load_round_trip(self, tmp_path: Path):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        store.upsert_dest_tip_snapshot(swap_id=1, dest_chain='btc', tip=850_000, recorded_at=500)
+        store.upsert_dest_tip_snapshot(swap_id=2, dest_chain='btc', tip=850_010, recorded_at=510)
+
+        assert store.load_dest_tip_snapshots() == {1: 850_000, 2: 850_010}
+        store.close()
+
+    def test_first_write_wins_so_late_re_observation_cannot_overwrite(self, tmp_path: Path):
+        # On restart, a re-observation taken after the honest dest tx already
+        # landed would record a later tip and reject the payout as a replay.
+        # INSERT OR IGNORE means the original (earlier) snapshot is preserved.
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        store.upsert_dest_tip_snapshot(swap_id=1, dest_chain='btc', tip=850_000, recorded_at=500)
+        store.upsert_dest_tip_snapshot(swap_id=1, dest_chain='btc', tip=850_500, recorded_at=600)
+
+        assert store.load_dest_tip_snapshots() == {1: 850_000}
+        store.close()
+
+    def test_persists_across_store_instances(self, tmp_path: Path):
+        db_path = tmp_path / 'state.db'
+        store1 = ValidatorStateStore(db_path=db_path)
+        store1.upsert_dest_tip_snapshot(swap_id=1, dest_chain='btc', tip=850_000, recorded_at=500)
+        store1.close()
+
+        store2 = ValidatorStateStore(db_path=db_path)
+        assert store2.load_dest_tip_snapshots() == {1: 850_000}
+        store2.close()
+
+    def test_prune_drops_inactive_swaps(self, tmp_path: Path):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        store.upsert_dest_tip_snapshot(swap_id=1, dest_chain='btc', tip=100, recorded_at=1)
+        store.upsert_dest_tip_snapshot(swap_id=2, dest_chain='btc', tip=200, recorded_at=2)
+        store.upsert_dest_tip_snapshot(swap_id=3, dest_chain='btc', tip=300, recorded_at=3)
+
+        store.prune_dest_tip_snapshots({2})
+
+        assert store.load_dest_tip_snapshots() == {2: 200}
+        store.close()
+
+    def test_prune_with_empty_active_set_clears_all(self, tmp_path: Path):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        store.upsert_dest_tip_snapshot(swap_id=1, dest_chain='btc', tip=100, recorded_at=1)
+
+        store.prune_dest_tip_snapshots(set())
+
+        assert store.load_dest_tip_snapshots() == {}
+        store.close()
+
+    def test_fresh_init_db_has_dest_tip_snapshots_table(self, tmp_path: Path):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        conn = store.require_connection()
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='dest_tip_snapshots'"
+        ).fetchone()
+        assert row is not None
+        store.close()

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -208,8 +208,6 @@ class TestDestTipSnapshots:
     def test_fresh_init_db_has_dest_tip_snapshots_table(self, tmp_path: Path):
         store = ValidatorStateStore(db_path=tmp_path / 'state.db')
         conn = store.require_connection()
-        row = conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='dest_tip_snapshots'"
-        ).fetchone()
+        row = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='dest_tip_snapshots'").fetchone()
         assert row is not None
         store.close()


### PR DESCRIPTION
Two independent validator correctness fixes against open bug reports. They sit in adjacent code paths (`chain_verification.py` / `forward.py`) and are bundled together to keep reviewer overhead low.

---

## Fix 1 — Verify canonical payout in timeout-extension path (Fixes #403)

### Summary

- Extension verifier now derives `expected_user_receives` from `swap.rate` via `expected_swap_amounts`, instead of trusting the miner-controlled `swap.to_amount` that `mark_fulfilled` writes onto the swap.
- Extension verifier now pins `expected_sender=swap.miner_to_address`, matching the final-confirm path.

### Why

Before this change, `extend_fulfilled_near_timeout` checked `provider.verify_transaction(..., expected_amount=swap.to_amount, ...)` with no `expected_sender`. Final confirmation (`verify_miner_fulfillment` at `chain_verification.py:155+`) checks the canonical payout from rate/source-amount and pins the miner sender. The asymmetry meant a miner could:

1. Submit a real destination tx for 1 sat (or any underpayment).
2. Call `mark_fulfilled` with `to_amount=1` and that tx hash.
3. Final confirmation rejects — destination amount doesn't match canonical payout.
4. Extension path **accepts** — the dust tx matches the dust `to_amount`.
5. Validators propose a timeout extension, delaying slash by up to `MAX_EXTENSIONS_PER_SWAP * MAX_EXTENSION_BLOCKS` (2 × 250 = ~100 minutes).

The miner can't actually complete the swap this way, but they buy a free option to wait out adverse rate movement before committing to fulfill-or-slash. After this change, both verifiers apply the same "did the miner pay the canonical amount from the right address" definition.

---

## Fix 2 — Persist dest-tip snapshot across validator restart (Fixes #383)

### Summary

- New `dest_tip_snapshots` sqlite table + `upsert_dest_tip_snapshot` / `load_dest_tip_snapshots` / `prune_dest_tip_snapshots` helpers on `ValidatorStateStore` (following the `reservation_pins` idiom).
- `SwapVerifier` hydrates `dest_tip_at_init` from the store at construction; `observe_initiation` writes through; `prune_to_active` clears stale rows. Persistence failures fall back to in-memory-only, matching the existing fail-open discipline.
- `is_dest_tx_fresh` reject log now labels the bound as `initiated_block` (TAO destinations) vs `dest_tip_at_init` (non-TAO) instead of the misleading `initiated <tip>` it was emitting for non-TAO swaps.

### Why

`SwapVerifier.dest_tip_at_init` lived only in process memory. On validator restart (or process crash + respawn) mid-swap, the snapshot was lost. The next observation captured the current dest-chain tip — now past the honest payout block — and `is_dest_tx_fresh` rejected the miner's valid tx as a replay. An honest miner who delivered correctly got slashed.

Upsert uses `INSERT OR IGNORE` so a late re-observation cannot overwrite the original (earlier) snapshot. That's the core invariant — the first sighting is the only sighting that matters for the replay lower bound.

### Scope

This covers the restart / process-crash case, which is the common one. **Cold-start of a validator that was never running during the swap window** still needs a historical-lookup layer (new `ChainProvider` methods + binary search against Esplora / RPC). That's deferred as a follow-up — the fix here is intentionally partial.

### Rollout caveat

First restart after deploying this build: any swap that's already in-flight will still take a fresh (possibly late) snapshot on first sighting because nothing was persisted yet under the old build. Same fragility as today — not a regression — but worth flagging.

---

## Test plan

- [x] `uv run pytest tests/test_forward.py tests/test_chain_verification.py tests/test_state_store.py -v` — 36/36 pass
- [x] `uv run pytest tests/` — full suite 609/609 passes (was 599; +10 new tests)
- [ ] Manual: testnet swap with canonical `mark_fulfilled` still extends normally near timeout
- [ ] Manual: testnet swap with dust `mark_fulfilled` no longer triggers extension and times out on schedule
- [ ] Manual: restart validator mid-swap; confirm hydrated snapshot from sqlite, honest dest tx still verifies

## Follow-ups (not in this PR)

- Contract-side reject of `mark_fulfilled` when `to_amount < expected_user_receives` (defense-in-depth for #403; needs an ink! deploy).
- Historical destination-tip lookup for the cold-start case (#383; needs new `ChainProvider` ABC methods + Esplora/RPC binary search).