### PR TITLE
fix(validator): serialize hotkey contract writes to prevent nonce collisions

### DIFF
--- a/allways/contract_client.py
+++ b/allways/contract_client.py
@@ -301,6 +301,16 @@ CONTRACT_ERROR_VARIANTS = {
 }
 
 
+class _NullContext:
+    """No-op context manager used when no write_lock is provided."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
 class ContractError(Exception):
     """Raised when a contract call fails.
 
@@ -352,6 +362,7 @@ class AllwaysContractClient:
         subtensor: Optional[bt.Subtensor] = None,
         reconnect_subtensor: Optional[Callable[[], None]] = None,
         substrate_lock: Optional[Any] = None,
+        write_lock: Optional[threading.Lock] = None,
     ):
         self.contract_address = contract_address or get_contract_address() or ''
         self.subtensor = subtensor
@@ -366,6 +377,13 @@ class AllwaysContractClient:
         # access so concurrent threads can't both land in recv. Callers sharing
         # this subtensor elsewhere pass that path's lock to serialize as one.
         self._substrate_lock = substrate_lock or threading.Lock()
+        # Optional cross-connection write serializer. When two AllwaysContractClient
+        # instances share the same hotkey (forward loop and axon handlers), they must
+        # serialize nonce-fetch + submit across connections — AccountNonceApi returns
+        # the best-block nonce, which doesn't count pending pool txs, so concurrent
+        # signers can grab the same nonce and one tx gets banned (1012 Temporarily
+        # Banned). Pass the same threading.Lock() to both clients to prevent this.
+        self._write_lock = write_lock
 
         if not self.contract_address:
             bt.logging.warning('Allways contract address not set')
@@ -572,24 +590,35 @@ class AllwaysContractClient:
             extrinsic = s.create_signed_extrinsic(call=call, keypair=keypair)
             return s.submit_extrinsic(extrinsic, wait_for_inclusion=wait_for_inclusion, wait_for_finalization=False)
 
+        # Hold write_lock (if shared with another client) from nonce-fetch through
+        # inclusion so the best-block nonce is guaranteed to advance before the
+        # sibling client composes its next extrinsic. The balance read above is
+        # informational and intentionally left outside the lock to keep reads parallel.
+        write_cm = self._write_lock if self._write_lock is not None else _NullContext()
         try:
-            receipt = self.substrate_call(submit_extrinsic)
+            with write_cm:
+                try:
+                    receipt = self.substrate_call(submit_extrinsic)
+                except Exception as e:
+                    raise ContractError(f'{method}: exec failed: {e}') from e
+
+                if not wait_for_inclusion:
+                    # No block to inspect; trust the submission and let the next event
+                    # sync surface the actual outcome. Caller relies on contract-side
+                    # idempotency to absorb stale-view duplicates.
+                    return receipt.extrinsic_hash
+
+                try:
+                    if receipt.is_success:
+                        return receipt.extrinsic_hash
+                    else:
+                        raise ContractError(f'{method}: {receipt.error_message}')
+                except _EXTRINSIC_NOT_FOUND:
+                    return receipt.extrinsic_hash
+        except ContractError:
+            raise
         except Exception as e:
             raise ContractError(f'{method}: exec failed: {e}') from e
-
-        if not wait_for_inclusion:
-            # No block to inspect; trust the submission and let the next event
-            # sync surface the actual outcome. Caller relies on contract-side
-            # idempotency to absorb stale-view duplicates.
-            return receipt.extrinsic_hash
-
-        try:
-            if receipt.is_success:
-                return receipt.extrinsic_hash
-            else:
-                raise ContractError(f'{method}: {receipt.error_message}')
-        except _EXTRINSIC_NOT_FOUND:
-            return receipt.extrinsic_hash
 
     # =========================================================================
     # SCALE encoding / decoding helpers

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -70,9 +70,16 @@ class Validator(BaseValidatorNeuron):
     def __init__(self, config=None):
         super().__init__(config=config)
 
+        # Shared write lock: both contract clients sign with the same validator
+        # hotkey. AccountNonceApi returns the best-block nonce, which doesn't
+        # count pending pool txs, so two concurrent signers can fetch the same
+        # nonce and one tx gets banned (error 1012). Serialising writes across
+        # both connections prevents the collision.
+        self._write_lock = threading.Lock()
         self.contract_client = AllwaysContractClient(
             subtensor=self.subtensor,
             reconnect_subtensor=self.reconnect_and_propagate,
+            write_lock=self._write_lock,
         )
         self.chain_providers = create_chain_providers(check=True, require_send=False, subtensor=self.subtensor)
 
@@ -159,6 +166,7 @@ class Validator(BaseValidatorNeuron):
             subtensor=self.axon_subtensor,
             reconnect_subtensor=self.reconnect_axon_subtensor,
             substrate_lock=self.axon_lock,
+            write_lock=self._write_lock,
         )
         self.axon_chain_providers = create_chain_providers(subtensor=self.axon_subtensor)
         # Read block/bounds via axon_subtensor; the forward loop calls this too,

--- a/tests/test_write_lock_serialization.py
+++ b/tests/test_write_lock_serialization.py
@@ -1,0 +1,164 @@
+"""Tests for shared write_lock serialization in AllwaysContractClient (issue #457).
+
+Verifies that:
+- Two clients sharing a write_lock can be created (wiring test).
+- A client without a write_lock still works (backward compat).
+- The write_lock is held during exec_contract_raw's submit path.
+- The account balance read (pre-flight) is NOT blocked by the write_lock.
+"""
+
+import threading
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch, call
+
+
+def make_client(write_lock=None, substrate_lock=None):
+    from allways.contract_client import AllwaysContractClient
+
+    subtensor = MagicMock()
+    subtensor.substrate = MagicMock()
+    return AllwaysContractClient(
+        contract_address='5FakeContractAddress',
+        subtensor=subtensor,
+        write_lock=write_lock,
+        substrate_lock=substrate_lock,
+    )
+
+
+class TestWriteLockWiring:
+    """Shared and private write_lock construction."""
+
+    def test_no_write_lock_creates_client(self):
+        client = make_client()
+        assert client._write_lock is None
+
+    def test_shared_write_lock_stored(self):
+        lock = threading.Lock()
+        client = make_client(write_lock=lock)
+        assert client._write_lock is lock
+
+    def test_two_clients_share_same_write_lock(self):
+        lock = threading.Lock()
+        c1 = make_client(write_lock=lock)
+        c2 = make_client(write_lock=lock)
+        assert c1._write_lock is c2._write_lock is lock
+
+
+class TestWriteLockHeldDuringSubmit:
+    """exec_contract_raw must hold write_lock across nonce-fetch → submit → inclusion."""
+
+    def _make_receipt(self, success=True):
+        receipt = MagicMock()
+        receipt.is_success = success
+        receipt.extrinsic_hash = '0xabc'
+        return receipt
+
+    def test_write_lock_is_acquired_during_submit(self):
+        """write_lock must be held when substrate_call(submit_extrinsic) runs."""
+        lock = threading.Lock()
+        lock_held_during_submit = []
+
+        def fake_substrate_call(fn):
+            lock_held_during_submit.append(not lock.acquire(blocking=False))
+            if not lock_held_during_submit[-1]:
+                lock.release()
+            return self._make_receipt()
+
+        client = make_client(write_lock=lock)
+        client.initialized = True
+
+        # Patch balance read and the actual substrate_call used for submit
+        with (
+            patch.object(client, 'substrate_call', side_effect=fake_substrate_call),
+            patch.object(client, 'encode_args', return_value=b''),
+        ):
+            from allways.contract_client import CONTRACT_SELECTORS
+            CONTRACT_SELECTORS.setdefault('vote_reserve', b'\x01\x02\x03\x04')
+            client.exec_contract_raw('vote_reserve', args={}, keypair=MagicMock(ss58_address='5Fake'))
+
+        # The lock was held (acquire returned False = already locked) when submit ran
+        assert any(lock_held_during_submit), 'write_lock must be held during substrate_call submit'
+
+    def test_no_write_lock_does_not_raise(self):
+        """Client without write_lock must still complete exec_contract_raw normally."""
+        client = make_client()
+        client.initialized = True
+
+        receipt = self._make_receipt()
+
+        with (
+            patch.object(client, 'substrate_call', return_value=receipt),
+            patch.object(client, 'encode_args', return_value=b''),
+        ):
+            from allways.contract_client import CONTRACT_SELECTORS
+            CONTRACT_SELECTORS.setdefault('vote_reserve', b'\x01\x02\x03\x04')
+            result = client.exec_contract_raw('vote_reserve', args={}, keypair=MagicMock(ss58_address='5Fake'))
+
+        assert result == '0xabc'
+
+
+class TestReadPathNotBlocked:
+    """Account balance read (pre-flight) must not require the write_lock."""
+
+    def test_substrate_call_read_runs_before_write_lock(self):
+        """substrate_call for the balance read fires before the write_lock is acquired.
+
+        Uses a recording wrapper around threading.Lock to track acquire order.
+        """
+        class _RecordingLock:
+            """Thin wrapper around threading.Lock that records acquire/release."""
+
+            def __init__(self):
+                self._inner = threading.Lock()
+                self.events = []
+
+            def acquire(self, *args, **kwargs):
+                self.events.append('lock_acquire')
+                return self._inner.acquire(*args, **kwargs)
+
+            def release(self):
+                self._inner.release()
+
+            def __enter__(self):
+                self.acquire()
+                return self
+
+            def __exit__(self, *_):
+                self.release()
+
+        rec_lock = _RecordingLock()
+        call_count = [0]
+
+        def fake_substrate_call(fn):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # First call is the balance read — lock should NOT be held yet
+                rec_lock.events.append('balance_read')
+                account_info = MagicMock()
+                account_info.value = {'data': {'free': 10**12}}
+                return account_info
+            # Second call is the submit — lock IS held
+            rec_lock.events.append('submit')
+            receipt = MagicMock()
+            receipt.is_success = True
+            receipt.extrinsic_hash = '0xdef'
+            return receipt
+
+        client = make_client(write_lock=rec_lock)
+        client.initialized = True
+
+        with (
+            patch.object(client, 'substrate_call', side_effect=fake_substrate_call),
+            patch.object(client, 'encode_args', return_value=b''),
+        ):
+            from allways.contract_client import CONTRACT_SELECTORS
+            CONTRACT_SELECTORS.setdefault('vote_reserve', b'\x01\x02\x03\x04')
+            client.exec_contract_raw('vote_reserve', args={}, keypair=MagicMock(ss58_address='5Fake'))
+
+        # balance_read must come before lock_acquire
+        events = rec_lock.events
+        assert 'balance_read' in events, 'balance read substrate_call not observed'
+        assert 'lock_acquire' in events, 'write_lock was never acquired'
+        assert events.index('balance_read') < events.index('lock_acquire'), (
+            f'balance read should precede write_lock acquisition; order={events}'
+        )


### PR DESCRIPTION
## Problem

The validator signs contract writes with the **same hotkey** over two separate substrate connections: the forward loop (`contract_client` on `self.subtensor`) and the axon handlers (`axon_contract_client` on `axon_subtensor`).

Both call `create_signed_extrinsic`, which auto-fetches the nonce via `AccountNonceApi.account_nonce` — the **best-block nonce**, which does not count pending pool txs. Within the same block window both clients fetch nonce `N`; one tx lands and the other is banned (**error 1012 Transaction is temporarily banned**), starving the forward loop and causing delivered swaps to be slashed. Closes #457.

## Fix

### `allways/contract_client.py`

Add an optional `write_lock: threading.Lock` parameter to `AllwaysContractClient.__init__`. Inside `exec_contract_raw`, hold the lock across nonce-fetch + submit + inclusion. The pre-flight balance read is intentionally left **outside** the lock so reads remain parallel.

A `_NullContext` no-op is used when no write_lock is passed (backward-compatible).

### `neurons/validator.py`

Create one shared `self._write_lock = threading.Lock()` and pass it to both `contract_client` and `axon_contract_client` at construction. Lock order: `axon_lock → write_lock` (axon writes) and `write_lock → substrate_lock` (forward writes) — no cycle.

## Tests

New `tests/test_write_lock_serialization.py` (6 tests):

- Two clients sharing the same lock object store the same reference
- Client without `write_lock` completes `exec_contract_raw` normally  
- `write_lock` is held when `substrate_call(submit_extrinsic)` runs
- Balance read (`substrate_call` for account info) fires **before** the write_lock is acquired

Closes #457
