### PR TITLE
fix(bitcoin): accept uppercase bech32 proof addresses

### DIFF
--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -23,8 +23,19 @@ LOG_RPC = '[BTC-RPC]'
 LOG_ESPLORA = '[Esplora]'
 
 
+def canonical_bech32_address(address: str) -> str:
+    """Lowercase uniform-case bech32/bech32m addresses; reject mixed-case."""
+    lower = address.lower()
+    if not lower.startswith(('bc1', 'tb1', 'bcrt1')):
+        return address
+    if address != lower and address != address.upper():
+        return ''
+    return lower
+
+
 def detect_address_type(address: str) -> str:
     """Detect Bitcoin address type from its prefix."""
+    address = canonical_bech32_address(address)
     if address.startswith('bc1q'):
         return ADDR_TYPE_P2WPKH
     if address.startswith('bc1p'):
@@ -60,7 +71,7 @@ def to_mainnet_address(address: str) -> str:
     v0, and Taproot); returns the address unchanged if it can't be parsed.
     """
     try:
-        return address_to_scriptpubkey(address).address(NETWORKS['main'])
+        return address_to_scriptpubkey(canonical_bech32_address(address)).address(NETWORKS['main'])
     except Exception:
         return address
 

--- a/tests/test_bitcoin_signing.py
+++ b/tests/test_bitcoin_signing.py
@@ -28,20 +28,35 @@ class TestDetectAddressType:
     def test_p2wpkh(self):
         assert detect_address_type('bc1q6tvmnmetj8vfz98vuetpvtuplqtj4uvvwjgxxc') == ADDR_TYPE_P2WPKH
 
+    def test_uppercase_p2wpkh(self):
+        assert detect_address_type('BC1Q6TVMNMETJ8VFZ98VUETPVUTUPLQTJ4UVVWJGXXC') == ADDR_TYPE_P2WPKH
+
     def test_p2sh_p2wpkh(self):
         assert detect_address_type('37XAVCtKEvPbx2rpkxx7FmrUsetFXSawx5') == ADDR_TYPE_P2SH_P2WPKH
 
     def test_p2tr(self):
         assert detect_address_type('bc1pxyz') == ADDR_TYPE_P2TR
 
+    def test_uppercase_p2tr(self):
+        assert detect_address_type('BC1PXYZ') == ADDR_TYPE_P2TR
+
+    def test_mixed_case_bech32_rejected(self):
+        assert detect_address_type('bc1Q6TVMNMETJ8VFZ98VUETPVUTUPLQTJ4UVVWJGXXC') == 'unknown'
+
     def test_regtest_p2wpkh(self):
         assert detect_address_type('bcrt1q6tvmnmetj8vfz98vuetpvtuplqtj4uvvtest') == ADDR_TYPE_P2WPKH
+
+    def test_uppercase_regtest_p2wpkh(self):
+        assert detect_address_type('BCRT1Q6TVMNMETJ8VFZ98VUETPVUTUPLQTJ4UVVTEST') == ADDR_TYPE_P2WPKH
 
     def test_regtest_p2tr(self):
         assert detect_address_type('bcrt1pxyz') == ADDR_TYPE_P2TR
 
     def test_testnet_p2wpkh(self):
         assert detect_address_type('tb1q6tvmnmetj8vfz98vuetpvtuplqtj4uvvtest') == ADDR_TYPE_P2WPKH
+
+    def test_uppercase_testnet_p2wpkh(self):
+        assert detect_address_type('TB1Q6TVMNMETJ8VFZ98VUETPVUTUPLQTJ4UVVTEST') == ADDR_TYPE_P2WPKH
 
     def test_unknown(self):
         assert detect_address_type('xyz123') == 'unknown'
@@ -190,6 +205,12 @@ class TestBitcoinProviderVerifyFromProof:
         addr, _, signature = sign_message(TEST_WIF, 'p2wpkh', TEST_MESSAGE, deterministic=True)
 
         assert provider.verify_from_proof(addr, TEST_MESSAGE, signature) is True
+
+    def test_uppercase_p2wpkh_signature_verifies(self):
+        provider = make_lightweight_provider()
+        addr, _, signature = sign_message(TEST_WIF, 'p2wpkh', TEST_MESSAGE, deterministic=True)
+
+        assert provider.verify_from_proof(addr.upper(), TEST_MESSAGE, signature) is True
 
     def test_wrong_message_fails_verification(self):
         provider = make_lightweight_provider()


### PR DESCRIPTION
## Summary
- Fixes #474 by normalizing uniform-case bech32/bech32m BTC addresses before proof address type detection.
- Keeps mixed-case bech32 rejected per BIP-173 while preserving existing base58 behavior.
- Applies the same canonicalization before mainnet re-encoding so uppercase segwit addresses verify through the BIP-137 proof path.

## Test plan
- `uv run pytest tests/test_bitcoin_signing.py`
- `uv run ruff check allways/chain_providers/bitcoin.py tests/test_bitcoin_signing.py`
- Direct repro check: uppercase `BC1Q...` returns `p2wpkh`; mixed-case `bc1Q...` returns `unknown`.

Fixes #474