### PR TITLE
 Bound reverse-swap dest payout to miner collateral

### DIFF
--- a/allways/cli/swap_commands/quote.py
+++ b/allways/cli/swap_commands/quote.py
@@ -172,7 +172,16 @@ def quote_command(from_chain: str, to_chain: str, amount: float):
         human_receives = user_receives / (10**dst_chain_def.decimals)
 
         tao_amount_rao = derive_tao_leg(from_chain, from_amount, to_chain, to_amount)
-        viable, reason = check_swap_viability(tao_amount_rao, collateral, min_swap_rao, max_swap_rao)
+        viable, reason = check_swap_viability(
+            tao_amount_rao,
+            collateral,
+            min_swap_rao,
+            max_swap_rao,
+            from_chain=from_chain,
+            to_chain=to_chain,
+            to_amount=to_amount,
+            rate=pair.rate_str,
+        )
         # "in swap" takes precedence over amount-viability: even if the amount
         # fits, the miner can't accept a new reservation until the current one
         # resolves. Shown yellow rather than red to signal "temporary".

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -884,7 +884,16 @@ def swap_now_command(
         console.print('[yellow]Warning: could not verify swap bounds (contract unreachable)[/yellow]')
         min_swap, max_swap = 0, 0
 
-    viable, reason = check_swap_viability(tao_amount, selected_collateral, min_swap, max_swap)
+    viable, reason = check_swap_viability(
+        tao_amount,
+        selected_collateral,
+        min_swap,
+        max_swap,
+        from_chain=from_chain,
+        to_chain=to_chain,
+        to_amount=to_amount,
+        rate=selected_pair.rate_str,
+    )
     if not viable:
         console.print(
             f'[red]Swap cannot be initiated at this amount: {reason} '

--- a/allways/utils/rate.py
+++ b/allways/utils/rate.py
@@ -105,6 +105,35 @@ def derive_tao_leg(from_chain: str, from_amount: int, to_chain: str, to_amount: 
     return 0
 
 
+def is_reverse_payout_direction(from_chain: str, to_chain: str) -> bool:
+    """True when the miner delivers native dest (not TAO) — reverse of canonical order."""
+    canon_from, _ = canonical_pair(from_chain, to_chain)
+    return from_chain != canon_from
+
+
+def max_dest_from_collateral(
+    collateral_rao: int,
+    rate: str,
+    from_chain: str,
+    to_chain: str,
+) -> int:
+    """Max dest-chain payout collateral can back at ``rate`` for reverse swaps.
+
+    For TAO→BTC the miner must deliver BTC; collateral is TAO. Returns the same
+    value as ``calculate_to_amount(collateral, rate, is_reverse=True, ...)``.
+    """
+    if not is_reverse_payout_direction(from_chain, to_chain):
+        return 0
+    canon_from, canon_to = canonical_pair(from_chain, to_chain)
+    return calculate_to_amount(
+        collateral_rao,
+        rate,
+        True,
+        get_chain(canon_to).decimals,
+        get_chain(canon_from).decimals,
+    )
+
+
 def quote_within_slippage(quoted: int, recomputed: int, slippage_bps: int) -> bool:
     """True if `recomputed` is no more than `slippage_bps` below `quoted`.
 
@@ -124,6 +153,11 @@ def check_swap_viability(
     miner_collateral_rao: int,
     min_swap_rao: int,
     max_swap_rao: int,
+    *,
+    from_chain: str = '',
+    to_chain: str = '',
+    to_amount: int = 0,
+    rate: str = '',
 ) -> tuple[bool, str]:
     """Check whether a swap can pass vote_initiate for a given miner.
 
@@ -131,11 +165,26 @@ def check_swap_viability(
     (collateral). Returns (viable, reason) — reason is empty on success.
     Bounds are global and should be checked against any single rate before
     the per-miner loop; collateral is per-miner.
+
+    For reverse swaps (e.g. TAO→BTC) the miner delivers native dest; bound
+    ``to_amount`` to what collateral can back at the committed rate. For forward
+    swaps (BTC→TAO) the TAO leg must fit within collateral.
     """
     if min_swap_rao > 0 and tao_amount_rao < min_swap_rao:
         return False, f'below min swap ({min_swap_rao / 1_000_000_000:.4f} TAO)'
     if max_swap_rao > 0 and tao_amount_rao > max_swap_rao:
         return False, f'above max swap ({max_swap_rao / 1_000_000_000:.4f} TAO)'
+
+    if from_chain and to_chain and rate and is_reverse_payout_direction(from_chain, to_chain):
+        max_dest = max_dest_from_collateral(miner_collateral_rao, rate, from_chain, to_chain)
+        if max_dest <= 0:
+            return False, 'rate produces no collateral-backed dest payout'
+        if to_amount > max_dest:
+            return False, 'dest payout exceeds collateral-backed limit'
+        if tao_amount_rao > miner_collateral_rao:
+            return False, f'insufficient collateral ({tao_amount_rao / 1_000_000_000:.4f} TAO needed)'
+        return True, ''
+
     if tao_amount_rao > miner_collateral_rao:
         return False, f'insufficient collateral ({tao_amount_rao / 1_000_000_000:.4f} TAO needed)'
     return True, ''

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -23,7 +23,13 @@ from allways.contract_client import AllwaysContractClient, ContractError
 from allways.synapses import MinerActivateSynapse, SwapConfirmSynapse, SwapReserveSynapse
 from allways.utils.logging import miner_label as _miner_label
 from allways.utils.proofs import reserve_proof_message, swap_proof_message
-from allways.utils.rate import calculate_to_amount, derive_tao_leg, quote_within_slippage
+from allways.utils.rate import (
+    calculate_to_amount,
+    derive_tao_leg,
+    is_reverse_payout_direction,
+    max_dest_from_collateral,
+    quote_within_slippage,
+)
 from allways.utils.scale import encode_bytes, encode_str, encode_u128
 from allways.validator.state_store import PendingConfirm, ReservationPin
 
@@ -407,6 +413,18 @@ async def handle_swap_reserve(
             if synapse.tao_amount > collateral:
                 reject_synapse(synapse, 'Insufficient miner collateral', ctx)
                 return synapse
+
+            if is_reverse_payout_direction(synapse.from_chain, synapse.to_chain):
+                rate_str = reserve_rate_str or str(reserve_rate)
+                max_dest = max_dest_from_collateral(
+                    collateral,
+                    rate_str,
+                    synapse.from_chain,
+                    synapse.to_chain,
+                )
+                if max_dest <= 0 or synapse.to_amount > max_dest:
+                    reject_synapse(synapse, 'Dest payout exceeds collateral-backed limit', ctx)
+                    return synapse
 
             min_collateral = validator.bounds_cache.min_collateral()
             if min_collateral > 0 and collateral < min_collateral:

--- a/smart-contracts/ink/lib.rs
+++ b/smart-contracts/ink/lib.rs
@@ -156,6 +156,8 @@ mod allways_swap_manager {
     // Callers on both the miner and validator side hardcode the same value so
     // no one needs to poll the contract to compute fee_amount.
     const FEE_DIVISOR: u128 = 100;
+    // Fixed-point rate denominator — must match allways.constants.RATE_PRECISION.
+    const RATE_PRECISION: u128 = 1_000_000_000_000_000_000;
 
     // Optimistic extension parameters. Window kept comfortably below the
     // client-side EXTEND_THRESHOLD_BLOCKS (=20) so finalization always lands
@@ -217,6 +219,109 @@ mod allways_swap_manager {
             let mut output = <ink::env::hash::Keccak256 as ink::env::hash::HashOutput>::Type::default();
             ink::env::hash_encoded::<ink::env::hash::Keccak256, _>(value, &mut output);
             Hash::from(output)
+        }
+
+        fn chain_decimals(chain: &str) -> u32 {
+            if chain == "tao" {
+                9
+            } else {
+                8
+            }
+        }
+
+        fn canonical_pair<'a>(chain_a: &'a str, chain_b: &'a str) -> (&'a str, &'a str) {
+            if chain_b == "tao" {
+                (chain_a, chain_b)
+            } else if chain_a == "tao" {
+                (chain_b, chain_a)
+            } else if chain_a < chain_b {
+                (chain_a, chain_b)
+            } else {
+                (chain_b, chain_a)
+            }
+        }
+
+        fn is_reverse_payout(from_chain: &str, to_chain: &str) -> bool {
+            let (canon_from, _) = Self::canonical_pair(from_chain, to_chain);
+            from_chain != canon_from
+        }
+
+        fn parse_rate_fixed(rate: &str) -> Result<u128, Error> {
+            if rate.is_empty() || rate.starts_with('-') {
+                return Err(Error::InvalidAmount);
+            }
+            let (int_part, frac_part) = match rate.split_once('.') {
+                Some((a, b)) => (a, b),
+                None => (rate, ""),
+            };
+            let int_val: u128 = int_part.parse().map_err(|_| Error::InvalidAmount)?;
+            let mut frac_val: u128 = 0;
+            let mut frac_digits: u32 = 0;
+            for ch in frac_part.chars() {
+                if !ch.is_ascii_digit() {
+                    return Err(Error::InvalidAmount);
+                }
+                if frac_digits >= 18 {
+                    break;
+                }
+                frac_val = frac_val
+                    .saturating_mul(10)
+                    .saturating_add(u128::from(ch as u8 - b'0'));
+                frac_digits += 1;
+            }
+            if frac_digits < 18 {
+                frac_val = frac_val.saturating_mul(10u128.pow(18 - frac_digits));
+            }
+            Ok(int_val
+                .saturating_mul(RATE_PRECISION)
+                .saturating_add(frac_val))
+        }
+
+        /// Reverse-direction to_amount — mirrors ``calculate_to_amount`` in Python.
+        fn calculate_to_amount_reverse(
+            from_amount: Balance,
+            rate: &str,
+            to_decimals: u32,
+            from_decimals: u32,
+        ) -> Result<Balance, Error> {
+            let rate_fixed = Self::parse_rate_fixed(rate)?;
+            if rate_fixed == 0 {
+                return Ok(0);
+            }
+            let from = u128::from(from_amount);
+            let decimal_diff = i64::from(to_decimals) - i64::from(from_decimals);
+            let result = if decimal_diff >= 0 {
+                let divisor = rate_fixed.saturating_mul(10u128.pow(decimal_diff as u32));
+                if divisor == 0 {
+                    0
+                } else {
+                    from.saturating_mul(RATE_PRECISION) / divisor
+                }
+            } else {
+                let multiplier = 10u128.pow((-decimal_diff) as u32);
+                from.saturating_mul(RATE_PRECISION)
+                    .saturating_mul(multiplier)
+                    / rate_fixed
+            };
+            Ok(Balance::try_from(result).unwrap_or(Balance::MAX))
+        }
+
+        fn max_dest_from_collateral(
+            collateral: Balance,
+            rate: &str,
+            from_chain: &str,
+            to_chain: &str,
+        ) -> Result<Balance, Error> {
+            if !Self::is_reverse_payout(from_chain, to_chain) {
+                return Ok(0);
+            }
+            let (canon_from, canon_to) = Self::canonical_pair(from_chain, to_chain);
+            Self::calculate_to_amount_reverse(
+                collateral,
+                rate,
+                Self::chain_decimals(canon_to),
+                Self::chain_decimals(canon_from),
+            )
         }
 
         fn clear_confirmed_reservation(&mut self, miner: AccountId) {
@@ -868,7 +973,17 @@ mod allways_swap_manager {
 
             self.consensus_vote(miner, REQ_INITIATE, request_hash, move |this| {
                 let miner_collateral = this.collateral.get(miner).unwrap_or(0);
-                if tao_amount > miner_collateral {
+                if Self::is_reverse_payout(&from_chain, &to_chain) {
+                    let max_to = Self::max_dest_from_collateral(
+                        miner_collateral,
+                        &rate,
+                        &from_chain,
+                        &to_chain,
+                    )?;
+                    if to_amount > max_to {
+                        return Err(Error::InsufficientCollateral);
+                    }
+                } else if tao_amount > miner_collateral {
                     return Err(Error::InsufficientCollateral);
                 }
 

--- a/tests/test_swap_viability.py
+++ b/tests/test_swap_viability.py
@@ -1,0 +1,93 @@
+"""Collateral viability checks — forward vs reverse payout legs."""
+
+from allways.constants import BTC_TO_SAT, TAO_TO_RAO
+from allways.utils.rate import (
+    calculate_to_amount,
+    check_swap_viability,
+    max_dest_from_collateral,
+)
+
+BTC_DEC = 8
+TAO_DEC = 9
+
+
+class TestMaxDestFromCollateral:
+    def test_tao_to_btc_caps_at_collateral_rate(self):
+        collateral = 5 * TAO_TO_RAO
+        max_dest = max_dest_from_collateral(collateral, '345', 'tao', 'btc')
+        expected = calculate_to_amount(collateral, '345', True, TAO_DEC, BTC_DEC)
+        assert max_dest == expected
+        assert max_dest < BTC_TO_SAT  # 5 TAO cannot back 1 BTC @ 345
+
+    def test_btc_to_tao_is_not_reverse_payout(self):
+        assert max_dest_from_collateral(5 * TAO_TO_RAO, '345', 'btc', 'tao') == 0
+
+
+class TestCheckSwapViability:
+    def test_forward_swap_requires_tao_within_collateral(self):
+        viable, reason = check_swap_viability(
+            3_450_000_000,
+            5 * TAO_TO_RAO,
+            0,
+            0,
+            from_chain='btc',
+            to_chain='tao',
+            to_amount=3_450_000_000,
+            rate='345',
+        )
+        assert viable is True
+        assert reason == ''
+
+    def test_forward_swap_rejects_tao_above_collateral(self):
+        viable, reason = check_swap_viability(
+            10 * TAO_TO_RAO,
+            5 * TAO_TO_RAO,
+            0,
+            0,
+            from_chain='btc',
+            to_chain='tao',
+            to_amount=10 * TAO_TO_RAO,
+            rate='345',
+        )
+        assert viable is False
+        assert 'insufficient collateral' in reason
+
+    def test_reverse_swap_rejects_unbounded_dest_payout(self):
+        collateral = 5 * TAO_TO_RAO
+        tao_send = int(0.1 * TAO_TO_RAO)
+        max_dest = max_dest_from_collateral(collateral, '345', 'tao', 'btc')
+        viable, reason = check_swap_viability(
+            tao_send,
+            collateral,
+            0,
+            0,
+            from_chain='tao',
+            to_chain='btc',
+            to_amount=max_dest + 1,
+            rate='345',
+        )
+        assert viable is False
+        assert reason == 'dest payout exceeds collateral-backed limit'
+
+    def test_reverse_swap_accepts_collateral_backed_dest(self):
+        collateral = 5 * TAO_TO_RAO
+        tao_send = int(0.1 * TAO_TO_RAO)
+        to_amount = calculate_to_amount(tao_send, '345', True, TAO_DEC, BTC_DEC)
+        max_dest = max_dest_from_collateral(collateral, '345', 'tao', 'btc')
+        assert to_amount <= max_dest
+        viable, reason = check_swap_viability(
+            tao_send,
+            collateral,
+            0,
+            0,
+            from_chain='tao',
+            to_chain='btc',
+            to_amount=to_amount,
+            rate='345',
+        )
+        assert viable is True
+        assert reason == ''
+
+    def test_legacy_call_without_direction_still_checks_tao_leg(self):
+        viable, _ = check_swap_viability(10 * TAO_TO_RAO, 5 * TAO_TO_RAO, 0, 0)
+        assert viable is False


### PR DESCRIPTION
## Summary

Fixes [#402](https://github.com/entrius/allways/issues/402) / [#396](https://github.com/entrius/allways/issues/396) — TAO→BTC swaps only checked `tao_amount ≤ collateral`, so miners could advertise huge BTC payouts while timeout slash stayed capped at the TAO leg.

## Related Issue

Fixes #402

## Change Type

- [x] Bug fix (contract + off-chain)
- [x] Regression tests
- [ ] New feature

## What Changed

- **`max_dest_from_collateral`** + extended **`check_swap_viability`** — reverse swaps (TAO→*) bound `to_amount` to collateral converted at committed rate
- **CLI** (`quote.py`, `swap.py`) — pass direction/rate/to_amount into viability check
- **Validator axon** (`handle_swap_reserve`) — reject dest payout above collateral-backed max
- **Contract** (`vote_initiate`) — on-chain mirror: reverse payout checks `to_amount ≤ max_dest_from_collateral`; forward swaps still check `tao_amount ≤ collateral`

## Files Changed

| File | Change |
|------|--------|
| `allways/utils/rate.py` | `max_dest_from_collateral`, `is_reverse_payout_direction`, extended `check_swap_viability` |
| `allways/cli/swap_commands/quote.py` | Pass swap direction into viability |
| `allways/cli/swap_commands/swap.py` | Pass swap direction into viability |
| `allways/validator/axon_handlers.py` | Reserve-time dest payout guard |
| `smart-contracts/ink/lib.rs` | Rate math + `vote_initiate` collateral guard |
| `tests/test_swap_viability.py` | Regression tests |

## Validation

```bash
cd allways
uv run pytest tests/test_swap_viability.py tests/test_rate.py -v
cd smart-contracts/ink && cargo check
```

## Deploy note

This changes **ink contract logic** (`vote_initiate`). Off-chain guards help immediately; full enforcement requires **contract redeploy** on the target network.