### PR TITLE
Preserve the synchronous reserve-time pin (fix quote↔settlement rate divergence)

### DIFF
--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -874,19 +874,49 @@ class ContractEventWatcher:
                 f'{block_num} — no pin written, will fall back'
             )
             return
-        self.state_store.upsert_reservation_pin(
-            ReservationPin(
-                miner_hotkey=miner,
-                reserve_block=block_num,
-                from_chain=commitment.from_chain,
-                to_chain=commitment.to_chain,
-                rate_str=commitment.rate_str,
-                counter_rate_str=commitment.counter_rate_str,
-                miner_from_address=commitment.from_address,
-                miner_to_address=commitment.to_address,
-                reserved_until=reserved_until,
+        # Only BACKFILL the settlement pin — never overwrite one the reserve
+        # handler already wrote. ``handle_swap_reserve`` pins the commitment at
+        # the instant it validated the user's quote, which is the rate the
+        # on-chain ``to_amount`` was reserved against. Re-reading at ``block_num``
+        # can capture a DIFFERENT rate when the miner moved its commitment
+        # between the handler's read and the on-chain inclusion of
+        # ``vote_reserve`` — e.g. a miner oscillating its rate every few blocks
+        # lands the reservation's inclusion block on a stale tick. Overwriting
+        # then makes the settlement rate disagree with the reserved ``to_amount``
+        # and the user is short-changed at confirm (see swap 2405: reserved at
+        # 370, pinned to 280, settled 24% low). The synchronous pin is
+        # authoritative; this read only matters when that write failed.
+        #
+        # NOTE / TODO(contract-v2, multi-validator): with one validator the
+        # synchronous pin is always present and correct, so preferring it fully
+        # closes the divergence. Once multiple validators reserve, each one's
+        # synchronous pin is read at its own instant and they are NOT
+        # deterministic across the set. The real fix then is to bind
+        # (reserve_block, rate) into the reservation at quorum and verify
+        # rate == CommitmentOf(reserve_block) within the user's slippage band,
+        # so every validator derives an identical, quote-consistent settlement
+        # rate. That requires the reserve hash + Reservation struct to carry the
+        # rate, i.e. a smart-contract iteration. Until v2 lands, back off to the
+        # synchronous pin here.
+        if self.state_store.get_reservation_pin(miner) is None:
+            self.state_store.upsert_reservation_pin(
+                ReservationPin(
+                    miner_hotkey=miner,
+                    reserve_block=block_num,
+                    from_chain=commitment.from_chain,
+                    to_chain=commitment.to_chain,
+                    rate_str=commitment.rate_str,
+                    counter_rate_str=commitment.counter_rate_str,
+                    miner_from_address=commitment.from_address,
+                    miner_to_address=commitment.to_address,
+                    reserved_until=reserved_until,
+                )
             )
-        )
+        else:
+            bt.logging.info(
+                f'EventWatcher: reserve-time pin already present for {miner[:8]} '
+                f'at block {block_num} — preserving synchronous pin (not overwriting)'
+            )
         # Emit pin lifecycle events into the scoring overlay. The reservation
         # locks in BOTH offered directions for this miner (the contract takes
         # the miner offline for any new swap until this reservation resolves),

--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -874,38 +874,11 @@ class ContractEventWatcher:
                 f'{block_num} — no pin written, will fall back'
             )
             return
-        # Only BACKFILL the settlement pin — never overwrite one the reserve
-        # handler already wrote. ``handle_swap_reserve`` pins the commitment at
-        # the instant it validated the user's quote, which is the rate the
-        # on-chain ``to_amount`` was reserved against. Re-reading at ``block_num``
-        # can capture a DIFFERENT rate when the miner moved its commitment
-        # between the handler's read and the on-chain inclusion of
-        # ``vote_reserve`` — e.g. a miner oscillating its rate every few blocks
-        # lands the reservation's inclusion block on a stale tick. Overwriting
-        # then makes the settlement rate disagree with the reserved ``to_amount``
-        # and the user is short-changed at confirm (see swap 2405: reserved at
-        # 370, pinned to 280, settled 24% low). The synchronous pin is
-        # authoritative; this read only matters when that write failed.
-        #
-        # NOTE / TODO(contract-v2, multi-validator): with one validator the
-        # synchronous pin is always present and correct, so preferring it fully
-        # closes the divergence. Once multiple validators reserve, each one's
-        # synchronous pin is read at its own instant and they are NOT
-        # deterministic across the set. The real fix then is to bind
-        # (reserve_block, rate) into the reservation at quorum and verify
-        # rate == CommitmentOf(reserve_block) within the user's slippage band,
-        # so every validator derives an identical, quote-consistent settlement
-        # rate. That requires the reserve hash + Reservation struct to carry the
-        # rate, i.e. a smart-contract iteration. Until v2 lands, back off to the
-        # synchronous pin here.
-        # Preserve only the synchronous pin for THIS reservation. ``reserved_until``
-        # is distinct per reservation, so an existing pin whose TTL differs belongs
-        # to a PRIOR reservation (e.g. one abandoned without a swap and not yet
-        # swept by ``purge_expired_reservation_pins``) and must still be
-        # overwritten — backfill, don't inherit it. Without this check a failed
-        # synchronous write, or an event replay on a fresh DB that sees an
-        # abandoned ``MinerReserved`` before this one, would settle the swap
-        # against the stale reservation's rate AND addresses.
+        # Backfill only — the synchronous pin from handle_swap_reserve is the rate
+        # the user's quote was validated against; this re-read can see a different
+        # tick if the miner moved. Key on reserved_until so a stale pin from a
+        # prior reservation is still overwritten. (Single-validator scope + the
+        # multi-validator/contract-v2 fix: see PR #451.)
         existing = self.state_store.get_reservation_pin(miner)
         if existing is None or existing.reserved_until != reserved_until:
             self.state_store.upsert_reservation_pin(

--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -874,11 +874,9 @@ class ContractEventWatcher:
                 f'{block_num} — no pin written, will fall back'
             )
             return
-        # Backfill only — the synchronous pin from handle_swap_reserve is the rate
-        # the user's quote was validated against; this re-read can see a different
-        # tick if the miner moved. Key on reserved_until so a stale pin from a
-        # prior reservation is still overwritten. (Single-validator scope + the
-        # multi-validator/contract-v2 fix: see PR #451.)
+        # Backfill only: keep handle_swap_reserve's synchronous pin (the rate the
+        # quote was validated against), but key on reserved_until so a stale pin
+        # from a prior reservation is still overwritten. See PR #451.
         existing = self.state_store.get_reservation_pin(miner)
         if existing is None or existing.reserved_until != reserved_until:
             self.state_store.upsert_reservation_pin(

--- a/allways/validator/event_watcher.py
+++ b/allways/validator/event_watcher.py
@@ -898,7 +898,16 @@ class ContractEventWatcher:
         # rate. That requires the reserve hash + Reservation struct to carry the
         # rate, i.e. a smart-contract iteration. Until v2 lands, back off to the
         # synchronous pin here.
-        if self.state_store.get_reservation_pin(miner) is None:
+        # Preserve only the synchronous pin for THIS reservation. ``reserved_until``
+        # is distinct per reservation, so an existing pin whose TTL differs belongs
+        # to a PRIOR reservation (e.g. one abandoned without a swap and not yet
+        # swept by ``purge_expired_reservation_pins``) and must still be
+        # overwritten — backfill, don't inherit it. Without this check a failed
+        # synchronous write, or an event replay on a fresh DB that sees an
+        # abandoned ``MinerReserved`` before this one, would settle the swap
+        # against the stale reservation's rate AND addresses.
+        existing = self.state_store.get_reservation_pin(miner)
+        if existing is None or existing.reserved_until != reserved_until:
             self.state_store.upsert_reservation_pin(
                 ReservationPin(
                     miner_hotkey=miner,

--- a/tests/test_event_watcher.py
+++ b/tests/test_event_watcher.py
@@ -466,6 +466,47 @@ class TestReservationPin:
         assert pin.reserve_block == 898
         w.state_store.close()
 
+    def test_stale_prior_reservation_pin_is_backfilled(self, tmp_path: Path):
+        """A pin left over from a PRIOR reservation (different reserved_until,
+        e.g. one abandoned without a swap and not yet purged) must not be
+        inherited by the current reservation. The guard keys on reserved_until,
+        so a MinerReserved for a new reservation backfills over the stale pin —
+        otherwise a failed synchronous write or a fresh-DB replay would settle
+        the new swap against the old reservation's rate and addresses."""
+        from allways.validator.state_store import ReservationPin
+
+        w = make_watcher(tmp_path, netuid=2, subtensor=MagicMock())
+        # Stale pin from a prior, abandoned reservation (reserved_until=1000).
+        w.state_store.upsert_reservation_pin(
+            ReservationPin(
+                miner_hotkey='hk_a',
+                reserve_block=898,
+                from_chain='btc',
+                to_chain='tao',
+                rate_str='370',
+                counter_rate_str='0.0029',
+                miner_from_address='bc1-OLD',
+                miner_to_address='5old',
+                reserved_until=1000,
+            )
+        )
+        # A new reservation (reserved_until=1200) with no synchronous pin —
+        # the inclusion-block read is the only source, so it must write through.
+        fresh = make_pinned_commitment(rate_str='345', from_address='bc1-NEW', to_address='5new')
+        with patch(
+            'allways.validator.event_watcher.read_miner_commitment',
+            return_value=fresh,
+        ):
+            w.apply_event(1100, 'MinerReserved', {'miner': 'hk_a', 'reserved_until': 1200})
+
+        pin = w.state_store.get_reservation_pin('hk_a')
+        assert pin.reserved_until == 1200  # current reservation, not the stale one
+        assert pin.rate_str == '345'  # backfilled — stale 370 overwritten
+        assert pin.reserve_block == 1100
+        assert pin.miner_from_address == 'bc1-NEW'
+        assert pin.miner_to_address == '5new'
+        w.state_store.close()
+
     def test_commitment_read_raising_writes_no_pin(self, tmp_path: Path):
         """A transient RPC error or a pruned block must not write a pin and
         must not let the exception escape apply_event."""

--- a/tests/test_event_watcher.py
+++ b/tests/test_event_watcher.py
@@ -430,6 +430,42 @@ class TestReservationPin:
         assert pin.miner_to_address == '5miner'
         w.state_store.close()
 
+    def test_existing_synchronous_pin_is_not_overwritten(self, tmp_path: Path):
+        """The reserve handler's synchronous pin captures the rate the user's
+        quote was validated against and is authoritative. A later MinerReserved
+        re-read at the inclusion block must NOT clobber it, even when the miner
+        moved its commitment in between — that divergence short-changed the user
+        in swap 2405 (reserved at 370, overwritten to 280)."""
+        from allways.validator.state_store import ReservationPin
+
+        w = make_watcher(tmp_path, netuid=2, subtensor=MagicMock())
+        # Synchronous pin as handle_swap_reserve writes it at quote time.
+        w.state_store.upsert_reservation_pin(
+            ReservationPin(
+                miner_hotkey='hk_a',
+                reserve_block=898,
+                from_chain='btc',
+                to_chain='tao',
+                rate_str='370',
+                counter_rate_str='0.0029',
+                miner_from_address='bc1-miner',
+                miner_to_address='5miner',
+                reserved_until=1000,
+            )
+        )
+        # The inclusion-block read sees the miner's oscillated-down rate.
+        moved = make_pinned_commitment(rate_str='280')
+        with patch(
+            'allways.validator.event_watcher.read_miner_commitment',
+            return_value=moved,
+        ):
+            w.apply_event(900, 'MinerReserved', {'miner': 'hk_a', 'reserved_until': 1000})
+
+        pin = w.state_store.get_reservation_pin('hk_a')
+        assert pin.rate_str == '370'  # preserved — not overwritten with 280
+        assert pin.reserve_block == 898
+        w.state_store.close()
+
     def test_commitment_read_raising_writes_no_pin(self, tmp_path: Path):
         """A transient RPC error or a pruned block must not write a pin and
         must not let the exception escape apply_event."""


### PR DESCRIPTION
## Problem

A user reserved a swap at one rate but settled at a worse one — silently, well beyond the protocol fee. Concretely, swap **2405** (btc→tao): reserved/quoted at rate **370** (`to_amount = 315,610,000`), but the swap settled at rate **280** (`deliveredAmount = 236,451,600`) — the user received ~**25%** less than the swap's own `destAmount`, with no slippage check in between.

### Root cause

The reservation pin is written **twice**:

1. **`handle_swap_reserve`** writes a *synchronous* pin at the instant it reads the miner's commitment to validate the user's quote. This is the rate the on-chain `to_amount` was reserved against — and, critically, the rate the user's slippage band was checked against — i.e. correct.
2. **`event_watcher.record_reservation_pin`** then re-reads the commitment at the reservation's **on-chain inclusion block** and **overwrites** the pin (`INSERT OR REPLACE`, keyed by miner).

When the miner moves its rate between the handler's read and the inclusion of `vote_reserve`, those two reads see different rates. For 2405 the miner was **oscillating 370↔280 every ~2 blocks**, and the inclusion block landed on a 280 tick (verified against the archive node):

```
8329917  370
8329918  370
8329919  280   ← reservation inclusion block → watcher pinned 280
8329920  370
8329922  280
```

At `handle_swap_confirm`, the divergence is baked in: `to_amount` (370-based) comes from the on-chain reservation, while `rate` comes from the (overwritten) pin (280). `expected_swap_amounts` — the single source of truth for both miner delivery and validator verification — keys off `rate`, so the miner delivered the 280 amount and the validator confirmed it. **Nothing anywhere compares the 370 amount to the 280 rate.** Note the irony: at the confirm/initiate block the miner's live rate was back to 370, so even the no-pin live-commitment fallback would have delivered 370 — the overwritten pin actively *harmed* the user it exists to protect.

## Fix

The synchronous pin is the authoritative reserve-time rate. Make the watcher's read a pure **backfill**: only write the settlement pin when there is no pin **for this reservation** already. The guard is keyed on `reserved_until` (distinct per reservation), so it preserves the synchronous pin for the live reservation but still overwrites a stale pin left from a prior, abandoned reservation (one that expired without a swap and hasn't yet been purged). This stops the overwrite that introduced the stale rate, so confirm settles at the rate the user reserved against — and the user's slippage band was measured against.

- Scoring-overlay pin events are intentionally **left reading the canonical block** — that's the separate "pinned-rate-during-reservation" scoring workstream, not settlement.
- A `NOTE / TODO(contract-v2, multi-validator)` documents the scope: this relies on the **single-validator** invariant (exactly one authoritative synchronous pin). With multiple validators, each synchronous pin is read at its own instant and isn't deterministic across the set; the correct fix then is to bind `(reserve_block, rate)` into the reservation at quorum and verify `rate == CommitmentOf(reserve_block)` within the user's slippage band — which needs the reserve hash + `Reservation` struct to carry the rate, i.e. a **smart-contract iteration**. Until v2 lands, we back off to the synchronous pin.

## Why this is safe now

There is currently a single whitelisted validator, so the synchronous pin is always present and authoritative — preferring it fully closes the divergence. The change degrades gracefully: if the synchronous write ever fails, the watcher still backfills the inclusion-block read **for that reservation**, and a stale pin from a *prior* reservation is overwritten rather than inherited (the `reserved_until` keying).

## Tests

- New `test_existing_synchronous_pin_is_not_overwritten` — asserts a pre-existing 370 pin survives a `MinerReserved` re-read that sees 280 (the swap-2405 case).
- New `test_stale_prior_reservation_pin_is_backfilled` — asserts the guard is keyed on `reserved_until`: a pin left from a *prior* reservation (different TTL) is overwritten by a new `MinerReserved`, so a failed synchronous write or a fresh-DB event replay can't settle a swap against a stale reservation's rate/addresses.
- Existing `test_miner_reserved_writes_expected_pin` still passes (fresh state → backfill writes the pin).
- Full suite: **664 passed**.

## Not in scope

- The multi-validator/contract-v2 fix (documented in the TODO).
- **The miner's rate-setting behavior itself.** A miner may change its posted rate at any block — that is legitimate and this PR does not police it. This is purely a **user-protection** invariant: a reservation must settle at the miner's rate *at the instant the reservation was validated* (the rate the user's slippage band was checked against), not at some later tick the user never agreed to. The oscillation is merely what made the two pin-writes disagree; the fix makes settlement honor the quote-checked rate — it does not, and should not, penalize the miner for moving its rate.
- Retroactive relief for swap 2405's user (the swap is COMPLETED on-chain and irreversible).
