### PR TITLE
fix: accept uppercase bech32 addresses in detect_address_type

### DIFF
--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -25,22 +25,34 @@ LOG_ESPLORA = '[Esplora]'
 
 def detect_address_type(address: str) -> str:
     """Detect Bitcoin address type from its prefix."""
-    if address.startswith('bc1q'):
+    if not address:
+        return 'unknown'
+
+    lower = address.lower()
+    if lower.startswith(('bc1', 'tb1', 'bcrt1')):
+        # BIP-173: bech32 must be all-lowercase or all-uppercase, never mixed.
+        if address != lower and address != address.upper():
+            return 'unknown'
+        addr = lower
+    else:
+        addr = address
+
+    if addr.startswith('bc1q'):
         return ADDR_TYPE_P2WPKH
-    if address.startswith('bc1p'):
+    if addr.startswith('bc1p'):
         return ADDR_TYPE_P2TR
-    if address.startswith('3'):
+    if addr.startswith('3'):
         return ADDR_TYPE_P2SH_P2WPKH
-    if address.startswith('1'):
+    if addr.startswith('1'):
         return ADDR_TYPE_P2PKH
     # Regtest/testnet prefixes
-    if address.startswith('bcrt1q') or address.startswith('tb1q'):
+    if addr.startswith('bcrt1q') or addr.startswith('tb1q'):
         return ADDR_TYPE_P2WPKH
-    if address.startswith('bcrt1p') or address.startswith('tb1p'):
+    if addr.startswith('bcrt1p') or addr.startswith('tb1p'):
         return ADDR_TYPE_P2TR
-    if address.startswith('2'):
+    if addr.startswith('2'):
         return ADDR_TYPE_P2SH_P2WPKH
-    if address.startswith('m') or address.startswith('n'):
+    if addr.startswith('m') or addr.startswith('n'):
         return ADDR_TYPE_P2PKH
     return 'unknown'
 
@@ -59,6 +71,9 @@ def to_mainnet_address(address: str) -> str:
     Re-encodes the scriptPubKey under the mainnet network (handles legacy, segwit
     v0, and Taproot); returns the address unchanged if it can't be parsed.
     """
+    lower = address.lower()
+    if lower.startswith(('bc1', 'tb1', 'bcrt1')) and (address == lower or address == address.upper()):
+        address = lower
     try:
         return address_to_scriptpubkey(address).address(NETWORKS['main'])
     except Exception:

--- a/tests/test_bitcoin_signing.py
+++ b/tests/test_bitcoin_signing.py
@@ -28,6 +28,15 @@ class TestDetectAddressType:
     def test_p2wpkh(self):
         assert detect_address_type('bc1q6tvmnmetj8vfz98vuetpvtuplqtj4uvvwjgxxc') == ADDR_TYPE_P2WPKH
 
+    def test_p2wpkh_uppercase_bech32(self):
+        assert (
+            detect_address_type('BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4')
+            == ADDR_TYPE_P2WPKH
+        )
+
+    def test_mixed_case_bech32_rejected(self):
+        assert detect_address_type('Bc1qw508d6qejxtdg4y5r3zarvvary0c5xw7kv8f3t4') == 'unknown'
+
     def test_p2sh_p2wpkh(self):
         assert detect_address_type('37XAVCtKEvPbx2rpkxx7FmrUsetFXSawx5') == ADDR_TYPE_P2SH_P2WPKH
 
@@ -190,6 +199,11 @@ class TestBitcoinProviderVerifyFromProof:
         addr, _, signature = sign_message(TEST_WIF, 'p2wpkh', TEST_MESSAGE, deterministic=True)
 
         assert provider.verify_from_proof(addr, TEST_MESSAGE, signature) is True
+
+    def test_uppercase_bech32_address_verifies(self):
+        provider = make_lightweight_provider()
+        addr, _, signature = sign_message(TEST_WIF, 'p2wpkh', TEST_MESSAGE, deterministic=True)
+        assert provider.verify_from_proof(addr.upper(), TEST_MESSAGE, signature) is True
 
     def test_wrong_message_fails_verification(self):
         provider = make_lightweight_provider()


### PR DESCRIPTION
## Summary
Fixes #474 — uppercase bech32 (BIP-173) addresses were classified as `unknown`, blocking `sign_from_proof` / `verify_from_proof` for swap reserve/confirm flows.

## Changes
- `detect_address_type()`: normalize uniform upper/lower bech32; reject mixed-case
- `to_mainnet_address()`: lowercase bech32 before embit decode for verification
- Tests: uppercase detection + `verify_from_proof` roundtrip

## Testing
`uv run pytest tests/test_bitcoin_signing.py` — 46 passed
