### PR TITLE
feat(solana): emergency halt switch

### DIFF
--- a/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
@@ -42,7 +42,8 @@ pub const POOL_SEED: &[u8] = b"pool";
 /// v2: Phase 8 (on-chain miner quotes + per-validator weights).
 /// v3: Phase 9 (reservation lottery + flat reservation fee).
 /// v4: Phase 10 (consensus-governed validator weights).
-pub const CONFIG_VERSION: u32 = 4;
+/// v5: emergency halt switch.
+pub const CONFIG_VERSION: u32 = 5;
 
 /// Max validators in the whitelist (bounds the Config `validators` Vec and a round's voters).
 pub const MAX_VALIDATORS: usize = 16;

--- a/smart-contracts/solana/programs/allways_swap_manager/src/error.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/error.rs
@@ -41,6 +41,8 @@ pub enum ErrorCode {
     NotMiner,
     #[msg("No validators configured")]
     NoValidators,
+    #[msg("System is halted")]
+    SystemHalted,
 
     // --- Phase 3: reservations ---
     #[msg("Swap amount is below the configured minimum")]

--- a/smart-contracts/solana/programs/allways_swap_manager/src/events.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/events.rs
@@ -136,3 +136,8 @@ pub struct ValidatorWeightsUpdated {
     pub count: u8,
     pub updated_at: i64,
 }
+
+#[event]
+pub struct HaltSet {
+    pub halted: bool,
+}

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/admin.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/admin.rs
@@ -2,6 +2,7 @@ use anchor_lang::prelude::*;
 
 use crate::constants::{CONFIG_SEED, MAX_VALIDATORS};
 use crate::error::ErrorCode;
+use crate::events::HaltSet;
 use crate::state::{Config, ValidatorInfo};
 
 /// Admin-only config mutations (validator set + consensus threshold).
@@ -52,5 +53,12 @@ pub fn set_consensus_threshold(ctx: Context<AdminConfig>, percent: u8) -> Result
     require!((1..=100).contains(&percent), ErrorCode::InvalidThreshold);
     ctx.accounts.config.consensus_threshold_percent = percent;
     msg!("consensus threshold = {}%", percent);
+    Ok(())
+}
+
+pub fn set_halted(ctx: Context<AdminConfig>, halted: bool) -> Result<()> {
+    ctx.accounts.config.halted = halted;
+    emit!(HaltSet { halted });
+    msg!("halted = {}", halted);
     Ok(())
 }

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/initialize.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/initialize.rs
@@ -61,6 +61,7 @@ pub fn handler(
     config.consensus_threshold_percent = consensus_threshold_percent;
     config.validators = Vec::new();
     config.last_weights_update = 0;
+    config.halted = false;
     config.bump = ctx.bumps.config;
 
     let vault = &mut ctx.accounts.vault;

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/open_or_request.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/open_or_request.rs
@@ -79,6 +79,7 @@ pub fn handler(
     from_amount: u128,
     to_amount: u128,
 ) -> Result<()> {
+    require!(!ctx.accounts.config.halted, ErrorCode::SystemHalted);
     require!(
         !from_chain.is_empty()
             && !to_chain.is_empty()

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/post_collateral.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/post_collateral.rs
@@ -33,6 +33,7 @@ pub struct PostCollateral<'info> {
 }
 
 pub fn handler(ctx: Context<PostCollateral>, amount: u64) -> Result<()> {
+    require!(!ctx.accounts.config.halted, ErrorCode::SystemHalted);
     require!(amount > 0, ErrorCode::InvalidAmount);
 
     let miner_key = ctx.accounts.miner.key();

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/vote_activate.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/vote_activate.rs
@@ -39,6 +39,7 @@ pub struct VoteActivate<'info> {
 }
 
 pub fn handler(ctx: Context<VoteActivate>) -> Result<()> {
+    require!(!ctx.accounts.config.halted, ErrorCode::SystemHalted);
     require!(!ctx.accounts.miner_state.active, ErrorCode::MinerAlreadyActive);
     require!(
         ctx.accounts.miner_state.collateral >= ctx.accounts.config.min_collateral,

--- a/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
@@ -64,6 +64,11 @@ pub mod allways_swap_manager {
     pub fn set_consensus_threshold(ctx: Context<AdminConfig>, percent: u8) -> Result<()> {
         admin::set_consensus_threshold(ctx, percent)
     }
+    /// Emergency halt: admin toggles the global halt flag (gates deposits / activations /
+    /// reservation pools, mirroring the ink! `set_halted`).
+    pub fn set_halted(ctx: Context<AdminConfig>, halted: bool) -> Result<()> {
+        admin::set_halted(ctx, halted)
+    }
     /// Phase 8: set a validator's draw weight (admin bootstrap/fallback; superseded for routine use
     /// by the Phase 10 consensus path below).
     pub fn set_validator_weight(

--- a/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
@@ -42,6 +42,8 @@ pub struct Config {
     pub validators: Vec<ValidatorInfo>,
     /// Unix timestamp of the last consensus weight update (0 = never). Gates the update cadence floor.
     pub last_weights_update: i64,
+    /// Emergency halt: when true, new deposits / activations / reservation pools are rejected.
+    pub halted: bool,
     /// Stored PDA bump.
     pub bump: u8,
 }

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
@@ -481,7 +481,7 @@ fn onchain_initialize_creates_config() {
     let admin = admin_keypair();
     let cfg = read_config(&rpc);
     assert_eq!(cfg.admin, admin.pubkey(), "admin recorded");
-    assert_eq!(cfg.version, 4, "schema version");
+    assert_eq!(cfg.version, 5, "schema version");
     assert_eq!(cfg.min_collateral, MIN_COLLATERAL);
     assert_eq!(cfg.consensus_threshold_percent, THRESHOLD);
     assert_eq!(cfg.fulfillment_timeout_secs, TIMEOUT_SECS);


### PR DESCRIPTION
Ports the ink! `set_halted` emergency halt into the Solana contract, faithfully and surgically.

## Scan
Every halt touchpoint in the ink! contract was enumerated. Halt gated exactly **3** mutating entrypoints: `post_collateral`, `vote_reserve`, `vote_activate`.

## Mapping
| ink! gate | Solana gate |
|---|---|
| `post_collateral` | `post_collateral` ✅ |
| `vote_activate` | `vote_activate` ✅ |
| `vote_reserve` | `open_or_request` (the reservation-creation entry) ✅ |

`resolve_pool` is **not** gated — pools opened before a halt can still settle, mirroring ink! blocking only new reserve votes, not in-flight completion. `vote_initiate`/`confirm`/`timeout`/`vote_deactivate`/`withdraw` are not gated, matching ink!.

## Changes
- `Config.halted` field + `halted=false` at `initialize`
- `SystemHalted` error
- admin `set_halted` instruction + `HaltSet` event
- `require!(!config.halted, SystemHalted)` on the 3 entrypoints
- `CONFIG_VERSION` 4 → 5

Library type-checks clean. (Integration tests embed the built `.so` via `include_bytes!`, so they require `anchor build` to run.)