### PR TITLE
[Bug]: Extension finalize drops reservation pin before confirm

### DIFF
--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -308,6 +308,7 @@ def try_extend_reservation(
         # The matching ReservationExtensionFinalized event won't be picked up
         # until the next forward step's event_watcher.sync_to.
         self.state_store.update_reserved_until(item.miner_hotkey, finalized_target)
+        self.state_store.update_reservation_pin_reserved_until(item.miner_hotkey, finalized_target)
         reserved_until = finalized_target
         # The just-finalized proposal is gone from contract storage; refresh
         # so downstream challenge/propose see the post-finalize state instead


### PR DESCRIPTION
## Summary

Closes #441.

Update reservation pin when inline extension finalize bumps `reserved_until`.

## Changes

- `allways/validator/forward.py`: call `update_reservation_pin_reserved_until` alongside `update_reserved_until`.

## Test plan

- [ ] Manual / extend pending-confirm tests for pin survival after finalize.
