### PR TITLE
fix(validator): serialize hotkey contract writes to prevent nonce collisions

### DIFF
--- a/allways/contract_client.py
+++ b/allways/contract_client.py
@@ -352,6 +352,7 @@ class AllwaysContractClient:
         subtensor: Optional[bt.Subtensor] = None,
         reconnect_subtensor: Optional[Callable[[], None]] = None,
         substrate_lock: Optional[Any] = None,
+        write_lock: Optional[Any] = None,
     ):
         self.contract_address = contract_address or get_contract_address() or ''
         self.subtensor = subtensor
@@ -366,6 +367,10 @@ class AllwaysContractClient:
         # access so concurrent threads can't both land in recv. Callers sharing
         # this subtensor elsewhere pass that path's lock to serialize as one.
         self._substrate_lock = substrate_lock or threading.Lock()
+        # One hotkey = one nonce sequence. Clients that sign with the same
+        # hotkey across separate connections must share this so two threads
+        # can't fetch the same nonce and get one extrinsic pool-banned.
+        self._write_lock = write_lock or threading.Lock()
 
         if not self.contract_address:
             bt.logging.warning('Allways contract address not set')
@@ -573,7 +578,11 @@ class AllwaysContractClient:
             return s.submit_extrinsic(extrinsic, wait_for_inclusion=wait_for_inclusion, wait_for_finalization=False)
 
         try:
-            receipt = self.substrate_call(submit_extrinsic)
+            # Hold the write lock across nonce-fetch → submit → inclusion so the
+            # best-block nonce advances before the next signer (any connection on
+            # the same hotkey) composes. Reads stay outside it, so they're parallel.
+            with self._write_lock:
+                receipt = self.substrate_call(submit_extrinsic)
         except Exception as e:
             raise ContractError(f'{method}: exec failed: {e}') from e
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -70,9 +70,15 @@ class Validator(BaseValidatorNeuron):
     def __init__(self, config=None):
         super().__init__(config=config)
 
+        # Forward loop and axon handlers both sign contract writes with the
+        # validator hotkey over separate connections; share one lock so their
+        # nonce sequences can't collide (one would get pool-banned). Reads stay
+        # on their own per-connection locks, so they remain parallel.
+        self.write_lock = threading.Lock()
         self.contract_client = AllwaysContractClient(
             subtensor=self.subtensor,
             reconnect_subtensor=self.reconnect_and_propagate,
+            write_lock=self.write_lock,
         )
         self.chain_providers = create_chain_providers(check=True, require_send=False, subtensor=self.subtensor)
 
@@ -159,6 +165,7 @@ class Validator(BaseValidatorNeuron):
             subtensor=self.axon_subtensor,
             reconnect_subtensor=self.reconnect_axon_subtensor,
             substrate_lock=self.axon_lock,
+            write_lock=self.write_lock,
         )
         self.axon_chain_providers = create_chain_providers(subtensor=self.axon_subtensor)
         # Read block/bounds via axon_subtensor; the forward loop calls this too,

--- a/tests/test_contract_client.py
+++ b/tests/test_contract_client.py
@@ -6,6 +6,7 @@ callback (which must replace ``client.subtensor`` with a fresh handle)
 and retries the call once. Anything else propagates as-is.
 """
 
+import threading
 from unittest.mock import MagicMock
 
 import pytest
@@ -199,3 +200,35 @@ class TestExtensionSelectorWiring:
             'TargetNotForward',
             'InvalidTarget',
         }
+
+
+class TestWriteLockSerialization:
+    """One hotkey = one nonce sequence; writes across connections must serialize."""
+
+    def test_shared_write_lock_object(self):
+        shared = threading.Lock()
+        a = AllwaysContractClient(contract_address='5xx', subtensor=make_subtensor(), write_lock=shared)
+        b = AllwaysContractClient(contract_address='5xx', subtensor=make_subtensor(), write_lock=shared)
+        assert a._write_lock is b._write_lock is shared
+
+    def test_default_write_lock_is_private(self):
+        a = AllwaysContractClient(contract_address='5xx', subtensor=make_subtensor())
+        b = AllwaysContractClient(contract_address='5xx', subtensor=make_subtensor())
+        assert a._write_lock is not b._write_lock
+
+    def test_write_lock_held_during_submit_not_reads(self):
+        # The submit closure runs under the write lock; the account-nonce/balance
+        # read (a lambda) runs outside it, so reads stay parallel.
+        shared = threading.Lock()
+        client = AllwaysContractClient(contract_address='5xx', subtensor=make_subtensor(), write_lock=shared)
+        receipt = MagicMock(is_success=True, extrinsic_hash='0xabc')
+        held_during = {}
+
+        def fake_substrate_call(fn):
+            held_during[getattr(fn, '__name__', '<lambda>')] = shared.locked()
+            return receipt if getattr(fn, '__name__', '') == 'submit_extrinsic' else MagicMock()
+
+        client.substrate_call = fake_substrate_call
+        client.exec_contract_raw('confirm_swap', args={'swap_id': 1}, keypair=client.readonly_keypair)
+        assert held_during.get('submit_extrinsic') is True
+        assert held_during.get('<lambda>') is False


### PR DESCRIPTION
## What
Share one **write lock** across the forward-loop contract client and the axon-handler contract client, held from nonce-fetch through inclusion, so the validator hotkey's nonce sequence can't collide.

## Why
The validator signs contract writes with the same hotkey over **two separate substrate connections** — the forward loop (`self.contract_client` on `self.subtensor`: confirm/timeout/extensions) and the axon handlers (`self.axon_contract_client` on `self.axon_subtensor`: vote_reserve/vote_activate).

`create_signed_extrinsic` auto-fetches the nonce via `AccountNonceApi.account_nonce` — the **best-block** nonce, which doesn't count pending pool txs. Within a block window every fetch returns the same number. With two uncoordinated signers on one account, both can grab nonce `N`; one lands, the other is rejected and the tx-pool **bans** it (`1012 Transaction is temporarily banned`).

During a halt this became constant: the axon side floods `vote_reserve` attempts, which contended/advanced the nonce and starved the forward loop's `confirm_swap` votes — delivered swaps blew past `timeout_block` and got slashed (e.g. swaps 3728/3729). This contention is **not** halt-specific; sustained reserve volume can reproduce it.

A dedicated subtensor node does **not** fix this — the node returns the same best-block nonce to both connections; it detects the duplicate, it doesn't prevent it. The fix is client-side coordination.

## How
- `AllwaysContractClient` takes an optional shared `write_lock`; `exec_contract_raw` holds it across `nonce-fetch → submit → (wait_for_inclusion)` so the best-block nonce advances before the next signer composes.
- `neurons/validator.py` creates one `write_lock` and passes it to **both** clients.
- Reads stay on their per-connection recv locks, so they remain parallel — no change to axon responsiveness.

Lock order is `axon_lock → write_lock` (axon writes) and `write_lock → main lock` (forward writes); no path takes `write_lock → axon_lock`, so no cycle.

## Scope / tradeoff
Small, contained safeguard — **core swap logic untouched**, only the low-level submit path gains a lock. Writes now serialize across connections (~1 write/block with wait-for-inclusion), which is far above current load. The planned `force_batch` single-writer flush is the throughput follow-up; this lands first as the safe guard.

## Tests
- `TestWriteLockSerialization`: shared vs private lock wiring, and that the lock is held during submit but **not** during the account read (reads stay parallel).
- Full suite: **692 passed**; `ruff check` + `ruff format` clean.