### PR TITLE
feat(scoring): hard-zero credibility above the timeout limit

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -65,8 +65,8 @@ VOLUME_WEIGHT_ALPHA: float = 0.5
 CREDIBILITY_RAMP_OBSERVATIONS: int = 10
 # More than this many timed-out swaps within CREDIBILITY_WINDOW_BLOCKS hard-zeros
 # a miner's credibility (and thus their whole reward) until the old timeouts age
-# out of the rolling window. 0-3 tolerated; the 4th timeout zeros credibility.
-CREDIBILITY_MAX_TIMEOUTS: int = 3
+# out of the rolling window. 0-2 tolerated; the 3rd timeout zeros credibility.
+CREDIBILITY_MAX_TIMEOUTS: int = 2
 
 # ─── Emission Recycling ────────────────────────────────────
 RECYCLE_UID = 53  # Subnet owner UID

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -63,6 +63,10 @@ SUCCESS_EXPONENT: int = 3
 VOLUME_WEIGHT_ALPHA: float = 0.5
 # Closed swaps required for full credibility (0 → 100% linear ramp).
 CREDIBILITY_RAMP_OBSERVATIONS: int = 10
+# More than this many timed-out swaps within CREDIBILITY_WINDOW_BLOCKS hard-zeros
+# a miner's credibility (and thus their whole reward) until the old timeouts age
+# out of the rolling window. 0-3 tolerated; the 4th timeout zeros credibility.
+CREDIBILITY_MAX_TIMEOUTS: int = 3
 
 # ─── Emission Recycling ────────────────────────────────────
 RECYCLE_UID = 53  # Subnet owner UID

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -17,6 +17,7 @@ import numpy as np
 
 from allways.chains import canonical_pair
 from allways.constants import (
+    CREDIBILITY_MAX_TIMEOUTS,
     CREDIBILITY_RAMP_OBSERVATIONS,
     CREDIBILITY_WINDOW_BLOCKS,
     DIRECTION_POOLS,
@@ -249,6 +250,7 @@ def calculate_miner_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
             wt.record_credibility(
                 closed_swaps=sum(success_stats.get(hotkey, (0, 0))),
                 ramp_target=CREDIBILITY_RAMP_OBSERVATIONS,
+                timed_out=success_stats.get(hotkey, (0, 0))[1],
             )
             crown_share_dir = blocks / total_crown_dir
             vol_dir = volumes_dir.get(hotkey, 0)
@@ -384,8 +386,13 @@ def success_rate(stats: Optional[Tuple[int, int]]) -> float:
 
 def credibility_ramp(stats: Optional[Tuple[int, int]]) -> float:
     """Linear ramp to full credibility at CREDIBILITY_RAMP_OBSERVATIONS closed
-    swaps. Applied linearly to the reward, not cubed. Zero observations → 0."""
+    swaps. Applied linearly to the reward, not cubed. Zero observations → 0.
+    More than CREDIBILITY_MAX_TIMEOUTS timed-out swaps in the window hard-zeros
+    credibility — a rolling penalty that recovers as old timeouts age out."""
     if not stats or stats == (0, 0):
+        return 0.0
+    _completed, timed_out = stats
+    if timed_out > CREDIBILITY_MAX_TIMEOUTS:
         return 0.0
     return min(1.0, sum(stats) / CREDIBILITY_RAMP_OBSERVATIONS)
 

--- a/allways/validator/scoring_trace.py
+++ b/allways/validator/scoring_trace.py
@@ -10,7 +10,12 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 import bittensor as bt
 import numpy as np
 
-from allways.constants import CREDIBILITY_RAMP_OBSERVATIONS, RECYCLE_UID, TAO_TO_RAO
+from allways.constants import (
+    CREDIBILITY_MAX_TIMEOUTS,
+    CREDIBILITY_RAMP_OBSERVATIONS,
+    RECYCLE_UID,
+    TAO_TO_RAO,
+)
 
 if TYPE_CHECKING:
     from allways.validator.scoring import DirectionTrace
@@ -45,9 +50,12 @@ class WeightingTrace:
         self.participation = min(1.0, self.volume_share / crown_share) if crown_share > 0 else 1.0
         self.volume_factor = factor
 
-    def record_credibility(self, closed_swaps: int, ramp_target: int) -> None:
+    def record_credibility(self, closed_swaps: int, ramp_target: int, timed_out: int = 0) -> None:
         self.closed_swaps = closed_swaps
-        self.credibility_ramp = min(1.0, closed_swaps / ramp_target) if ramp_target > 0 else 1.0
+        if timed_out > CREDIBILITY_MAX_TIMEOUTS:
+            self.credibility_ramp = 0.0
+        else:
+            self.credibility_ramp = min(1.0, closed_swaps / ramp_target) if ramp_target > 0 else 1.0
 
 
 def log_scoring_trace(

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -161,17 +161,17 @@ class TestCredibilityRampHelper:
         """1 closed swap → ramp 0.1; 5 closed → 0.5. Counts tolerated timeouts too."""
         assert credibility_ramp((1, 0)) == 0.1
         assert credibility_ramp((5, 0)) == 0.5
-        assert credibility_ramp((2, 3)) == 0.5  # 3 timeouts tolerated
+        assert credibility_ramp((3, 2)) == 0.5  # 2 timeouts tolerated
 
     def test_caps_at_full_ramp(self):
         assert credibility_ramp((10, 0)) == 1.0
 
     def test_excess_timeouts_hard_zero(self):
-        """More than CREDIBILITY_MAX_TIMEOUTS (3) timeouts → 0, regardless of volume."""
-        assert credibility_ramp((8, 3)) == 1.0  # 3 tolerated, fully ramped
-        assert credibility_ramp((8, 4)) == 0.0  # 4th timeout zeros it
+        """More than CREDIBILITY_MAX_TIMEOUTS (2) timeouts → 0, regardless of volume."""
+        assert credibility_ramp((8, 2)) == 1.0  # 2 tolerated, fully ramped
+        assert credibility_ramp((8, 3)) == 0.0  # 3rd timeout zeros it
         assert credibility_ramp((90, 10)) == 0.0  # high volume can't rescue it
-        assert credibility_ramp((0, 4)) == 0.0
+        assert credibility_ramp((0, 3)) == 0.0
 
 
 class TestCrownHoldersHelper:
@@ -2052,21 +2052,21 @@ class TestCredibilityRamp:
         v.state_store.close()
 
     def test_tolerated_timeouts_advance_ramp_but_hurt_raw_rate(self, tmp_path: Path):
-        """7 completed + 3 timed_out (within the 3-timeout tolerance) → ramp = 1.0,
-        raw = 0.7 → 0.7³ × 1.0."""
+        """8 completed + 2 timed_out (within the 2-timeout tolerance) → ramp = 1.0,
+        raw = 0.8 → 0.8³ × 1.0."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
         v = make_validator(tmp_path, hotkeys, baseline_credibility=False)
         self.seed_btc_tao_crown(v, 'hk_a')
-        for i in range(7):
+        for i in range(8):
             v.state_store.insert_swap_outcome(
                 swap_id=i + 1, miner_hotkey='hk_a', completed=True, resolved_block=100 + i
             )
-        for i in range(3):
+        for i in range(2):
             v.state_store.insert_swap_outcome(
                 swap_id=100 + i, miner_hotkey='hk_a', completed=False, resolved_block=200 + i
             )
         rewards, _ = calculate_miner_rewards(v)
-        np.testing.assert_allclose(rewards[0], POOL_BTC_TAO * 0.7**3, atol=1e-6)
+        np.testing.assert_allclose(rewards[0], POOL_BTC_TAO * 0.8**3, atol=1e-6)
         v.state_store.close()
 
     def test_excess_timeouts_zero_reward(self, tmp_path: Path):

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -158,14 +158,20 @@ class TestCredibilityRampHelper:
         assert credibility_ramp((0, 0)) == 0.0
 
     def test_scales_linearly_below_threshold(self):
-        """1 closed swap → ramp 0.1; 5 closed → 0.5. Counts timeouts too."""
+        """1 closed swap → ramp 0.1; 5 closed → 0.5. Counts tolerated timeouts too."""
         assert credibility_ramp((1, 0)) == 0.1
         assert credibility_ramp((5, 0)) == 0.5
-        assert credibility_ramp((2, 3)) == 0.5
+        assert credibility_ramp((2, 3)) == 0.5  # 3 timeouts tolerated
 
     def test_caps_at_full_ramp(self):
         assert credibility_ramp((10, 0)) == 1.0
-        assert credibility_ramp((90, 10)) == 1.0
+
+    def test_excess_timeouts_hard_zero(self):
+        """More than CREDIBILITY_MAX_TIMEOUTS (3) timeouts → 0, regardless of volume."""
+        assert credibility_ramp((8, 3)) == 1.0  # 3 tolerated, fully ramped
+        assert credibility_ramp((8, 4)) == 0.0  # 4th timeout zeros it
+        assert credibility_ramp((90, 10)) == 0.0  # high volume can't rescue it
+        assert credibility_ramp((0, 4)) == 0.0
 
 
 class TestCrownHoldersHelper:
@@ -1693,6 +1699,15 @@ class TestWeightingTraceRecorders:
         wt.record_credibility(closed_swaps=5, ramp_target=0)
         assert wt.credibility_ramp == 1.0
 
+    def test_record_credibility_excess_timeouts_zero(self):
+        """Trace mirrors the reward rule: >3 timeouts → ramp shown as 0."""
+        from allways.validator.scoring_trace import WeightingTrace
+
+        wt = WeightingTrace()
+        wt.record_credibility(closed_swaps=100, ramp_target=10, timed_out=4)
+        assert wt.closed_swaps == 100
+        assert wt.credibility_ramp == 0.0
+
 
 class TestVolumeWeighting:
     """End-to-end volume weighting via calculate_miner_rewards."""
@@ -2036,8 +2051,27 @@ class TestCredibilityRamp:
         np.testing.assert_allclose(rewards[0], POOL_BTC_TAO, atol=1e-6)
         v.state_store.close()
 
-    def test_timeouts_advance_ramp_but_hurt_raw_rate(self, tmp_path: Path):
-        """5 completed + 5 timed_out → ramp = 1.0, raw = 0.5 → 0.5³ × 1.0 = 0.125."""
+    def test_tolerated_timeouts_advance_ramp_but_hurt_raw_rate(self, tmp_path: Path):
+        """7 completed + 3 timed_out (within the 3-timeout tolerance) → ramp = 1.0,
+        raw = 0.7 → 0.7³ × 1.0."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
+        v = make_validator(tmp_path, hotkeys, baseline_credibility=False)
+        self.seed_btc_tao_crown(v, 'hk_a')
+        for i in range(7):
+            v.state_store.insert_swap_outcome(
+                swap_id=i + 1, miner_hotkey='hk_a', completed=True, resolved_block=100 + i
+            )
+        for i in range(3):
+            v.state_store.insert_swap_outcome(
+                swap_id=100 + i, miner_hotkey='hk_a', completed=False, resolved_block=200 + i
+            )
+        rewards, _ = calculate_miner_rewards(v)
+        np.testing.assert_allclose(rewards[0], POOL_BTC_TAO * 0.7**3, atol=1e-6)
+        v.state_store.close()
+
+    def test_excess_timeouts_zero_reward(self, tmp_path: Path):
+        """5 completed + 5 timed_out → 5 timeouts > 3 → credibility hard-zeroed →
+        reward 0 despite a high raw fulfillment count."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
         v = make_validator(tmp_path, hotkeys, baseline_credibility=False)
         self.seed_btc_tao_crown(v, 'hk_a')
@@ -2050,7 +2084,7 @@ class TestCredibilityRamp:
                 swap_id=100 + i, miner_hotkey='hk_a', completed=False, resolved_block=200 + i
             )
         rewards, _ = calculate_miner_rewards(v)
-        np.testing.assert_allclose(rewards[0], POOL_BTC_TAO * 0.5**3, atol=1e-6)
+        np.testing.assert_allclose(rewards[0], 0.0, atol=1e-6)
         v.state_store.close()
 
     def test_unearned_ramp_portion_recycles(self, tmp_path: Path):


### PR DESCRIPTION
## What

Adds a rolling-window hard floor on miner credibility: **more than `CREDIBILITY_MAX_TIMEOUTS` (2) timed-out swaps within `CREDIBILITY_WINDOW_BLOCKS` (~30d) forces the credibility ramp to `0`** — which, since `ramp` is a multiplicand in `crown × cap × vol × rate³ × ramp`, zeros the miner's whole reward for the round.

## Why

Previously the credibility ramp only ever ramped *up*: `credibility_ramp()` returned `min(1.0, closed_swaps / 10)`, and a timeout counted *toward* the ramp as just another observation. So a high-volume miner could rack up many timeouts and still earn a `1.00×` credibility multiplier — the only penalty lived in the cubed `success_rate` term. We want repeated timeouts to be disqualifying, not merely dilutive.

## Behavior

- `0–2` timeouts in the window: tolerated (ramp unchanged).
- `3rd` timeout: credibility → `0` (reward → `0`).
- **Rolling / auto-recover:** credibility returns once old timeouts age out of the 30-day window and the count drops back to ≤2. No new persistent state.

## Changes

- `constants.py`: new `CREDIBILITY_MAX_TIMEOUTS = 2`.
- `scoring.py`: `credibility_ramp()` returns `0.0` when `timed_out > CREDIBILITY_MAX_TIMEOUTS`.
- `scoring_trace.py`: `record_credibility()` mirrors the zero so the validator's own stdout log is honest.
- Tests: updated the assertions that encoded the old "timeouts advance ramp" behavior; added boundary + integration coverage (`(8,2)→full`, `(8,3)→0`, 5+5 swaps → reward 0). `pytest tests/test_scoring_v1.py` → 127 passed.

## Related (must land together)

This is the source-of-truth change. The dashboard mirror + UI display land alongside:
- das-allways (API mirror): https://github.com/entrius/das-allways/pull/33
- allways-ui (display): https://github.com/entrius/allways-ui/pull/111