### PR TITLE
fix(cli): recognize an initiated swap in post-tx instead of reporting expiry

### DIFF
--- a/allways/cli/swap_commands/post_tx.py
+++ b/allways/cli/swap_commands/post_tx.py
@@ -17,7 +17,12 @@ from allways.cli.swap_commands.helpers import (
     print_contract_error,
     resolve_source_tx_block,
 )
-from allways.cli.swap_commands.swap import from_smallest_unit, poll_for_swap_creation, sign_and_broadcast_confirm
+from allways.cli.swap_commands.swap import (
+    from_smallest_unit,
+    poll_for_swap_creation,
+    resolve_recent_swap_id,
+    sign_and_broadcast_confirm,
+)
 from allways.constants import NETUID_FINNEY
 from allways.contract_client import ContractError
 
@@ -70,6 +75,20 @@ def post_tx_command(tx_hash: str, tx_block: int):
         return
 
     if reserved_until <= current_block:
+        # reserved_until drops to 0 the moment the swap initiates (the contract clears
+        # the reservation row in vote_initiate), which by block number alone is
+        # indistinguishable from a genuine expiry. Check for a live swap first so we
+        # don't tell the user their reservation expired — and delete the pending
+        # record — when it actually advanced into a swap.
+        try:
+            swap_id = resolve_recent_swap_id(client, state.miner_hotkey)
+        except ContractError:
+            swap_id = None
+        if swap_id is not None:
+            clear_pending_swap()
+            console.print(f'\n[green]Your reservation has advanced into a swap. ID: {swap_id}[/green]')
+            console.print(f'[dim]Watch with: alw view swap {swap_id} --watch[/dim]\n')
+            return
         clear_pending_swap()
         console.print('[red]Reservation has expired.[/red]')
         console.print('[dim]Run `alw swap now` to start a new swap.[/dim]')


### PR DESCRIPTION
After a swap initiates, the contract clears the reservation row (`vote_initiate`), so `get_miner_reserved_until` returns 0 and `alw swap post-tx`'s `reserved_until <= current_block` check reads it as an expired reservation — it deletes `pending_swap.json` and tells the user to start over, even though the swap is live. `alw view reservation` already hedges this case and points at active-swaps; post-tx didn't.

Look up the miner's active swap with `resolve_recent_swap_id` before assuming expiry. If there's a swap, point the user at it (`alw view swap <id> --watch`) the same way the post-confirm success path does. Genuine expiry (no swap) is unchanged.

Closes #473
