### PR TITLE
fix(cli): recognize an initiated swap in post-tx and resume-reservation instead of reporting expiry

### DIFF
--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -613,7 +613,13 @@ def probe_pending_reservation(client, state: PendingSwapState, current_block: in
     try:
         if client.get_miner_has_active_swap(state.miner_hotkey):
             for swap in client.get_miner_active_swaps(state.miner_hotkey):
-                if swap.user_from_address == state.user_from_address and swap.user_to_address == state.receive_address:
+                # vote_initiate removes the reservation row, so a post-initiate
+                # hydrate can't recover user_from_address. Match on the
+                # persisted receive_address and require from-address agreement
+                # only when we have one.
+                to_match = bool(state.receive_address) and swap.user_to_address == state.receive_address
+                from_match = not state.user_from_address or swap.user_from_address == state.user_from_address
+                if to_match and from_match:
                     return ReservationStatus(kind='our_swap', swap=swap)
     except ContractError:
         return ReservationStatus(kind='rpc_error')

--- a/allways/cli/swap_commands/post_tx.py
+++ b/allways/cli/swap_commands/post_tx.py
@@ -14,12 +14,11 @@ from allways.cli.swap_commands.helpers import (
     load_pending_swap,
     loading,
     mark_pending_swap_tx_sent,
-    print_contract_error,
+    probe_pending_reservation,
     resolve_source_tx_block,
 )
 from allways.cli.swap_commands.swap import from_smallest_unit, poll_for_swap_creation, sign_and_broadcast_confirm
 from allways.constants import NETUID_FINNEY
-from allways.contract_client import ContractError
 
 
 @click.command('post-tx', cls=StyledCommand, show_disclaimer=True)
@@ -60,20 +59,31 @@ def post_tx_command(tx_hash: str, tx_block: int):
     # amounts, miner addresses are pulled live from get_reservation.
     hydrate_pending_swap(state, client)
 
-    # Validate reservation is still active on-chain
-    try:
-        with loading('Reading reservation status...'):
-            reserved_until = client.get_miner_reserved_until(state.miner_hotkey)
-            current_block = subtensor.get_current_block()
-    except ContractError as e:
-        print_contract_error('Failed to read reservation status', e)
+    # Reconcile against on-chain state. vote_initiate removes the reservation
+    # row, so a bare `reserved_until <= current_block` check reads an initiated
+    # swap as an expired reservation (#473) — the probe tells them apart.
+    with loading('Reading reservation status...'):
+        current_block = subtensor.get_current_block()
+        status = probe_pending_reservation(client, state, current_block)
+
+    if status.kind == 'rpc_error':
+        console.print('[red]Failed to read reservation status from contract.[/red]')
+        console.print('[dim]State file kept — you can retry this command.[/dim]')
         return
 
-    if reserved_until <= current_block:
+    if status.kind == 'our_swap':
         clear_pending_swap()
-        console.print('[red]Reservation has expired.[/red]')
+        console.print(f'\n[green bold]Your swap is already on-chain! ID: {status.swap.id}[/green bold]')
+        console.print(f'[dim]Watch with: alw view swap {status.swap.id} --watch[/dim]\n')
+        return
+
+    if status.kind in ('expired', 'replaced'):
+        clear_pending_swap()
+        console.print('[red]Reservation is no longer active.[/red]')
         console.print('[dim]Run `alw swap now` to start a new swap.[/dim]')
         return
+
+    reserved_until = status.reserved_until
 
     remaining = reserved_until - current_block
     human_amount = from_smallest_unit(state.from_amount, state.from_chain)

--- a/allways/cli/swap_commands/resume.py
+++ b/allways/cli/swap_commands/resume.py
@@ -20,6 +20,7 @@ from allways.cli.swap_commands.helpers import (
     load_pending_swap,
     loading,
     mark_pending_swap_tx_sent,
+    probe_pending_reservation,
     resolve_source_tx_block,
 )
 from allways.cli.swap_commands.swap import (
@@ -91,6 +92,48 @@ def resume_reservation_command(from_tx_hash_opt: Optional[str], auto_send: bool,
     except ContractError:
         pass
 
+    # Reconcile against on-chain state before rendering the summary. After
+    # vote_initiate the reservation row is gone, so hydration leaves
+    # from_chain empty and the old summary-first flow crashed in
+    # from_smallest_unit via get_chain('') (#473). The probe also tells an
+    # initiated swap apart from an expired reservation.
+    with loading('Checking on-chain swap status...'):
+        current_block = subtensor.get_current_block()
+        status = probe_pending_reservation(client, state, current_block)
+
+    if status.kind == 'rpc_error':
+        console.print('[red]Failed to read reservation status from contract.[/red]')
+        console.print('[dim]State file kept — retry with: alw swap resume-reservation[/dim]')
+        return
+
+    if status.kind == 'our_swap':
+        clear_pending_swap()
+        console.print(f'\n[green]Swap already on-chain! ID: {status.swap.id}[/green]')
+        console.print(f'[dim]Watch with: alw view swap {status.swap.id} --watch[/dim]')
+        if not skip_confirm:
+            from allways.cli.swap_commands.view import watch_swap
+
+            final = watch_swap(client, status.swap.id)
+            if final and final.status == SwapStatus.COMPLETED:
+                from allways.cli.swap_commands.swap import display_receipt
+
+                display_receipt(final)
+        return
+
+    if status.kind in ('expired', 'replaced'):
+        clear_pending_swap()
+        console.print('\n[yellow]Reservation is no longer active.[/yellow]')
+        console.print(
+            '[dim]Either the reservation expired, or your swap already initiated and may be in progress '
+            'or completed. Check with: alw view active-swaps[/dim]\n'
+        )
+        console.print('[dim]Start a new swap with: alw swap now[/dim]')
+        return
+
+    # ours_active — the reservation row exists and matches our local state,
+    # so hydration populated the display fields the summary needs.
+    reserved_until = status.reserved_until
+
     # Display pending swap summary
     elapsed_min = (time.time() - state.created_at) / 60
     human_send = from_smallest_unit(state.from_amount, state.from_chain)
@@ -107,53 +150,6 @@ def resume_reservation_command(from_tx_hash_opt: Optional[str], auto_send: bool,
     )
     console.print()
     console.print(Panel(summary, title='[bold]Pending Swap[/bold]', expand=False))
-
-    # Check if swap is already on-chain (cheap bool check before expensive scan)
-    try:
-        with loading('Checking on-chain swap status...'):
-            has_swap = client.get_miner_has_active_swap(state.miner_hotkey)
-        if has_swap:
-            for swap in client.get_miner_active_swaps(state.miner_hotkey):
-                is_ours = (
-                    swap.user_from_address == state.user_from_address or swap.user_to_address == state.receive_address
-                )
-                if is_ours:
-                    clear_pending_swap()
-                    console.print(f'\n[green]Swap already on-chain! ID: {swap.id}[/green]')
-                    if not skip_confirm:
-                        from allways.cli.swap_commands.view import watch_swap
-
-                        final = watch_swap(client, swap.id)
-                        if final and final.status == SwapStatus.COMPLETED:
-                            from allways.cli.swap_commands.swap import display_receipt
-
-                            display_receipt(final)
-                    return
-    except ContractError:
-        pass
-
-    # Check reservation status — if expired, there's nothing to resume
-    try:
-        with loading('Reading reservation status...'):
-            reserved_until = client.get_miner_reserved_until(state.miner_hotkey)
-            current_block = subtensor.get_current_block()
-        reservation_active = reserved_until > current_block
-    except ContractError as e:
-        console.print(f'[red]Failed to read reservation status: {e}[/red]')
-        return
-
-    if not reservation_active:
-        # Reservation is cleared either on expiry or when vote_initiate succeeds.
-        # A silent initiate means the swap is already in flight or has completed —
-        # surface both possibilities rather than assuming expiry.
-        clear_pending_swap()
-        console.print('\n[yellow]Reservation is no longer active.[/yellow]')
-        console.print(
-            '[dim]Either the reservation expired, or your swap already initiated and may be in progress '
-            'or completed. Check with: alw view active-swaps[/dim]\n'
-        )
-        console.print('[dim]Start a new swap with: alw swap now[/dim]')
-        return
 
     remaining = reserved_until - current_block
     console.print(f'\n[green]Reservation still active ({blocks_to_minutes_str(remaining)} left)[/green]')

--- a/tests/test_cli_pending_swap_reconciliation.py
+++ b/tests/test_cli_pending_swap_reconciliation.py
@@ -1,0 +1,163 @@
+"""post-tx / resume-reservation: recognize an initiated swap before assuming expiry (#473).
+
+After vote_initiate the contract removes the reservation row, so
+``get_miner_reserved_until`` returns 0 and ``hydrate_pending_swap`` can't
+repopulate the contract-derived fields. The old flows read that state as an
+expired reservation: post-tx deleted pending_swap.json and told the user to
+re-reserve, and resume-reservation crashed rendering the summary
+(``get_chain('')``). These tests pin the probe-based reconciliation both
+commands now share.
+"""
+
+from unittest.mock import MagicMock
+
+from click.testing import CliRunner
+
+import allways.cli.swap_commands.post_tx as post_tx_mod
+import allways.cli.swap_commands.resume as resume_mod
+from allways.classes import Swap, SwapStatus
+from allways.cli.swap_commands.helpers import PendingSwapState
+from allways.contract_client import ContractError
+
+CURRENT_BLOCK = 1_000_000
+
+
+def make_state(**overrides) -> PendingSwapState:
+    """Post-initiate shape: persisted fields only — hydration fails once the
+    reservation row is gone, so contract-derived fields keep their dataclass
+    defaults ('' chains, 0 amounts)."""
+    base = dict(
+        miner_hotkey='5MinerHk',
+        receive_address='5UserHk',
+        netuid=2,
+        wallet_name='default',
+        hotkey_name='default',
+        from_tx_hash='abc123',
+        request_hash='req-hash',
+        created_at=0.0,
+    )
+    base.update(overrides)
+    return PendingSwapState(**base)
+
+
+def make_swap(**overrides) -> Swap:
+    base = dict(
+        id=7,
+        user_hotkey='5UserHk',
+        miner_hotkey='5MinerHk',
+        from_chain='btc',
+        to_chain='tao',
+        from_amount=100_000,
+        to_amount=300_000_000,
+        tao_amount=300_000_000,
+        user_from_address='tb1quser',
+        user_to_address='5UserHk',
+        status=SwapStatus.ACTIVE,
+    )
+    base.update(overrides)
+    return Swap(**base)
+
+
+def make_initiated_client(swap) -> MagicMock:
+    """Contract-client double for the post-initiate window: reservation row
+    removed (get_reservation None / reserved_until 0), our swap live."""
+    client = MagicMock()
+    client.get_halted.return_value = False
+    client.get_miner_has_active_swap.return_value = True
+    client.get_miner_active_swaps.return_value = [swap]
+    client.get_reservation.return_value = None
+    client.get_miner_reserved_until.return_value = 0
+    client.get_reservation_data.return_value = None
+    return client
+
+
+def make_expired_client() -> MagicMock:
+    """No swap and no reservation row — a genuinely expired reservation."""
+    client = MagicMock()
+    client.get_halted.return_value = False
+    client.get_miner_has_active_swap.return_value = False
+    client.get_miner_active_swaps.return_value = []
+    client.get_reservation.return_value = None
+    client.get_miner_reserved_until.return_value = 0
+    client.get_reservation_data.return_value = None
+    return client
+
+
+def wire(monkeypatch, mod, state, client) -> list:
+    """Point a command module's context/state seams at test doubles.
+
+    Returns the list that records clear_pending_swap calls. The real
+    hydrate_pending_swap and probe_pending_reservation run against the
+    client double so the reconciliation path under test stays unmocked.
+    """
+    subtensor = MagicMock()
+    subtensor.get_current_block.return_value = CURRENT_BLOCK
+    cleared = []
+    monkeypatch.setattr(mod, 'load_pending_swap', lambda: state)
+    monkeypatch.setattr(mod, 'get_cli_context', lambda *a, **k: ({}, MagicMock(), subtensor, client))
+    monkeypatch.setattr(mod, 'clear_pending_swap', lambda: cleared.append(True))
+    return cleared
+
+
+def test_post_tx_points_at_initiated_swap_instead_of_expiring(monkeypatch):
+    """The #473 repro: re-running post-tx after the swap initiated must point
+    at the live swap, not claim expiry and advise a new reservation."""
+    cleared = wire(monkeypatch, post_tx_mod, make_state(), make_initiated_client(make_swap()))
+
+    result = CliRunner().invoke(post_tx_mod.post_tx_command, ['deadbeef'])
+
+    assert result.exception is None
+    assert 'already on-chain! ID: 7' in result.output
+    assert 'alw view swap 7' in result.output
+    assert 'no longer active' not in result.output
+    assert 'alw swap now' not in result.output
+    # Local record is cleared only after handing the user the swap id.
+    assert cleared == [True]
+
+
+def test_post_tx_expired_reservation_still_clears_and_advises_new_swap(monkeypatch):
+    cleared = wire(monkeypatch, post_tx_mod, make_state(), make_expired_client())
+
+    result = CliRunner().invoke(post_tx_mod.post_tx_command, ['deadbeef'])
+
+    assert result.exception is None
+    assert 'no longer active' in result.output
+    assert 'alw swap now' in result.output
+    assert cleared == [True]
+
+
+def test_post_tx_rpc_error_keeps_state_file(monkeypatch):
+    client = make_expired_client()
+    client.get_miner_has_active_swap.side_effect = ContractError('rpc down')
+    cleared = wire(monkeypatch, post_tx_mod, make_state(), client)
+
+    result = CliRunner().invoke(post_tx_mod.post_tx_command, ['deadbeef'])
+
+    assert result.exception is None
+    assert 'Failed to read reservation status' in result.output
+    assert cleared == []
+
+
+def test_resume_reports_initiated_swap_instead_of_crashing(monkeypatch):
+    """resume-reservation shares the root cause: it ignored the hydrate
+    failure and crashed formatting the summary with an empty chain id
+    (get_chain(''))."""
+    cleared = wire(monkeypatch, resume_mod, make_state(), make_initiated_client(make_swap()))
+
+    result = CliRunner().invoke(resume_mod.resume_reservation_command, ['--yes'])
+
+    assert result.exception is None
+    assert 'Swap already on-chain! ID: 7' in result.output
+    assert 'alw view swap 7' in result.output
+    assert cleared == [True]
+
+
+def test_resume_expired_reservation_clears_and_advises_new_swap(monkeypatch):
+    cleared = wire(monkeypatch, resume_mod, make_state(), make_expired_client())
+
+    result = CliRunner().invoke(resume_mod.resume_reservation_command, ['--yes'])
+
+    assert result.exception is None
+    assert 'no longer active' in result.output
+    assert 'alw swap now' in result.output
+    assert cleared == [True]

--- a/tests/test_probe_pending_reservation.py
+++ b/tests/test_probe_pending_reservation.py
@@ -123,6 +123,57 @@ def test_active_swap_for_different_user_does_not_match():
     assert result.kind == 'expired'
 
 
+def test_our_swap_matches_on_receive_address_when_hydration_failed():
+    """#473: vote_initiate removes the reservation row, so a post-initiate
+    hydrate can't recover user_from_address. The persisted receive_address
+    alone must be enough to recognize our swap instead of reporting it
+    expired."""
+    state = make_state(user_from_address='')
+    swap = make_swap(user_to_address=state.receive_address)
+    client = make_client(active_swaps=[swap])
+
+    result = probe_pending_reservation(client, state, CURRENT_BLOCK)
+
+    assert result.kind == 'our_swap'
+    assert result.swap is swap
+
+
+def test_unhydrated_state_still_excludes_other_users_swaps():
+    """Relaxing the from-address requirement must not loosen the match for
+    swaps sending to someone else's receive address."""
+    state = make_state(user_from_address='')
+    other = make_swap(user_from_address='tb1qsomeoneelse', user_to_address='5OtherHk')
+    client = make_client(active_swaps=[other])
+
+    result = probe_pending_reservation(client, state, CURRENT_BLOCK)
+
+    assert result.kind == 'expired'
+
+
+def test_from_address_mismatch_is_not_our_swap_when_hydrated():
+    """When we do know our from-address, a swap that matches only the
+    receive address must still agree on it."""
+    state = make_state()
+    swap = make_swap(user_from_address='tb1qsomeoneelse', user_to_address=state.receive_address)
+    client = make_client(active_swaps=[swap])
+
+    result = probe_pending_reservation(client, state, CURRENT_BLOCK)
+
+    assert result.kind == 'expired'
+
+
+def test_blank_receive_address_never_matches():
+    """A degenerate state file with no receive_address must not wildcard-match
+    a swap whose user_to_address is also empty."""
+    state = make_state(user_from_address='', receive_address='')
+    swap = make_swap(user_to_address='')
+    client = make_client(active_swaps=[swap])
+
+    result = probe_pending_reservation(client, state, CURRENT_BLOCK)
+
+    assert result.kind == 'expired'
+
+
 def test_expired_when_no_swap_and_no_reservation():
     state = make_state()
     client = make_client()


### PR DESCRIPTION
## Problem

Closes #473.

After a swap initiates, `vote_initiate` clears the reservation row, so `get_miner_reserved_until` returns 0. `alw swap post-tx` validated the reservation with a bare `reserved_until <= current_block` check, which can't tell an initiated swap from an expired reservation: it deleted `pending_swap.json` and printed "Reservation has expired. Run `alw swap now` to start a new swap." A user whose swap actually succeeded loses local tracking of it and — following the on-screen advice — reserves a second miner and sends source funds again. Re-running `post-tx` in this window is a directed path, not an accident: `post-tx`'s own retry hint and `view reservation`'s re-broadcast guidance both send users back to it while validators are confirming.

`alw swap resume-reservation` shares the root cause: it ignored the `hydrate_pending_swap` False return (hydration fails once the reservation row is gone), then crashed rendering the summary panel with an empty chain id (`from_smallest_unit` → `get_chain('')`) before its own active-swap check could run.

## Fix

Both commands now reconcile through the existing `probe_pending_reservation` helper (already used by `swap now`, `view reservation`, and `status`) instead of hand-rolled expiry checks:

- `post_tx.py` — probes before validating. `our_swap` prints the swap id + `alw view swap <id> --watch` and clears the local record only after handing the user that pointer; `expired`/`replaced` keeps the clear-and-re-reserve advice; `rpc_error` keeps the state file and suggests retrying.
- `resume.py` — probes before rendering the summary panel, so the unhydrated post-initiate state can no longer reach `get_chain('')`. The summary renders only on `ours_active`, where the reservation row exists and hydration is guaranteed to have populated its fields. The command's hand-rolled active-swap scan and `reserved_until > current_block` check are replaced by the same probe branches.
- `helpers.py` — `probe_pending_reservation`'s swap match required `user_from_address` agreement, but that field is hydrated from the very reservation row `vote_initiate` deletes, so post-initiate probes mis-read our own swap as `expired`. The match now keys on the persisted `receive_address` and requires from-address agreement only when one is known. (Side benefit: `alw status`'s pending-reservation row now shows "became swap #N" instead of "Expired" in the same window.)

## Tests

- `tests/test_probe_pending_reservation.py` — new cases: the #473 shape (unhydrated state + live swap → `our_swap`); unhydrated state still excludes other users' swaps; hydrated from-address mismatch still excluded; a degenerate blank `receive_address` never wildcard-matches.
- `tests/test_cli_pending_swap_reconciliation.py` (new) — command-level via `CliRunner`, with the real probe and hydration running against a contract-client double: `post-tx` points at the initiated swap instead of claiming expiry; genuinely expired reservations still clear and advise `alw swap now`; RPC errors keep the state file; `resume-reservation` reports the on-chain swap instead of crashing on `get_chain('')`.

All six behavior tests fail on `test` before the fix (post-tx claims expiry, resume crashes) and pass after.

## Test plan

- `uv run pytest tests/ -q` — 710 passed
- `uv run pre-commit run --all-files` — trailing-whitespace, EOF, line-ending, ruff lint + format all pass; pre-push pytest hook passed on push