### PR TITLE
fix(bitcoin): enforce network in is_valid_address to reject wrong-network addresses

### DIFF
--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -45,6 +45,29 @@ def detect_address_type(address: str) -> str:
     return 'unknown'
 
 
+def _address_network(address: str) -> str:
+    """Classify an address by its implied BTC network.
+
+    Returns one of:
+    - 'mainnet'         — bc1q…, bc1p…, 1…, 3…
+    - 'testnet-bech32'  — tb1q…, tb1p…  (testnet/testnet4 native-segwit only)
+    - 'testnet-base58'  — m…, n…, 2…  (testnet base58 version bytes,
+                          shared with regtest due to Bitcoin Core's design)
+    - 'regtest'         — bcrt1q…, bcrt1p…
+    - 'unknown'
+    """
+    if address.startswith(('bc1q', 'bc1p', '1', '3')):
+        return 'mainnet'
+    if address.startswith(('tb1q', 'tb1p')):
+        return 'testnet-bech32'
+    if address.startswith(('bcrt1q', 'bcrt1p')):
+        return 'regtest'
+    # base58 version bytes 0x6f (m/n) and 0xc4 (2) are shared by testnet and regtest
+    if address[:1] in ('m', 'n', '2'):
+        return 'testnet-base58'
+    return 'unknown'
+
+
 def to_mainnet_wif(wif: str) -> str:
     """Convert a testnet/regtest WIF (0xef) to mainnet (0x80) for signing libraries."""
     decoded = base58.b58decode_check(wif)
@@ -526,13 +549,31 @@ class BitcoinProvider(ChainProvider):
             return 0
 
     def is_valid_address(self, address: str) -> bool:
-        """Validate BTC address format without RPC (embit decode; all types incl. Taproot)."""
+        """Validate BTC address format and network against the configured BTC_NETWORK.
+
+        Rejects addresses that belong to a different network (e.g. testnet addresses
+        on a mainnet provider) to prevent misdirected on-chain sends.
+        """
         if not address or not isinstance(address, str):
             return False
         try:
-            return address_to_scriptpubkey(address) is not None
+            if address_to_scriptpubkey(address) is None:
+                return False
         except Exception:
             return False
+        addr_net = _address_network(address)
+        if addr_net == 'unknown':
+            return False
+        configured = self.network  # 'mainnet', 'testnet', 'testnet4', or 'regtest'
+        if configured in ('mainnet', ''):
+            return addr_net == 'mainnet'
+        if configured in ('testnet', 'testnet4'):
+            # tb1… (bech32) and m/n/2 (base58) are valid; bcrt1… is regtest-only
+            return addr_net in ('testnet-bech32', 'testnet-base58')
+        if configured == 'regtest':
+            # regtest uses bcrt1… bech32 and the testnet base58 version bytes (m/n/2)
+            return addr_net in ('regtest', 'testnet-base58')
+        return False
 
     def get_wif(self, address: str) -> Optional[str]:
         """Get WIF private key from env var or Bitcoin Core wallet."""

--- a/tests/test_bitcoin_signing.py
+++ b/tests/test_bitcoin_signing.py
@@ -274,30 +274,41 @@ class TestBroadcastedTxidsTracking:
         assert provider.broadcasted_txids == set()
 
 
-class TestIsValidAddress:
-    """BTC address format validation — must accept every standard type
-    (legacy, segwit v0, and Taproot/bech32m) and reject malformed input.
+def make_lightweight_provider_for_network(network: str) -> 'BitcoinProvider':
+    env = {'BTC_MODE': 'lightweight', 'BTC_PRIVATE_KEY': TEST_WIF, 'BTC_NETWORK': network}
+    with patch.dict(os.environ, env, clear=False):
+        return BitcoinProvider()
 
-    Taproot regression guard: the old bech32-only check rejected all `bc1p…`
-    addresses, blocking TAO->BTC payouts to Taproot wallets (issue #448).
+
+class TestIsValidAddress:
+    """BTC address format and network validation.
+
+    Each provider network must accept only its own addresses and reject
+    addresses from other networks (issue #460). Taproot regression guard:
+    the old bech32-only check rejected all bc1p… addresses (issue #448).
     """
 
-    # mainnet / testnet / regtest × P2PKH / P2SH / P2WPKH / P2WSH / P2TR
-    VALID = [
-        '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2',  # mainnet P2PKH
-        '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy',  # mainnet P2SH
-        'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',  # mainnet P2WPKH
-        'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3',  # mainnet P2WSH
-        'bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr',  # mainnet P2TR
-        'mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn',  # testnet P2PKH
-        '2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vc',  # testnet P2SH
-        'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx',  # testnet P2WPKH
-        'tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c',  # testnet P2TR (BIP-350)
-        'bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080',  # regtest P2WPKH
-        'bcrt1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqc8gma6',  # regtest P2TR
+    MAINNET_ADDRS = [
+        '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2',  # P2PKH
+        '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy',  # P2SH
+        'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',  # P2WPKH
+        'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3',  # P2WSH
+        'bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr',  # P2TR
     ]
-
-    INVALID = [
+    TESTNET_ADDRS = [
+        'mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn',  # P2PKH (base58 shared with regtest)
+        '2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vc',  # P2SH  (base58 shared with regtest)
+        'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx',  # P2WPKH
+        'tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c',  # P2TR
+    ]
+    REGTEST_ADDRS = [
+        'bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080',  # P2WPKH
+        'bcrt1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqc8gma6',  # P2TR
+        # m/n/2 base58 accepted by regtest (shares testnet version bytes)
+        'mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn',
+        '2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vc',
+    ]
+    MALFORMED = [
         '',
         'notanaddress',
         '0x71C7656EC7ab88b098defB751B7401B5f6d8976F',  # ETH address
@@ -305,19 +316,72 @@ class TestIsValidAddress:
         'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3XX',  # corrupted v0
     ]
 
-    def test_accepts_all_standard_types(self):
-        provider = make_lightweight_provider()
-        for addr in self.VALID:
-            assert provider.is_valid_address(addr), f'should accept {addr}'
+    # --- mainnet provider ---
 
-    def test_accepts_taproot(self):
-        """Explicit #448 guard: Taproot payout addresses must validate."""
+    def test_mainnet_accepts_mainnet_addresses(self):
+        provider = make_lightweight_provider()  # defaults to mainnet
+        for addr in self.MAINNET_ADDRS:
+            assert provider.is_valid_address(addr), f'mainnet provider should accept {addr}'
+
+    def test_mainnet_accepts_taproot(self):
+        """Explicit #448 guard: Taproot payout addresses must validate on mainnet."""
         provider = make_lightweight_provider()
         assert provider.is_valid_address('bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr')
 
+    def test_mainnet_rejects_testnet_addresses(self):
+        provider = make_lightweight_provider()
+        for addr in self.TESTNET_ADDRS:
+            assert not provider.is_valid_address(addr), f'mainnet provider should reject testnet {addr}'
+
+    def test_mainnet_rejects_regtest_bech32_addresses(self):
+        provider = make_lightweight_provider()
+        for addr in ('bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080',
+                     'bcrt1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqc8gma6'):
+            assert not provider.is_valid_address(addr), f'mainnet provider should reject regtest {addr}'
+
+    # --- testnet provider ---
+
+    def test_testnet_accepts_testnet_addresses(self):
+        provider = make_lightweight_provider_for_network('testnet')
+        for addr in self.TESTNET_ADDRS:
+            assert provider.is_valid_address(addr), f'testnet provider should accept {addr}'
+
+    def test_testnet_rejects_mainnet_addresses(self):
+        provider = make_lightweight_provider_for_network('testnet')
+        for addr in self.MAINNET_ADDRS:
+            assert not provider.is_valid_address(addr), f'testnet provider should reject mainnet {addr}'
+
+    def test_testnet_rejects_regtest_bech32_addresses(self):
+        """bcrt1… is regtest-only and must be rejected by a testnet provider."""
+        provider = make_lightweight_provider_for_network('testnet')
+        for addr in ('bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080',
+                     'bcrt1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqc8gma6'):
+            assert not provider.is_valid_address(addr), f'testnet provider should reject {addr}'
+
+    # --- regtest provider ---
+
+    def test_regtest_accepts_regtest_addresses(self):
+        provider = make_lightweight_provider_for_network('regtest')
+        for addr in self.REGTEST_ADDRS:
+            assert provider.is_valid_address(addr), f'regtest provider should accept {addr}'
+
+    def test_regtest_rejects_mainnet_addresses(self):
+        provider = make_lightweight_provider_for_network('regtest')
+        for addr in self.MAINNET_ADDRS:
+            assert not provider.is_valid_address(addr), f'regtest provider should reject mainnet {addr}'
+
+    def test_regtest_rejects_testnet_bech32_addresses(self):
+        """tb1… is testnet-only bech32; regtest uses bcrt1…."""
+        provider = make_lightweight_provider_for_network('regtest')
+        for addr in ('tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx',
+                     'tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c'):
+            assert not provider.is_valid_address(addr), f'regtest provider should reject testnet bech32 {addr}'
+
+    # --- common ---
+
     def test_rejects_malformed(self):
         provider = make_lightweight_provider()
-        for addr in self.INVALID:
+        for addr in self.MALFORMED:
             assert not provider.is_valid_address(addr), f'should reject {addr!r}'
 
     def test_rejects_non_string(self):


### PR DESCRIPTION
## Problem

`BitcoinProvider.is_valid_address` validated address *format* (embit scriptpubkey decode) but never checked the address *network*. A mainnet-configured provider accepted testnet (`tb1q…`, `m…`, `n…`) and regtest (`bcrt1q…`) addresses as valid.

Failure mode (issue #460): a user pastes a wrong-network destination address → passes the CLI pre-check and validator confirm → miner broadcasts real BTC to the re-encoded scriptpubkey on the live network → validator's exact-string destination match fails → swap never confirms and miner loses funds with no on-chain credit.

## Fix

****

Add a module-level helper `_address_network(address)` that classifies an address into one of four disjoint network classes:

| Result | Covers |
|---|---|
| `mainnet` | `bc1q…`, `bc1p…`, `1…`, `3…` |
| `testnet-bech32` | `tb1q…`, `tb1p…` |
| `testnet-base58` | `m…`, `n…`, `2…` (shared version bytes, see below) |
| `regtest` | `bcrt1q…`, `bcrt1p…` |

Update `is_valid_address` to call it after the embit format check and accept only addresses whose class matches `self.network`:

- **mainnet** → `mainnet`
- **testnet / testnet4** → `testnet-bech32` or `testnet-base58`
- **regtest** → `regtest` or `testnet-base58`

The four-way split (rather than three-way) handles Bitcoin Core regtest correctly: regtest reuses testnet base58 version bytes (`m`/`n`/`2`) for legacy address types, so a regtest provider must accept those while still rejecting testnet-specific `tb1…` bech32 addresses.

## Tests

****

Replace the old `VALID` list (which mixed mainnet, testnet, and regtest addresses and tested all against a mainnet provider) with per-network address lists and network-specific tests:

- Mainnet provider: accepts mainnet, rejects testnet and regtest bech32
- Testnet provider: accepts tb1/m/n/2, rejects mainnet and regtest bech32
- Regtest provider: accepts bcrt1/m/n/2, rejects mainnet and testnet bech32

12 tests total, all pass. The #448 Taproot regression guard is preserved as `test_mainnet_accepts_taproot`.

Closes #460
