### PR TITLE
chore(solana): compress verbose comment blocks (comments only)

### DIFF
--- a/smart-contracts/solana/programs/allways_swap_manager/src/consensus.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/consensus.rs
@@ -6,14 +6,13 @@ use crate::error::ErrorCode;
 use crate::state::{Config, ValidatorInfo, VoteRound};
 
 /// Canonical bound hash for a vote round, from (request_type, target pubkey).
-/// Later phases extend the preimage with amounts/addresses the seeds don't cover.
 pub fn request_hash(request_type: u8, target: &Pubkey) -> [u8; 32] {
     hashv(&[&[request_type], target.as_ref()]).to_bytes()
 }
 
 /// Bound hash for an initiate round — binds the user-side payout fields the seeds/reservation don't
-/// cover (closes v2 #2 / #411: `user`, `user_from_addr`, `user_to_addr`, `from_tx_block`). The
-/// miner quote + amounts come from the immutable reservation, so they need not be re-bound here.
+/// cover (`user`, `user_from_addr`, `user_to_addr`, `from_tx_block`). Miner quote + amounts come
+/// from the immutable reservation, so they need not be re-bound here.
 #[allow(clippy::too_many_arguments)]
 pub fn initiate_hash(
     miner: &Pubkey,
@@ -36,13 +35,13 @@ pub fn initiate_hash(
 }
 
 /// Bound hash for a swap-keyed round (confirm/timeout). All params live in the seeds (`swap_key`),
-/// so this is a trivial binding like activate/deactivate.
+/// so the binding is trivial.
 pub fn swap_request_hash(request_type: u8, swap_key: &[u8; 32]) -> [u8; 32] {
     hashv(&[&[request_type], swap_key]).to_bytes()
 }
 
-/// Bound hash for the validator-weight round (Phase 10): binds the full snapshot —
-/// `REQ_SET_WEIGHTS || (each validator key in config order) || (each weight LE)`. Binding the keys too
+/// Bound hash for the validator-weight round: binds the full snapshot —
+/// `REQ_SET_WEIGHTS || (each validator key in config order) || (each weight LE)`. Binding the keys
 /// means a validator-set change between voters invalidates the round (hash mismatch), so a stale
 /// vector can't be applied to a changed set. `validators` and `weights` are index-aligned.
 pub fn weights_hash(validators: &[ValidatorInfo], weights: &[u64]) -> [u8; 32] {
@@ -74,9 +73,8 @@ pub fn record_vote<'info>(
         ErrorCode::NotValidator
     );
 
-    // An empty voter list means no open round (freshly allocated, or reset after a prior
-    // round closed) — robust regardless of the clock's absolute value. A non-empty but
-    // expired round is treated as stale and reopened.
+    // Empty voter list means no open round (fresh or reset) — robust regardless of the clock's
+    // absolute value. A non-empty but expired round is stale and reopened.
     let stale =
         !round.voters.is_empty() && now.saturating_sub(round.created_at) > VOTE_ROUND_TTL_SECS;
     if round.voters.is_empty() || stale {

--- a/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
@@ -30,20 +30,15 @@ pub const SWAP_SEED: &[u8] = b"swap";
 pub const TX_SEED: &[u8] = b"tx";
 
 /// PDA seed prefix for a miner's standing per-pair quote
-/// (`seeds = [QUOTE_SEED, miner_pubkey, from_chain, to_chain]`). Phase 8.
+/// (`seeds = [QUOTE_SEED, miner_pubkey, from_chain, to_chain]`).
 #[constant]
 pub const QUOTE_SEED: &[u8] = b"quote";
 
-/// PDA seed prefix for a per-miner reservation-lottery pool (`seeds = [POOL_SEED, miner]`). Phase 9.
+/// PDA seed prefix for a per-miner reservation-lottery pool (`seeds = [POOL_SEED, miner]`).
 #[constant]
 pub const POOL_SEED: &[u8] = b"pool";
 
 /// On-chain schema/version, surfaced for upgrade tracking. Bumped as phases land.
-/// v2: Phase 8 (on-chain miner quotes + per-validator weights).
-/// v3: Phase 9 (reservation lottery + flat reservation fee).
-/// v4: Phase 10 (consensus-governed validator weights).
-/// v5: emergency halt switch.
-/// v6: runtime config setters (fee/window/interval promoted to Config).
 pub const CONFIG_VERSION: u32 = 6;
 
 /// Max validators in the whitelist (bounds the Config `validators` Vec and a round's voters).
@@ -52,26 +47,23 @@ pub const MAX_VALIDATORS: usize = 16;
 /// A vote round older than this (seconds) is treated as stale and reset before recording a new vote.
 pub const VOTE_ROUND_TTL_SECS: i64 = 1800;
 
-/// Request types (keys into a vote round). Mirror the ink! contract's request enum.
-/// (REQ_RESERVE removed in Phase 9 — reservations are now lottery-based, not consensus-voted.)
+/// Request types (keys into a vote round). REQ_RESERVE is gone: reservations are lottery-based.
 pub const REQ_ACTIVATE: u8 = 0;
 pub const REQ_INITIATE: u8 = 2;
 pub const REQ_DEACTIVATE: u8 = 5;
 pub const REQ_CONFIRM: u8 = 6;
 pub const REQ_TIMEOUT: u8 = 7;
-/// Phase 10: global (non-per-target) round for the validator-weight vector.
+/// Global (non-per-target) round for the validator-weight vector.
 pub const REQ_SET_WEIGHTS: u8 = 8;
 
-// NOTE: deploy-time **economic** levers (FEE_DIVISOR, RESERVATION_FEE_LAMPORTS, POOL_WINDOW_SECS,
-// WEIGHTS_UPDATE_MIN_INTERVAL_SECS, plus the collateral & quote-fee knobs) now live in `tunables.rs`
-// — one home for everything you might retune at deploy. This file keeps only **structural** constants
-// (seeds, request-type bytes, max lengths, chain facts).
+// Deploy-time economic levers live in `tunables.rs`. This file keeps only structural
+// constants (seeds, request-type bytes, max lengths, chain facts).
 
-/// Solana slot time (ms) — a chain property (not an economic lever), used with
-/// `tunables::POOL_WINDOW_SECS` to pin the draw's future seed slot from the window duration.
+/// Solana slot time (ms): a chain property, paired with `tunables::POOL_WINDOW_SECS` to pin
+/// the draw's future seed slot.
 pub const SLOT_MS: u64 = 400;
 
-/// Bounded max lengths for stored strings (see SOLANA_MIGRATION_RESEARCH.md §14).
+/// Bounded max lengths for stored strings.
 pub const MAX_ADDR_LEN: usize = 80;
 pub const MAX_CHAIN_LEN: usize = 16;
 pub const MAX_RATE_LEN: usize = 32;

--- a/smart-contracts/solana/programs/allways_swap_manager/src/events.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/events.rs
@@ -1,9 +1,8 @@
 use anchor_lang::prelude::*;
 
-/// Collateral-affecting events carry the **resulting total**, not a blind delta — so any consumer
-/// can set an absolute baseline from a single event instead of accumulating from an unknown start
-/// (v2 cleanup #5; the missing-baseline footgun behind the v1.0.9 mass-recycle outage). Phase 4's
-/// fee/slash events MUST follow the same post-total rule.
+/// Collateral events carry the resulting total, not a delta — so a consumer can set an absolute
+/// baseline from one event instead of accumulating from an unknown start. Fee/slash events follow
+/// the same post-total rule.
 #[event]
 pub struct CollateralPosted {
     pub miner: Pubkey,
@@ -69,7 +68,7 @@ pub struct TreasuryWithdrawn {
     pub recipient: Pubkey,
     /// Amount withdrawn this call (lamports).
     pub amount: u64,
-    /// Treasury balance remaining after this call (lamports) — post-total per the §5 convention.
+    /// Treasury balance remaining after this call (lamports) — post-total per convention.
     pub total: u64,
 }
 

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/open_or_request.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/open_or_request.rs
@@ -9,10 +9,9 @@ use crate::error::ErrorCode;
 use crate::events::{PoolOpened, ReservationRequested};
 use crate::state::{Config, MinerQuote, MinerState, Pool, Request, Reservation, Vault};
 
-/// A validator opens (or joins) a per-miner reservation-lottery pool for a specific pair. The first
-/// caller opens the pool and pins the miner's on-chain quote for `(from_chain, to_chain)`; later
-/// in-window callers add one request each (same pinned pair). EVERY call pays a flat, non-refundable
-/// reservation fee (validator → vault treasury) — the anti-spam gate against reserving every pool.
+/// A validator opens (or joins) a per-miner reservation-lottery pool for a pair. First caller opens
+/// and pins the miner's quote; later in-window callers add one request each (same pinned pair). Every
+/// call pays a flat, non-refundable reservation fee (validator -> vault) — the anti-spam gate.
 #[derive(Accounts)]
 #[instruction(from_chain: String, to_chain: String)]
 pub struct OpenOrRequest<'info> {
@@ -33,8 +32,7 @@ pub struct OpenOrRequest<'info> {
     )]
     pub miner_state: Account<'info, MinerState>,
 
-    /// The miner's standing quote for this pair — must exist (can't pool a pair the miner doesn't
-    /// quote). Pinned into the Pool snapshot at open.
+    /// The miner's standing quote for this pair — must exist; pinned into the Pool snapshot at open.
     #[account(
         seeds = [QUOTE_SEED, miner.key().as_ref(), from_chain.as_bytes(), to_chain.as_bytes()],
         bump = quote.bump,
@@ -53,9 +51,8 @@ pub struct OpenOrRequest<'info> {
     #[account(mut, seeds = [VAULT_SEED], bump = vault.bump)]
     pub vault: Account<'info, Vault>,
 
-    /// The per-miner reservation slot — created empty on first open, checked so a new contest can't be
-    /// opened while a reservation is still active (it would overwrite the winner's hold). Populated by
-    /// `resolve_pool`.
+    /// The per-miner reservation slot — checked so a new contest can't be opened while a reservation
+    /// is still active (it would overwrite the winner's hold). Populated by `resolve_pool`.
     #[account(
         init_if_needed,
         payer = validator,

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/resolve_pool.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/resolve_pool.rs
@@ -10,13 +10,13 @@ use crate::lottery::{draw_seed, pick_weighted};
 use crate::state::{Config, MinerState, Pool, Reservation};
 
 /// Permissionless. After a pool's window closes, run the stake-weighted draw over its requests and
-/// create the (unchanged) `Reservation` for the winning request's taker. Resets the pool for reuse.
+/// create the `Reservation` for the winner, then reset the pool for reuse.
 ///
-/// Randomness (Level 1): `seed = keccak(pool_key || SlotHashes[seed_slot])` — a future slot pinned at
-/// open, unknown then, fixed once produced. If that slot hasn't been produced yet → `SeedNotReady`
-/// (retry). If it has rolled off the SlotHashes window (or the sysvar is empty, e.g. LiteSVM) → a
-/// deterministic fallback seed keeps the pool resolvable (residual grind is bounded; a reservation
-/// only grants a hold — moving funds still needs `vote_initiate` consensus + a real on-chain tx).
+/// Randomness: `seed = keccak(pool_key || SlotHashes[seed_slot])` — a future slot pinned at open,
+/// unknown then, fixed once produced. If that slot rolled off the SlotHashes window (or the sysvar is
+/// empty, e.g. LiteSVM) a deterministic fallback keeps the pool resolvable; residual grind is bounded
+/// since a reservation only grants a hold — moving funds still needs `vote_initiate` consensus + a
+/// real on-chain tx.
 #[derive(Accounts)]
 pub struct ResolvePool<'info> {
     #[account(mut)]
@@ -62,17 +62,15 @@ pub fn handler(ctx: Context<ResolvePool>) -> Result<()> {
     require!(!ctx.accounts.pool.requests.is_empty(), ErrorCode::NoRequests);
     require!(now > ctx.accounts.pool.closes_at, ErrorCode::PoolNotClosed);
     // No active check: a miner force-deactivated mid-window still resolves into a reservation that
-    // simply expires unused (validators won't initiate). Keeps the pool from wedging open.
+    // expires unused — keeps the pool from wedging open.
 
     let pool_key = ctx.accounts.pool.key();
     let seed_slot = ctx.accounts.pool.seed_slot;
 
-    // Resolve the seed slot's hash from the SlotHashes sysvar (descending by slot, 40 bytes/entry
-    // after an 8-byte count). The time window (now > closes_at) guarantees the pinned slot is
-    // produced by the time this is callable on a real chain, so the exact match is the normal path.
-    // If it's absent — rolled off the ~512-slot window, or an empty sysvar under LiteSVM — fall back
-    // to a deterministic seed so the pool stays resolvable (bounded residual; a reservation is only
-    // a hold — funds still need vote_initiate consensus + a real on-chain tx).
+    // Resolve the seed slot's hash from SlotHashes (descending by slot, 40 bytes/entry after an
+    // 8-byte count). The time window (now > closes_at) guarantees the pinned slot is produced on a
+    // real chain, so the exact match is the normal path; absence (rolled off, or empty under LiteSVM)
+    // takes the deterministic fallback below.
     let slot_hash: Option<[u8; 32]> = {
         let data = ctx.accounts.slot_hashes.try_borrow_data()?;
         let mut found = None;
@@ -102,8 +100,8 @@ pub fn handler(ctx: Context<ResolvePool>) -> Result<()> {
         None => draw_seed(&pool_key, &seed_slot.to_le_bytes()),
     };
 
-    // Weights aligned with requests: each request's validator weight from the config set (0 if it has
-    // been removed). pick_weighted falls back to uniform if every weight is 0.
+    // Weight per request = its validator's config weight (0 if removed). pick_weighted falls back to
+    // uniform if every weight is 0.
     let weights: Vec<u64> = ctx
         .accounts
         .pool
@@ -136,7 +134,7 @@ pub fn handler(ctx: Context<ResolvePool>) -> Result<()> {
     };
 
     // Create the Reservation for the winner — same shape vote_reserve produced, so everything
-    // downstream (vote_initiate/fulfill/confirm/timeout) is unchanged.
+    // downstream is unchanged.
     let ttl = ctx.accounts.config.reservation_ttl_secs;
     let reservation_bump = ctx.bumps.reservation;
     let r = &mut ctx.accounts.reservation;

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/set_quote.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/set_quote.rs
@@ -7,13 +7,10 @@ use crate::events::QuoteSet;
 use crate::state::{MinerQuote, Vault};
 use crate::tunables::quote_update_fee;
 
-/// Miner publishes (or overwrites) its standing quote for one pair-direction. Permissionless: any
-/// signer may post — a quote is advertised data that can't move funds, rent self-limits spam, and
-/// the validator/UI filters to registered miners. `(from_chain, to_chain)` ordering encodes the
-/// direction, so the reverse direction is a separate quote (no `counter_rate`). First call lazily
-/// creates the PDA (miner pays rent) and is otherwise free; subsequent calls overwrite in place and
-/// pay a **decaying anti-flashing fee** (`tunables::quote_update_fee`) into the vault treasury — high
-/// for rapid churn, zero once a quote has stood long enough.
+/// Miner publishes (or overwrites) its standing quote for one pair-direction. Permissionless: a quote
+/// is advertised data that can't move funds and rent self-limits spam. First call creates the PDA
+/// (free); subsequent calls overwrite in place and pay a decaying anti-flashing fee
+/// (`tunables::quote_update_fee`) into the vault treasury — high for rapid churn, zero once stable.
 #[derive(Accounts)]
 #[instruction(from_chain: String, to_chain: String)]
 pub struct SetQuote<'info> {
@@ -45,8 +42,7 @@ pub fn handler(
     rate: String,
     liquidity: u128,
 ) -> Result<()> {
-    // Mechanical sanity only — chain identity/validity is the off-chain layer's call (chains are
-    // opaque bounded strings on-chain).
+    // Mechanical sanity only — chains are opaque bounded strings; validity is the off-chain layer's call.
     require!(
         !from_chain.is_empty()
             && !to_chain.is_empty()
@@ -70,9 +66,8 @@ pub fn handler(
     let miner_key = ctx.accounts.miner.key();
     let bump = ctx.bumps.quote;
 
-    // Anti-flashing churn fee: charged only when overwriting an existing quote (a fresh PDA has a
-    // zeroed `miner`), and decaying to zero the longer the prior quote stood. Fee → vault treasury,
-    // preserving the vault invariant (lamports == rent + total_collateral + treasury_total).
+    // Anti-flashing churn fee: only when overwriting (fresh PDA has zeroed `miner`), decaying to zero
+    // the longer the prior quote stood. Fee -> vault treasury, preserving the vault invariant.
     let fee = if ctx.accounts.quote.miner != Pubkey::default() {
         quote_update_fee(now.saturating_sub(ctx.accounts.quote.updated_at))
     } else {

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/timeout_swap.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/timeout_swap.rs
@@ -7,9 +7,8 @@ use crate::events::SwapTimedOut;
 use crate::penalty::apply_penalty;
 use crate::state::{Config, MinerState, Swap, SwapStatus, Vault, VoteRound};
 
-/// Validators time out a swap whose deadline passed. On quorum the miner's collateral is slashed up
-/// to the swap size and refunded to the user (native lamports, vault → user), the miner is freed,
-/// and the Swap account is closed.
+/// Validators time out a swap whose deadline passed. On quorum the miner's collateral is slashed and
+/// refunded to the user (vault -> user), the miner is freed, and the Swap account is closed.
 #[derive(Accounts)]
 #[instruction(swap_key: [u8; 32])]
 pub struct TimeoutSwap<'info> {
@@ -87,10 +86,9 @@ pub fn handler(ctx: Context<TimeoutSwap>, swap_key: [u8; 32]) -> Result<()> {
         let miner = ctx.accounts.swap.miner;
         let min_collateral = ctx.accounts.config.min_collateral;
 
-        // v2 #4: a failed swap is penalized at the over-collateralization multiplier (1.10×), and
-        // the entire slash is refunded to the wronged user (made more than whole). The 1.1× initiate
-        // guard + one-swap-at-a-time invariant guarantee the miner can cover it; apply_penalty still
-        // clamps to available collateral as a safety net.
+        // Penalize at the over-collateralization multiplier and refund the whole slash to the user.
+        // The initiate-time gate + one-swap-at-a-time invariant guarantee the miner can cover it;
+        // apply_penalty still clamps to available collateral as a safety net.
         let penalty = crate::tunables::required_collateral(sol_amount);
 
         let slash = apply_penalty(

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/vote_initiate.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/vote_initiate.rs
@@ -10,10 +10,9 @@ use crate::error::ErrorCode;
 use crate::events::SwapInitiated;
 use crate::state::{Config, MinerState, Reservation, Swap, SwapStatus, TxMarker, VoteRound};
 
-/// A validator votes to initiate a swap against an active reservation. The miner quote
-/// (addresses/rate/amounts/chains) is sourced from the immutable Reservation — never from args
-/// (v2 #1b). The bound hash binds the user-side payout fields (v2 #2). On quorum the Swap is created,
-/// the source-tx replay marker is set, and the reservation is consumed.
+/// A validator votes to initiate a swap against an active reservation. Miner quote terms are sourced
+/// from the immutable Reservation — never from args; the bound hash binds the user-side payout fields.
+/// On quorum the Swap is created, the source-tx replay marker is set, and the reservation is consumed.
 #[derive(Accounts)]
 #[instruction(swap_key: [u8; 32])]
 pub struct VoteInitiate<'info> {
@@ -98,8 +97,8 @@ pub fn handler(
             ErrorCode::NoReservation
         );
         require!(user_from_address == resv.from_addr, ErrorCode::UserMismatch);
-        // Over-collateralization gate (v2 #4): the miner must hold the swap size scaled by the
-        // tunable requirement (1.10× today), so a failed swap has a slash buffer beyond 1:1.
+        // Over-collateralization gate: miner must hold the swap size x the tunable requirement,
+        // so a failed swap has a slash buffer beyond 1:1.
         require!(
             ctx.accounts.miner_state.collateral >= crate::tunables::required_collateral(resv.sol_amount),
             ErrorCode::InsufficientCollateral

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/vote_set_weights.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/vote_set_weights.rs
@@ -6,11 +6,9 @@ use crate::error::ErrorCode;
 use crate::events::ValidatorWeightsUpdated;
 use crate::state::{Config, VoteRound};
 
-/// A validator votes to set the full validator-weight vector (Phase 10). Validators read every
-/// validator's stake off-chain, assemble a vector **index-aligned to `Config.validators`**, and submit
-/// it; on quorum the weights are saved. Everyone votes the same snapshot (hash-bound on keys+weights),
-/// so divergent vectors never co-count. Replaces the admin `set_validator_weight` stub for governance;
-/// the lottery draw already consumes `.weight`, so nothing downstream changes.
+/// A validator votes to set the full validator-weight vector. Validators submit a vector index-aligned
+/// to `Config.validators`; on quorum the weights are saved. Everyone votes the same snapshot
+/// (hash-bound on keys+weights), so divergent vectors never co-count.
 #[derive(Accounts)]
 pub struct VoteSetWeights<'info> {
     #[account(mut)]
@@ -35,8 +33,7 @@ pub struct VoteSetWeights<'info> {
 pub fn handler(ctx: Context<VoteSetWeights>, weights: Vec<u64>) -> Result<()> {
     let now = Clock::get()?.unix_timestamp;
 
-    // Cadence floor: weights can't be re-set faster than the minimum interval (anti-thrash). First
-    // update (last_weights_update == 0) is always allowed.
+    // Cadence floor (anti-thrash): can't re-set faster than the min interval; first update is always allowed.
     let last = ctx.accounts.config.last_weights_update;
     require!(
         last == 0

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/withdraw_collateral.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/withdraw_collateral.rs
@@ -5,10 +5,9 @@ use crate::error::ErrorCode;
 use crate::events::CollateralWithdrawn;
 use crate::state::{Config, MinerState, Vault};
 
-/// Miner withdraws SOL collateral back to their wallet. Guards mirror the ink! contract:
-/// miner must be inactive, have no in-flight swap, and (if deactivated) be past the
-/// post-deactivation cooldown (2× fulfillment timeout). Lamports move vault → miner via
-/// direct lamport math (the program owns the vault).
+/// Miner withdraws SOL collateral back to their wallet. Guards: miner must be inactive, have no
+/// in-flight swap, and (if deactivated) be past the post-deactivation cooldown (2x fulfillment
+/// timeout). Lamports move vault -> miner via direct lamport math (the program owns the vault).
 #[derive(Accounts)]
 pub struct WithdrawCollateral<'info> {
     #[account(mut)]

--- a/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
@@ -20,7 +20,7 @@ declare_id!("BtVm5a1hKvMrrEHQ876Ev23dYVZAkWpYkf86VZi3z1Li");
 pub mod allways_swap_manager {
     use super::*;
 
-    /// Phase 0–3: create Config + Vault with collateral bounds, timeout, consensus threshold,
+    /// Create Config + Vault with collateral bounds, timeout, consensus threshold,
     /// swap-size bounds, and reservation TTL.
     #[allow(clippy::too_many_arguments)]
     pub fn initialize(
@@ -45,17 +45,17 @@ pub mod allways_swap_manager {
         )
     }
 
-    /// Phase 1: miner deposits SOL collateral into the vault.
+    /// Miner deposits SOL collateral into the vault.
     pub fn post_collateral(ctx: Context<PostCollateral>, amount: u64) -> Result<()> {
         post_collateral::handler(ctx, amount)
     }
 
-    /// Phase 1: miner withdraws SOL collateral (subject to inactive / no-swap / cooldown guards).
+    /// Miner withdraws SOL collateral (subject to inactive / no-swap / cooldown guards).
     pub fn withdraw_collateral(ctx: Context<WithdrawCollateral>, amount: u64) -> Result<()> {
         withdraw_collateral::handler(ctx, amount)
     }
 
-    // --- Phase 2: validator-set admin (Phase 8: per-validator draw weight) ---
+    // --- Validator-set admin (with per-validator draw weight) ---
     pub fn add_validator(ctx: Context<AdminConfig>, validator: Pubkey, weight: u64) -> Result<()> {
         admin::add_validator(ctx, validator, weight)
     }
@@ -66,7 +66,7 @@ pub mod allways_swap_manager {
         admin::set_consensus_threshold(ctx, percent)
     }
     /// Emergency halt: admin toggles the global halt flag (gates deposits / activations /
-    /// reservation pools, mirroring the ink! `set_halted`).
+    /// reservation pools).
     pub fn set_halted(ctx: Context<AdminConfig>, halted: bool) -> Result<()> {
         admin::set_halted(ctx, halted)
     }
@@ -99,8 +99,8 @@ pub mod allways_swap_manager {
     pub fn set_weights_update_min_interval(ctx: Context<AdminConfig>, secs: i64) -> Result<()> {
         admin::set_weights_update_min_interval(ctx, secs)
     }
-    /// Phase 8: set a validator's draw weight (admin bootstrap/fallback; superseded for routine use
-    /// by the Phase 10 consensus path below).
+    /// Set a validator's draw weight (admin bootstrap/fallback; superseded for routine use
+    /// by the consensus path below).
     pub fn set_validator_weight(
         ctx: Context<AdminConfig>,
         validator: Pubkey,
@@ -109,14 +109,14 @@ pub mod allways_swap_manager {
         admin::set_validator_weight(ctx, validator, weight)
     }
 
-    // --- Phase 10: consensus-governed validator weights ---
+    // --- Consensus-governed validator weights ---
     /// A validator submits the full weight vector (index-aligned to `Config.validators`); on quorum
     /// the weights are saved. Validators read stake off-chain and converge on one snapshot.
     pub fn vote_set_weights(ctx: Context<VoteSetWeights>, weights: Vec<u64>) -> Result<()> {
         vote_set_weights::handler(ctx, weights)
     }
 
-    // --- Phase 2: miner activation consensus ---
+    // --- Miner activation consensus ---
     /// A validator votes to activate a miner (active on quorum).
     pub fn vote_activate(ctx: Context<VoteActivate>) -> Result<()> {
         vote_activate::handler(ctx)
@@ -130,9 +130,9 @@ pub mod allways_swap_manager {
         deactivate::handler(ctx)
     }
 
-    // --- Phase 9: reservation lottery (replaces vote_reserve) ---
+    // --- Reservation lottery ---
     /// A validator opens or joins a per-miner reservation-lottery pool for a pair. First caller pins
-    /// the miner's on-chain quote; every caller pays a flat anti-spam fee → treasury.
+    /// the miner's on-chain quote; every caller pays a flat anti-spam fee to treasury.
     #[allow(clippy::too_many_arguments)]
     pub fn open_or_request(
         ctx: Context<OpenOrRequest>,
@@ -163,7 +163,7 @@ pub mod allways_swap_manager {
         resolve_pool::handler(ctx)
     }
 
-    // --- Phase 4: swap lifecycle ---
+    // --- Swap lifecycle ---
     /// A validator votes to initiate a swap against an active reservation (created on quorum).
     pub fn vote_initiate(
         ctx: Context<VoteInitiate>,
@@ -202,16 +202,15 @@ pub mod allways_swap_manager {
         timeout_swap::handler(ctx, swap_key)
     }
 
-    // --- Phase 6: treasury ---
+    // --- Treasury ---
     /// Admin withdraws accrued protocol fees from the vault treasury to a recipient.
     pub fn withdraw_treasury(ctx: Context<WithdrawTreasury>, amount: u64) -> Result<()> {
         withdraw_treasury::handler(ctx, amount)
     }
 
-    // --- Phase 8: on-chain miner quotes ---
-    /// Miner publishes/overwrites its standing quote for one pair-direction
-    /// (`(from_chain, to_chain)` encodes direction; the reverse direction is a separate quote).
-    /// Permissionless: any signer may post; the validator/UI filters to registered miners.
+    // --- On-chain miner quotes ---
+    /// Miner publishes/overwrites its standing quote for one pair-direction (the reverse is a
+    /// separate quote). Permissionless: the validator/UI filters to registered miners.
     pub fn set_quote(
         ctx: Context<SetQuote>,
         from_chain: String,

--- a/smart-contracts/solana/programs/allways_swap_manager/src/lottery.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/lottery.rs
@@ -1,6 +1,5 @@
-//! Reservation-lottery draw primitives (Phase 9). Pure + deterministic so the same winner is
-//! computed by everyone resolving the same pool; unit-tested standalone (LiteSVM may not populate the
-//! SlotHashes sysvar, so the on-chain seed read is integration-tested while these are unit-tested).
+//! Reservation-lottery draw primitives. Pure + deterministic so everyone resolving the same pool
+//! computes the same winner.
 
 use anchor_lang::prelude::*;
 use solana_keccak_hasher::hashv;
@@ -15,8 +14,7 @@ pub fn draw_seed(pool_key: &Pubkey, slothash: &[u8]) -> u128 {
 }
 
 /// Stake-weighted pick: cumulative-bucket over `weights`, `x = seed % total_weight`, return the index
-/// whose bucket contains `x`. If `total_weight == 0` (e.g. all entrants unweighted), fall back to a
-/// uniform pick by index. Caller guarantees `weights` is non-empty.
+/// whose bucket contains `x`. If `total_weight == 0`, fall back to uniform pick. `weights` non-empty.
 pub fn pick_weighted(seed: u128, weights: &[u64]) -> usize {
     let total: u128 = weights.iter().map(|&w| w as u128).sum();
     if total == 0 {

--- a/smart-contracts/solana/programs/allways_swap_manager/src/penalty.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/penalty.rs
@@ -4,12 +4,11 @@ use crate::error::ErrorCode;
 use crate::state::{MinerState, Vault};
 
 /// Deduct up to `amount` from the miner's collateral (clamped to available), shrink the vault's
-/// collateral total accordingly, and auto-deactivate the miner if the remainder falls below
-/// `min_collateral`. Returns the actual amount deducted. Mirrors ink! `apply_collateral_penalty`.
+/// collateral total, and auto-deactivate the miner if the remainder falls below `min_collateral`.
+/// Returns the actual amount deducted.
 ///
-/// Lamports are NOT moved here — the caller decides where the deducted value goes (treasury accrual
-/// for a fee vs. a payout to the user for a slash), so the vault invariant
-/// (`lamports == rent + total_collateral + treasury_total`) is preserved by the caller.
+/// Lamports are NOT moved here — the caller decides where the value goes (treasury vs. user payout),
+/// so the vault invariant (lamports == rent + total_collateral + treasury_total) stays the caller's.
 pub fn apply_penalty(
     miner_state: &mut Account<MinerState>,
     vault: &mut Account<Vault>,

--- a/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
@@ -2,21 +2,15 @@ use anchor_lang::prelude::*;
 
 use crate::constants::{MAX_ADDR_LEN, MAX_CHAIN_LEN, MAX_RATE_LEN, MAX_TX_LEN, MAX_VALIDATORS};
 
-/// A whitelisted validator and its draw weight (Phase 8).
-///
-/// `weight` is the stake-weight seam a future oracle writes through (Phase 10); for now the admin
-/// sets it (`add_validator` / `set_validator_weight`), default uniform `1`. Consensus stays
-/// count-based — `weight` is consumed ONLY by the Phase 9 reservation-lottery draw.
+/// A whitelisted validator and its draw weight. `weight` (default 1, admin-set) is the
+/// stake-weight seam consumed ONLY by the reservation-lottery draw; consensus stays count-based.
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
 pub struct ValidatorInfo {
     pub key: Pubkey,
     pub weight: u64,
 }
 
-/// Singleton config PDA (`seeds = [CONFIG_SEED]`).
-///
-/// Grows phase by phase (treasury counter, swap config — see SOLANA_MIGRATION_RESEARCH.md §14).
-/// All amounts in lamports, durations in seconds.
+/// Singleton config PDA (`seeds = [CONFIG_SEED]`). All amounts in lamports, durations in seconds.
 #[account]
 #[derive(InitSpace)]
 pub struct Config {
@@ -28,7 +22,7 @@ pub struct Config {
     pub min_collateral: u64,
     /// Maximum collateral a miner may post (lamports). 0 = no cap.
     pub max_collateral: u64,
-    /// Swap fulfillment timeout (seconds). Phase 1 cooldown = 2×; Phase 4 swap timeout.
+    /// Swap fulfillment timeout (seconds); withdrawal cooldown = 2x this.
     pub fulfillment_timeout_secs: i64,
     /// Swap-size bounds on the collateral-backed (SOL) amount, in lamports. 0 = unbounded.
     pub min_swap_amount: u64,
@@ -78,11 +72,10 @@ pub struct MinerState {
     pub collateral: u64,
     /// Whether the miner is active (set via consensus).
     pub active: bool,
-    /// Whether the miner currently has an in-flight swap (Phase 4).
+    /// Whether the miner currently has an in-flight swap.
     pub has_active_swap: bool,
-    /// Unix timestamp the miner is committed (busy) until — covers an open pool, a held reservation,
-    /// and an in-flight swap. `now >= busy_until` means free. Self-clearing (no clear instruction
-    /// needed). Read by `deactivate` / `withdraw_collateral` as the non-bypassable busy lock.
+    /// Unix ts the miner is busy until (open pool, held reservation, or in-flight swap). Self-clearing
+    /// (`now >= busy_until` = free); the non-bypassable busy lock for deactivate/withdraw_collateral.
     pub busy_until: i64,
     /// Unix timestamp of last deactivation (0 = never). Gates the withdrawal cooldown.
     pub deactivation_at: i64,
@@ -92,10 +85,8 @@ pub struct MinerState {
 
 /// A consensus vote round PDA (`seeds = [VOTE_SEED, &[request_type], target]`).
 ///
-/// Accumulates validator votes for one request (e.g. activate a miner). `bound_hash` binds
-/// every voter to identical request parameters (keccak of the canonical request) — for requests
-/// whose params live entirely in the seeds this is trivially satisfied, but later phases
-/// (reserve/initiate) carry amounts/addresses the seeds don't, where it prevents bait-and-switch.
+/// `bound_hash` binds every voter to identical request params (keccak of the canonical request),
+/// preventing bait-and-switch on requests whose params aren't fully in the seeds (reserve/initiate).
 #[account]
 #[derive(InitSpace)]
 pub struct VoteRound {
@@ -112,10 +103,9 @@ pub struct VoteRound {
 
 /// Confirmed reservation for a miner (`seeds = [RESV_SEED, miner]`).
 ///
-/// Created by `resolve_pool` (lottery draw); consumed by `vote_initiate` (Phase 4) or left to
-/// expire. `reserved_until == 0` means no active reservation (slot empty/cleared);
-/// `reserved_until >= now` means active; `0 < reserved_until < now` means expired (overwritable).
-/// `from_addr` is kept so Phase 4 can verify the initiating user matches the reserver.
+/// Created by `resolve_pool` (lottery draw); consumed by `vote_initiate` or left to expire.
+/// `reserved_until`: 0 = empty, >= now = active, 0 < it < now = expired (overwritable).
+/// `from_addr` is kept so initiate can verify the initiating user matches the reserver.
 #[account]
 #[derive(InitSpace)]
 pub struct Reservation {
@@ -133,9 +123,8 @@ pub struct Reservation {
     /// Off-chain leg amounts in their own assets (u128 to cover wei-scale).
     pub from_amount: u128,
     pub to_amount: u128,
-    /// Pinned miner quote — captured + hash-bound at reserve time so it is an immutable quote.
-    /// Phase 4's `vote_initiate` MUST honor these (not the miner's live commitment): this closes
-    /// the rate-swing / deposit-address-theft total-loss bug (v2 cleanup #1).
+    /// Pinned miner quote — hash-bound at reserve time. `vote_initiate` MUST honor these (not the
+    /// miner's live commitment): closes the rate-swing / deposit-address-theft total-loss bug.
     #[max_len(MAX_ADDR_LEN)]
     pub miner_from_addr: String,
     #[max_len(MAX_ADDR_LEN)]
@@ -157,9 +146,8 @@ pub enum SwapStatus {
 }
 
 /// An in-flight swap (`seeds = [SWAP_SEED, swap_key]`, swap_key = keccak(from_tx_hash)).
-/// Created by `vote_initiate` on quorum; closed by `confirm_swap` / `timeout_swap`.
-/// Chains/amounts/miner-quote are copied from the (immutable) Reservation; user-side fields come
-/// from the initiate vote (and are hash-bound). Identified by from_tx_hash, not a u64 counter.
+/// Created by `vote_initiate` on quorum; closed by `confirm_swap` / `timeout_swap`. Chains/amounts/
+/// miner-quote copied from the immutable Reservation; user-side fields from the hash-bound initiate vote.
 #[account]
 #[derive(InitSpace)]
 pub struct Swap {
@@ -196,9 +184,8 @@ pub struct Swap {
     pub bump: u8,
 }
 
-/// Permanent source-tx replay marker (`seeds = [TX_SEED, swap_key]`). Set `used = true` on initiate
-/// quorum and never closed — outlives the Swap (which closes on completion), mirroring ink!'s
-/// `used_from_tx`. A from_tx_hash can initiate at most one swap, ever.
+/// Permanent source-tx replay marker (`seeds = [TX_SEED, swap_key]`). Set `used` on initiate quorum
+/// and never closed, so it outlives the Swap: a from_tx_hash can initiate at most one swap, ever.
 #[account]
 #[derive(InitSpace)]
 pub struct TxMarker {
@@ -206,15 +193,13 @@ pub struct TxMarker {
     pub bump: u8,
 }
 
-/// A miner's standing on-chain quote for one pair-direction (Phase 8)
+/// A miner's standing on-chain quote for one pair-direction
 /// (`seeds = [QUOTE_SEED, miner, from_chain, to_chain]`).
 ///
-/// Replaces the off-chain Bittensor commitment string. A miner advertises its whole book by writing
-/// one of these per pair-direction it offers (`tao→btc`, `btc→tao`, `sol→btc`, …) — the `(from_chain,
-/// to_chain)` ordering encodes direction, so there is no `counter_rate` field (the reverse direction
-/// is its own PDA). Permissionless to write (`set_quote`); the validator/UI filters to registered
-/// miners. Mutable: `set_quote` overwrites in place — pools (Phase 9) pin whatever's current, so
-/// staleness is the miner's problem. Closed + rent-refunded via `remove_quote`.
+/// Replaces the off-chain Bittensor commitment string: one PDA per direction (the `(from_chain,
+/// to_chain)` ordering encodes direction, so no `counter_rate`). Permissionless to write
+/// (`set_quote`, overwrites in place); pools pin whatever's current, so staleness is the miner's
+/// problem. Closed + rent-refunded via `remove_quote`.
 #[account]
 #[derive(InitSpace)]
 pub struct MinerQuote {
@@ -241,8 +226,8 @@ pub struct MinerQuote {
     pub bump: u8,
 }
 
-/// One validator's entry into a reservation lottery `Pool` (Phase 9). Carries the taker-side intent;
-/// the miner quote (rate/addresses/chains) is the pool's pinned snapshot, not per-request.
+/// One validator's entry into a reservation lottery `Pool`. Carries only the taker-side intent;
+/// the miner quote is the pool's pinned snapshot, not per-request.
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
 pub struct Request {
     /// The validator that routed this request (also the lottery weight key + dedup key).
@@ -259,14 +244,12 @@ pub struct Request {
     pub to_amount: u128,
 }
 
-/// A reservation-lottery contest for one idle miner (`seeds = [POOL_SEED, miner]`), Phase 9.
+/// A reservation-lottery contest for one idle miner (`seeds = [POOL_SEED, miner]`).
 ///
-/// Opened by the first validator to route a request (which pins the miner's on-chain quote for the
-/// chosen pair); collects ≤16 requests over a window; `resolve_pool` runs a stake-weighted draw after
-/// `closes_at` and creates the (unchanged) `Reservation` for the winner. Keyed **per-miner** — the
-/// opener pins the pair and later in-window requests must match it. Rent is paid once by the first
-/// opener and the account is **reused** across contests (`opened_at == 0` = available, mirroring
-/// `VoteRound`); `resolve_pool` resets it rather than closing.
+/// Opened by the first validator to route a request (pinning the miner's quote for the chosen pair);
+/// later in-window requests must match that pair. `resolve_pool` runs a stake-weighted draw after
+/// `closes_at` and creates the winner's `Reservation`. Keyed per-miner; the account is reused across
+/// contests (`opened_at == 0` = available), reset rather than closed by `resolve_pool`.
 #[account]
 #[derive(InitSpace)]
 pub struct Pool {

--- a/smart-contracts/solana/programs/allways_swap_manager/src/tunables.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/tunables.rs
@@ -1,38 +1,22 @@
-//! Hardcoded, deploy-time-tunable **economic** parameters — the knobs you change-and-redeploy.
-//!
-//! Kept in one file (not in `Config`/`state.rs`, not scattered through handlers) so every economic
-//! lever is legible in one place. These are compile-time constants: editing one requires a redeploy,
-//! and every value is **range-checked at compile time** (`const _: () = assert!(…)`) AND by a unit
-//! test below — so an out-of-range edit fails `cargo test`/the build, never production.
+//! Deploy-time economic knobs (change-and-redeploy). One file so every
+//! lever is visible; each is range-checked at compile time + a unit test.
 
-/// Basis-points denominator (10_000 bps = 1.00×). Shared by every ×-multiplier below.
 pub const BPS_DENOMINATOR: u64 = 10_000;
 
-/// Collateral a miner must hold to **back a swap**, as a fraction of the swap size, in basis points
-/// (10_000 = 1.00×, 11_000 = 1.10×). Over-collateralizing (> 1.00×) reserves a slash buffer so a
-/// failed swap can make the user whole *and* penalize the miner (v2 cleanup #4).
-///
-/// Bounds (enforced below + by `tests::collateral_requirement_within_bounds`):
-/// `COLLATERAL_REQUIREMENT_BPS_MIN` (1.00×, never under-collateralized) ≤ x ≤
-/// `COLLATERAL_REQUIREMENT_BPS_MAX` (2.00×, sanity ceiling).
-pub const COLLATERAL_REQUIREMENT_BPS: u64 = 11_000; // 1.10× — current setting
+/// Collateral a miner must hold per swap, in bps (11_000 = 1.10x). The >1x
+/// buffer lets a failed swap make the user whole and still penalize the miner.
+pub const COLLATERAL_REQUIREMENT_BPS: u64 = 11_000;
+pub const COLLATERAL_REQUIREMENT_BPS_MIN: u64 = 10_000; // floor 1.0x
+pub const COLLATERAL_REQUIREMENT_BPS_MAX: u64 = 20_000; // ceiling 2.0x
 
-/// Hard floor: a swap must always be at least fully collateralized.
-pub const COLLATERAL_REQUIREMENT_BPS_MIN: u64 = 10_000; // 1.0×
-/// Hard ceiling: more than 2× would price out honest miners with no extra safety payoff.
-pub const COLLATERAL_REQUIREMENT_BPS_MAX: u64 = 20_000; // 2.0×
-
-// Compile-time guard: the build won't compile if the setting leaves [1.0×, 2.0×].
+// Compile-time guard: the build won't compile if the setting leaves [1.0x, 2.0x].
 const _: () = assert!(
     COLLATERAL_REQUIREMENT_BPS >= COLLATERAL_REQUIREMENT_BPS_MIN
         && COLLATERAL_REQUIREMENT_BPS <= COLLATERAL_REQUIREMENT_BPS_MAX,
     "COLLATERAL_REQUIREMENT_BPS must be within [1.0x, 2.0x] (10_000..=20_000 bps)"
 );
-
-/// Collateral (lamports) required to back a swap of `sol_amount` lamports
-/// = `sol_amount × COLLATERAL_REQUIREMENT_BPS / 10_000`, rounded up so a fractional requirement is
-/// never under-met. Computed in u128 and clamped to `u64::MAX` so an extreme size can't wrap (it
-/// simply demands more than any miner could hold).
+/// Collateral (lamports) for a swap of `sol_amount`. Ceil-div so it's never under-met;
+/// u128 math clamped to u64::MAX so an extreme size can't wrap.
 pub fn required_collateral(sol_amount: u64) -> u64 {
     let numer = (sol_amount as u128).saturating_mul(COLLATERAL_REQUIREMENT_BPS as u128);
     // round up (ceil-div): require at least the exact fraction.
@@ -43,23 +27,13 @@ pub fn required_collateral(sol_amount: u64) -> u64 {
     req.min(u64::MAX as u128) as u64
 }
 
-// --- Quote-update churn fee (anti-flashing) ---
-//
-// Updating a *standing* quote too soon after its last write costs a small, treasury-bound fee that
-// **decays to zero** the longer the quote has stood. This discourages rapid quote-flashing without
-// scaring miners off the network: first-time creation is free (only rent), and a quote left to
-// stand becomes free to update again. Stepwise (not continuous exponential) — deterministic and
-// cheap on-chain, with the same "cheaper the longer you wait" intent.
-//
-// Tiers, by seconds since the previous update:
-//   elapsed < TIER1_MAX_SECS          → TIER1_LAMPORTS  (rapid churn — most expensive)
-//   TIER1_MAX ≤ elapsed < TIER2_MAX   → TIER2_LAMPORTS
-//   elapsed ≥ TIER2_MAX_SECS          → 0               (a stable quote — free)
-// All collected fees go to the vault treasury.
-pub const QUOTE_UPDATE_FEE_TIER1_LAMPORTS: u64 = 10_000_000; // 0.01 SOL — churn within 5 min
+// Quote-update churn fee (anti-flashing): updating a standing quote soon after its
+// last write costs a treasury-bound fee that decays to zero the longer it has stood.
+// Creation is free; stepwise tiers (not continuous) keep it deterministic on-chain.
+pub const QUOTE_UPDATE_FEE_TIER1_LAMPORTS: u64 = 10_000_000; // 0.01 SOL, churn within 5 min
 pub const QUOTE_UPDATE_FEE_TIER1_MAX_SECS: i64 = 300; // 5 min
-pub const QUOTE_UPDATE_FEE_TIER2_LAMPORTS: u64 = 1_000_000; // 0.001 SOL — 5–10 min
-pub const QUOTE_UPDATE_FEE_TIER2_MAX_SECS: i64 = 600; // 10 min → free thereafter
+pub const QUOTE_UPDATE_FEE_TIER2_LAMPORTS: u64 = 1_000_000; // 0.001 SOL, 5-10 min
+pub const QUOTE_UPDATE_FEE_TIER2_MAX_SECS: i64 = 600; // 10 min, free thereafter
 
 // Sanity: windows must increase and the fee must not increase as time passes (monotone decay).
 const _: () = assert!(
@@ -68,9 +42,8 @@ const _: () = assert!(
     "quote-update fee tiers must decay over increasing windows"
 );
 
-/// Fee (lamports) for updating a standing quote `elapsed_secs` after its previous write. A negative
-/// or zero elapsed (clock skew / same-second churn) falls into the most-expensive tier. Applies only
-/// to updates — the caller charges nothing on first creation.
+/// Fee (lamports) for updating a standing quote `elapsed_secs` after its previous write.
+/// Negative/zero elapsed (clock skew) falls into the most-expensive tier; creation is free.
 pub fn quote_update_fee(elapsed_secs: i64) -> u64 {
     if elapsed_secs < QUOTE_UPDATE_FEE_TIER1_MAX_SECS {
         QUOTE_UPDATE_FEE_TIER1_LAMPORTS
@@ -82,33 +55,23 @@ pub fn quote_update_fee(elapsed_secs: i64) -> u64 {
 }
 
 // --- Protocol fees & timing ---
-//
-// Moved here from `constants.rs` so every deploy-time economic lever lives in one file. All are
-// compile-time constants: change-and-redeploy, nothing stored in `Config`. (Structural constants —
-// PDA seeds, request-type bytes, max string lengths, `SLOT_MS` — stay in `constants.rs`.)
 
-/// Protocol fee divisor — 1% (immutable policy), `fee = sol_amount / FEE_DIVISOR`. Compile-time
-/// only (not promoted to a runtime setter).
+/// Protocol fee divisor: 1% (immutable policy), `fee = sol_amount / FEE_DIVISOR`.
 pub const FEE_DIVISOR: u64 = 100;
 
-// The next three are **initial seed defaults** — `initialize` copies them into `Config` and they are
-// runtime-tunable thereafter via the admin setters added in #486 (`set_reservation_fee`,
-// `set_pool_window`, `set_weights_update_min_interval`). Kept here so the deploy-time defaults sit
-// with the other economic levers; handlers read the live `Config` value, not these consts.
+// The next three are initial seed defaults: `initialize` copies them into `Config`, then
+// they're runtime-tunable via admin setters. Handlers read live `Config`, not these consts.
 
-/// Initial flat anti-spam fee (lamports) per reservation request (`open_or_request`), validator →
-/// vault treasury, non-refundable. Seeds `Config.reservation_fee_lamports`. 0.02 SOL — sized so a
-/// pool-open (which now busies the miner for the window + reservation TTL, #485) isn't cheap to grief.
+/// Initial flat anti-spam fee (lamports) per reservation request, non-refundable to treasury.
+/// 0.02 SOL: a pool-open busies the miner for the window + TTL, so it shouldn't be cheap to grief.
 pub const RESERVATION_FEE_LAMPORTS: u64 = 20_000_000;
 
-/// Initial reservation-lottery pooling window (seconds). Seeds `Config.pool_window_secs`. How long a
-/// pool collects contending requests before `resolve_pool` runs the stake-weighted draw — a longer
-/// window gathers more validators for a fairer draw at the cost of reservation latency. Must stay
-/// well below the reservation TTL. Paired with `constants::SLOT_MS` to pin the draw's future seed slot.
+/// Initial reservation-lottery pooling window (seconds). Longer = more validators for a fairer
+/// stake-weighted draw, at the cost of latency. Must stay well below the reservation TTL.
 pub const POOL_WINDOW_SECS: i64 = 60;
 
-/// Initial minimum seconds between successful validator-weight updates (Phase 10) — an anti-thrash
-/// floor, not a schedule. Seeds `Config.weights_update_min_interval_secs`.
+/// Initial min seconds between successful validator-weight updates: an anti-thrash floor, not
+/// a schedule. Seeds `Config.weights_update_min_interval_secs`.
 pub const WEIGHTS_UPDATE_MIN_INTERVAL_SECS: i64 = 3600;
 
 #[cfg(test)]


### PR DESCRIPTION
Tightens the comment "books" across the swap-manager program to the project's terse house style. **Comments only — zero code changes.**

## What
- Multi-line prose blocks compressed to 1-2 lines across 15 files
- Kept the WHY: invariants, security rationale (busy lock, bait-and-switch defense, rate-swing total-loss bug, anti-thrash floor, vault invariant)
- Dropped: restated mechanics the code already shows, phase numbers, and `SOLANA_MIGRATION_RESEARCH.md §N` / ink!-mirror cross-references

## Safety
- Verified mechanically: with comments stripped, every changed file is **byte-identical** to `contract-v2` — no code line changed, moved, or reindented
- `cargo check` clean
- No formatter run (deliberately — local rustfmt disagrees with the repo's formatting and would add thousands of lines of noise)

Net: −232 / +146 lines, all comments.