### PR TITLE
fix(rate): strip whitespace from swap rate strings in calculate_to_amount

### DIFF
--- a/allways/utils/rate.py
+++ b/allways/utils/rate.py
@@ -37,6 +37,7 @@ def calculate_to_amount(
         to_decimals: Decimal places for canonical dest chain (e.g. 9 for TAO)
         from_decimals: Decimal places for canonical source chain (e.g. 8 for BTC)
     """
+    rate = rate.strip()
     rate_fixed = int(Decimal(rate) * RATE_PRECISION)
     if rate_fixed == 0:
         return 0

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -14,6 +14,16 @@ ETH_DEC = 18
 class TestBtcToTao:
     """BTC → TAO: forward direction, multiply by rate."""
 
+    def test_rate_string_whitespace_stripped(self):
+        source = int(Decimal('0.01') * BTC_TO_SAT)
+        padded = calculate_to_amount(
+            source, ' 345 ', is_reverse=False, to_decimals=TAO_DEC, from_decimals=BTC_DEC
+        )
+        plain = calculate_to_amount(
+            source, '345', is_reverse=False, to_decimals=TAO_DEC, from_decimals=BTC_DEC
+        )
+        assert padded == plain
+
     def test_standard_rate(self):
         # 0.01 BTC @ rate 345 (1 BTC = 345 TAO) → 3.45 TAO
         source = int(Decimal('0.01') * BTC_TO_SAT)  # 1_000_000 sat


### PR DESCRIPTION
## Summary

Strip whitespace from swap rate strings in `calculate_to_amount` so padded on-chain rates parse consistently across miner, validator, and CLI.

## Related Issues

Closes #427

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [ ] Manually tested

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Changes are documented (if applicable)
