### PR TITLE
feat(solana): charge churn fee on remove_quote (close-recreate bypass)

### DIFF
--- a/smart-contracts/solana/programs/allways_swap_manager/src/events.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/events.rs
@@ -93,6 +93,9 @@ pub struct QuoteRemoved {
     pub miner: Pubkey,
     pub from_chain: String,
     pub to_chain: String,
+    /// Anti-flashing churn fee paid into the treasury on removal (lamports); 0 once the quote has
+    /// stood past the decay window. Mirrors `QuoteSet.update_fee` so close-then-recreate can't dodge it.
+    pub remove_fee: u64,
 }
 
 // --- Phase 9: reservation lottery (pool keyed per miner) ---

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/remove_quote.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/remove_quote.rs
@@ -1,11 +1,16 @@
 use anchor_lang::prelude::*;
+use anchor_lang::system_program::{transfer, Transfer};
 
-use crate::constants::QUOTE_SEED;
+use crate::constants::{QUOTE_SEED, VAULT_SEED};
+use crate::error::ErrorCode;
 use crate::events::QuoteRemoved;
-use crate::state::MinerQuote;
+use crate::state::{MinerQuote, Vault};
+use crate::tunables::quote_update_fee;
 
 /// Miner removes one of its quotes. The PDA is closed (`close = miner`) and its rent refunded to the
-/// miner. `has_one = miner` ensures only the owner can remove it.
+/// miner. `has_one = miner` ensures only the owner can remove it. Removing a still-fresh quote pays
+/// the same decaying anti-flashing fee as an in-place update (`set_quote`), so close-then-recreate
+/// can't dodge the churn fee.
 #[derive(Accounts)]
 #[instruction(from_chain: String, to_chain: String)]
 pub struct RemoveQuote<'info> {
@@ -20,13 +25,40 @@ pub struct RemoveQuote<'info> {
         bump = quote.bump,
     )]
     pub quote: Account<'info, MinerQuote>,
+
+    /// Treasury sink for the churn fee (native lamports accrue here).
+    #[account(mut, seeds = [VAULT_SEED], bump = vault.bump)]
+    pub vault: Account<'info, Vault>,
+
+    pub system_program: Program<'info, System>,
 }
 
 pub fn handler(ctx: Context<RemoveQuote>, from_chain: String, to_chain: String) -> Result<()> {
+    let now = Clock::get()?.unix_timestamp;
+    let fee = quote_update_fee(now.saturating_sub(ctx.accounts.quote.updated_at));
+    if fee > 0 {
+        transfer(
+            CpiContext::new(
+                ctx.accounts.system_program.key(),
+                Transfer {
+                    from: ctx.accounts.miner.to_account_info(),
+                    to: ctx.accounts.vault.to_account_info(),
+                },
+            ),
+            fee,
+        )?;
+        let vault = &mut ctx.accounts.vault;
+        vault.treasury_total = vault
+            .treasury_total
+            .checked_add(fee)
+            .ok_or(ErrorCode::Overflow)?;
+    }
+
     emit!(QuoteRemoved {
         miner: ctx.accounts.miner.key(),
         from_chain,
         to_chain,
+        remove_fee: fee,
     });
     Ok(())
 }

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
@@ -891,8 +891,13 @@ fn remove_quote_ix(m: &Pubkey, from_chain: &str, to_chain: &str) -> Instruction 
             to_chain: to_chain.to_string(),
         }
         .data(),
-        allways_swap_manager::accounts::RemoveQuote { miner: *m, quote: quote_pda(m, from_chain, to_chain) }
-            .to_account_metas(None),
+        allways_swap_manager::accounts::RemoveQuote {
+            miner: *m,
+            quote: quote_pda(m, from_chain, to_chain),
+            vault: vault_pda(),
+            system_program: SYSTEM_PROGRAM,
+        }
+        .to_account_metas(None),
     )
 }
 

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_quote.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_quote.rs
@@ -137,6 +137,8 @@ fn remove_quote_ix(
         allways_swap_manager::accounts::RemoveQuote {
             miner: *miner,
             quote: quote_pda(program_id, miner, from_chain, to_chain),
+            vault: vault_pda(program_id),
+            system_program: SYSTEM_PROGRAM,
         }
         .to_account_metas(None),
     )
@@ -239,10 +241,13 @@ fn test_remove_quote_closes_and_refunds() {
     svm.airdrop(&miner.pubkey(), 10_000_000_000).unwrap();
     let m = miner.pubkey();
 
+    set_clock(&mut svm, 1_000_000);
     send(&mut svm, set_quote_ix(&program_id, &m, "btc", "tao", "a", "b", "340", 1), &m, &miner).expect("set");
     let before = svm.get_account(&m).unwrap().lamports;
     assert!(svm.get_account(&quote_pda(&program_id, &m, "btc", "tao")).map(|a| a.lamports > 0).unwrap_or(false));
 
+    // Let the quote stand past the decay window so removal is fee-free — isolates the rent refund.
+    set_clock(&mut svm, 1_000_000 + QUOTE_UPDATE_FEE_TIER2_MAX_SECS + 1);
     send(&mut svm, remove_quote_ix(&program_id, &m, "btc", "tao"), &m, &miner).expect("remove");
     let after = svm.get_account(&m).unwrap().lamports;
     // PDA gone (zero lamports / closed) and rent refunded to miner.
@@ -283,6 +288,30 @@ fn test_quote_update_fee_decays() {
     );
     send(&mut svm, set_quote_ix(&program_id, &m, "btc", "tao", "a", "b", "343", 1), &m, &miner).expect("free update");
     assert_eq!(treasury(&svm, &program_id), after_t2, "long-standing quote updates for free");
+}
+
+#[test]
+fn test_remove_fresh_quote_charges_churn_fee() {
+    // Closing a fresh quote pays the same decaying fee as an in-place update, so the
+    // remove-then-recreate path can't be used to dodge the anti-flashing fee.
+    let (mut svm, program_id) = setup();
+    let miner = Keypair::new();
+    svm.airdrop(&miner.pubkey(), 10_000_000_000).unwrap();
+    let m = miner.pubkey();
+    set_clock(&mut svm, 1_000_000);
+
+    // Create (free), then remove immediately (elapsed 0 < 5 min) → tier-1 fee to treasury.
+    send(&mut svm, set_quote_ix(&program_id, &m, "btc", "tao", "a", "b", "340", 1), &m, &miner).expect("create");
+    assert_eq!(treasury(&svm, &program_id), 0, "creation charges no fee");
+    send(&mut svm, remove_quote_ix(&program_id, &m, "btc", "tao"), &m, &miner).expect("remove fresh");
+    assert_eq!(treasury(&svm, &program_id), QUOTE_UPDATE_FEE_TIER1_LAMPORTS, "fresh remove charges tier-1");
+
+    // Recreate, let it stand past the decay window, then remove → free (symmetric with set_quote).
+    send(&mut svm, set_quote_ix(&program_id, &m, "btc", "tao", "a", "b", "341", 1), &m, &miner).expect("recreate");
+    set_clock(&mut svm, 1_000_000 + QUOTE_UPDATE_FEE_TIER2_MAX_SECS + 1);
+    let before = treasury(&svm, &program_id);
+    send(&mut svm, remove_quote_ix(&program_id, &m, "btc", "tao"), &m, &miner).expect("remove stale");
+    assert_eq!(treasury(&svm, &program_id), before, "long-standing remove is free");
 }
 
 #[test]


### PR DESCRIPTION
Closes a bypass in the #484 anti-flashing quote fee.

## The hole
`set_quote` detects "first creation" (free) by a zeroed quote PDA. But `remove_quote` does `close = miner` — it deletes the PDA and refunds rent. So:

1. `remove_quote` → PDA closed, rent back
2. `set_quote` → fresh PDA → `miner == default` → **fee = 0**

Net cost to flash-bypass ≈ tx fees + a rent round-trip (a wash). The 0.01 SOL churn fee is fully dodged.

## Fix
`remove_quote` charges the **same** `quote_update_fee`, keyed off how long the quote stood. Disturbing a fresh quote costs the same whether you overwrite it in place or close-then-recreate; a long-standing quote still removes free.

- `RemoveQuote` gains `vault` + `system_program` (mirrors `SetQuote`)
- `QuoteRemoved` gains `remove_fee`

## Tests
- New `test_remove_fresh_quote_charges_churn_fee`: fresh remove → tier-1; stale remove → free
- `test_remove_quote_closes_and_refunds`: warps past the decay window so it stays a pure rent-refund check
- On-chain + integration remove-quote helpers updated for the new accounts

> Built against `contract-v2` (host `cargo check` clean). LiteSVM/e2e need the SBF toolchain — not run locally.