### PR TITLE
[Bug]: Swap direction lost when tracker resolves before terminal event

### DIFF
--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -694,9 +694,9 @@ class ContractEventWatcher:
         if self.swap_tracker is None:
             return '', ''
         swap = self.swap_tracker.active.get(swap_id)
-        if swap is None:
-            return '', ''
-        return (swap.from_chain or '').lower(), (swap.to_chain or '').lower()
+        if swap is not None:
+            return (swap.from_chain or '').lower(), (swap.to_chain or '').lower()
+        return self.swap_tracker.resolved_directions.get(swap_id, ('', ''))
 
     def record_reservation_pin(self, block_num: int, miner: str, reserved_until: int) -> None:
         """Pin the miner's commitment as of the reservation block ``block_num``.

--- a/allways/validator/swap_tracker.py
+++ b/allways/validator/swap_tracker.py
@@ -38,6 +38,7 @@ class SwapTracker:
         self.last_scanned_id = 0
         self.active: Dict[int, Swap] = {}
         self.voted_ids: Set[int] = set()
+        self.resolved_directions: Dict[int, tuple[str, str]] = {}
 
     def _label(self, swap: Swap) -> str:
         return _swap_label_with_uid(swap, self.metagraph)
@@ -82,6 +83,10 @@ class SwapTracker:
         swap = self.active.pop(swap_id, None)
         if swap is None:
             return
+        self.resolved_directions[swap_id] = (
+            (swap.from_chain or '').lower(),
+            (swap.to_chain or '').lower(),
+        )
         swap.status = status
         swap.completed_block = block
         self.voted_ids.discard(swap_id)

--- a/tests/test_swap_tracker.py
+++ b/tests/test_swap_tracker.py
@@ -160,6 +160,15 @@ class TestRefreshNullHandling:
 
         assert 51 not in tracker.active
 
+    def test_resolve_caches_direction_for_late_terminal_events(self):
+        tracker = make_tracker()
+        swap = make_swap(swap_id=52, from_chain='btc', to_chain='tao')
+        tracker.active[swap.id] = swap
+
+        tracker.resolve(swap_id=52, status=SwapStatus.COMPLETED, block=600)
+
+        assert tracker.resolved_directions[52] == ('btc', 'tao')
+
     def test_terminal_status_drops_without_retry(self):
         tracker = make_tracker()
         swap = make_swap(swap_id=53)


### PR DESCRIPTION
## Summary

Closes #439.

Cache swap `(from_chain, to_chain)` in `SwapTracker.resolved_directions` on `resolve()` and read it from `ContractEventWatcher`.

## Changes

- `allways/validator/swap_tracker.py`: populate `resolved_directions` when dropping active swaps.
- `allways/validator/event_watcher.py`: use cached direction fallback.
- `tests/test_swap_tracker.py`: regression test.

## Test plan

- [ ] `pytest tests/test_swap_tracker.py -q`
