### PR TITLE
refactor(solana): per-miner collateral vaults

### DIFF
--- a/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
@@ -4,9 +4,10 @@ use anchor_lang::prelude::*;
 #[constant]
 pub const CONFIG_SEED: &[u8] = b"config";
 
-/// PDA seed for the singleton native-SOL collateral vault (`seeds = [VAULT_SEED]`).
+/// PDA seed prefix for a per-miner native-SOL collateral vault (`seeds = [COLLATERAL_SEED, miner]`) —
+/// each miner's collateral in its own account: trustless custody + no shared-vault contention.
 #[constant]
-pub const VAULT_SEED: &[u8] = b"vault";
+pub const COLLATERAL_SEED: &[u8] = b"collateral";
 
 /// PDA seed prefix for per-miner state (`seeds = [MINER_SEED, miner_pubkey]`).
 #[constant]

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/confirm_swap.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/confirm_swap.rs
@@ -2,16 +2,16 @@ use anchor_lang::prelude::*;
 
 use crate::consensus::{record_vote, reset_round, swap_request_hash};
 use crate::constants::{
-    CONFIG_SEED, FEE_DIVISOR, MINER_SEED, REQ_CONFIRM, SWAP_SEED, TREASURY_SEED, VAULT_SEED, VOTE_SEED,
+    COLLATERAL_SEED, CONFIG_SEED, FEE_DIVISOR, MINER_SEED, REQ_CONFIRM, SWAP_SEED, TREASURY_SEED,
+    VOTE_SEED,
 };
 use crate::error::ErrorCode;
 use crate::events::SwapCompleted;
 use crate::penalty::apply_penalty;
-use crate::state::{Config, MinerState, Swap, SwapStatus, Treasury, Vault, VoteRound};
+use crate::state::{CollateralVault, Config, MinerState, Swap, SwapStatus, Treasury, VoteRound};
 
 /// Validators confirm a fulfilled swap. On quorum the 1% fee is moved from the miner's collateral
-/// into the Treasury PDA (lamports move vault → treasury), the miner is freed, and the Swap
-/// account is closed (rent reclaimed).
+/// vault into the Treasury PDA, the miner is freed, and the Swap account is closed (rent reclaimed).
 #[derive(Accounts)]
 #[instruction(swap_key: [u8; 32])]
 pub struct ConfirmSwap<'info> {
@@ -32,10 +32,11 @@ pub struct ConfirmSwap<'info> {
     )]
     pub miner_state: Account<'info, MinerState>,
 
-    #[account(mut, seeds = [VAULT_SEED], bump = vault.bump)]
-    pub vault: Account<'info, Vault>,
+    /// The miner's own collateral vault — the 1% fee is debited from here.
+    #[account(mut, seeds = [COLLATERAL_SEED, miner.key().as_ref()], bump = collateral_vault.bump)]
+    pub collateral_vault: Account<'info, CollateralVault>,
 
-    /// Subnet treasury — the 1% fee moves here out of the miner's collateral.
+    /// Subnet treasury — the 1% fee moves here out of the miner's collateral vault.
     #[account(mut, seeds = [TREASURY_SEED], bump = treasury.bump)]
     pub treasury: Account<'info, Treasury>,
 
@@ -85,17 +86,11 @@ pub fn handler(ctx: Context<ConfirmSwap>, swap_key: [u8; 32]) -> Result<()> {
         let fee = sol_amount / FEE_DIVISOR;
         let min_collateral = ctx.accounts.config.min_collateral;
 
-        let actual_fee = apply_penalty(
-            &mut ctx.accounts.miner_state,
-            &mut ctx.accounts.vault,
-            min_collateral,
-            fee,
-            now,
-        )?;
-        // Move the fee lamports out of the collateral vault and into the subnet treasury (both are
-        // program-owned PDAs → direct lamport math). apply_penalty already shrank total_collateral.
+        let actual_fee = apply_penalty(&mut ctx.accounts.miner_state, min_collateral, fee, now)?;
+        // Move the fee out of the miner's collateral vault into the subnet treasury (both are
+        // program-owned PDAs → direct lamport math). apply_penalty already shrank the ledger.
         if actual_fee > 0 {
-            ctx.accounts.vault.to_account_info().sub_lamports(actual_fee)?;
+            ctx.accounts.collateral_vault.to_account_info().sub_lamports(actual_fee)?;
             ctx.accounts.treasury.to_account_info().add_lamports(actual_fee)?;
             ctx.accounts.treasury.total = ctx
                 .accounts

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/initialize.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/initialize.rs
@@ -2,13 +2,13 @@ use anchor_lang::prelude::*;
 
 use crate::constants::{
     CONFIG_SEED, CONFIG_VERSION, POOL_WINDOW_SECS, RESERVATION_FEE_LAMPORTS, TREASURY_SEED,
-    VAULT_SEED, WEIGHTS_UPDATE_MIN_INTERVAL_SECS,
+    WEIGHTS_UPDATE_MIN_INTERVAL_SECS,
 };
-use crate::state::{Config, Treasury, Vault};
+use crate::state::{Config, Treasury};
 
-/// Create the singleton Config + native-SOL Vault PDAs. Records admin, collateral bounds,
+/// Create the singleton Config + subnet-revenue Treasury PDAs. Records admin, collateral bounds,
 /// fulfillment timeout (seconds), and the consensus threshold. Validator set starts empty
-/// (populated via `add_validator`).
+/// (populated via `add_validator`). Collateral vaults are per-miner and created lazily on deposit.
 #[derive(Accounts)]
 pub struct Initialize<'info> {
     #[account(mut)]
@@ -22,15 +22,6 @@ pub struct Initialize<'info> {
         bump,
     )]
     pub config: Account<'info, Config>,
-
-    #[account(
-        init,
-        payer = admin,
-        space = 8 + Vault::INIT_SPACE,
-        seeds = [VAULT_SEED],
-        bump,
-    )]
-    pub vault: Account<'info, Vault>,
 
     #[account(
         init,
@@ -80,10 +71,6 @@ pub fn handler(
     config.pool_window_secs = POOL_WINDOW_SECS;
     config.weights_update_min_interval_secs = WEIGHTS_UPDATE_MIN_INTERVAL_SECS;
     config.bump = ctx.bumps.config;
-
-    let vault = &mut ctx.accounts.vault;
-    vault.total_collateral = 0;
-    vault.bump = ctx.bumps.vault;
 
     let treasury = &mut ctx.accounts.treasury;
     treasury.total = 0;

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/post_collateral.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/post_collateral.rs
@@ -1,14 +1,14 @@
 use anchor_lang::prelude::*;
 use anchor_lang::system_program::{transfer, Transfer};
 
-use crate::constants::{CONFIG_SEED, MINER_SEED, VAULT_SEED};
+use crate::constants::{COLLATERAL_SEED, CONFIG_SEED, MINER_SEED};
 use crate::error::ErrorCode;
 use crate::events::CollateralPosted;
-use crate::state::{Config, MinerState, Vault};
+use crate::state::{CollateralVault, Config, MinerState};
 
-/// Miner deposits SOL collateral. Lamports move miner → vault (system CPI); the miner's
-/// `MinerState` ledger and the vault's `total_collateral` both increase. First deposit
-/// lazily creates the `MinerState` PDA (miner pays its rent).
+/// Miner deposits SOL collateral into their OWN per-miner collateral vault (system CPI). The
+/// `MinerState.collateral` ledger increases; the lamports land in `[COLLATERAL_SEED, miner]`. First
+/// deposit lazily creates both the `MinerState` and the collateral-vault PDAs (miner pays rent).
 #[derive(Accounts)]
 pub struct PostCollateral<'info> {
     #[account(mut)]
@@ -26,8 +26,15 @@ pub struct PostCollateral<'info> {
     )]
     pub miner_state: Account<'info, MinerState>,
 
-    #[account(mut, seeds = [VAULT_SEED], bump = vault.bump)]
-    pub vault: Account<'info, Vault>,
+    /// The miner's own collateral vault — holds only this miner's collateral lamports.
+    #[account(
+        init_if_needed,
+        payer = miner,
+        space = 8 + CollateralVault::INIT_SPACE,
+        seeds = [COLLATERAL_SEED, miner.key().as_ref()],
+        bump,
+    )]
+    pub collateral_vault: Account<'info, CollateralVault>,
 
     pub system_program: Program<'info, System>,
 }
@@ -45,13 +52,13 @@ pub fn handler(ctx: Context<PostCollateral>, amount: u64) -> Result<()> {
         ErrorCode::ExceedsMaxCollateral
     );
 
-    // Move lamports miner -> vault via the system program.
+    // Move lamports miner -> the miner's own collateral vault via the system program.
     transfer(
         CpiContext::new(
             ctx.accounts.system_program.key(),
             Transfer {
                 from: ctx.accounts.miner.to_account_info(),
-                to: ctx.accounts.vault.to_account_info(),
+                to: ctx.accounts.collateral_vault.to_account_info(),
             },
         ),
         amount,
@@ -65,12 +72,7 @@ pub fn handler(ctx: Context<PostCollateral>, amount: u64) -> Result<()> {
         ms.bump = bump;
     }
     ms.collateral = new_collateral;
-
-    let vault = &mut ctx.accounts.vault;
-    vault.total_collateral = vault
-        .total_collateral
-        .checked_add(amount)
-        .ok_or(ErrorCode::Overflow)?;
+    ctx.accounts.collateral_vault.bump = ctx.bumps.collateral_vault;
 
     emit!(CollateralPosted {
         miner: miner_key,

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/timeout_swap.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/timeout_swap.rs
@@ -1,14 +1,14 @@
 use anchor_lang::prelude::*;
 
 use crate::consensus::{record_vote, reset_round, swap_request_hash};
-use crate::constants::{CONFIG_SEED, MINER_SEED, REQ_TIMEOUT, SWAP_SEED, VAULT_SEED, VOTE_SEED};
+use crate::constants::{COLLATERAL_SEED, CONFIG_SEED, MINER_SEED, REQ_TIMEOUT, SWAP_SEED, VOTE_SEED};
 use crate::error::ErrorCode;
 use crate::events::SwapTimedOut;
 use crate::penalty::apply_penalty;
-use crate::state::{Config, MinerState, Swap, SwapStatus, Vault, VoteRound};
+use crate::state::{CollateralVault, Config, MinerState, Swap, SwapStatus, VoteRound};
 
 /// Validators time out a swap whose deadline passed. On quorum the miner's collateral is slashed and
-/// refunded to the user (vault -> user), the miner is freed, and the Swap account is closed.
+/// refunded to the user (collateral vault -> user), the miner is freed, and the Swap is closed.
 #[derive(Accounts)]
 #[instruction(swap_key: [u8; 32])]
 pub struct TimeoutSwap<'info> {
@@ -29,8 +29,9 @@ pub struct TimeoutSwap<'info> {
     )]
     pub miner_state: Account<'info, MinerState>,
 
-    #[account(mut, seeds = [VAULT_SEED], bump = vault.bump)]
-    pub vault: Account<'info, Vault>,
+    /// The miner's own collateral vault — the slash is debited from here.
+    #[account(mut, seeds = [COLLATERAL_SEED, miner.key().as_ref()], bump = collateral_vault.bump)]
+    pub collateral_vault: Account<'info, CollateralVault>,
 
     /// CHECK: receives the slashed refund; must equal `swap.user`.
     #[account(mut)]
@@ -92,17 +93,11 @@ pub fn handler(ctx: Context<TimeoutSwap>, swap_key: [u8; 32]) -> Result<()> {
         // clamps to available collateral as a safety net.
         let penalty = crate::constants::required_collateral(sol_amount);
 
-        let slash = apply_penalty(
-            &mut ctx.accounts.miner_state,
-            &mut ctx.accounts.vault,
-            min_collateral,
-            penalty,
-            now,
-        )?;
+        let slash = apply_penalty(&mut ctx.accounts.miner_state, min_collateral, penalty, now)?;
 
-        // Refund the slashed collateral to the user (vault → user, native lamports).
+        // Refund the slashed collateral to the user (miner's collateral vault → user, native lamports).
         if slash > 0 {
-            ctx.accounts.vault.to_account_info().sub_lamports(slash)?;
+            ctx.accounts.collateral_vault.to_account_info().sub_lamports(slash)?;
             ctx.accounts.user.to_account_info().add_lamports(slash)?;
         }
         ctx.accounts.miner_state.has_active_swap = false;

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/withdraw_collateral.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/withdraw_collateral.rs
@@ -1,13 +1,13 @@
 use anchor_lang::prelude::*;
 
-use crate::constants::{CONFIG_SEED, MINER_SEED, VAULT_SEED};
+use crate::constants::{COLLATERAL_SEED, CONFIG_SEED, MINER_SEED};
 use crate::error::ErrorCode;
 use crate::events::CollateralWithdrawn;
-use crate::state::{Config, MinerState, Vault};
+use crate::state::{CollateralVault, Config, MinerState};
 
-/// Miner withdraws SOL collateral back to their wallet. Guards: miner must be inactive, have no
-/// in-flight swap, and (if deactivated) be past the post-deactivation cooldown (2x fulfillment
-/// timeout). Lamports move vault -> miner via direct lamport math (the program owns the vault).
+/// Miner withdraws SOL collateral from their own collateral vault back to their wallet. Guards: miner
+/// must be inactive, have no in-flight swap, not be busy, and (if deactivated) be past the
+/// post-deactivation cooldown (2x fulfillment timeout). Lamports move vault -> miner (program-owned).
 #[derive(Accounts)]
 pub struct WithdrawCollateral<'info> {
     #[account(mut)]
@@ -24,8 +24,8 @@ pub struct WithdrawCollateral<'info> {
     )]
     pub miner_state: Account<'info, MinerState>,
 
-    #[account(mut, seeds = [VAULT_SEED], bump = vault.bump)]
-    pub vault: Account<'info, Vault>,
+    #[account(mut, seeds = [COLLATERAL_SEED, miner.key().as_ref()], bump = collateral_vault.bump)]
+    pub collateral_vault: Account<'info, CollateralVault>,
 }
 
 pub fn handler(ctx: Context<WithdrawCollateral>, amount: u64) -> Result<()> {
@@ -54,17 +54,12 @@ pub fn handler(ctx: Context<WithdrawCollateral>, amount: u64) -> Result<()> {
         require!(now >= cooldown_end, ErrorCode::WithdrawCooldownActive);
     }
 
-    // Move lamports vault -> miner (program-owned vault → direct lamport math).
-    ctx.accounts.vault.to_account_info().sub_lamports(amount)?;
+    // Move lamports the miner's collateral vault -> miner (program-owned → direct lamport math).
+    ctx.accounts.collateral_vault.to_account_info().sub_lamports(amount)?;
     ctx.accounts.miner.to_account_info().add_lamports(amount)?;
 
-    // Update ledgers.
+    // Update ledger.
     ctx.accounts.miner_state.collateral = collateral
-        .checked_sub(amount)
-        .ok_or(ErrorCode::Overflow)?;
-    let vault = &mut ctx.accounts.vault;
-    vault.total_collateral = vault
-        .total_collateral
         .checked_sub(amount)
         .ok_or(ErrorCode::Overflow)?;
 

--- a/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
@@ -20,7 +20,7 @@ declare_id!("BtVm5a1hKvMrrEHQ876Ev23dYVZAkWpYkf86VZi3z1Li");
 pub mod allways_swap_manager {
     use super::*;
 
-    /// Create Config + Vault with collateral bounds, timeout, consensus threshold,
+    /// Create Config + Treasury with collateral bounds, timeout, consensus threshold,
     /// swap-size bounds, and reservation TTL.
     #[allow(clippy::too_many_arguments)]
     pub fn initialize(

--- a/smart-contracts/solana/programs/allways_swap_manager/src/penalty.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/penalty.rs
@@ -1,18 +1,16 @@
 use anchor_lang::prelude::*;
 
 use crate::error::ErrorCode;
-use crate::state::{MinerState, Vault};
+use crate::state::MinerState;
 
-/// Deduct up to `amount` from the miner's collateral (clamped to available), shrink the vault's
-/// collateral total, and auto-deactivate the miner if the remainder falls below `min_collateral`.
-/// Returns the actual amount deducted.
+/// Deduct up to `amount` from the miner's collateral (clamped to available) and auto-deactivate the
+/// miner if the remainder falls below `min_collateral`. Returns the actual amount deducted.
 ///
-/// Lamports are NOT moved here — the caller decides where the deducted value goes (a fee moved to the
-/// treasury PDA on confirm, vs. a payout to the user on a slash), preserving the collateral-vault
-/// invariant (`lamports == rent + total_collateral`).
+/// Lamports are NOT moved here — the caller moves `actual` out of the miner's per-miner collateral
+/// vault (to the treasury on a confirm fee, or to the user on a slash), keeping that vault's
+/// invariant (`lamports == rent + collateral`).
 pub fn apply_penalty(
     miner_state: &mut Account<MinerState>,
-    vault: &mut Account<Vault>,
     min_collateral: u64,
     amount: u64,
     now: i64,
@@ -23,10 +21,6 @@ pub fn apply_penalty(
         return Ok(0);
     }
     miner_state.collateral = current.checked_sub(actual).ok_or(ErrorCode::Overflow)?;
-    vault.total_collateral = vault
-        .total_collateral
-        .checked_sub(actual)
-        .ok_or(ErrorCode::Overflow)?;
 
     if miner_state.collateral < min_collateral && miner_state.active {
         miner_state.active = false;

--- a/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
@@ -48,16 +48,14 @@ pub struct Config {
     pub bump: u8,
 }
 
-/// Singleton native-SOL collateral vault PDA (`seeds = [VAULT_SEED]`), program-owned.
+/// Per-miner native-SOL collateral vault PDA (`seeds = [COLLATERAL_SEED, miner]`), program-owned.
 ///
-/// Holds ONLY miner collateral — never subnet revenue (that lives in the separate `Treasury`). This
-/// makes collateral trustless: it leaves only via the owning miner's `withdraw_collateral` or a slash
-/// to the wronged user on a failed swap. Invariant: vault.lamports == rent_exempt + total_collateral.
+/// Each miner's collateral lives in its OWN account — trustless custody (leaves only via the owning
+/// miner's `withdraw_collateral` or a slash to the wronged user) and no shared-vault write contention.
+/// The amount is `MinerState.collateral`; invariant: lamports == rent_exempt + collateral.
 #[account]
 #[derive(InitSpace)]
-pub struct Vault {
-    /// Σ of all miners' collateral credited to the vault (lamports), excludes the rent reserve.
-    pub total_collateral: u64,
+pub struct CollateralVault {
     /// Stored PDA bump.
     pub bump: u8,
 }
@@ -81,7 +79,7 @@ pub struct Treasury {
 pub struct MinerState {
     /// The miner (hotkey-equivalent) this state belongs to.
     pub miner: Pubkey,
-    /// Collateral credited to this miner (lamports). Backed 1:1 by lamports in the Vault.
+    /// Collateral credited to this miner (lamports). Backed 1:1 by lamports in the miner's collateral vault.
     pub collateral: u64,
     /// Whether the miner is active (set via consensus).
     pub active: bool,

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
@@ -12,7 +12,7 @@
 //
 // Requirements / caveats:
 //   * A FRESH validator each run (`solana-test-validator --reset`). `initialize` creates singleton
-//     Config/Vault PDAs; re-running against a dirty ledger will see them already present.
+//     Config/Treasury PDAs; re-running against a dirty ledger will see them already present.
 //   * Real wall-clock — the clock CANNOT be warped. So these cover the happy path and
 //     time-independent guards only. Generous TTL/timeout values are used in `initialize` so nothing
 //     expires mid-test. Reservation-expiry / swap-timeout stay in LiteSVM.
@@ -25,7 +25,7 @@ use {
         InstructionData, ToAccountMetas,
     },
     allways_swap_manager::state::{
-        Config, MinerQuote, MinerState, Pool, Reservation, Swap, SwapStatus, Treasury, TxMarker, Vault,
+        Config, MinerQuote, MinerState, Pool, Reservation, Swap, SwapStatus, Treasury, TxMarker,
     },
     solana_commitment_config::CommitmentConfig,
     solana_keccak_hasher::hashv,
@@ -73,8 +73,8 @@ fn pid() -> Pubkey {
 fn config_pda() -> Pubkey {
     Pubkey::find_program_address(&[b"config"], &pid()).0
 }
-fn vault_pda() -> Pubkey {
-    Pubkey::find_program_address(&[b"vault"], &pid()).0
+fn collateral_vault_pda(m: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&[b"collateral", m.as_ref()], &pid()).0
 }
 fn treasury_pda() -> Pubkey {
     Pubkey::find_program_address(&[b"treasury"], &pid()).0
@@ -147,16 +147,12 @@ fn read_config(rpc: &RpcClient) -> Config {
     let a = rpc.get_account(&config_pda()).expect("config account");
     Config::try_deserialize(&mut a.data.as_slice()).unwrap()
 }
-fn read_vault(rpc: &RpcClient) -> Vault {
-    let a = rpc.get_account(&vault_pda()).expect("vault account");
-    Vault::try_deserialize(&mut a.data.as_slice()).unwrap()
-}
 fn read_treasury(rpc: &RpcClient) -> Treasury {
     let a = rpc.get_account(&treasury_pda()).expect("treasury account");
     Treasury::try_deserialize(&mut a.data.as_slice()).unwrap()
 }
-fn vault_lamports(rpc: &RpcClient) -> u64 {
-    rpc.get_account(&vault_pda()).map(|a| a.lamports).unwrap_or(0)
+fn collateral_vault_lamports(rpc: &RpcClient, m: &Pubkey) -> u64 {
+    rpc.get_account(&collateral_vault_pda(m)).map(|a| a.lamports).unwrap_or(0)
 }
 fn read_miner(rpc: &RpcClient, m: &Pubkey) -> MinerState {
     let a = rpc.get_account(&miner_pda(m)).expect("miner state account");
@@ -191,7 +187,6 @@ fn init_ix(admin: &Pubkey) -> Instruction {
         allways_swap_manager::accounts::Initialize {
             admin: *admin,
             config: config_pda(),
-            vault: vault_pda(),
             treasury: treasury_pda(),
             system_program: SYSTEM_PROGRAM,
         }
@@ -222,7 +217,7 @@ fn post_ix(miner: &Pubkey, amount: u64) -> Instruction {
             miner: *miner,
             config: config_pda(),
             miner_state: miner_pda(miner),
-            vault: vault_pda(),
+            collateral_vault: collateral_vault_pda(miner),
             system_program: SYSTEM_PROGRAM,
         }
         .to_account_metas(None),
@@ -351,7 +346,7 @@ fn confirm_ix(validator: &Pubkey, miner: &Pubkey, from_tx_hash: &str) -> Instruc
             config: config_pda(),
             miner: *miner,
             miner_state: miner_pda(miner),
-            vault: vault_pda(),
+            collateral_vault: collateral_vault_pda(miner),
             treasury: treasury_pda(),
             swap: swap_pda(&key),
             vote_round: vote_pda(REQ_CONFIRM, &key),
@@ -428,10 +423,10 @@ fn shared() -> &'static Shared {
             fund(&rpc, &v.pubkey(), 100 * LAMPORTS_PER_SOL);
         }
 
-        // Initialize the singleton Config + Vault iff not already present (idempotent).
+        // Initialize the singleton Config + Treasury iff not already present (idempotent).
         if !account_exists(&rpc, &config_pda()) {
             send(&rpc, init_ix(&admin.pubkey()), &admin.pubkey(), &admin)
-                .expect("initialize singleton Config/Vault (needs a FRESH --reset validator)");
+                .expect("initialize singleton Config/Treasury (needs a FRESH --reset validator)");
         }
 
         // Whitelist the 3 validators iff not already in the set (idempotent).
@@ -494,11 +489,10 @@ fn reserved_miner(rpc: &RpcClient) -> Keypair {
     miner
 }
 
-/// Collateral-vault invariant: lamports == rent_reserve + total_collateral (treasury is its own PDA).
-/// We don't know the rent reserve a priori (the vault is a shared singleton), so the caller passes
-/// it (captured once, right after the vault exists).
-fn invariant_holds(rpc: &RpcClient, rent_reserve: u64) -> bool {
-    vault_lamports(rpc) == rent_reserve + read_vault(rpc).total_collateral
+/// Per-miner collateral-vault invariant: lamports == rent_reserve + MinerState.collateral. The rent
+/// reserve isn't known a priori, so the caller captures it once (right after the vault exists).
+fn invariant_holds(rpc: &RpcClient, miner: &Pubkey, rent_reserve: u64) -> bool {
+    collateral_vault_lamports(rpc, miner) == rent_reserve + read_miner(rpc, miner).collateral
 }
 
 // ════════════════════════════════════════════════════════════════════════════════
@@ -518,8 +512,6 @@ fn onchain_initialize_creates_config() {
     assert_eq!(cfg.consensus_threshold_percent, THRESHOLD);
     assert_eq!(cfg.fulfillment_timeout_secs, TIMEOUT_SECS);
     assert_eq!(cfg.reservation_ttl_secs, TTL_SECS);
-    // Vault exists and is a valid singleton.
-    let _ = read_vault(&rpc);
 }
 
 #[test]
@@ -565,7 +557,6 @@ fn onchain_vote_set_weights_quorum() {
 fn onchain_post_collateral() {
     let _ = shared();
     let rpc = rpc();
-    let before = read_vault(&rpc).total_collateral;
 
     let miner = funded_keypair(&rpc, 100 * LAMPORTS_PER_SOL);
     send(&rpc, post_ix(&miner.pubkey(), COLLATERAL), &miner.pubkey(), &miner).expect("post");
@@ -575,9 +566,11 @@ fn onchain_post_collateral() {
     assert_eq!(ms.miner, miner.pubkey());
     assert_eq!(ms.collateral, COLLATERAL, "miner collateral credited");
     assert!(!ms.active, "not active yet");
-    // Vault total_collateral grew by exactly COLLATERAL (post-total semantics: the new global total
-    // equals the prior total plus this deposit).
-    assert_eq!(read_vault(&rpc).total_collateral, before + COLLATERAL, "vault post-total");
+    // The per-miner collateral vault now holds at least the deposited collateral (rent + COLLATERAL).
+    assert!(
+        collateral_vault_lamports(&rpc, &miner.pubkey()) >= COLLATERAL,
+        "collateral lamports held in the per-miner vault"
+    );
 }
 
 #[test]
@@ -751,11 +744,10 @@ fn onchain_confirm_swap_full_lifecycle() {
     let _ = shared();
     let rpc = rpc();
     let vals = validator_keypairs();
-    // Capture the vault rent reserve = lamports - collateral before our swap.
-    let rent_reserve = vault_lamports(&rpc) - read_vault(&rpc).total_collateral;
-    assert!(invariant_holds(&rpc, rent_reserve), "vault invariant pre-flow");
-
     let miner = reserved_miner(&rpc);
+    // Capture this miner's collateral-vault rent reserve = lamports - collateral, before the swap.
+    let rent_reserve = collateral_vault_lamports(&rpc, &miner.pubkey()) - read_miner(&rpc, &miner.pubkey()).collateral;
+    assert!(invariant_holds(&rpc, &miner.pubkey(), rent_reserve), "collateral-vault invariant pre-flow");
     let user = Keypair::new().pubkey();
     let tx = "srctx_confirm";
 
@@ -780,8 +772,8 @@ fn onchain_confirm_swap_full_lifecycle() {
     // Swap closed, miner freed.
     assert!(!account_exists(&rpc, &swap_pda(&swap_key(tx))), "swap account closed");
     assert!(!read_miner(&rpc, &miner.pubkey()).has_active_swap, "miner freed");
-    // Vault invariant holds after the fee move.
-    assert!(invariant_holds(&rpc, rent_reserve), "vault invariant after fee");
+    // Collateral-vault invariant holds after the fee move.
+    assert!(invariant_holds(&rpc, &miner.pubkey(), rent_reserve), "collateral-vault invariant after fee");
 }
 
 #[test]

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_collateral.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_collateral.rs
@@ -1,11 +1,11 @@
-// Phase 1 — collateral deposit/withdraw + vault invariant (LiteSVM, in-process).
+// Phase 1 — collateral deposit/withdraw + per-miner vault invariant (LiteSVM, in-process).
 //   cargo test -p allways_swap_manager --test test_collateral
 use {
     anchor_lang::{
         prelude::Pubkey, solana_program::instruction::Instruction, AccountDeserialize,
         InstructionData, ToAccountMetas,
     },
-    allways_swap_manager::state::{MinerState, Vault},
+    allways_swap_manager::state::MinerState,
     litesvm::LiteSVM,
     solana_keypair::Keypair,
     solana_message::{Message, VersionedMessage},
@@ -18,14 +18,14 @@ const SYSTEM_PROGRAM: Pubkey = anchor_lang::solana_program::system_program::ID;
 fn config_pda(program_id: &Pubkey) -> Pubkey {
     Pubkey::find_program_address(&[b"config"], program_id).0
 }
-fn vault_pda(program_id: &Pubkey) -> Pubkey {
-    Pubkey::find_program_address(&[b"vault"], program_id).0
-}
 fn treasury_pda(program_id: &Pubkey) -> Pubkey {
     Pubkey::find_program_address(&[b"treasury"], program_id).0
 }
 fn miner_pda(program_id: &Pubkey, miner: &Pubkey) -> Pubkey {
     Pubkey::find_program_address(&[b"miner", miner.as_ref()], program_id).0
+}
+fn collateral_vault_pda(program_id: &Pubkey, miner: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&[b"collateral", miner.as_ref()], program_id).0
 }
 
 fn send(svm: &mut LiteSVM, ix: Instruction, payer: &Pubkey, signer: &Keypair) -> Result<(), String> {
@@ -59,7 +59,6 @@ fn setup(max_collateral: u64) -> (LiteSVM, Pubkey) {
         allways_swap_manager::accounts::Initialize {
             admin: admin.pubkey(),
             config: config_pda(&program_id),
-            vault: vault_pda(&program_id),
             treasury: treasury_pda(&program_id),
             system_program: SYSTEM_PROGRAM,
         }
@@ -77,7 +76,7 @@ fn post_ix(program_id: &Pubkey, miner: &Pubkey, amount: u64) -> Instruction {
             miner: *miner,
             config: config_pda(program_id),
             miner_state: miner_pda(program_id, miner),
-            vault: vault_pda(program_id),
+            collateral_vault: collateral_vault_pda(program_id, miner),
             system_program: SYSTEM_PROGRAM,
         }
         .to_account_metas(None),
@@ -92,18 +91,14 @@ fn withdraw_ix(program_id: &Pubkey, miner: &Pubkey, amount: u64) -> Instruction 
             miner: *miner,
             config: config_pda(program_id),
             miner_state: miner_pda(program_id, miner),
-            vault: vault_pda(program_id),
+            collateral_vault: collateral_vault_pda(program_id, miner),
         }
         .to_account_metas(None),
     )
 }
 
-fn vault_lamports(svm: &LiteSVM, program_id: &Pubkey) -> u64 {
-    svm.get_account(&vault_pda(program_id)).unwrap().lamports
-}
-fn vault_total(svm: &LiteSVM, program_id: &Pubkey) -> u64 {
-    let a = svm.get_account(&vault_pda(program_id)).unwrap();
-    Vault::try_deserialize(&mut a.data.as_slice()).unwrap().total_collateral
+fn collateral_vault_lamports(svm: &LiteSVM, program_id: &Pubkey, miner: &Pubkey) -> u64 {
+    svm.get_account(&collateral_vault_pda(program_id, miner)).unwrap().lamports
 }
 fn miner_collateral(svm: &LiteSVM, program_id: &Pubkey, miner: &Pubkey) -> u64 {
     let a = svm.get_account(&miner_pda(program_id, miner)).unwrap();
@@ -116,27 +111,24 @@ fn test_post_and_withdraw_maintains_invariant() {
     let miner = Keypair::new();
     svm.airdrop(&miner.pubkey(), 100_000_000_000).unwrap();
 
-    // After init, vault holds only its rent reserve and total_collateral == 0.
-    let rent_reserve = vault_lamports(&svm, &program_id);
-    assert_eq!(vault_total(&svm, &program_id), 0);
-
     let dep1 = 2_000_000_000u64;
     send(&mut svm, post_ix(&program_id, &miner.pubkey(), dep1), &miner.pubkey(), &miner).expect("post1");
-    assert_eq!(miner_collateral(&svm, &program_id, &miner.pubkey()), dep1);
-    assert_eq!(vault_total(&svm, &program_id), dep1);
-    assert_eq!(vault_lamports(&svm, &program_id), rent_reserve + dep1, "invariant after deposit 1");
+    // First deposit lazily creates the per-miner collateral vault; derive its rent reserve.
+    let m = miner.pubkey();
+    let rent_reserve = collateral_vault_lamports(&svm, &program_id, &m) - dep1;
+    assert_eq!(miner_collateral(&svm, &program_id, &m), dep1);
+    assert_eq!(collateral_vault_lamports(&svm, &program_id, &m), rent_reserve + dep1, "invariant after deposit 1");
 
     let dep2 = 1_000_000_000u64;
-    send(&mut svm, post_ix(&program_id, &miner.pubkey(), dep2), &miner.pubkey(), &miner).expect("post2");
-    assert_eq!(vault_total(&svm, &program_id), dep1 + dep2);
-    assert_eq!(vault_lamports(&svm, &program_id), rent_reserve + dep1 + dep2, "invariant after deposit 2");
+    send(&mut svm, post_ix(&program_id, &m, dep2), &m, &miner).expect("post2");
+    assert_eq!(miner_collateral(&svm, &program_id, &m), dep1 + dep2);
+    assert_eq!(collateral_vault_lamports(&svm, &program_id, &m), rent_reserve + dep1 + dep2, "invariant after deposit 2");
 
     let wd = 1_500_000_000u64;
-    send(&mut svm, withdraw_ix(&program_id, &miner.pubkey(), wd), &miner.pubkey(), &miner).expect("withdraw");
+    send(&mut svm, withdraw_ix(&program_id, &m, wd), &m, &miner).expect("withdraw");
     let remaining = dep1 + dep2 - wd;
-    assert_eq!(miner_collateral(&svm, &program_id, &miner.pubkey()), remaining);
-    assert_eq!(vault_total(&svm, &program_id), remaining);
-    assert_eq!(vault_lamports(&svm, &program_id), rent_reserve + remaining, "invariant after withdraw");
+    assert_eq!(miner_collateral(&svm, &program_id, &m), remaining);
+    assert_eq!(collateral_vault_lamports(&svm, &program_id, &m), rent_reserve + remaining, "invariant after withdraw");
 }
 
 #[test]

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_consensus.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_consensus.rs
@@ -23,8 +23,8 @@ fn pid() -> Pubkey {
 fn config_pda() -> Pubkey {
     Pubkey::find_program_address(&[b"config"], &pid()).0
 }
-fn vault_pda() -> Pubkey {
-    Pubkey::find_program_address(&[b"vault"], &pid()).0
+fn collateral_vault_pda(m: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&[b"collateral", m.as_ref()], &pid()).0
 }
 fn treasury_pda() -> Pubkey {
     Pubkey::find_program_address(&[b"treasury"], &pid()).0
@@ -67,7 +67,6 @@ fn init_ix(admin: &Pubkey, min_collateral: u64, threshold: u8) -> Instruction {
         allways_swap_manager::accounts::Initialize {
             admin: *admin,
             config: config_pda(),
-            vault: vault_pda(),
             treasury: treasury_pda(),
             system_program: SYSTEM_PROGRAM,
         }
@@ -93,7 +92,7 @@ fn post_ix(miner: &Pubkey, amount: u64) -> Instruction {
             miner: *miner,
             config: config_pda(),
             miner_state: miner_pda(miner),
-            vault: vault_pda(),
+            collateral_vault: collateral_vault_pda(miner),
             system_program: SYSTEM_PROGRAM,
         }
         .to_account_metas(None),

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_initialize.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_initialize.rs
@@ -5,7 +5,7 @@ use {
         prelude::Pubkey, solana_program::instruction::Instruction, AccountDeserialize,
         InstructionData, ToAccountMetas,
     },
-    allways_swap_manager::state::{Config, Treasury, Vault},
+    allways_swap_manager::state::{Config, Treasury},
     litesvm::LiteSVM,
     solana_keypair::Keypair,
     solana_message::{Message, VersionedMessage},
@@ -25,7 +25,6 @@ fn test_initialize_creates_config() {
     svm.airdrop(&admin_pk, 10_000_000_000).unwrap();
 
     let (config_pda, _) = Pubkey::find_program_address(&[b"config"], &program_id);
-    let (vault_pda, _) = Pubkey::find_program_address(&[b"vault"], &program_id);
     let (treasury_pda, _) = Pubkey::find_program_address(&[b"treasury"], &program_id);
 
     let ix = Instruction::new_with_bytes(
@@ -43,7 +42,6 @@ fn test_initialize_creates_config() {
         allways_swap_manager::accounts::Initialize {
             admin: admin_pk,
             config: config_pda,
-            vault: vault_pda,
             treasury: treasury_pda,
             system_program: anchor_lang::solana_program::system_program::ID,
         }
@@ -65,10 +63,6 @@ fn test_initialize_creates_config() {
     assert_eq!(config.fulfillment_timeout_secs, 12_600);
     assert_eq!(config.consensus_threshold_percent, 66);
     assert!(config.validators.is_empty());
-
-    let vault_acct = svm.get_account(&vault_pda).expect("vault exists");
-    let vault = Vault::try_deserialize(&mut vault_acct.data.as_slice()).unwrap();
-    assert_eq!(vault.total_collateral, 0);
 
     let treasury_acct = svm.get_account(&treasury_pda).expect("treasury exists");
     let treasury = Treasury::try_deserialize(&mut treasury_acct.data.as_slice()).unwrap();

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_quote.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_quote.rs
@@ -28,9 +28,6 @@ const SYSTEM_PROGRAM: Pubkey = anchor_lang::solana_program::system_program::ID;
 fn config_pda(program_id: &Pubkey) -> Pubkey {
     Pubkey::find_program_address(&[b"config"], program_id).0
 }
-fn vault_pda(program_id: &Pubkey) -> Pubkey {
-    Pubkey::find_program_address(&[b"vault"], program_id).0
-}
 fn treasury_pda(program_id: &Pubkey) -> Pubkey {
     Pubkey::find_program_address(&[b"treasury"], program_id).0
 }
@@ -72,7 +69,6 @@ fn setup() -> (LiteSVM, Pubkey) {
         allways_swap_manager::accounts::Initialize {
             admin: admin.pubkey(),
             config: config_pda(&program_id),
-            vault: vault_pda(&program_id),
             treasury: treasury_pda(&program_id),
             system_program: SYSTEM_PROGRAM,
         }

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_reservation.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_reservation.rs
@@ -36,8 +36,8 @@ fn pid() -> Pubkey {
 fn config_pda() -> Pubkey {
     Pubkey::find_program_address(&[b"config"], &pid()).0
 }
-fn vault_pda() -> Pubkey {
-    Pubkey::find_program_address(&[b"vault"], &pid()).0
+fn collateral_vault_pda(m: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&[b"collateral", m.as_ref()], &pid()).0
 }
 fn treasury_pda() -> Pubkey {
     Pubkey::find_program_address(&[b"treasury"], &pid()).0
@@ -88,7 +88,6 @@ fn init_ix(admin: &Pubkey, min_swap: u64, max_swap: u64, ttl: i64) -> Instructio
         allways_swap_manager::accounts::Initialize {
             admin: *admin,
             config: config_pda(),
-            vault: vault_pda(),
             treasury: treasury_pda(),
             system_program: SYSTEM_PROGRAM,
         }
@@ -111,7 +110,7 @@ fn post_ix(miner: &Pubkey, amount: u64) -> Instruction {
             miner: *miner,
             config: config_pda(),
             miner_state: miner_pda(miner),
-            vault: vault_pda(),
+            collateral_vault: collateral_vault_pda(miner),
             system_program: SYSTEM_PROGRAM,
         }
         .to_account_metas(None),

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_swap.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_swap.rs
@@ -6,7 +6,7 @@ use {
         AccountDeserialize, InstructionData, ToAccountMetas,
     },
     allways_swap_manager::constants::{POOL_WINDOW_SECS, RESERVATION_FEE_LAMPORTS},
-    allways_swap_manager::state::{MinerState, Swap, Treasury, Vault},
+    allways_swap_manager::state::{MinerState, Swap, Treasury},
     litesvm::LiteSVM,
     solana_keccak_hasher::hashv,
     solana_keypair::Keypair,
@@ -41,8 +41,8 @@ fn pid() -> Pubkey {
 fn config_pda() -> Pubkey {
     Pubkey::find_program_address(&[b"config"], &pid()).0
 }
-fn vault_pda() -> Pubkey {
-    Pubkey::find_program_address(&[b"vault"], &pid()).0
+fn collateral_vault_pda(m: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&[b"collateral", m.as_ref()], &pid()).0
 }
 fn treasury_pda() -> Pubkey {
     Pubkey::find_program_address(&[b"treasury"], &pid()).0
@@ -101,7 +101,6 @@ fn init_ix(admin: &Pubkey) -> Instruction {
         allways_swap_manager::accounts::Initialize {
             admin: *admin,
             config: config_pda(),
-            vault: vault_pda(),
             treasury: treasury_pda(),
             system_program: SYSTEM_PROGRAM,
         }
@@ -124,7 +123,7 @@ fn post_ix(miner: &Pubkey, amount: u64) -> Instruction {
             miner: *miner,
             config: config_pda(),
             miner_state: miner_pda(miner),
-            vault: vault_pda(),
+            collateral_vault: collateral_vault_pda(miner),
             system_program: SYSTEM_PROGRAM,
         }
         .to_account_metas(None),
@@ -269,7 +268,7 @@ fn confirm_ix(validator: &Pubkey, miner: &Pubkey, from_tx_hash: &str) -> Instruc
             config: config_pda(),
             miner: *miner,
             miner_state: miner_pda(miner),
-            vault: vault_pda(),
+            collateral_vault: collateral_vault_pda(miner),
             treasury: treasury_pda(),
             swap: swap_pda(&key),
             vote_round: vote_pda(REQ_CONFIRM, &key),
@@ -288,7 +287,7 @@ fn timeout_ix(validator: &Pubkey, miner: &Pubkey, user: &Pubkey, from_tx_hash: &
             config: config_pda(),
             miner: *miner,
             miner_state: miner_pda(miner),
-            vault: vault_pda(),
+            collateral_vault: collateral_vault_pda(miner),
             user: *user,
             swap: swap_pda(&key),
             vote_round: vote_pda(REQ_TIMEOUT, &key),
@@ -302,16 +301,12 @@ fn miner_state(svm: &LiteSVM, m: &Pubkey) -> MinerState {
     let a = svm.get_account(&miner_pda(m)).unwrap();
     MinerState::try_deserialize(&mut a.data.as_slice()).unwrap()
 }
-fn vault(svm: &LiteSVM) -> Vault {
-    let a = svm.get_account(&vault_pda()).unwrap();
-    Vault::try_deserialize(&mut a.data.as_slice()).unwrap()
-}
 fn treasury_total(svm: &LiteSVM) -> u64 {
     let a = svm.get_account(&treasury_pda()).unwrap();
     Treasury::try_deserialize(&mut a.data.as_slice()).unwrap().total
 }
-fn vault_lamports(svm: &LiteSVM) -> u64 {
-    svm.get_account(&vault_pda()).unwrap().lamports
+fn collateral_vault_lamports(svm: &LiteSVM, m: &Pubkey) -> u64 {
+    svm.get_account(&collateral_vault_pda(m)).unwrap().lamports
 }
 fn lamports(svm: &LiteSVM, p: &Pubkey) -> u64 {
     svm.get_account(p).map(|a| a.lamports).unwrap_or(0)
@@ -333,7 +328,6 @@ fn setup_with_collateral(collateral: u64) -> (LiteSVM, Vec<Keypair>, Keypair, u6
     let admin = Keypair::new();
     svm.airdrop(&admin.pubkey(), 100_000_000_000).unwrap();
     send(&mut svm, init_ix(&admin.pubkey()), &admin.pubkey(), &admin).expect("init");
-    let rent_reserve = vault_lamports(&svm);
 
     let mut vals = Vec::new();
     for _ in 0..3 {
@@ -346,6 +340,8 @@ fn setup_with_collateral(collateral: u64) -> (LiteSVM, Vec<Keypair>, Keypair, u6
     let miner = Keypair::new();
     svm.airdrop(&miner.pubkey(), 100_000_000_000).unwrap();
     send(&mut svm, post_ix(&miner.pubkey(), collateral), &miner.pubkey(), &miner).expect("post");
+    // The per-miner collateral vault is created by the deposit above; derive its rent reserve.
+    let rent_reserve = collateral_vault_lamports(&svm, &miner.pubkey()) - collateral;
     send(&mut svm, set_quote_ix(&miner.pubkey()), &miner.pubkey(), &miner).expect("quote");
     send(&mut svm, vote_activate_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0]).expect("a0");
     send(&mut svm, vote_activate_ix(&vals[1].pubkey(), &miner.pubkey()), &vals[1].pubkey(), &vals[1]).expect("a1");
@@ -379,9 +375,9 @@ fn do_reserve(svm: &mut LiteSVM, opener: &Keypair, miner: &Pubkey) {
     send(svm, resolve_ix(&opener.pubkey(), miner), &opener.pubkey(), opener).expect("resolve");
 }
 
-fn invariant_holds(svm: &LiteSVM, rent_reserve: u64) -> bool {
-    // Collateral vault holds only collateral now; treasury revenue lives in a separate PDA.
-    vault_lamports(svm) == rent_reserve + vault(svm).total_collateral
+fn invariant_holds(svm: &LiteSVM, miner: &Pubkey, rent_reserve: u64) -> bool {
+    // Each miner's collateral vault holds only that miner's collateral; revenue is in the treasury.
+    collateral_vault_lamports(svm, miner) == rent_reserve + miner_state(svm, miner).collateral
 }
 
 #[test]
@@ -486,7 +482,7 @@ fn test_fulfill_confirm_fee_and_invariant() {
     let (mut svm, vals, miner, rent) = setup();
     let user = Keypair::new().pubkey();
     do_initiate(&mut svm, &vals, &miner.pubkey(), "srctx1", &user);
-    assert!(invariant_holds(&svm, rent));
+    assert!(invariant_holds(&svm, &miner.pubkey(), rent));
 
     // confirm before fulfill must fail
     assert!(confirm_only(&mut svm, &vals[0], &miner.pubkey(), "srctx1").is_err());
@@ -507,7 +503,7 @@ fn test_fulfill_confirm_fee_and_invariant() {
     );
     assert!(!miner_state(&svm, &miner.pubkey()).has_active_swap);
     assert!(svm.get_account(&swap_pda(&swap_key("srctx1"))).is_none(), "swap closed");
-    assert!(invariant_holds(&svm, rent), "vault invariant after fee");
+    assert!(invariant_holds(&svm, &miner.pubkey(), rent), "collateral-vault invariant after fee");
 }
 
 fn confirm_only(svm: &mut LiteSVM, v: &Keypair, miner: &Pubkey, tx: &str) -> Result<(), String> {
@@ -538,7 +534,7 @@ fn test_timeout_slash_refund_and_invariant() {
     assert_eq!(lamports(&svm, &user.pubkey()), user_before + slash, "user refunded full 1.1x slash");
     assert!(!miner_state(&svm, &miner.pubkey()).has_active_swap);
     assert!(svm.get_account(&swap_pda(&swap_key("srctx1"))).is_none(), "swap closed");
-    assert!(invariant_holds(&svm, rent), "vault invariant after slash");
+    assert!(invariant_holds(&svm, &miner.pubkey(), rent), "collateral-vault invariant after slash");
 }
 
 fn timeout_only(svm: &mut LiteSVM, v: &Keypair, miner: &Pubkey, user: &Pubkey, tx: &str) -> Result<(), String> {

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_treasury.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_treasury.rs
@@ -7,7 +7,7 @@ use {
         AccountDeserialize, InstructionData, ToAccountMetas,
     },
     allways_swap_manager::constants::{POOL_WINDOW_SECS, RESERVATION_FEE_LAMPORTS},
-    allways_swap_manager::state::{Treasury, Vault},
+    allways_swap_manager::state::Treasury,
     litesvm::LiteSVM,
     solana_keccak_hasher::hashv,
     solana_keypair::Keypair,
@@ -27,8 +27,8 @@ fn pid() -> Pubkey {
 fn cfg() -> Pubkey {
     Pubkey::find_program_address(&[b"config"], &pid()).0
 }
-fn vault_pda() -> Pubkey {
-    Pubkey::find_program_address(&[b"vault"], &pid()).0
+fn collateral_vault_pda(m: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&[b"collateral", m.as_ref()], &pid()).0
 }
 fn treasury_pda() -> Pubkey {
     Pubkey::find_program_address(&[b"treasury"], &pid()).0
@@ -70,10 +70,6 @@ fn send(svm: &mut LiteSVM, ix: Instruction, payer: &Pubkey, s: &Keypair) -> Resu
     let tx = VersionedTransaction::try_new(VersionedMessage::Legacy(msg), &[s]).unwrap();
     svm.send_transaction(tx).map(|_| ()).map_err(|e| format!("{:?}", e))
 }
-fn vault(svm: &LiteSVM) -> Vault {
-    let a = svm.get_account(&vault_pda()).unwrap();
-    Vault::try_deserialize(&mut a.data.as_slice()).unwrap()
-}
 fn treasury(svm: &LiteSVM) -> Treasury {
     let a = svm.get_account(&treasury_pda()).unwrap();
     Treasury::try_deserialize(&mut a.data.as_slice()).unwrap()
@@ -97,8 +93,8 @@ fn withdraw_ix(admin: &Pubkey, recipient: &Pubkey, amount: u64) -> Instruction {
 }
 
 /// Full flow that accrues treasury (one reservation fee from the lottery + the 1% confirm fee);
-/// returns (svm, admin, total_treasury, vault_rent_reserve).
-fn setup_with_fee() -> (LiteSVM, Keypair, u64, u64) {
+/// returns (svm, admin, total_treasury).
+fn setup_with_fee() -> (LiteSVM, Keypair, u64) {
     let mut svm = LiteSVM::new();
     svm.add_program(pid(), include_bytes!("../../../target/deploy/allways_swap_manager.so")).unwrap();
     set_clock(&mut svm, BASE_TS);
@@ -112,9 +108,8 @@ fn setup_with_fee() -> (LiteSVM, Keypair, u64, u64) {
             min_collateral: 1_000_000_000, max_collateral: 0, fulfillment_timeout_secs: 3_600,
             consensus_threshold_percent: 66, min_swap_amount: 0, max_swap_amount: 0, reservation_ttl_secs: 1_800,
         }.data(),
-        allways_swap_manager::accounts::Initialize { admin: admin.pubkey(), config: cfg(), vault: vault_pda(), treasury: treasury_pda(), system_program: SYS }.to_account_metas(None),
+        allways_swap_manager::accounts::Initialize { admin: admin.pubkey(), config: cfg(), treasury: treasury_pda(), system_program: SYS }.to_account_metas(None),
     ), &admin.pubkey(), &admin).expect("init");
-    let rent_reserve = lam(&svm, &vault_pda());
 
     let mut vals = Vec::new();
     for _ in 0..3 {
@@ -131,7 +126,7 @@ fn setup_with_fee() -> (LiteSVM, Keypair, u64, u64) {
     svm.airdrop(&miner.pubkey(), 100_000_000_000).unwrap();
     send(&mut svm, Instruction::new_with_bytes(pid(),
         &allways_swap_manager::instruction::PostCollateral { amount: 10_000_000_000 }.data(),
-        allways_swap_manager::accounts::PostCollateral { miner: miner.pubkey(), config: cfg(), miner_state: miner_pda(&miner.pubkey()), vault: vault_pda(), system_program: SYS }.to_account_metas(None),
+        allways_swap_manager::accounts::PostCollateral { miner: miner.pubkey(), config: cfg(), miner_state: miner_pda(&miner.pubkey()), collateral_vault: collateral_vault_pda(&miner.pubkey()), system_program: SYS }.to_account_metas(None),
     ), &miner.pubkey(), &miner).expect("post");
 
     let activate = |svm: &mut LiteSVM, v: &Keypair| {
@@ -178,19 +173,19 @@ fn setup_with_fee() -> (LiteSVM, Keypair, u64, u64) {
     let confirm = |svm: &mut LiteSVM, v: &Keypair| {
         send(svm, Instruction::new_with_bytes(pid(),
             &allways_swap_manager::instruction::ConfirmSwap { swap_key: key }.data(),
-            allways_swap_manager::accounts::ConfirmSwap { validator: v.pubkey(), config: cfg(), miner: miner.pubkey(), miner_state: miner_pda(&miner.pubkey()), vault: vault_pda(), treasury: treasury_pda(), swap: swap_pda(&key), vote_round: vote_pda(6, &key), system_program: SYS }.to_account_metas(None),
+            allways_swap_manager::accounts::ConfirmSwap { validator: v.pubkey(), config: cfg(), miner: miner.pubkey(), miner_state: miner_pda(&miner.pubkey()), collateral_vault: collateral_vault_pda(&miner.pubkey()), treasury: treasury_pda(), swap: swap_pda(&key), vote_round: vote_pda(6, &key), system_program: SYS }.to_account_metas(None),
         ), &v.pubkey(), v).expect("confirm");
     };
     confirm(&mut svm, &vals[0]);
     confirm(&mut svm, &vals[1]);
 
     // treasury = reservation fee + the 1% confirm fee (quote creation is free).
-    (svm, admin, SOL_AMOUNT / 100 + RESERVATION_FEE_LAMPORTS, rent_reserve)
+    (svm, admin, SOL_AMOUNT / 100 + RESERVATION_FEE_LAMPORTS)
 }
 
 #[test]
 fn test_withdraw_treasury_happy_path() {
-    let (mut svm, admin, fee, rent) = setup_with_fee();
+    let (mut svm, admin, fee) = setup_with_fee();
     assert_eq!(treasury(&svm).total, fee, "fee accrued");
 
     // Treasury-side conservation: lamports above the rent reserve always equal `total`.
@@ -202,14 +197,14 @@ fn test_withdraw_treasury_happy_path() {
 
     assert_eq!(lam(&svm, &recipient), before + fee, "recipient received fees");
     assert_eq!(treasury(&svm).total, 0, "treasury drained");
-    // both PDAs conserve lamports: vault == rent + collateral; treasury == rent + total.
-    assert_eq!(lam(&svm, &vault_pda()), rent + vault(&svm).total_collateral);
+    // Treasury conserves lamports: lamports == rent + total. (Per-miner collateral-vault conservation
+    // is covered in test_collateral / test_swap.)
     assert_eq!(lam(&svm, &treasury_pda()), treasury_rent + treasury(&svm).total, "treasury lamports == rent + total");
 }
 
 #[test]
 fn test_non_admin_cannot_withdraw() {
-    let (mut svm, _admin, fee, _rent) = setup_with_fee();
+    let (mut svm, _admin, fee) = setup_with_fee();
     let outsider = Keypair::new();
     svm.airdrop(&outsider.pubkey(), 1_000_000_000).unwrap();
     let res = send(&mut svm, withdraw_ix(&outsider.pubkey(), &outsider.pubkey(), fee), &outsider.pubkey(), &outsider);
@@ -219,7 +214,7 @@ fn test_non_admin_cannot_withdraw() {
 
 #[test]
 fn test_cannot_overdraw_treasury() {
-    let (mut svm, admin, fee, _rent) = setup_with_fee();
+    let (mut svm, admin, fee) = setup_with_fee();
     let recipient = Keypair::new().pubkey();
     let res = send(&mut svm, withdraw_ix(&admin.pubkey(), &recipient, fee + 1), &admin.pubkey(), &admin);
     assert!(res.is_err(), "withdrawing more than treasury rejected");

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_validator_weight.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_validator_weight.rs
@@ -25,9 +25,6 @@ const BASE_TS: i64 = 1_700_000_000;
 fn config_pda(program_id: &Pubkey) -> Pubkey {
     Pubkey::find_program_address(&[b"config"], program_id).0
 }
-fn vault_pda(program_id: &Pubkey) -> Pubkey {
-    Pubkey::find_program_address(&[b"vault"], program_id).0
-}
 fn treasury_pda(program_id: &Pubkey) -> Pubkey {
     Pubkey::find_program_address(&[b"treasury"], program_id).0
 }
@@ -69,7 +66,6 @@ fn setup() -> (LiteSVM, Pubkey, Keypair) {
         allways_swap_manager::accounts::Initialize {
             admin: admin.pubkey(),
             config: config_pda(&program_id),
-            vault: vault_pda(&program_id),
             treasury: treasury_pda(&program_id),
             system_program: SYSTEM_PROGRAM,
         }


### PR DESCRIPTION
**Stacked on #490** (`solana-review-followups`). Until #490 merges, this PR's diff shows #490's changes too; once #490 lands in `contract-v2`, it collapses to just the per-miner-collateral change. Review #490 first.

## What

Replace the single shared collateral `Vault` with **per-miner `CollateralVault` PDAs** (`seeds=[b"collateral", miner]`). Each miner's collateral lamports live in their own account; `MinerState.collateral` stays the authoritative ledger. The `Treasury` PDA (subnet revenue) is unchanged.

## Why

The shared `Vault` was both a write-serialization point and a cheap-to-grief congestion target: a miner spamming self-deposits could eat the vault's ~12M-CU/block budget and **delay swap settlement** (`confirm`/`timeout` wrote the same account). Per-miner vaults:
- **isolate the DOS blast radius** — a miner's deposit/withdraw spam only congests their own PDA;
- **parallelize** collateral ops across different miners;
- make custody **literal** — a miner's collateral is in their own account, movable only by their own `withdraw_collateral` or a quorum slash.

No fund-access change: deposit/withdraw were already signer-scoped to the owner.

## Changes
- New `CollateralVault { bump }`; `Vault` struct + `VAULT_SEED` removed.
- `post_collateral`/`withdraw_collateral` move lamports between the miner and *their own* vault (lazily created on first deposit, miner-paid rent).
- `confirm_swap`: 1% fee → Treasury from the miner's vault; `timeout_swap`: slash → user from the miner's vault.
- `apply_penalty` drops the shared-total bookkeeping (per-account invariant: `lamports == rent + collateral`).
- `initialize` no longer creates a shared vault.

## Tests
- LiteSVM **65/65**; `e2e.sh` **24/24** (build + deploy + on-chain, exercising the per-miner vaults end-to-end).
- Per-miner invariant assertions (`collateral_vault(miner).lamports == rent + MinerState.collateral`); removed the obsolete shared-`total_collateral` checks.