### PR TITLE
feat(solana): dynamic pool bids (in-window request updates)

### DIFF
--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/open_or_request.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/open_or_request.rs
@@ -129,24 +129,35 @@ pub fn handler(
     let active_reservation = resv.reserved_until != 0 && resv.reserved_until >= now;
     require!(!active_reservation, ErrorCode::MinerReserved);
 
-    // Flat, non-refundable anti-spam fee: validator → treasury (subnet revenue, every call).
-    let fee = ctx.accounts.config.reservation_fee_lamports;
-    transfer(
-        CpiContext::new(
-            ctx.accounts.system_program.key(),
-            Transfer {
-                from: ctx.accounts.validator.to_account_info(),
-                to: ctx.accounts.treasury.to_account_info(),
-            },
-        ),
-        fee,
-    )?;
-    ctx.accounts.treasury.total = ctx
-        .accounts
-        .treasury
-        .total
-        .checked_add(fee)
-        .ok_or(ErrorCode::Overflow)?;
+    // Flat, non-refundable anti-spam fee: validator → treasury (subnet revenue). Charged only on a
+    // fresh entry (open or first join) — a same-validator in-window bid UPDATE is free, so refining a
+    // bid against the pinned rate isn't taxed.
+    let is_update = ctx.accounts.pool.opened_at != 0
+        && ctx
+            .accounts
+            .pool
+            .requests
+            .iter()
+            .any(|r| r.validator == ctx.accounts.validator.key());
+    if !is_update {
+        let fee = ctx.accounts.config.reservation_fee_lamports;
+        transfer(
+            CpiContext::new(
+                ctx.accounts.system_program.key(),
+                Transfer {
+                    from: ctx.accounts.validator.to_account_info(),
+                    to: ctx.accounts.treasury.to_account_info(),
+                },
+            ),
+            fee,
+        )?;
+        ctx.accounts.treasury.total = ctx
+            .accounts
+            .treasury
+            .total
+            .checked_add(fee)
+            .ok_or(ErrorCode::Overflow)?;
+    }
 
     let miner_key = ctx.accounts.miner.key();
     let validator_key = ctx.accounts.validator.key();
@@ -202,19 +213,21 @@ pub fn handler(
             seed_slot,
         });
     } else {
-        // JOIN — must be within the window, same pinned pair, and not a duplicate validator.
+        // JOIN or UPDATE — must be within the window and match the pinned pair.
         let pool = &mut ctx.accounts.pool;
         require!(now <= pool.closes_at, ErrorCode::PoolClosed);
         require!(
             pool.from_chain == from_chain && pool.to_chain == to_chain,
             ErrorCode::MinerBusyDifferentPair
         );
-        require!(
-            !pool.requests.iter().any(|r| r.validator == validator_key),
-            ErrorCode::AlreadyRequested
-        );
-        require!(pool.requests.len() < MAX_VALIDATORS, ErrorCode::ValidatorSetFull);
-        pool.requests.push(req);
+        // Upsert: a repeat call from the same validator updates its bid in place (dynamic bidding
+        // while the window is open); a new validator is appended, subject to the set cap.
+        if let Some(existing) = pool.requests.iter_mut().find(|r| r.validator == validator_key) {
+            *existing = req;
+        } else {
+            require!(pool.requests.len() < MAX_VALIDATORS, ErrorCode::ValidatorSetFull);
+            pool.requests.push(req);
+        }
 
         emit!(ReservationRequested {
             miner: miner_key,

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_reservation.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_reservation.rs
@@ -299,13 +299,21 @@ fn test_each_request_charges_fee() {
 }
 
 #[test]
-fn test_duplicate_validator_rejected() {
+fn test_validator_can_update_request() {
+    // A repeat call from the same validator while the pool is open UPDATES its bid in place (no
+    // AlreadyRequested reject): the request count stays 1 and the content reflects the new bid.
     let (mut svm, _admin, vals, miner) = setup(0, 0);
-    let user = Keypair::new().pubkey();
-    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL", &user, "u1", "uSOL", 1, 1, 0), &vals[0].pubkey(), &vals[0]).expect("open");
-    let dup = send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL", &user, "u1", "uSOL", 1, 1, 0), &vals[0].pubkey(), &vals[0]);
-    assert!(dup.is_err(), "same validator twice in one pool must be rejected");
-    assert_eq!(pool(&svm, &miner.pubkey()).requests.len(), 1);
+    let u1 = Keypair::new().pubkey();
+    let u2 = Keypair::new().pubkey();
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL", &u1, "u1", "uSOL", 1_000_000_000, 1, 0), &vals[0].pubkey(), &vals[0]).expect("open");
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL", &u2, "u2", "uSOL2", 2_000_000_000, 7, 0), &vals[0].pubkey(), &vals[0]).expect("update");
+
+    let p = pool(&svm, &miner.pubkey());
+    assert_eq!(p.requests.len(), 1, "update replaces in place, not appended");
+    assert_eq!(p.requests[0].validator, vals[0].pubkey());
+    assert_eq!(p.requests[0].user, u2, "bid updated to the new user");
+    assert_eq!(p.requests[0].user_from_addr, "u2");
+    assert_eq!(p.requests[0].sol_amount, 2_000_000_000, "bid updated to the new amount");
 }
 
 #[test]
@@ -536,4 +544,43 @@ fn test_swap_amount_bounds_cannot_be_contradictory() {
     assert!(send(&mut svm, set_max_swap_ix(&admin.pubkey(), 500_000_000), &admin.pubkey(), &admin).is_err(), "max < min rejected");
     assert!(send(&mut svm, set_min_swap_ix(&admin.pubkey(), 6_000_000_000), &admin.pubkey(), &admin).is_err(), "min > max rejected");
     send(&mut svm, set_max_swap_ix(&admin.pubkey(), 8_000_000_000), &admin.pubkey(), &admin).expect("widening max is allowed");
+}
+#[test]
+fn test_update_reflected_in_reservation() {
+    // The updated bid (not the original) is what wins and becomes the reservation.
+    let (mut svm, _admin, vals, miner) = setup(0, 0);
+    let u1 = Keypair::new().pubkey();
+    let u2 = Keypair::new().pubkey();
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL", &u1, "fromA", "toA", 1_000_000_000, 1, 0), &vals[0].pubkey(), &vals[0]).expect("open");
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL", &u2, "fromB", "toB", 2_000_000_000, 9, 0), &vals[0].pubkey(), &vals[0]).expect("update");
+
+    set_clock(&mut svm, BASE_TS + POOL_WINDOW_SECS + 1);
+    send(&mut svm, resolve_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0]).expect("resolve");
+
+    let r = reservation(&svm, &miner.pubkey());
+    assert_eq!(r.sol_amount, 2_000_000_000, "reservation reflects the updated bid amount");
+    assert_eq!(r.from_addr, "fromB", "reservation reflects the updated user");
+}
+
+#[test]
+fn test_update_is_free() {
+    // First entry pays the reservation fee; a same-validator in-window update is free.
+    let (mut svm, _admin, vals, miner) = setup(0, 0);
+    let user = Keypair::new().pubkey();
+    let t0 = treasury(&svm);
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL", &user, "u1", "uSOL", 1, 1, 0), &vals[0].pubkey(), &vals[0]).expect("open");
+    assert_eq!(treasury(&svm), t0 + RESERVATION_FEE_LAMPORTS, "first entry pays the fee");
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL", &user, "u1", "uSOL", 2, 2, 0), &vals[0].pubkey(), &vals[0]).expect("update");
+    assert_eq!(treasury(&svm), t0 + RESERVATION_FEE_LAMPORTS, "in-window update is free (no extra fee)");
+}
+
+#[test]
+fn test_update_after_window_close_fails() {
+    // Once the window closes, no further updates (must resolve first).
+    let (mut svm, _admin, vals, miner) = setup(0, 0);
+    let user = Keypair::new().pubkey();
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL", &user, "u1", "uSOL", 1, 1, 0), &vals[0].pubkey(), &vals[0]).expect("open");
+    set_clock(&mut svm, BASE_TS + POOL_WINDOW_SECS + 1);
+    let late = send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL", &user, "u1", "uSOL", 2, 2, 0), &vals[0].pubkey(), &vals[0]);
+    assert!(late.is_err(), "cannot update after the window closed");
 }


### PR DESCRIPTION
**Stacked on #491 → #490.** Until those merge, this PR's diff includes their changes too; once they land in `contract-v2` it collapses to just this change. Review order: #490 → #491 → this.

## What

A validator gets **one shot** per reservation pool today — a second `open_or_request` from the same validator while the pool is open is rejected with `AlreadyRequested`. This lets a validator **update its bid in place** while the window is still open (upsert), frozen once the pool resolves.

## Why

The miner's rate is **pinned at pool open**, so the intended workflow is for a validator to run its user-selection *after* a pool opens (bidding against a now-stable rate) and refine as better users arrive. Part B of the reservation/initiation evolution.

- **No lottery gaming:** draw odds are stake-weighted, not amount/time-weighted.
- **Miner protected:** terms stay pinned regardless; an updated bid re-runs the amount-bounds + over-collateral checks (top of the handler).
- **`busy_until` unchanged:** set only at OPEN, never extended by an update.

## Changes (one handler)

`open_or_request.rs`:
- **JOIN branch** upserts: a repeat call from the same validator replaces its `Request` in place; a new validator is appended (subject to `MAX_VALIDATORS`).
- **Fee** is now charged only on a *fresh* entry (open or first join); a same-validator in-window **update is free** (refinement isn't taxed). Different validators each still pay.
- `ErrorCode::AlreadyRequested` left defined (now unused) to avoid IDL churn.

## Tests
- `test_validator_can_update_request` (replaces the old dup-reject test), `test_update_reflected_in_reservation`, `test_update_is_free`, `test_update_after_window_close_fails`.
- LiteSVM **68/68**; `e2e.sh` **24/24** (build + deploy + on-chain).