### PR TITLE
chore: bump version 1.0.9 -> 1.0.10

### DIFF
--- a/allways/__init__.py
+++ b/allways/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '1.0.9'
+__version__ = '1.0.10'
 version_split = __version__.split('.')
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))


### PR DESCRIPTION
Bumps `__version__` to 1.0.10 (`__spec_version__` 1009 -> 1010).

1.0.9 shipped two behavior changes without a version increment:
- #444 reject self-transfer (A->A) swap legs
- #445 accept 0x-prefixed signatures in source-address proof (was rejecting valid web/JS-client reserves), plus axon rate-limiting plumbing and CLI 429 handling

This bump gives operators a version number that reflects those changes.