### PR TITLE
Log crown holder UID + rate per forward step

### DIFF
--- a/allways/utils/logging.py
+++ b/allways/utils/logging.py
@@ -69,3 +69,29 @@ def swap_label(swap: Any, metagraph: Optional[Any] = None) -> str:
     direction = f'{(swap.from_chain or "?").upper()}->{(swap.to_chain or "?").upper()}'
     miner = miner_label(metagraph, getattr(swap, 'miner_hotkey', ''))
     return f'Swap #{swap.id} [{direction} {miner}]'
+
+
+def log_crown_winners(
+    metagraph: Any,
+    block: int,
+    snapshot: dict[tuple[str, str], list[tuple[str, str, str, float, float, int]]],
+) -> None:
+    """One greppable info line per forward pass naming the current crown holder
+    UID and rate per direction:
+
+        forward: crown holders @ block=N | btc->tao uid=42 rate=326.42 | tao->btc uid=17 rate=339.62
+
+    Ties render as ``uid=42,55``. Empty directions render as ``btc->tao none``.
+    ASCII arrows so ``grep 'crown holders'`` and ``grep 'btc->tao'`` work
+    without copy-pasting unicode."""
+    hotkey_to_uid = {hk: uid for uid, hk in enumerate(metagraph.hotkeys)}
+    parts = [f'forward: crown holders @ block={block}']
+    for (from_chain, to_chain), rows in snapshot.items():
+        direction = f'{from_chain}->{to_chain}'
+        if not rows:
+            parts.append(f'{direction} none')
+            continue
+        uids = ','.join(str(hotkey_to_uid.get(row[2], '?')) for row in rows)
+        rate = rows[0][4]
+        parts.append(f'{direction} uid={uids} rate={rate:g}')
+    bt.logging.info(' | '.join(parts))

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -15,7 +15,7 @@ from allways.constants import (
     EXTEND_THRESHOLD_BLOCKS,
 )
 from allways.contract_client import ContractError, is_contract_rejection
-from allways.utils.logging import log_on_change
+from allways.utils.logging import log_crown_winners, log_on_change
 from allways.utils.logging import swap_label as _swap_label
 from allways.utils.rate import expected_swap_amounts
 from allways.utils.scale import strip_hex_prefix
@@ -123,7 +123,7 @@ async def forward(self: Validator) -> None:
     # HaltBanner + top-right "paused" indicator (both fed by /halt off
     # contract_events) signal the recycle state to users in the meantime.
     crown_snapshot = snapshot_current_crown_holders(self)
-    log_crown_winners(self, crown_snapshot)
+    log_crown_winners(self.metagraph, self.block, crown_snapshot)
     if self.database_storage.is_enabled():
         try:
             self.database_storage.upsert_current_crown_snapshot(crown_snapshot)
@@ -135,31 +135,6 @@ def clear_provider_caches(self: Validator) -> None:
     for provider in self.chain_providers.values():
         if hasattr(provider, 'clear_cache'):
             provider.clear_cache()
-
-
-def log_crown_winners(
-    self: Validator,
-    snapshot: dict[tuple[str, str], list[tuple[str, str, str, float, float, int]]],
-) -> None:
-    """One greppable line per forward step naming the current crown holder UID
-    and rate per direction. Format:
-
-        forward: crown holders @ block=N | btc->tao uid=42 rate=326.42 | tao->btc uid=17 rate=339.62
-
-    Ties render as ``uid=42,55``. Directions with no qualifying holder render
-    as ``btc->tao none``. ASCII arrows so ``grep 'crown holders'`` and
-    ``grep 'btc->tao'`` both work without copy-pasting unicode."""
-    hotkey_to_uid = {hk: uid for uid, hk in enumerate(self.metagraph.hotkeys)}
-    parts = [f'forward: crown holders @ block={self.block}']
-    for (from_chain, to_chain), rows in snapshot.items():
-        direction = f'{from_chain}->{to_chain}'
-        if not rows:
-            parts.append(f'{direction} none')
-            continue
-        uids = ','.join(str(hotkey_to_uid.get(row[2], '?')) for row in rows)
-        rate = rows[0][4]
-        parts.append(f'{direction} uid={uids} rate={rate:g}')
-    bt.logging.info(' | '.join(parts))
 
 
 def initialize_pending_user_reservations(self: Validator) -> None:

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -112,17 +112,21 @@ async def forward(self: Validator) -> None:
     # Live current-crown snapshot — runs after every other phase so DB
     # latency here can't push vote_initiate, finalize, or timeout-extension
     # RPC past their block deadlines. Sub-ms in-memory compute plus a small
-    # bounded write; gated by STORE_DB_RESULTS and wrapped so DB outages
-    # never propagate into the forward loop. No halt check here — that
-    # RPC is the expensive one; halt-aware clearing happens once per
+    # bounded write; the write is gated by STORE_DB_RESULTS and wrapped so
+    # DB outages never propagate into the forward loop. The compute runs
+    # unconditionally so the per-step crown log line below works for
+    # validators that haven't opted into DB writes. No halt check here —
+    # that RPC is the expensive one; halt-aware clearing happens once per
     # scoring round inside _flush_halt_window. Worst case the live table
     # shows the actual best-rate holder during halt for up to one
     # SCORING_WINDOW_BLOCKS (~1h) until the next round clears it; the
     # HaltBanner + top-right "paused" indicator (both fed by /halt off
     # contract_events) signal the recycle state to users in the meantime.
+    crown_snapshot = snapshot_current_crown_holders(self)
+    log_crown_winners(self, crown_snapshot)
     if self.database_storage.is_enabled():
         try:
-            self.database_storage.upsert_current_crown_snapshot(snapshot_current_crown_holders(self))
+            self.database_storage.upsert_current_crown_snapshot(crown_snapshot)
         except Exception as e:
             bt.logging.warning(f'current_crown_holders snapshot failed: {e}')
 
@@ -131,6 +135,31 @@ def clear_provider_caches(self: Validator) -> None:
     for provider in self.chain_providers.values():
         if hasattr(provider, 'clear_cache'):
             provider.clear_cache()
+
+
+def log_crown_winners(
+    self: Validator,
+    snapshot: dict[tuple[str, str], list[tuple[str, str, str, float, float, int]]],
+) -> None:
+    """One greppable line per forward step naming the current crown holder UID
+    and rate per direction. Format:
+
+        forward: crown holders @ block=N | btc->tao uid=42 rate=326.42 | tao->btc uid=17 rate=339.62
+
+    Ties render as ``uid=42,55``. Directions with no qualifying holder render
+    as ``btc->tao none``. ASCII arrows so ``grep 'crown holders'`` and
+    ``grep 'btc->tao'`` both work without copy-pasting unicode."""
+    hotkey_to_uid = {hk: uid for uid, hk in enumerate(self.metagraph.hotkeys)}
+    parts = [f'forward: crown holders @ block={self.block}']
+    for (from_chain, to_chain), rows in snapshot.items():
+        direction = f'{from_chain}->{to_chain}'
+        if not rows:
+            parts.append(f'{direction} none')
+            continue
+        uids = ','.join(str(hotkey_to_uid.get(row[2], '?')) for row in rows)
+        rate = rows[0][4]
+        parts.append(f'{direction} uid={uids} rate={rate:g}')
+    bt.logging.info(' | '.join(parts))
 
 
 def initialize_pending_user_reservations(self: Validator) -> None:


### PR DESCRIPTION
## Summary

Adds one greppable info line per forward pass naming the current crown holder UID and rate per direction. The snapshot was already being computed for `current_crown_holders` (per #390); this lifts the compute out of the `STORE_DB_RESULTS` gate so validators that haven't opted into DB writes also see the log.

## Format

```
forward: crown holders @ block=4523191 | btc->tao uid=42 rate=326.42 | tao->btc uid=17 rate=339.62
```

- **Ties** → `uid=42,55` (comma-joined UIDs, all share the same rate)
- **Empty direction** → `btc->tao none`
- **ASCII arrows** so `grep 'crown holders'` and `grep 'btc->tao'` both work without copy-pasting unicode
- **UID instead of hotkey** — easier to scan and matches existing log conventions in `initialize_pending_user_reservations`

## Why

Crown attribution was previously DB-only. Devs without `STORE_DB_RESULTS=1` had no visibility into who won crown without querying Postgres. One INFO line per forward pass (~once every several blocks) is cheap and lets you `grep 'crown holders' validator.log` to audit attribution directly.

## Test plan

- [x] `pytest tests/test_scoring_v1.py tests/test_event_watcher.py` — 180/180 pass
- [x] `ruff format` + `ruff check` clean
- [ ] Staging validator: confirm the line appears once per forward pass with sensible UIDs and rates
- [ ] Confirm a tied direction renders as `uid=A,B`
- [ ] Confirm an empty direction renders as `... none`