### PR TITLE
fix(validator): fast-reject reservations while halted

### DIFF
--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -304,6 +304,13 @@ async def handle_swap_reserve(
     )
 
     try:
+        # Halt blocks reservations contract-side; fast-reject here so a halt
+        # can't flood doomed vote_reserve extrinsics that starve confirm/timeout
+        # votes. halted() fails open, so an RPC blip falls through to the contract.
+        if validator.bounds_cache.halted():
+            reject_synapse(synapse, 'System is halted — reservations paused', ctx)
+            return synapse
+
         # Cheap, local checks BEFORE axon_lock — invalid signatures, missing fields,
         # and bad direction are rejected without serializing on the substrate websocket.
         if not synapse.from_address or not synapse.from_address_proof:

--- a/tests/test_axon_handlers.py
+++ b/tests/test_axon_handlers.py
@@ -588,6 +588,7 @@ def make_reserve_validator(
     validator.bounds_cache.min_collateral.return_value = 0
     validator.bounds_cache.min_swap_amount.return_value = 0
     validator.bounds_cache.max_swap_amount.return_value = 0
+    validator.bounds_cache.halted.return_value = False
     validator.wallet = MagicMock()
     return validator
 
@@ -994,3 +995,22 @@ class TestMinerActivateExecutability:
         assert mock_read.call_args.kwargs['min_swap_rao'] == 500_000_000
         assert mock_read.call_args.kwargs['max_swap_rao'] == 5_000_000_000
         validator.axon_contract_client.vote_activate.assert_not_called()
+
+
+class TestHaltFastReject:
+    """A halted system rejects reservations without submitting any extrinsic."""
+
+    def test_halted_rejects_without_voting(self):
+        validator = make_reserve_validator()
+        validator.bounds_cache.halted.return_value = True
+        result = run_reserve_handler(validator, make_reserve_synapse())
+        assert result.accepted is False
+        assert 'halt' in (result.rejection_reason or '').lower()
+        validator.axon_contract_client.vote_reserve.assert_not_called()
+
+    def test_halted_short_circuits_before_substrate_work(self):
+        validator = make_reserve_validator()
+        validator.bounds_cache.halted.return_value = True
+        with patch('allways.validator.axon_handlers.read_miner_commitment') as read_cmt:
+            asyncio.run(handle_swap_reserve(validator, make_reserve_synapse()))
+        read_cmt.assert_not_called()


### PR DESCRIPTION
## What
When the system is halted, `handle_swap_reserve` now rejects the request **immediately** — before any provider/substrate work or extrinsic submission — instead of running the full handler and letting the contract reject the `vote_reserve`.

## Why
A halt blocks reservations contract-side (`vote_reserve` → `SystemHalted` revert). Today the validator still does the full handler work and **submits the doomed extrinsic anyway**. During a halt that becomes a **retry storm**: miners re-request, each rejected reserve burns a full round-trip, and those writes contend for the validator hotkey's nonce/write path — **starving the confirm/timeout votes for in-flight swaps** (the failure mode behind the 3728/3729 slashes).

Rejecting at the source removes the storm: no doomed extrinsics, no chain spam, and confirm/timeout votes for in-flight swaps run unobstructed during a halt (those aren't halt-gated and are supposed to keep resolving).

## How
- `handle_swap_reserve` checks `validator.bounds_cache.halted()` first and `reject_synapse(...)` returns before proof/balance/commitment reads or any vote.
- `bounds_cache.halted()` is cached (short TTL) and **fails open** — on an RPC blip it returns not-halted, so we never wrongly refuse a valid reserve; worst case we fall through to the contract's own rejection (today's behavior).
- Scope: reservations only (`handle_miner_activate` / `vote_activate` are low-volume and left as-is).

## Tests
- `TestHaltFastReject`: halted → rejected with no `vote_reserve` submitted, and short-circuits before `read_miner_commitment`.
- Default `bounds_cache.halted` → `False` in the reserve test helper so existing reserve tests exercise the live path.
- Full suite: **691 passed**; ruff + format clean.

## Notes
Separate from #457 (the write-lock nonce fix). This PR alone neutralizes the *halt-induced* flood at the source; #457 fixes the underlying nonce collision generally. They're complementary.