### PR TITLE
fix: Purge pending confirms when miner deregisters

### DIFF
--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -128,6 +128,12 @@ def initialize_pending_user_reservations(self: Validator) -> None:
 
     for item in items:
         swap_label = f'{item.from_chain.upper()}->{item.to_chain.upper()}'
+        if item.miner_hotkey not in hotkey_to_uid:
+            self.state_store.remove(item.miner_hotkey)
+            bt.logging.info(
+                f'PendingConfirm [{swap_label} ({item.miner_hotkey[:8]})]: miner deregistered, dropping'
+            )
+            continue
         uid = hotkey_to_uid.get(item.miner_hotkey, '?')
         miner_short = f'UID {uid} ({item.miner_hotkey[:8]})'
         provider = self.chain_providers.get(item.from_chain)
@@ -403,10 +409,17 @@ def purge_deregistered_hotkeys(self: Validator) -> None:
     stale = {hk for (hk, _, _) in self.last_known_rates.keys()} - current_hotkeys
     if not stale:
         return
+    pending_dropped = 0
     for hk in stale:
+        if self.state_store.has(hk):
+            pending_dropped += 1
         self.state_store.delete_hotkey(hk)
     self.last_known_rates = {k: v for k, v in self.last_known_rates.items() if k[0] not in stale}
     bt.logging.info(f'forward: dropped state for {len(stale)} deregistered miner(s)')
+    if pending_dropped:
+        bt.logging.info(
+            f'forward: removed {pending_dropped} pending confirm(s) for deregistered miner(s)'
+        )
 
 
 async def confirm_miner_fulfillments(

--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -695,6 +695,7 @@ class ValidatorStateStore:
             conn.execute('DELETE FROM swap_outcomes WHERE miner_hotkey = ?', (hotkey,))
             conn.execute('DELETE FROM reservation_pins WHERE miner_hotkey = ?', (hotkey,))
             conn.execute('DELETE FROM reservation_pin_events WHERE hotkey = ?', (hotkey,))
+            conn.execute('DELETE FROM pending_confirms WHERE miner_hotkey = ?', (hotkey,))
             conn.commit()
 
     def prune_events_older_than(self, cutoff_block: int) -> None:

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -11,7 +11,12 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from allways.classes import Swap, SwapStatus
-from allways.validator.forward import extend_fulfilled_near_timeout
+from allways.validator.forward import (
+    extend_fulfilled_near_timeout,
+    initialize_pending_user_reservations,
+    purge_deregistered_hotkeys,
+)
+from allways.validator.state_store import PendingConfirm, ValidatorStateStore
 from allways.validator.swap_tracker import SwapTracker
 
 # Real swap 206 numbers: extension 2 was proposed at this block, and a BTC
@@ -136,3 +141,59 @@ class TestExtendFulfilledNearTimeout:
 
         v.optimistic_extensions.maybe_propose_timeout.assert_not_called()
         v.optimistic_extensions.maybe_challenge_timeout.assert_not_called()
+
+
+PENDING_CONFIRM_SAMPLE = PendingConfirm(
+    miner_hotkey='miner-gone',
+    from_tx_hash='tx-1',
+    from_chain='btc',
+    to_chain='tao',
+    from_address='bc1-user',
+    to_address='5user',
+    tao_amount=123,
+    from_amount=456,
+    to_amount=789,
+    miner_from_address='bc1-miner',
+    miner_to_address='5miner',
+    rate_str='350',
+    reserved_until=1000,
+)
+
+
+class TestPurgeDeregisteredHotkeys:
+    def test_clears_pending_confirms_for_stale_hotkeys(self, tmp_path):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        store.enqueue(PENDING_CONFIRM_SAMPLE)
+        assert store.has('miner-gone')
+
+        v = SimpleNamespace(
+            metagraph=SimpleNamespace(hotkeys=['miner-live']),
+            last_known_rates={('miner-gone', 'btc', 'tao'): '350'},
+            state_store=store,
+        )
+        purge_deregistered_hotkeys(v)
+
+        assert not store.has('miner-gone')
+        assert v.last_known_rates == {}
+        store.close()
+
+
+class TestInitializePendingSkipsDeregistered:
+    def test_drops_pending_for_hotkey_not_in_metagraph(self, tmp_path):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        store.enqueue(PENDING_CONFIRM_SAMPLE)
+        provider = MagicMock()
+
+        v = SimpleNamespace(
+            metagraph=SimpleNamespace(hotkeys=['miner-live']),
+            state_store=store,
+            block=100,
+            chain_providers={'btc': provider},
+            event_watcher=SimpleNamespace(open_swap_count={'miner-gone': 0}),
+            contract_client=MagicMock(),
+        )
+        initialize_pending_user_reservations(v)
+
+        assert not store.has('miner-gone')
+        provider.verify_transaction.assert_not_called()
+        store.close()

--- a/tests/test_rate_state.py
+++ b/tests/test_rate_state.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from allways.validator.state_store import ValidatorStateStore
+from allways.validator.state_store import PendingConfirm, ValidatorStateStore
 
 
 def make_store(tmp_path: Path) -> ValidatorStateStore:
@@ -186,6 +186,32 @@ class TestDeleteHotkey:
         # hk2 untouched
         assert store.get_latest_rate_before('hk2', 'tao', 'btc', block=200) is not None
         assert 'hk2' in store.get_success_rates_since(0)
+        store.close()
+
+    def test_removes_pending_confirms(self, tmp_path: Path):
+        store = make_store(tmp_path)
+        store.enqueue(
+            PendingConfirm(
+                miner_hotkey='hk1',
+                from_tx_hash='tx-1',
+                from_chain='btc',
+                to_chain='tao',
+                from_address='bc1-user',
+                to_address='5user',
+                tao_amount=123,
+                from_amount=456,
+                to_amount=789,
+                miner_from_address='bc1-miner',
+                miner_to_address='5miner',
+                rate_str='350',
+                reserved_until=1000,
+            )
+        )
+        assert store.has('hk1')
+
+        store.delete_hotkey('hk1')
+
+        assert not store.has('hk1')
         store.close()
 
 

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -10,7 +10,7 @@ fresh ``init_db()`` creating the table.
 from dataclasses import replace
 from pathlib import Path
 
-from allways.validator.state_store import ReservationPin, ValidatorStateStore
+from allways.validator.state_store import PendingConfirm, ReservationPin, ValidatorStateStore
 
 PIN_SAMPLE1 = ReservationPin(
     miner_hotkey='miner-1',
@@ -145,6 +145,32 @@ class TestReservationPinCrossTable:
 
         store.delete_hotkey('miner-1')
         assert store.get_reservation_pin('miner-1') is None
+        store.close()
+
+    def test_delete_hotkey_clears_pending_confirm(self, tmp_path: Path):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        store.enqueue(
+            PendingConfirm(
+                miner_hotkey='miner-1',
+                from_tx_hash='tx-1',
+                from_chain='btc',
+                to_chain='tao',
+                from_address='bc1-user',
+                to_address='5user',
+                tao_amount=123,
+                from_amount=456,
+                to_amount=789,
+                miner_from_address='bc1-miner',
+                miner_to_address='5miner',
+                rate_str='350',
+                reserved_until=1000,
+            )
+        )
+        assert store.has('miner-1')
+
+        store.delete_hotkey('miner-1')
+
+        assert not store.has('miner-1')
         store.close()
 
     def test_fresh_init_db_has_reservation_pins_table(self, tmp_path: Path):


### PR DESCRIPTION
## Summary

Fixes [#414](https://github.com/entrius/allways/issues/414) — `purge_deregistered_hotkeys` called `delete_hotkey`, which cleared rates/pins but left `pending_confirms` rows. Orphaned queue entries kept draining until reservation expiry.

## Related Issue

Fixes #414

## Change Type

- [x] Bug fix
- [x] Regression tests
- [ ] New feature
- [ ] Refactor

## What Changed

- `delete_hotkey` also deletes `pending_confirms` for the hotkey
- `purge_deregistered_hotkeys` logs when queued confirms were removed
- `initialize_pending_user_reservations` drops rows for hotkeys no longer in the metagraph (defense in depth)

## Files Changed

| File | Change |
|------|--------|
| `allways/validator/state_store.py` | `delete_hotkey` clears `pending_confirms` |
| `allways/validator/forward.py` | Log pending drops on deregister; skip deregistered miners in pending drain |
| `tests/test_rate_state.py` | Assert pending row removed by `delete_hotkey` |
| `tests/test_state_store.py` | Cross-table pending cleanup regression |
| `tests/test_forward.py` | Purge + initialize_pending deregistered-miner tests |

## Validation

```bash
cd allways
uv run --python 3.12 pytest tests/test_rate_state.py tests/test_state_store.py tests/test_forward.py -v
```

## Test Plan

- [ ] `pytest tests/test_rate_state.py::TestDeleteHotkey::test_removes_pending_confirms -v`
- [ ] `pytest tests/test_forward.py::TestPurgeDeregisteredHotkeys -v`
- [ ] `pytest tests/test_forward.py::TestInitializePendingSkipsDeregistered -v`
- [ ] Full validator test suite green on `test` branch