### PR TITLE
fix(validator): serialize TAO source-balance check under axon_lock

### DIFF
--- a/allways/chain_providers/base.py
+++ b/allways/chain_providers/base.py
@@ -31,6 +31,11 @@ class ChainProvider(ABC):
     3. Add {ENV_PREFIX}_* vars to .env
     """
 
+    # True if this provider's RPCs hit the shared substrate websocket, so
+    # callers must serialise them under axon_lock. HTTP-backed providers leave
+    # this False and stay lock-free.
+    uses_substrate: bool = False
+
     @abstractmethod
     def get_chain(self) -> ChainDefinition: ...
 

--- a/allways/chain_providers/subtensor.py
+++ b/allways/chain_providers/subtensor.py
@@ -20,6 +20,9 @@ class SubtensorProvider(ChainProvider):
     clear error if they attempt to send.
     """
 
+    # RPCs run on the shared substrate websocket — callers serialise via axon_lock.
+    uses_substrate = True
+
     # Balances pallet index and transfer call indices on Subtensor
     _BALANCES_PALLET = 5
     _TRANSFER_CALLS = {0: 'transfer_allow_death', 3: 'transfer_keep_alive', 7: 'transfer_all'}

--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -325,9 +325,14 @@ async def handle_swap_reserve(
             reject_synapse(synapse, 'Invalid source address proof', ctx)
             return synapse
 
-        # Source-chain RPC — separate connection from substrate, so it doesn't
-        # need axon_lock and shouldn't block the substrate websocket.
-        balance = provider.get_balance(synapse.from_address)
+        # A TAO source reads balance over the shared substrate websocket, so it
+        # must serialise under axon_lock; a BTC source is HTTP and stays lock-free
+        # to avoid stalling the forward loop behind a slow Esplora call.
+        if provider.uses_substrate:
+            with validator.axon_lock:
+                balance = provider.get_balance(synapse.from_address)
+        else:
+            balance = provider.get_balance(synapse.from_address)
         if balance < synapse.from_amount:
             reject_synapse(synapse, 'Insufficient source balance', ctx)
             return synapse

--- a/tests/test_axon_handlers.py
+++ b/tests/test_axon_handlers.py
@@ -889,6 +889,71 @@ class TestReserveExecutabilityGate:
         validator.axon_contract_client.vote_reserve.assert_not_called()
 
 
+class TestSourceBalanceLock:
+    """The source-balance check must serialise on axon_lock for a substrate
+    source (TAO) but stay lock-free for an HTTP source (BTC) — otherwise the
+    TAO get_balance races the lock-protected readers and trips the substrate
+    `cannot call recv while another thread is already running recv` error."""
+
+    def test_provider_uses_substrate_flags(self):
+        """TAO provider hits the shared websocket; BTC is HTTP and lock-free."""
+        from allways.chain_providers.base import ChainProvider
+        from allways.chain_providers.bitcoin import BitcoinProvider
+        from allways.chain_providers.subtensor import SubtensorProvider
+
+        assert ChainProvider.uses_substrate is False
+        assert SubtensorProvider.uses_substrate is True
+        assert BitcoinProvider.uses_substrate is False
+
+    def test_tao_source_balance_check_holds_axon_lock(self):
+        """A TAO-sourced reserve must acquire axon_lock around get_balance."""
+        validator = make_reserve_validator()
+        lock = validator.axon_lock
+
+        tao = MagicMock()
+        tao.uses_substrate = True
+        tao.verify_from_proof.return_value = True
+        # Record whether the lock is held at the moment get_balance runs.
+        held = {}
+
+        def _get_balance(_addr):
+            held['locked'] = not lock.acquire(blocking=False)
+            if not held['locked']:
+                lock.release()
+            return 10**18
+
+        tao.get_balance.side_effect = _get_balance
+        validator.axon_chain_providers = {'tao': tao, 'btc': MagicMock()}
+
+        commitment = make_commitment(from_chain='tao', to_chain='btc')
+        synapse = make_reserve_synapse(from_chain='tao', to_chain='btc', from_address='5user')
+        run_reserve_handler(validator, synapse, commitment=commitment)
+
+        assert held.get('locked') is True
+
+    def test_btc_source_balance_check_is_lock_free(self):
+        """A BTC-sourced reserve must NOT hold axon_lock during get_balance, so
+        a slow Esplora call can't stall the lock-protected forward loop."""
+        validator = make_reserve_validator()
+        lock = validator.axon_lock
+
+        btc = validator.axon_chain_providers['btc']
+        btc.uses_substrate = False
+        held = {}
+
+        def _get_balance(_addr):
+            held['locked'] = not lock.acquire(blocking=False)
+            if not held['locked']:
+                lock.release()
+            return 10**18
+
+        btc.get_balance.side_effect = _get_balance
+
+        run_reserve_handler(validator, make_reserve_synapse())
+
+        assert held.get('locked') is False
+
+
 class TestMinerActivateExecutability:
     def _activate_synapse(
         self, hotkey: str = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'


### PR DESCRIPTION
## Root cause

The validator logs recurring `cannot call recv while another thread is already running recv or recv_streaming` errors. Root cause: a single substrate websocket call was made **outside** the lock that serializes that connection.

In `handle_swap_reserve` (`allways/validator/axon_handlers.py`), the source-balance check `provider.get_balance(synapse.from_address)` ran outside the `with validator.axon_lock:` block. The comment claimed the source-chain RPC is "a separate connection from substrate, so it doesn't need axon_lock."

That is true for a **BTC source** (Esplora/Maestro = HTTP) but **false for a TAO source**: the subtensor provider's `get_balance` calls `self.subtensor.get_balance(...)` on `axon_subtensor` — the exact websocket `axon_lock` exists to serialize. So every TAO->BTC reserve raced the lock-protected readers (other axon handler threads + the forward loop's `bounds_cache` reads on `axon_subtensor`), tripping the recv collision.

## Fix

- Add `uses_substrate: bool = False` on the chain-provider base (`base.py`); set `uses_substrate = True` on the subtensor/TAO provider (`subtensor.py`). BTC stays at the default `False`.
- Gate the balance check on the flag: serialize the TAO read under `axon_lock`, keep BTC's HTTP read lock-free so a ~300ms Esplora call can't stall the forward loop. (`axon_lock` is an `RLock`, so the later re-acquire in the main block is fine.)

```python
if provider.uses_substrate:
    with validator.axon_lock:
        balance = provider.get_balance(synapse.from_address)
else:
    balance = provider.get_balance(synapse.from_address)
```

## Other handlers scanned

Scanned `handle_miner_activate` and `handle_swap_confirm` for the same pattern (any `provider.*` / `axon_subtensor.*` substrate call outside `axon_lock`). **No additional leaks found** — both wrap all their substrate work (`is_hotkey_registered`, `read_miner_commitment`, contract reads/votes, `get_current_block`, `verify_transaction`) inside `with validator.axon_lock`. The only leak was the reserve-time balance check.

## Tests

Added `TestSourceBalanceLock` in `tests/test_axon_handlers.py`:
- asserts `SubtensorProvider.uses_substrate is True`, `BitcoinProvider.uses_substrate is False`, base default `False`;
- handler-level test that a TAO-sourced reserve holds `axon_lock` around `get_balance`, and that a BTC-sourced reserve does **not**.

Full suite: `689 passed`. `ruff check` + `ruff format --check` clean.