### PR TITLE
feat(solana): runtime config setters (re-target to contract-v2)

### DIFF
--- a/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
@@ -43,7 +43,8 @@ pub const POOL_SEED: &[u8] = b"pool";
 /// v3: Phase 9 (reservation lottery + flat reservation fee).
 /// v4: Phase 10 (consensus-governed validator weights).
 /// v5: emergency halt switch.
-pub const CONFIG_VERSION: u32 = 5;
+/// v6: runtime config setters (fee/window/interval promoted to Config).
+pub const CONFIG_VERSION: u32 = 6;
 
 /// Max validators in the whitelist (bounds the Config `validators` Vec and a round's voters).
 pub const MAX_VALIDATORS: usize = 16;
@@ -64,21 +65,19 @@ pub const REQ_SET_WEIGHTS: u8 = 8;
 /// Protocol fee divisor — 1% (immutable), `fee = sol_amount / FEE_DIVISOR`.
 pub const FEE_DIVISOR: u64 = 100;
 
-/// Flat anti-spam fee (lamports) a validator pays per reservation request (`open_or_request`),
-/// non-refundable → vault treasury. Static at deployment (Phase 9). Default 0.001 SOL.
+/// Initial flat anti-spam fee (lamports) per reservation request, seeded into Config at init and
+/// runtime-tunable via `set_reservation_fee`. Default 0.001 SOL.
 pub const RESERVATION_FEE_LAMPORTS: u64 = 1_000_000;
 
-/// Reservation-lottery pooling window (seconds): how long a pool collects requests before it can be
-/// resolved. Contending validators route within slots (~400ms), so a few seconds suffices; tune at
-/// deployment. Must stay well below the reservation TTL (separate windows). Static at deployment.
+/// Initial reservation-lottery pooling window (seconds), seeded into Config at init and tunable via
+/// `set_pool_window`. Must stay well below the reservation TTL (separate windows).
 pub const POOL_WINDOW_SECS: i64 = 3;
 
 /// Solana slot time (ms), used to pin the draw's future seed slot from the window duration.
 pub const SLOT_MS: u64 = 400;
 
-/// Phase 10: minimum seconds between successful validator-weight updates — a floor (anti-thrash /
-/// anti-grief), not a schedule. Validators' actual cadence (e.g. daily) is an off-chain policy ≥ this.
-/// Tunable at deployment.
+/// Initial minimum seconds between consensus weight updates — anti-thrash floor — seeded into Config
+/// at init and tunable via `set_weights_update_min_interval`.
 pub const WEIGHTS_UPDATE_MIN_INTERVAL_SECS: i64 = 3600;
 
 /// Bounded max lengths for stored strings (see SOLANA_MIGRATION_RESEARCH.md §14).

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/admin.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/admin.rs
@@ -62,3 +62,64 @@ pub fn set_halted(ctx: Context<AdminConfig>, halted: bool) -> Result<()> {
     msg!("halted = {}", halted);
     Ok(())
 }
+
+// --- Runtime config setters ( port of ink! owner setters; 0 = "unset" where applicable) ---
+
+pub fn set_min_collateral(ctx: Context<AdminConfig>, amount: u64) -> Result<()> {
+    ctx.accounts.config.min_collateral = amount;
+    msg!("min_collateral = {}", amount);
+    Ok(())
+}
+
+pub fn set_max_collateral(ctx: Context<AdminConfig>, amount: u64) -> Result<()> {
+    ctx.accounts.config.max_collateral = amount;
+    msg!("max_collateral = {}", amount);
+    Ok(())
+}
+
+pub fn set_fulfillment_timeout(ctx: Context<AdminConfig>, secs: i64) -> Result<()> {
+    require!(secs >= 60, ErrorCode::InvalidAmount);
+    ctx.accounts.config.fulfillment_timeout_secs = secs;
+    msg!("fulfillment_timeout_secs = {}", secs);
+    Ok(())
+}
+
+pub fn set_min_swap_amount(ctx: Context<AdminConfig>, amount: u64) -> Result<()> {
+    require!(amount == 0 || amount >= 1000, ErrorCode::InvalidAmount);
+    ctx.accounts.config.min_swap_amount = amount;
+    msg!("min_swap_amount = {}", amount);
+    Ok(())
+}
+
+pub fn set_max_swap_amount(ctx: Context<AdminConfig>, amount: u64) -> Result<()> {
+    ctx.accounts.config.max_swap_amount = amount;
+    msg!("max_swap_amount = {}", amount);
+    Ok(())
+}
+
+pub fn set_reservation_ttl(ctx: Context<AdminConfig>, secs: i64) -> Result<()> {
+    require!(secs > 0, ErrorCode::InvalidAmount);
+    ctx.accounts.config.reservation_ttl_secs = secs;
+    msg!("reservation_ttl_secs = {}", secs);
+    Ok(())
+}
+
+pub fn set_reservation_fee(ctx: Context<AdminConfig>, lamports: u64) -> Result<()> {
+    ctx.accounts.config.reservation_fee_lamports = lamports;
+    msg!("reservation_fee_lamports = {}", lamports);
+    Ok(())
+}
+
+pub fn set_pool_window(ctx: Context<AdminConfig>, secs: i64) -> Result<()> {
+    require!(secs > 0, ErrorCode::InvalidAmount);
+    ctx.accounts.config.pool_window_secs = secs;
+    msg!("pool_window_secs = {}", secs);
+    Ok(())
+}
+
+pub fn set_weights_update_min_interval(ctx: Context<AdminConfig>, secs: i64) -> Result<()> {
+    require!(secs >= 0, ErrorCode::InvalidAmount);
+    ctx.accounts.config.weights_update_min_interval_secs = secs;
+    msg!("weights_update_min_interval_secs = {}", secs);
+    Ok(())
+}

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/initialize.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/initialize.rs
@@ -1,6 +1,9 @@
 use anchor_lang::prelude::*;
 
-use crate::constants::{CONFIG_SEED, CONFIG_VERSION, VAULT_SEED};
+use crate::constants::{
+    CONFIG_SEED, CONFIG_VERSION, POOL_WINDOW_SECS, RESERVATION_FEE_LAMPORTS, VAULT_SEED,
+    WEIGHTS_UPDATE_MIN_INTERVAL_SECS,
+};
 use crate::error::ErrorCode;
 use crate::state::{Config, Vault};
 
@@ -62,6 +65,9 @@ pub fn handler(
     config.validators = Vec::new();
     config.last_weights_update = 0;
     config.halted = false;
+    config.reservation_fee_lamports = RESERVATION_FEE_LAMPORTS;
+    config.pool_window_secs = POOL_WINDOW_SECS;
+    config.weights_update_min_interval_secs = WEIGHTS_UPDATE_MIN_INTERVAL_SECS;
     config.bump = ctx.bumps.config;
 
     let vault = &mut ctx.accounts.vault;

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/open_or_request.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/open_or_request.rs
@@ -2,8 +2,8 @@ use anchor_lang::prelude::*;
 use anchor_lang::system_program::{transfer, Transfer};
 
 use crate::constants::{
-    CONFIG_SEED, MAX_ADDR_LEN, MAX_CHAIN_LEN, MINER_SEED, POOL_SEED, POOL_WINDOW_SECS, QUOTE_SEED,
-    RESERVATION_FEE_LAMPORTS, RESV_SEED, SLOT_MS, VAULT_SEED, MAX_VALIDATORS,
+    CONFIG_SEED, MAX_ADDR_LEN, MAX_CHAIN_LEN, MINER_SEED, POOL_SEED, QUOTE_SEED, RESV_SEED, SLOT_MS,
+    VAULT_SEED, MAX_VALIDATORS,
 };
 use crate::error::ErrorCode;
 use crate::events::{PoolOpened, ReservationRequested};
@@ -124,6 +124,7 @@ pub fn handler(
     require!(!active_reservation, ErrorCode::MinerReserved);
 
     // Flat, non-refundable anti-spam fee: validator → vault, accrued to treasury (every call).
+    let fee = ctx.accounts.config.reservation_fee_lamports;
     transfer(
         CpiContext::new(
             ctx.accounts.system_program.key(),
@@ -132,13 +133,13 @@ pub fn handler(
                 to: ctx.accounts.vault.to_account_info(),
             },
         ),
-        RESERVATION_FEE_LAMPORTS,
+        fee,
     )?;
     ctx.accounts.vault.treasury_total = ctx
         .accounts
         .vault
         .treasury_total
-        .checked_add(RESERVATION_FEE_LAMPORTS)
+        .checked_add(fee)
         .ok_or(ErrorCode::Overflow)?;
 
     let miner_key = ctx.accounts.miner.key();
@@ -162,10 +163,11 @@ pub fn handler(
             q.miner_to_addr.clone(),
             q.rate.clone(),
         );
+        let window = ctx.accounts.config.pool_window_secs;
         let seed_slot = clock
             .slot
-            .saturating_add((POOL_WINDOW_SECS as u64).saturating_mul(1000) / SLOT_MS);
-        let closes_at = now.saturating_add(POOL_WINDOW_SECS);
+            .saturating_add((window as u64).saturating_mul(1000) / SLOT_MS);
+        let closes_at = now.saturating_add(window);
 
         let pool = &mut ctx.accounts.pool;
         pool.miner = miner_key;

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/vote_set_weights.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/vote_set_weights.rs
@@ -1,7 +1,7 @@
 use anchor_lang::prelude::*;
 
 use crate::consensus::{record_vote, reset_round, weights_hash};
-use crate::constants::{CONFIG_SEED, REQ_SET_WEIGHTS, VOTE_SEED, WEIGHTS_UPDATE_MIN_INTERVAL_SECS};
+use crate::constants::{CONFIG_SEED, REQ_SET_WEIGHTS, VOTE_SEED};
 use crate::error::ErrorCode;
 use crate::events::ValidatorWeightsUpdated;
 use crate::state::{Config, VoteRound};
@@ -39,7 +39,8 @@ pub fn handler(ctx: Context<VoteSetWeights>, weights: Vec<u64>) -> Result<()> {
     // update (last_weights_update == 0) is always allowed.
     let last = ctx.accounts.config.last_weights_update;
     require!(
-        last == 0 || now.saturating_sub(last) >= WEIGHTS_UPDATE_MIN_INTERVAL_SECS,
+        last == 0
+            || now.saturating_sub(last) >= ctx.accounts.config.weights_update_min_interval_secs,
         ErrorCode::WeightsUpdateTooSoon
     );
 

--- a/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
@@ -69,6 +69,35 @@ pub mod allways_swap_manager {
     pub fn set_halted(ctx: Context<AdminConfig>, halted: bool) -> Result<()> {
         admin::set_halted(ctx, halted)
     }
+
+    // --- Runtime config setters (admin) ---
+    pub fn set_min_collateral(ctx: Context<AdminConfig>, amount: u64) -> Result<()> {
+        admin::set_min_collateral(ctx, amount)
+    }
+    pub fn set_max_collateral(ctx: Context<AdminConfig>, amount: u64) -> Result<()> {
+        admin::set_max_collateral(ctx, amount)
+    }
+    pub fn set_fulfillment_timeout(ctx: Context<AdminConfig>, secs: i64) -> Result<()> {
+        admin::set_fulfillment_timeout(ctx, secs)
+    }
+    pub fn set_min_swap_amount(ctx: Context<AdminConfig>, amount: u64) -> Result<()> {
+        admin::set_min_swap_amount(ctx, amount)
+    }
+    pub fn set_max_swap_amount(ctx: Context<AdminConfig>, amount: u64) -> Result<()> {
+        admin::set_max_swap_amount(ctx, amount)
+    }
+    pub fn set_reservation_ttl(ctx: Context<AdminConfig>, secs: i64) -> Result<()> {
+        admin::set_reservation_ttl(ctx, secs)
+    }
+    pub fn set_reservation_fee(ctx: Context<AdminConfig>, lamports: u64) -> Result<()> {
+        admin::set_reservation_fee(ctx, lamports)
+    }
+    pub fn set_pool_window(ctx: Context<AdminConfig>, secs: i64) -> Result<()> {
+        admin::set_pool_window(ctx, secs)
+    }
+    pub fn set_weights_update_min_interval(ctx: Context<AdminConfig>, secs: i64) -> Result<()> {
+        admin::set_weights_update_min_interval(ctx, secs)
+    }
     /// Phase 8: set a validator's draw weight (admin bootstrap/fallback; superseded for routine use
     /// by the Phase 10 consensus path below).
     pub fn set_validator_weight(

--- a/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
@@ -44,6 +44,12 @@ pub struct Config {
     pub last_weights_update: i64,
     /// Emergency halt: when true, new deposits / activations / reservation pools are rejected.
     pub halted: bool,
+    /// Flat anti-spam fee per reservation request, lamports (runtime-tunable; 0 disables).
+    pub reservation_fee_lamports: u64,
+    /// Reservation-lottery pooling window, seconds (runtime-tunable).
+    pub pool_window_secs: i64,
+    /// Minimum seconds between consensus weight updates (runtime-tunable anti-thrash floor).
+    pub weights_update_min_interval_secs: i64,
     /// Stored PDA bump.
     pub bump: u8,
 }

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
@@ -481,7 +481,7 @@ fn onchain_initialize_creates_config() {
     let admin = admin_keypair();
     let cfg = read_config(&rpc);
     assert_eq!(cfg.admin, admin.pubkey(), "admin recorded");
-    assert_eq!(cfg.version, 5, "schema version");
+    assert_eq!(cfg.version, 6, "schema version");
     assert_eq!(cfg.min_collateral, MIN_COLLATERAL);
     assert_eq!(cfg.consensus_threshold_percent, THRESHOLD);
     assert_eq!(cfg.fulfillment_timeout_secs, TIMEOUT_SECS);


### PR DESCRIPTION
Re-lands the runtime config setters directly on `contract-v2`.

**Why this exists:** #483 was opened with base `feat/solana-halt` and got merged into *that* branch instead of `contract-v2`, so the setters never reached `contract-v2`. #483 is closed/merged and can't be retargeted, so this is a fresh PR with the same changes cherry-picked onto current `contract-v2`. Supersedes #483.

## Contents (identical to #483)
- **6 ink! parity setters:** `set_min_collateral`, `set_max_collateral`, `set_fulfillment_timeout`, `set_min_swap_amount`, `set_max_swap_amount`, `set_reservation_ttl`.
- **3 new tunables promoted to runtime Config:** `reservation_fee_lamports`, `pool_window_secs`, `weights_update_min_interval_secs` (consts now seed defaults at `initialize`; handlers read from Config).
- Floors translated to sensible secs/lamports (`timeout >= 60`, `min_swap 0 || >= 1000`, `ttl/window > 0`); guard failures reuse `InvalidAmount`; `msg!`-only (matches existing setters).
- `CONFIG_VERSION` 5 → 6.

Cherry-picked clean onto current `contract-v2`; type-checks clean. Touches different hunks than #485 (pool-busy), so the two don't conflict.