### PR TITLE
fix(validator): cap dest-tip snapshot at payout block

### DIFF
--- a/allways/validator/chain_verification.py
+++ b/allways/validator/chain_verification.py
@@ -63,6 +63,10 @@ class SwapVerifier:
         except Exception:
             tip = None
         if tip and tip > 0:
+            # If fulfillment landed before a late snapshot (RPC retry), cap the
+            # lower bound so an honest payout is not rejected as a replay.
+            if swap.to_tx_block and swap.to_tx_block > 0:
+                tip = min(tip, swap.to_tx_block)
             self.dest_tip_at_init[swap.id] = tip
             if self.state_store is not None:
                 # Same fail-open discipline as the RPC call above: a sqlite

--- a/tests/test_chain_verification.py
+++ b/tests/test_chain_verification.py
@@ -92,6 +92,19 @@ class TestObserveInitiation:
 
         assert v.dest_tip_at_init[7] == 850_500
 
+    def test_late_snapshot_capped_when_payout_already_on_chain(self):
+        btc = MagicMock()
+        btc.get_current_block_height.side_effect = [None, 850_500]
+        v = SwapVerifier(chain_providers={'btc': btc})
+        swap = make_swap(swap_id=7, to_chain='btc')
+        swap.to_tx_block = 850_100
+
+        v.observe_initiation(swap)
+        v.observe_initiation(swap)
+
+        assert v.dest_tip_at_init[7] == 850_100
+        assert v.is_dest_tx_fresh(swap, tx_at(850_100)) is True
+
     def test_rpc_raises_treated_as_failure(self):
         btc = MagicMock()
         btc.get_current_block_height.side_effect = RuntimeError('boom')


### PR DESCRIPTION
## Summary

Closes #430. Cap dest-chain tip snapshot at `swap.to_tx_block` when fulfillment is already on-chain, so a late snapshot after RPC retry does not reject honest payouts.

## Changes

- `allways/validator/chain_verification.py`
- `tests/test_chain_verification.py`: `test_late_snapshot_capped_when_payout_already_on_chain`

## Test plan

- [x] `pytest tests/test_chain_verification.py -k late_snapshot_capped` (requires `bittensor` deps)
