### PR TITLE
fix(bitcoin): resolve #470 nested-segwit scriptSig and #471 claim signer mismatch

### DIFF
--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -720,10 +720,12 @@ class BitcoinProvider(ChainProvider):
             final_tx = psbt.tx
             for i, inp in enumerate(psbt.inputs):
                 if is_segwit:
+                    from embit.script import Script
+
                     for pub, sig in inp.partial_sigs.items():
                         final_tx.vin[i].witness = Witness([sig, pub.sec()])
                         if addr_type == 'p2sh-p2wpkh':
-                            final_tx.vin[i].script_sig = segwit_script.serialize()
+                            final_tx.vin[i].script_sig = Script(segwit_script.serialize())
                 else:
                     from embit.script import Script
 

--- a/allways/cli/swap_commands/claim.py
+++ b/allways/cli/swap_commands/claim.py
@@ -38,12 +38,12 @@ def claim_command(swap_id: int, yes: bool):
         print_contract_error('Failed to read pending slash', e)
         return
 
-    if pending_rao == 0:
-        try:
-            swap = client.get_swap(swap_id)
-        except ContractError:
-            swap = None
+    try:
+        swap = client.get_swap(swap_id)
+    except ContractError:
+        swap = None
 
+    if pending_rao == 0:
         if swap is not None and swap.status in (SwapStatus.ACTIVE, SwapStatus.FULFILLED):
             console.print(
                 f'[yellow]Swap #{swap_id} is still in progress (status: {swap.status.name}).[/yellow]\n'
@@ -60,9 +60,30 @@ def claim_command(swap_id: int, yes: bool):
         )
         return
 
+    signer_keypair = wallet.hotkey
+    signer_ss58 = wallet.hotkey.ss58_address
+    required_claimant = None
+    if swap is not None:
+        required_claimant = swap.user_hotkey
+        if required_claimant == wallet.coldkeypub.ss58_address:
+            signer_keypair = wallet.coldkey
+            signer_ss58 = wallet.coldkeypub.ss58_address
+        elif required_claimant == wallet.hotkey.ss58_address:
+            signer_keypair = wallet.hotkey
+            signer_ss58 = wallet.hotkey.ss58_address
+        else:
+            console.print(f'  Swap user:  [yellow]{required_claimant}[/yellow]')
+            console.print(
+                '[red]This wallet cannot claim this slash.[/red]\n'
+                '[dim]Claim must be signed by the original swap user account above.[/dim]\n'
+            )
+            return
+
     console.print(f'  Swap ID:    {swap_id}')
     console.print(f'  Amount:     [green]{from_rao(pending_rao):.4f} TAO[/green] ({pending_rao} rao)')
-    console.print(f'  Claiming:   {wallet.hotkey.ss58_address}')
+    if required_claimant:
+        console.print(f'  Swap user:  {required_claimant}')
+    console.print(f'  Claiming:   {signer_ss58}')
     console.print('[dim]  Only the original swap user can claim; others will be rejected on-chain.[/dim]\n')
 
     if not yes and not click.confirm('Confirm claiming slash?'):
@@ -71,7 +92,7 @@ def claim_command(swap_id: int, yes: bool):
 
     try:
         with loading('Submitting transaction...'):
-            client.claim_slash(wallet=wallet, swap_id=swap_id)
+            client.claim_slash(wallet=wallet, swap_id=swap_id, keypair=signer_keypair)
         console.print(f'[green]Successfully claimed {from_rao(pending_rao):.4f} TAO from swap #{swap_id}![/green]\n')
     except ContractError as e:
         print_contract_error('Failed to claim slash', e)

--- a/allways/contract_client.py
+++ b/allways/contract_client.py
@@ -1015,9 +1015,10 @@ class AllwaysContractClient:
         log_msg: str,
         args: Optional[dict] = None,
         value: int = 0,
+        keypair: Optional[Any] = None,
     ) -> str:
         self.ensure_initialized()
-        tx_hash = self.exec_contract_raw(method, args=args, keypair=wallet.hotkey, value=value)
+        tx_hash = self.exec_contract_raw(method, args=args, keypair=keypair or wallet.hotkey, value=value)
         bt.logging.info(f'{log_msg}: {tx_hash}')
         return tx_hash
 
@@ -1283,8 +1284,14 @@ class AllwaysContractClient:
         """Deactivate a miner directly on contract (permissionless)."""
         return self._exec_logged('deactivate', wallet, f'Miner {miner} deactivated', {'miner': miner})
 
-    def claim_slash(self, wallet: bt.Wallet, swap_id: int) -> str:
-        return self._exec_logged('claim_slash', wallet, f'Slash claimed for swap {swap_id}', {'swap_id': swap_id})
+    def claim_slash(self, wallet: bt.Wallet, swap_id: int, keypair: Optional[Any] = None) -> str:
+        return self._exec_logged(
+            'claim_slash',
+            wallet,
+            f'Slash claimed for swap {swap_id}',
+            {'swap_id': swap_id},
+            keypair=keypair,
+        )
 
     # =========================================================================
     # Admin Transaction Functions (Write — owner-only)

--- a/tests/test_bitcoin_signing.py
+++ b/tests/test_bitcoin_signing.py
@@ -273,6 +273,47 @@ class TestBroadcastedTxidsTracking:
         provider = make_lightweight_provider()
         assert provider.broadcasted_txids == set()
 
+    def test_nested_segwit_lightweight_send_serializes_scriptsig(self):
+        """Regression guard for #470: nested-segwit finalize must store a Script
+        object on script_sig, not raw bytes, so tx serialization succeeds."""
+        provider = make_lightweight_provider()
+        from_address, _, _ = sign_message(TEST_WIF, 'p2wpkh-p2sh', 'x', deterministic=True)
+        to_address, _, _ = sign_message(TEST_WIF, 'p2wpkh', 'y', deterministic=True)
+
+        utxo_resp = MagicMock()
+        utxo_resp.raise_for_status.return_value = None
+        utxo_resp.json.return_value = [{'txid': '11' * 32, 'vout': 0, 'value': 80_000}]
+
+        captured = {}
+
+        def fake_post(path: str, data: str, timeout: int = 30):
+            captured['raw_tx'] = data
+            return SimpleNamespace(status_code=200, text='aa' * 32)
+
+        with (
+            patch.dict(os.environ, {'BTC_PRIVATE_KEY': TEST_WIF}, clear=False),
+            patch.object(provider, 'btc_api_get', return_value=utxo_resp),
+            patch.object(provider, 'btc_api_post', side_effect=fake_post),
+        ):
+            result = provider.send_amount_lightweight(
+                to_address=to_address,
+                amount=10_000,
+                from_address=from_address,
+                fee_rate_override=1,
+            )
+
+        assert result == ('aa' * 32, 0)
+        raw_tx = captured.get('raw_tx')
+        assert raw_tx, 'expected send_amount_lightweight to broadcast a serialized transaction'
+
+        from embit.ec import PrivateKey
+        from embit.script import p2wpkh
+        from embit.transaction import Transaction as EmbitTx
+
+        tx = EmbitTx.from_string(raw_tx)
+        expected_redeem = p2wpkh(PrivateKey.from_wif(TEST_WIF).get_public_key()).serialize().hex()
+        assert tx.vin[0].script_sig.data.hex() == expected_redeem
+
 
 class TestIsValidAddress:
     """BTC address format validation — must accept every standard type

--- a/tests/test_claim_command.py
+++ b/tests/test_claim_command.py
@@ -1,0 +1,69 @@
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from allways.classes import Swap, SwapStatus
+from allways.cli.swap_commands import claim as claim_module
+from allways.cli.swap_commands.claim import claim_command
+
+
+def _make_swap(user_hotkey: str) -> Swap:
+    return Swap(
+        id=42,
+        user_hotkey=user_hotkey,
+        miner_hotkey='miner-hotkey',
+        from_chain='tao',
+        to_chain='btc',
+        from_amount=1,
+        to_amount=1,
+        tao_amount=1,
+        user_from_address='user-from',
+        user_to_address='user-to',
+        status=SwapStatus.TIMED_OUT,
+    )
+
+
+def _invoke(wallet, client):
+    config = {'network': 'test'}
+    with (
+        patch.object(claim_module, 'get_cli_context', return_value=(config, wallet, None, client)),
+        patch.object(claim_module, 'loading', return_value=nullcontext()),
+    ):
+        return CliRunner().invoke(claim_command, ['42', '--yes'], catch_exceptions=False)
+
+
+class TestClaimCommandSignerSelection:
+    def test_claim_uses_coldkey_when_swap_user_matches_coldkey(self):
+        coldkey_signer = object()
+        wallet = SimpleNamespace(
+            hotkey=SimpleNamespace(ss58_address='hot-addr'),
+            coldkeypub=SimpleNamespace(ss58_address='cold-addr'),
+            coldkey=coldkey_signer,
+        )
+        client = MagicMock()
+        client.get_pending_slash.return_value = 123_000_000
+        client.get_swap.return_value = _make_swap(user_hotkey='cold-addr')
+
+        result = _invoke(wallet, client)
+
+        assert result.exit_code == 0, result.output
+        client.claim_slash.assert_called_once_with(wallet=wallet, swap_id=42, keypair=coldkey_signer)
+        assert 'Claiming:   cold-addr' in result.output
+
+    def test_claim_refuses_when_wallet_cannot_sign_for_swap_user(self):
+        wallet = SimpleNamespace(
+            hotkey=SimpleNamespace(ss58_address='hot-addr'),
+            coldkeypub=SimpleNamespace(ss58_address='cold-addr'),
+            coldkey=object(),
+        )
+        client = MagicMock()
+        client.get_pending_slash.return_value = 123_000_000
+        client.get_swap.return_value = _make_swap(user_hotkey='external-user')
+
+        result = _invoke(wallet, client)
+
+        assert result.exit_code == 0, result.output
+        client.claim_slash.assert_not_called()
+        assert 'This wallet cannot claim this slash.' in result.output

--- a/tests/test_contract_client.py
+++ b/tests/test_contract_client.py
@@ -199,3 +199,40 @@ class TestExtensionSelectorWiring:
             'TargetNotForward',
             'InvalidTarget',
         }
+
+
+class TestClaimSlashSigner:
+    def test_claim_slash_uses_explicit_keypair_when_provided(self):
+        client = AllwaysContractClient(contract_address='5xx', subtensor=make_subtensor())
+        client.ensure_initialized = MagicMock()
+        client.exec_contract_raw = MagicMock(return_value='0xabc')
+        wallet = MagicMock()
+        wallet.hotkey = MagicMock()
+        cold = MagicMock()
+
+        tx_hash = client.claim_slash(wallet=wallet, swap_id=42, keypair=cold)
+
+        assert tx_hash == '0xabc'
+        client.exec_contract_raw.assert_called_once_with(
+            'claim_slash',
+            args={'swap_id': 42},
+            keypair=cold,
+            value=0,
+        )
+
+    def test_claim_slash_defaults_to_hotkey_signer(self):
+        client = AllwaysContractClient(contract_address='5xx', subtensor=make_subtensor())
+        client.ensure_initialized = MagicMock()
+        client.exec_contract_raw = MagicMock(return_value='0xdef')
+        wallet = MagicMock()
+        wallet.hotkey = MagicMock()
+
+        tx_hash = client.claim_slash(wallet=wallet, swap_id=7)
+
+        assert tx_hash == '0xdef'
+        client.exec_contract_raw.assert_called_once_with(
+            'claim_slash',
+            args={'swap_id': 7},
+            keypair=wallet.hotkey,
+            value=0,
+        )


### PR DESCRIPTION
## Summary
- Fixes #470 by setting nested-segwit (`p2sh-p2wpkh`) `script_sig` as `Script(...)` in lightweight BTC send finalization so serialization/broadcast succeeds.
- Fixes #471 by allowing `claim_slash` to use an explicit signer and selecting the signer in CLI claim flow based on `swap.user` (`coldkey` or `hotkey`).
- Adds a claim preflight guard that exits early with a clear message when the current wallet cannot sign for the swap user account.

## Tests
- Added nested-segwit send regression coverage in `tests/test_bitcoin_signing.py`.
- Added explicit signer/default signer tests in `tests/test_contract_client.py`.
- Added CLI claim signer-selection tests in new `tests/test_claim_command.py`.

## Validation run
- `uv run pytest tests/test_bitcoin_signing.py tests/test_contract_client.py tests/test_claim_command.py`
- `uv run ruff check allways/chain_providers/bitcoin.py allways/contract_client.py allways/cli/swap_commands/claim.py tests/test_bitcoin_signing.py tests/test_contract_client.py tests/test_claim_command.py`

Fixes #470
Fixes #471