### PR TITLE
chore: bump version 1.0.10 -> 1.0.11

### DIFF
--- a/allways/__init__.py
+++ b/allways/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '1.0.10'
+__version__ = '1.0.11'
 version_split = __version__.split('.')
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))


### PR DESCRIPTION
Bumps `__version__` to 1.0.11 ahead of the next test -> main release. One-line version bump, no behavior change.