### PR TITLE
feat(solana): deadline extensions (reservation + fulfillment)

### DIFF
--- a/smart-contracts/solana/programs/allways_swap_manager/src/consensus.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/consensus.rs
@@ -57,6 +57,16 @@ pub fn weights_hash(validators: &[ValidatorInfo], weights: &[u64]) -> [u8; 32] {
     hashv(&refs).to_bytes()
 }
 
+/// Assert `validator` is whitelisted — for consensus-free validator actions (deadline extensions)
+/// that gate on membership but open no vote round.
+pub fn ensure_validator(config: &Config, validator: &Pubkey) -> Result<()> {
+    require!(
+        config.validators.iter().any(|v| &v.key == validator),
+        ErrorCode::NotValidator
+    );
+    Ok(())
+}
+
 /// Record a validator's vote into `round`; returns true iff quorum is now reached.
 /// (Re)initializes a fresh or stale round, binds params via `bound_hash`, and dedupes voters.
 pub fn record_vote<'info>(

--- a/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
@@ -44,9 +44,9 @@ pub const POOL_SEED: &[u8] = b"pool";
 #[constant]
 pub const TREASURY_SEED: &[u8] = b"treasury";
 
-/// On-chain schema/version for upgrade tracking, bumped as phases land. v6: runtime config setters
-/// (fee/window/interval promoted to Config); see git history for the v2–v5 progression.
-pub const CONFIG_VERSION: u32 = 6;
+/// On-chain schema/version for upgrade tracking, bumped as phases land. v7: deadline extensions
+/// (max_total_extension_secs in Config; see git history for the v2–v6 progression).
+pub const CONFIG_VERSION: u32 = 7;
 
 /// Max validators in the whitelist (bounds the Config `validators` Vec and a round's voters).
 pub const MAX_VALIDATORS: usize = 16;
@@ -156,10 +156,28 @@ pub const POOL_WINDOW_SECS: i64 = 60;
 /// floor, not a schedule. Seeds `Config.weights_update_min_interval_secs`.
 pub const WEIGHTS_UPDATE_MIN_INTERVAL_SECS: i64 = 3600;
 
-/// Canonical deploy value for `fulfillment_timeout_secs` — 4h. Sized so the slowest chain (BTC
-/// confirmations) plus validator confirm fits before timeout fires, avoiding over-slashing an
-/// honest-but-unconfirmed miner. Pass at `initialize` (or `set_fulfillment_timeout`); not per-chain yet.
-pub const DEFAULT_FULFILLMENT_TIMEOUT_SECS: i64 = 14_400;
+/// Canonical deploy value for `fulfillment_timeout_secs` — 10 min (mirrors ink!'s 50-block default).
+/// Deliberately tight: the miner must broadcast within it, then validators extend the deadline as the
+/// destination tx confirms (see the extension system). Pass at `initialize` / `set_fulfillment_timeout`.
+pub const DEFAULT_FULFILLMENT_TIMEOUT_SECS: i64 = 600; // 10 min
+
+/// Canonical deploy value for `reservation_ttl_secs` — 10 min (mirrors ink!). Same model as the
+/// fulfillment timeout: a tight base, extended while the source tx confirms.
+pub const DEFAULT_RESERVATION_TTL_SECS: i64 = 600; // 10 min
+
+/// Total seconds a reservation/swap deadline may be slid forward across all extensions, frozen into
+/// each at creation as `deadline + this`. Seeds `Config.max_total_extension_secs`; runtime-tunable
+/// within [MIN, MAX]. 90 min covers two slow BTC blocks (the slowest chain) without back-to-back
+/// outliers stranding a correct miner; the ceiling is the only bound on how long a miner is held.
+pub const MAX_TOTAL_EXTENSION_SECS: i64 = 5_400; // 90 min
+pub const MAX_TOTAL_EXTENSION_SECS_MIN: i64 = 1_800; // 30 min — two 15-min BTC blocks
+pub const MAX_TOTAL_EXTENSION_SECS_MAX: i64 = 7_200; // 120 min — hard lid
+
+const _: () = assert!(
+    MAX_TOTAL_EXTENSION_SECS >= MAX_TOTAL_EXTENSION_SECS_MIN
+        && MAX_TOTAL_EXTENSION_SECS <= MAX_TOTAL_EXTENSION_SECS_MAX,
+    "MAX_TOTAL_EXTENSION_SECS must be within [30 min, 120 min]"
+);
 
 #[cfg(test)]
 mod tests {
@@ -178,6 +196,18 @@ mod tests {
         assert_eq!(quote_update_fee(86_400), 0);
         // Clock skew (negative elapsed) → most-expensive tier, never free.
         assert_eq!(quote_update_fee(-100), QUOTE_UPDATE_FEE_TIER1_LAMPORTS);
+    }
+
+    #[test]
+    fn total_extension_default_within_bounds() {
+        assert!(
+            (MAX_TOTAL_EXTENSION_SECS_MIN..=MAX_TOTAL_EXTENSION_SECS_MAX)
+                .contains(&MAX_TOTAL_EXTENSION_SECS),
+            "MAX_TOTAL_EXTENSION_SECS {} outside [{}, {}]",
+            MAX_TOTAL_EXTENSION_SECS,
+            MAX_TOTAL_EXTENSION_SECS_MIN,
+            MAX_TOTAL_EXTENSION_SECS_MAX,
+        );
     }
 
     #[test]

--- a/smart-contracts/solana/programs/allways_swap_manager/src/error.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/error.rs
@@ -69,6 +69,10 @@ pub enum ErrorCode {
     InvalidStatus,
     #[msg("Swap has not reached its timeout yet")]
     NotTimedOut,
+    #[msg("Extension target must be later than the current deadline")]
+    ExtensionNotLater,
+    #[msg("Extension target exceeds the deadline's absolute ceiling")]
+    ExtensionExceedsCeiling,
 
     // --- Phase 6: treasury ---
     #[msg("Withdrawal exceeds the accrued treasury balance")]

--- a/smart-contracts/solana/programs/allways_swap_manager/src/events.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/events.rs
@@ -61,6 +61,23 @@ pub struct SwapTimedOut {
     pub slash: u64,
 }
 
+/// A validator slid a reservation/swap deadline forward (single-validator, no quorum). Carries the
+/// new deadline (post-value) so consumers set an absolute, not a delta.
+#[event]
+pub struct ReservationExtended {
+    pub miner: Pubkey,
+    pub validator: Pubkey,
+    pub reserved_until: i64,
+}
+
+#[event]
+pub struct SwapTimeoutExtended {
+    pub swap_key: [u8; 32],
+    pub miner: Pubkey,
+    pub validator: Pubkey,
+    pub timeout_at: i64,
+}
+
 // --- Phase 6: treasury ---
 
 #[event]

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions.rs
@@ -1,6 +1,8 @@
 pub mod admin;
 pub mod confirm_swap;
 pub mod deactivate;
+pub mod extend_reservation;
+pub mod extend_timeout;
 pub mod initialize;
 pub mod mark_fulfilled;
 pub mod open_or_request;
@@ -22,6 +24,8 @@ pub mod withdraw_treasury;
 pub use admin::*;
 pub use confirm_swap::*;
 pub use deactivate::*;
+pub use extend_reservation::*;
+pub use extend_timeout::*;
 pub use initialize::*;
 pub use mark_fulfilled::*;
 pub use open_or_request::*;

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/admin.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/admin.rs
@@ -129,3 +129,10 @@ pub fn set_weights_update_min_interval(ctx: Context<AdminConfig>, secs: i64) -> 
     msg!("weights_update_min_interval_secs = {}", secs);
     Ok(())
 }
+
+pub fn set_max_total_extension(ctx: Context<AdminConfig>, secs: i64) -> Result<()> {
+    crate::validate::max_total_extension(secs)?;
+    ctx.accounts.config.max_total_extension_secs = secs;
+    msg!("max_total_extension_secs = {}", secs);
+    Ok(())
+}

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/extend_reservation.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/extend_reservation.rs
@@ -1,0 +1,56 @@
+use anchor_lang::prelude::*;
+
+use crate::consensus::ensure_validator;
+use crate::constants::{CONFIG_SEED, MINER_SEED, RESV_SEED};
+use crate::error::ErrorCode;
+use crate::events::ReservationExtended;
+use crate::state::{Config, MinerState, Reservation};
+
+/// A single validator slides a reservation's `reserved_until` forward while it waits on slow source-
+/// chain confirmation. No quorum — an extension moves no funds, so worst case it only delays a slash
+/// (still quorum-gated) up to the frozen ceiling. Monotonic + ceiling are the only guards; ignores
+/// `halted` so in-flight swaps can finish.
+#[derive(Accounts)]
+pub struct ExtendReservation<'info> {
+    pub validator: Signer<'info>,
+
+    #[account(seeds = [CONFIG_SEED], bump = config.bump)]
+    pub config: Account<'info, Config>,
+
+    /// CHECK: identified by address only; bound via PDA seeds + the miner_state constraint.
+    pub miner: UncheckedAccount<'info>,
+
+    #[account(
+        mut,
+        seeds = [MINER_SEED, miner.key().as_ref()],
+        bump = miner_state.bump,
+        constraint = miner_state.miner == miner.key(),
+    )]
+    pub miner_state: Account<'info, MinerState>,
+
+    #[account(mut, seeds = [RESV_SEED, miner.key().as_ref()], bump = reservation.bump)]
+    pub reservation: Account<'info, Reservation>,
+}
+
+pub fn handler(ctx: Context<ExtendReservation>, target_at: i64) -> Result<()> {
+    let validator = ctx.accounts.validator.key();
+    ensure_validator(&ctx.accounts.config, &validator)?;
+
+    let now = Clock::get()?.unix_timestamp;
+    let resv = &mut ctx.accounts.reservation;
+
+    // Must still be live — don't resurrect an expired (overwritable) reservation.
+    require!(resv.reserved_until != 0 && resv.reserved_until >= now, ErrorCode::NoReservation);
+    require!(target_at > resv.reserved_until, ErrorCode::ExtensionNotLater);
+    require!(target_at <= resv.max_extend_at, ErrorCode::ExtensionExceedsCeiling);
+
+    resv.reserved_until = target_at;
+    ctx.accounts.miner_state.busy_until = target_at;
+
+    emit!(ReservationExtended {
+        miner: ctx.accounts.miner.key(),
+        validator,
+        reserved_until: target_at,
+    });
+    Ok(())
+}

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/extend_timeout.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/extend_timeout.rs
@@ -1,0 +1,62 @@
+use anchor_lang::prelude::*;
+
+use crate::consensus::ensure_validator;
+use crate::constants::{CONFIG_SEED, MINER_SEED, SWAP_SEED};
+use crate::error::ErrorCode;
+use crate::events::SwapTimeoutExtended;
+use crate::state::{Config, MinerState, Swap, SwapStatus};
+
+/// Fulfillment-side mirror of `extend_reservation`: a single validator slides a swap's `timeout_at`
+/// forward while it waits on slow destination-chain confirmation. Same guards (monotonic + frozen
+/// ceiling), ignores `halted`. Allowed in Active or Fulfilled — the same gate as the timeout it defers.
+#[derive(Accounts)]
+#[instruction(swap_key: [u8; 32])]
+pub struct ExtendTimeout<'info> {
+    pub validator: Signer<'info>,
+
+    #[account(seeds = [CONFIG_SEED], bump = config.bump)]
+    pub config: Account<'info, Config>,
+
+    /// CHECK: bound via the miner_state seeds + the swap `has_one`.
+    pub miner: UncheckedAccount<'info>,
+
+    #[account(
+        mut,
+        seeds = [MINER_SEED, miner.key().as_ref()],
+        bump = miner_state.bump,
+        constraint = miner_state.miner == miner.key(),
+    )]
+    pub miner_state: Account<'info, MinerState>,
+
+    #[account(
+        mut,
+        seeds = [SWAP_SEED, swap_key.as_ref()],
+        bump = swap.bump,
+        has_one = miner,
+    )]
+    pub swap: Account<'info, Swap>,
+}
+
+pub fn handler(ctx: Context<ExtendTimeout>, swap_key: [u8; 32], target_at: i64) -> Result<()> {
+    let validator = ctx.accounts.validator.key();
+    ensure_validator(&ctx.accounts.config, &validator)?;
+
+    let swap = &mut ctx.accounts.swap;
+    require!(
+        swap.status == SwapStatus::Active || swap.status == SwapStatus::Fulfilled,
+        ErrorCode::InvalidStatus
+    );
+    require!(target_at > swap.timeout_at, ErrorCode::ExtensionNotLater);
+    require!(target_at <= swap.max_extend_at, ErrorCode::ExtensionExceedsCeiling);
+
+    swap.timeout_at = target_at;
+    ctx.accounts.miner_state.busy_until = target_at;
+
+    emit!(SwapTimeoutExtended {
+        swap_key,
+        miner: ctx.accounts.miner.key(),
+        validator,
+        timeout_at: target_at,
+    });
+    Ok(())
+}

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/initialize.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/initialize.rs
@@ -1,8 +1,8 @@
 use anchor_lang::prelude::*;
 
 use crate::constants::{
-    CONFIG_SEED, CONFIG_VERSION, POOL_WINDOW_SECS, RESERVATION_FEE_LAMPORTS, TREASURY_SEED,
-    WEIGHTS_UPDATE_MIN_INTERVAL_SECS,
+    CONFIG_SEED, CONFIG_VERSION, MAX_TOTAL_EXTENSION_SECS, POOL_WINDOW_SECS,
+    RESERVATION_FEE_LAMPORTS, TREASURY_SEED, WEIGHTS_UPDATE_MIN_INTERVAL_SECS,
 };
 use crate::state::{Config, Treasury};
 
@@ -70,6 +70,7 @@ pub fn handler(
     config.reservation_fee_lamports = RESERVATION_FEE_LAMPORTS;
     config.pool_window_secs = POOL_WINDOW_SECS;
     config.weights_update_min_interval_secs = WEIGHTS_UPDATE_MIN_INTERVAL_SECS;
+    config.max_total_extension_secs = MAX_TOTAL_EXTENSION_SECS;
     config.bump = ctx.bumps.config;
 
     let treasury = &mut ctx.accounts.treasury;

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/resolve_pool.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/resolve_pool.rs
@@ -137,6 +137,7 @@ pub fn handler(ctx: Context<ResolvePool>) -> Result<()> {
     // Create the Reservation for the winner — same shape vote_reserve produced, so everything
     // downstream is unchanged.
     let ttl = ctx.accounts.config.reservation_ttl_secs;
+    let extension_budget = ctx.accounts.config.max_total_extension_secs;
     let reservation_bump = ctx.bumps.reservation;
     let r = &mut ctx.accounts.reservation;
     r.bound_hash = [0u8; 32]; // unused post-lottery (no consensus binding); reserved_until is the sentinel
@@ -150,6 +151,7 @@ pub fn handler(ctx: Context<ResolvePool>) -> Result<()> {
     r.miner_to_addr = miner_to_addr;
     r.rate = rate;
     r.reserved_until = now.saturating_add(ttl);
+    r.max_extend_at = r.reserved_until.saturating_add(extension_budget);
     r.bump = reservation_bump;
 
     // Lock the miner busy for the reservation's life (read by deactivate/withdraw, non-bypassable).

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/vote_initiate.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/vote_initiate.rs
@@ -131,6 +131,7 @@ pub fn handler(
 
     if quorum {
         let timeout_at = now.saturating_add(ctx.accounts.config.fulfillment_timeout_secs);
+        let max_extend_at = timeout_at.saturating_add(ctx.accounts.config.max_total_extension_secs);
         let tx_marker_bump = ctx.bumps.tx_marker;
         let swap_bump = ctx.bumps.swap;
 
@@ -169,6 +170,7 @@ pub fn handler(
         swap.status = SwapStatus::Active;
         swap.initiated_at = now;
         swap.timeout_at = timeout_at;
+        swap.max_extend_at = max_extend_at;
         swap.fulfilled_at = 0;
         swap.bump = swap_bump;
 

--- a/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
@@ -99,6 +99,9 @@ pub mod allways_swap_manager {
     pub fn set_weights_update_min_interval(ctx: Context<AdminConfig>, secs: i64) -> Result<()> {
         admin::set_weights_update_min_interval(ctx, secs)
     }
+    pub fn set_max_total_extension(ctx: Context<AdminConfig>, secs: i64) -> Result<()> {
+        admin::set_max_total_extension(ctx, secs)
+    }
     /// Set a validator's draw weight (admin bootstrap/fallback; superseded for routine use
     /// by the consensus path below).
     pub fn set_validator_weight(
@@ -200,6 +203,22 @@ pub mod allways_swap_manager {
     /// Validators time out an overdue swap (slash → user refund; swap closed) on quorum.
     pub fn timeout_swap(ctx: Context<TimeoutSwap>, swap_key: [u8; 32]) -> Result<()> {
         timeout_swap::handler(ctx, swap_key)
+    }
+
+    // --- Deadline extensions (single validator, no quorum; bounded by a frozen ceiling) ---
+    /// A validator slides a reservation's deadline forward while it waits on slow source-chain
+    /// confirmation. Bounded by the per-reservation ceiling frozen at creation.
+    pub fn extend_reservation(ctx: Context<ExtendReservation>, target_at: i64) -> Result<()> {
+        extend_reservation::handler(ctx, target_at)
+    }
+    /// A validator slides a swap's fulfillment timeout forward while it waits on slow destination-chain
+    /// confirmation. Bounded by the per-swap ceiling frozen at creation.
+    pub fn extend_timeout(
+        ctx: Context<ExtendTimeout>,
+        swap_key: [u8; 32],
+        target_at: i64,
+    ) -> Result<()> {
+        extend_timeout::handler(ctx, swap_key, target_at)
     }
 
     // --- Treasury ---

--- a/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
@@ -44,6 +44,9 @@ pub struct Config {
     pub pool_window_secs: i64,
     /// Minimum seconds between consensus weight updates (runtime-tunable anti-thrash floor).
     pub weights_update_min_interval_secs: i64,
+    /// Total seconds a reservation/swap deadline may be slid forward, frozen into each at creation as
+    /// its `max_extend_at` ceiling. Runtime-tunable within [MIN, MAX] (see constants.rs).
+    pub max_total_extension_secs: i64,
     /// Stored PDA bump.
     pub bump: u8,
 }
@@ -144,6 +147,9 @@ pub struct Reservation {
     pub rate: String,
     /// Expiry, unix seconds (0 = empty).
     pub reserved_until: i64,
+    /// Absolute ceiling `reserved_until` may be extended to (unix seconds). Frozen at creation =
+    /// initial deadline + the Config budget then, so a later retune can't move an in-flight ceiling.
+    pub max_extend_at: i64,
     /// Stored PDA bump.
     pub bump: u8,
 }
@@ -191,6 +197,9 @@ pub struct Swap {
     pub status: SwapStatus,
     pub initiated_at: i64,
     pub timeout_at: i64,
+    /// Absolute ceiling `timeout_at` may be extended to (unix seconds). Frozen at creation =
+    /// initial timeout + the Config budget then, so a later retune can't move an in-flight ceiling.
+    pub max_extend_at: i64,
     pub fulfilled_at: i64,
     pub bump: u8,
 }

--- a/smart-contracts/solana/programs/allways_swap_manager/src/validate.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/validate.rs
@@ -3,6 +3,7 @@
 
 use anchor_lang::prelude::*;
 
+use crate::constants::{MAX_TOTAL_EXTENSION_SECS_MAX, MAX_TOTAL_EXTENSION_SECS_MIN};
 use crate::error::ErrorCode;
 
 /// Quorum threshold as a percent of the validator set.
@@ -50,5 +51,15 @@ pub fn swap_bounds(min: u64, max: u64) -> Result<()> {
 /// Collateral bounds must not be contradictory (max 0 = no cap).
 pub fn collateral_bounds(min: u64, max: u64) -> Result<()> {
     require!(max == 0 || min <= max, ErrorCode::InvalidBounds);
+    Ok(())
+}
+
+/// Total deadline-extension budget, clamped to [30 min, 120 min]: the floor keeps it above one BTC
+/// block; the ceiling caps how long a miner can be held, since it's the only such bound.
+pub fn max_total_extension(secs: i64) -> Result<()> {
+    require!(
+        (MAX_TOTAL_EXTENSION_SECS_MIN..=MAX_TOTAL_EXTENSION_SECS_MAX).contains(&secs),
+        ErrorCode::InvalidAmount
+    );
     Ok(())
 }

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
@@ -507,7 +507,7 @@ fn onchain_initialize_creates_config() {
     let admin = admin_keypair();
     let cfg = read_config(&rpc);
     assert_eq!(cfg.admin, admin.pubkey(), "admin recorded");
-    assert_eq!(cfg.version, 6, "schema version");
+    assert_eq!(cfg.version, 7, "schema version");
     assert_eq!(cfg.min_collateral, MIN_COLLATERAL);
     assert_eq!(cfg.consensus_threshold_percent, THRESHOLD);
     assert_eq!(cfg.fulfillment_timeout_secs, TIMEOUT_SECS);

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_extensions.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_extensions.rs
@@ -1,0 +1,442 @@
+// Phase 11 — deadline extensions: extend_reservation / extend_timeout (LiteSVM, clock-controlled).
+//   cargo test -p allways_swap_manager --test test_extensions
+//
+// Single-validator, no-quorum deadline pushes bounded by the per-account `max_extend_at` ceiling
+// frozen at creation. Covers: happy-path push (reservation + swap, Active and Fulfilled), the ceiling
+// cap, the monotonic guard, and the validator-only gate.
+use {
+    anchor_lang::{
+        prelude::Pubkey, solana_program::clock::Clock, solana_program::instruction::Instruction,
+        AccountDeserialize, InstructionData, ToAccountMetas,
+    },
+    allways_swap_manager::constants::{MAX_TOTAL_EXTENSION_SECS, POOL_WINDOW_SECS},
+    allways_swap_manager::state::{MinerState, Reservation, Swap},
+    litesvm::LiteSVM,
+    solana_keccak_hasher::hashv,
+    solana_keypair::Keypair,
+    solana_message::{Message, VersionedMessage},
+    solana_signer::Signer,
+    solana_transaction::versioned::VersionedTransaction,
+};
+
+const SYSTEM_PROGRAM: Pubkey = anchor_lang::solana_program::system_program::ID;
+const SLOT_HASHES_ID: Pubkey = Pubkey::from_str_const("SysvarS1otHashes111111111111111111111111111");
+const REQ_ACTIVATE: u8 = 0;
+const REQ_INITIATE: u8 = 2;
+const BASE_TS: i64 = 1_700_000_000;
+const TTL: i64 = 1_800;
+const TIMEOUT_SECS: i64 = 3_600;
+const COLLATERAL: u64 = 10_000_000_000;
+const SOL_AMOUNT: u64 = 2_000_000_000;
+
+const FROM_ADDR: &str = "userBTCaddr";
+const FROM_CHAIN: &str = "BTC";
+const TO_CHAIN: &str = "SOL";
+const MINER_FROM: &str = "minerBTCaddr";
+const MINER_TO: &str = "minerSOLaddr";
+const RATE: &str = "1.5";
+
+fn pid() -> Pubkey {
+    allways_swap_manager::id()
+}
+fn config_pda() -> Pubkey {
+    Pubkey::find_program_address(&[b"config"], &pid()).0
+}
+fn collateral_vault_pda(m: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&[b"collateral", m.as_ref()], &pid()).0
+}
+fn treasury_pda() -> Pubkey {
+    Pubkey::find_program_address(&[b"treasury"], &pid()).0
+}
+fn miner_pda(m: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&[b"miner", m.as_ref()], &pid()).0
+}
+fn vote_pda(req: u8, key: &[u8]) -> Pubkey {
+    Pubkey::find_program_address(&[b"vote", &[req], key], &pid()).0
+}
+fn resv_pda(m: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&[b"resv", m.as_ref()], &pid()).0
+}
+fn quote_pda(m: &Pubkey, f: &str, t: &str) -> Pubkey {
+    Pubkey::find_program_address(&[b"quote", m.as_ref(), f.as_bytes(), t.as_bytes()], &pid()).0
+}
+fn pool_pda(m: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&[b"pool", m.as_ref()], &pid()).0
+}
+fn swap_pda(key: &[u8; 32]) -> Pubkey {
+    Pubkey::find_program_address(&[b"swap", key], &pid()).0
+}
+fn tx_pda(key: &[u8; 32]) -> Pubkey {
+    Pubkey::find_program_address(&[b"tx", key], &pid()).0
+}
+fn swap_key(from_tx_hash: &str) -> [u8; 32] {
+    hashv(&[from_tx_hash.as_bytes()]).to_bytes()
+}
+
+fn set_clock(svm: &mut LiteSVM, ts: i64) {
+    let mut clock = svm.get_sysvar::<Clock>();
+    clock.unix_timestamp = ts;
+    svm.set_sysvar::<Clock>(&clock);
+}
+fn send(svm: &mut LiteSVM, ix: Instruction, payer: &Pubkey, signer: &Keypair) -> Result<(), String> {
+    svm.expire_blockhash();
+    let bh = svm.latest_blockhash();
+    let msg = Message::new_with_blockhash(&[ix], Some(payer), &bh);
+    let tx = VersionedTransaction::try_new(VersionedMessage::Legacy(msg), &[signer]).unwrap();
+    svm.send_transaction(tx).map(|_| ()).map_err(|e| format!("{:?}", e))
+}
+
+fn init_ix(admin: &Pubkey) -> Instruction {
+    Instruction::new_with_bytes(
+        pid(),
+        &allways_swap_manager::instruction::Initialize {
+            min_collateral: 1_000_000_000,
+            max_collateral: 0,
+            fulfillment_timeout_secs: TIMEOUT_SECS,
+            consensus_threshold_percent: 66,
+            min_swap_amount: 0,
+            max_swap_amount: 0,
+            reservation_ttl_secs: TTL,
+        }
+        .data(),
+        allways_swap_manager::accounts::Initialize {
+            admin: *admin,
+            config: config_pda(),
+            treasury: treasury_pda(),
+            system_program: SYSTEM_PROGRAM,
+        }
+        .to_account_metas(None),
+    )
+}
+fn add_validator_ix(admin: &Pubkey, v: Pubkey) -> Instruction {
+    Instruction::new_with_bytes(
+        pid(),
+        &allways_swap_manager::instruction::AddValidator { validator: v, weight: 1 }.data(),
+        allways_swap_manager::accounts::AdminConfig { admin: *admin, config: config_pda() }
+            .to_account_metas(None),
+    )
+}
+fn post_ix(miner: &Pubkey, amount: u64) -> Instruction {
+    Instruction::new_with_bytes(
+        pid(),
+        &allways_swap_manager::instruction::PostCollateral { amount }.data(),
+        allways_swap_manager::accounts::PostCollateral {
+            miner: *miner,
+            config: config_pda(),
+            miner_state: miner_pda(miner),
+            collateral_vault: collateral_vault_pda(miner),
+            system_program: SYSTEM_PROGRAM,
+        }
+        .to_account_metas(None),
+    )
+}
+fn vote_activate_ix(validator: &Pubkey, miner: &Pubkey) -> Instruction {
+    Instruction::new_with_bytes(
+        pid(),
+        &allways_swap_manager::instruction::VoteActivate {}.data(),
+        allways_swap_manager::accounts::VoteActivate {
+            validator: *validator,
+            config: config_pda(),
+            miner: *miner,
+            miner_state: miner_pda(miner),
+            vote_round: vote_pda(REQ_ACTIVATE, miner.as_ref()),
+            system_program: SYSTEM_PROGRAM,
+        }
+        .to_account_metas(None),
+    )
+}
+fn set_quote_ix(miner: &Pubkey) -> Instruction {
+    Instruction::new_with_bytes(
+        pid(),
+        &allways_swap_manager::instruction::SetQuote {
+            from_chain: FROM_CHAIN.to_string(),
+            to_chain: TO_CHAIN.to_string(),
+            miner_from_addr: MINER_FROM.to_string(),
+            miner_to_addr: MINER_TO.to_string(),
+            rate: RATE.to_string(),
+            liquidity: 1_000,
+        }
+        .data(),
+        allways_swap_manager::accounts::SetQuote {
+            miner: *miner,
+            quote: quote_pda(miner, FROM_CHAIN, TO_CHAIN),
+            treasury: treasury_pda(),
+            system_program: SYSTEM_PROGRAM,
+        }
+        .to_account_metas(None),
+    )
+}
+fn open_ix(validator: &Pubkey, miner: &Pubkey, user: &Pubkey) -> Instruction {
+    Instruction::new_with_bytes(
+        pid(),
+        &allways_swap_manager::instruction::OpenOrRequest {
+            from_chain: FROM_CHAIN.to_string(),
+            to_chain: TO_CHAIN.to_string(),
+            user: *user,
+            user_from_addr: FROM_ADDR.to_string(),
+            user_to_addr: "userSOLaddr".to_string(),
+            sol_amount: SOL_AMOUNT,
+            from_amount: 100_000,
+            to_amount: 0,
+        }
+        .data(),
+        allways_swap_manager::accounts::OpenOrRequest {
+            validator: *validator,
+            config: config_pda(),
+            miner: *miner,
+            miner_state: miner_pda(miner),
+            quote: quote_pda(miner, FROM_CHAIN, TO_CHAIN),
+            pool: pool_pda(miner),
+            treasury: treasury_pda(),
+            reservation: resv_pda(miner),
+            system_program: SYSTEM_PROGRAM,
+        }
+        .to_account_metas(None),
+    )
+}
+fn resolve_ix(caller: &Pubkey, miner: &Pubkey) -> Instruction {
+    Instruction::new_with_bytes(
+        pid(),
+        &allways_swap_manager::instruction::ResolvePool {}.data(),
+        allways_swap_manager::accounts::ResolvePool {
+            caller: *caller,
+            config: config_pda(),
+            miner: *miner,
+            miner_state: miner_pda(miner),
+            pool: pool_pda(miner),
+            reservation: resv_pda(miner),
+            slot_hashes: SLOT_HASHES_ID,
+            system_program: SYSTEM_PROGRAM,
+        }
+        .to_account_metas(None),
+    )
+}
+fn initiate_ix(validator: &Pubkey, miner: &Pubkey, from_tx_hash: &str, user: &Pubkey) -> Instruction {
+    let key = swap_key(from_tx_hash);
+    Instruction::new_with_bytes(
+        pid(),
+        &allways_swap_manager::instruction::VoteInitiate {
+            swap_key: key,
+            from_tx_hash: from_tx_hash.to_string(),
+            from_tx_block: 800_000,
+            user: *user,
+            user_from_address: FROM_ADDR.to_string(),
+            user_to_address: "userSOLaddr".to_string(),
+        }
+        .data(),
+        allways_swap_manager::accounts::VoteInitiate {
+            validator: *validator,
+            config: config_pda(),
+            miner: *miner,
+            miner_state: miner_pda(miner),
+            reservation: resv_pda(miner),
+            vote_round: vote_pda(REQ_INITIATE, miner.as_ref()),
+            tx_marker: tx_pda(&key),
+            swap: swap_pda(&key),
+            system_program: SYSTEM_PROGRAM,
+        }
+        .to_account_metas(None),
+    )
+}
+fn fulfill_ix(miner: &Pubkey, from_tx_hash: &str) -> Instruction {
+    let key = swap_key(from_tx_hash);
+    Instruction::new_with_bytes(
+        pid(),
+        &allways_swap_manager::instruction::MarkFulfilled {
+            swap_key: key,
+            to_tx_hash: "destTxHash".to_string(),
+            to_tx_block: 200,
+        }
+        .data(),
+        allways_swap_manager::accounts::MarkFulfilled { miner: *miner, swap: swap_pda(&key) }
+            .to_account_metas(None),
+    )
+}
+fn extend_reservation_ix(validator: &Pubkey, miner: &Pubkey, target_at: i64) -> Instruction {
+    Instruction::new_with_bytes(
+        pid(),
+        &allways_swap_manager::instruction::ExtendReservation { target_at }.data(),
+        allways_swap_manager::accounts::ExtendReservation {
+            validator: *validator,
+            config: config_pda(),
+            miner: *miner,
+            miner_state: miner_pda(miner),
+            reservation: resv_pda(miner),
+        }
+        .to_account_metas(None),
+    )
+}
+fn extend_timeout_ix(validator: &Pubkey, miner: &Pubkey, from_tx_hash: &str, target_at: i64) -> Instruction {
+    let key = swap_key(from_tx_hash);
+    Instruction::new_with_bytes(
+        pid(),
+        &allways_swap_manager::instruction::ExtendTimeout { swap_key: key, target_at }.data(),
+        allways_swap_manager::accounts::ExtendTimeout {
+            validator: *validator,
+            config: config_pda(),
+            miner: *miner,
+            miner_state: miner_pda(miner),
+            swap: swap_pda(&key),
+        }
+        .to_account_metas(None),
+    )
+}
+
+fn reservation(svm: &LiteSVM, m: &Pubkey) -> Reservation {
+    let a = svm.get_account(&resv_pda(m)).unwrap();
+    Reservation::try_deserialize(&mut a.data.as_slice()).unwrap()
+}
+fn swap(svm: &LiteSVM, from_tx_hash: &str) -> Swap {
+    let a = svm.get_account(&swap_pda(&swap_key(from_tx_hash))).unwrap();
+    Swap::try_deserialize(&mut a.data.as_slice()).unwrap()
+}
+fn busy_until(svm: &LiteSVM, m: &Pubkey) -> i64 {
+    let a = svm.get_account(&miner_pda(m)).unwrap();
+    MinerState::try_deserialize(&mut a.data.as_slice()).unwrap().busy_until
+}
+
+/// init + 3 validators + active miner + a confirmed reservation, clock at BASE_TS. The reservation
+/// is created at BASE_TS-100+window so it's live at BASE_TS. Returns (svm, vals, miner).
+fn setup() -> (LiteSVM, Vec<Keypair>, Keypair) {
+    let mut svm = LiteSVM::new();
+    svm.add_program(pid(), include_bytes!("../../../target/deploy/allways_swap_manager.so")).unwrap();
+    set_clock(&mut svm, BASE_TS);
+
+    let admin = Keypair::new();
+    svm.airdrop(&admin.pubkey(), 100_000_000_000).unwrap();
+    send(&mut svm, init_ix(&admin.pubkey()), &admin.pubkey(), &admin).expect("init");
+
+    let mut vals = Vec::new();
+    for _ in 0..3 {
+        let v = Keypair::new();
+        svm.airdrop(&v.pubkey(), 100_000_000_000).unwrap();
+        send(&mut svm, add_validator_ix(&admin.pubkey(), v.pubkey()), &admin.pubkey(), &admin).expect("add val");
+        vals.push(v);
+    }
+
+    let miner = Keypair::new();
+    svm.airdrop(&miner.pubkey(), 100_000_000_000).unwrap();
+    send(&mut svm, post_ix(&miner.pubkey(), COLLATERAL), &miner.pubkey(), &miner).expect("post");
+    send(&mut svm, set_quote_ix(&miner.pubkey()), &miner.pubkey(), &miner).expect("quote");
+    send(&mut svm, vote_activate_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0]).expect("a0");
+    send(&mut svm, vote_activate_ix(&vals[1].pubkey(), &miner.pubkey()), &vals[1].pubkey(), &vals[1]).expect("a1");
+
+    let setup_ts = BASE_TS - 100;
+    set_clock(&mut svm, setup_ts);
+    let user = Keypair::new().pubkey();
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), &user), &vals[0].pubkey(), &vals[0]).expect("open");
+    set_clock(&mut svm, setup_ts + POOL_WINDOW_SECS + 1);
+    send(&mut svm, resolve_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0]).expect("resolve");
+    set_clock(&mut svm, BASE_TS);
+    (svm, vals, miner)
+}
+
+fn do_initiate(svm: &mut LiteSVM, vals: &[Keypair], miner: &Pubkey, tx: &str, user: &Pubkey) {
+    send(svm, initiate_ix(&vals[0].pubkey(), miner, tx, user), &vals[0].pubkey(), &vals[0]).expect("i0");
+    send(svm, initiate_ix(&vals[1].pubkey(), miner, tx, user), &vals[1].pubkey(), &vals[1]).expect("i1");
+}
+
+// ---- extend_reservation ----
+
+#[test]
+fn test_extend_reservation_pushes_deadline_and_busy_lock() {
+    let (mut svm, vals, miner) = setup();
+    let r = reservation(&svm, &miner.pubkey());
+    assert_eq!(r.max_extend_at, r.reserved_until + MAX_TOTAL_EXTENSION_SECS, "ceiling frozen at creation");
+
+    let target = r.reserved_until + 300;
+    send(&mut svm, extend_reservation_ix(&vals[0].pubkey(), &miner.pubkey(), target), &vals[0].pubkey(), &vals[0]).expect("extend");
+
+    assert_eq!(reservation(&svm, &miner.pubkey()).reserved_until, target, "deadline pushed");
+    assert_eq!(busy_until(&svm, &miner.pubkey()), target, "busy lock kept in sync");
+}
+
+#[test]
+fn test_extend_reservation_repeated_until_ceiling() {
+    let (mut svm, vals, miner) = setup();
+    let ceiling = reservation(&svm, &miner.pubkey()).max_extend_at;
+
+    // Two successive nudges, both under the ceiling, accumulate.
+    let t1 = reservation(&svm, &miner.pubkey()).reserved_until + 1_000;
+    send(&mut svm, extend_reservation_ix(&vals[0].pubkey(), &miner.pubkey(), t1), &vals[0].pubkey(), &vals[0]).expect("nudge1");
+    let t2 = ceiling; // land exactly on the ceiling
+    send(&mut svm, extend_reservation_ix(&vals[1].pubkey(), &miner.pubkey(), t2), &vals[1].pubkey(), &vals[1]).expect("nudge2");
+    assert_eq!(reservation(&svm, &miner.pubkey()).reserved_until, ceiling);
+
+    // One past the ceiling is rejected.
+    let over = send(&mut svm, extend_reservation_ix(&vals[0].pubkey(), &miner.pubkey(), ceiling + 1), &vals[0].pubkey(), &vals[0]);
+    assert!(over.is_err(), "cannot extend past the frozen ceiling");
+}
+
+#[test]
+fn test_extend_reservation_must_be_monotonic() {
+    let (mut svm, vals, miner) = setup();
+    let current = reservation(&svm, &miner.pubkey()).reserved_until;
+    let backward = send(&mut svm, extend_reservation_ix(&vals[0].pubkey(), &miner.pubkey(), current), &vals[0].pubkey(), &vals[0]);
+    assert!(backward.is_err(), "target not later than current deadline is rejected");
+}
+
+#[test]
+fn test_extend_reservation_validator_only() {
+    let (mut svm, _vals, miner) = setup();
+    let outsider = Keypair::new();
+    svm.airdrop(&outsider.pubkey(), 1_000_000_000).unwrap();
+    let target = reservation(&svm, &miner.pubkey()).reserved_until + 300;
+    let res = send(&mut svm, extend_reservation_ix(&outsider.pubkey(), &miner.pubkey(), target), &outsider.pubkey(), &outsider);
+    assert!(res.is_err(), "non-validator cannot extend");
+}
+
+// ---- extend_timeout ----
+
+#[test]
+fn test_extend_timeout_active_pushes_deadline_and_busy_lock() {
+    let (mut svm, vals, miner) = setup();
+    let user = Keypair::new().pubkey();
+    do_initiate(&mut svm, &vals, &miner.pubkey(), "srctx1", &user);
+
+    let s = swap(&svm, "srctx1");
+    assert_eq!(s.max_extend_at, s.timeout_at + MAX_TOTAL_EXTENSION_SECS, "ceiling frozen at creation");
+
+    let target = s.timeout_at + 300;
+    send(&mut svm, extend_timeout_ix(&vals[0].pubkey(), &miner.pubkey(), "srctx1", target), &vals[0].pubkey(), &vals[0]).expect("extend");
+
+    assert_eq!(swap(&svm, "srctx1").timeout_at, target, "timeout pushed while Active");
+    assert_eq!(busy_until(&svm, &miner.pubkey()), target, "busy lock kept in sync");
+}
+
+#[test]
+fn test_extend_timeout_after_fulfilled() {
+    let (mut svm, vals, miner) = setup();
+    let user = Keypair::new().pubkey();
+    do_initiate(&mut svm, &vals, &miner.pubkey(), "srctx1", &user);
+    send(&mut svm, fulfill_ix(&miner.pubkey(), "srctx1"), &miner.pubkey(), &miner).expect("fulfill");
+
+    let target = swap(&svm, "srctx1").timeout_at + 300;
+    send(&mut svm, extend_timeout_ix(&vals[0].pubkey(), &miner.pubkey(), "srctx1", target), &vals[0].pubkey(), &vals[0]).expect("extend after fulfill");
+    assert_eq!(swap(&svm, "srctx1").timeout_at, target, "timeout pushed while Fulfilled");
+}
+
+#[test]
+fn test_extend_timeout_ceiling_and_monotonic() {
+    let (mut svm, vals, miner) = setup();
+    let user = Keypair::new().pubkey();
+    do_initiate(&mut svm, &vals, &miner.pubkey(), "srctx1", &user);
+    let s = swap(&svm, "srctx1");
+
+    let over = send(&mut svm, extend_timeout_ix(&vals[0].pubkey(), &miner.pubkey(), "srctx1", s.max_extend_at + 1), &vals[0].pubkey(), &vals[0]);
+    assert!(over.is_err(), "cannot extend past the frozen ceiling");
+    let backward = send(&mut svm, extend_timeout_ix(&vals[0].pubkey(), &miner.pubkey(), "srctx1", s.timeout_at), &vals[0].pubkey(), &vals[0]);
+    assert!(backward.is_err(), "target not later than current timeout is rejected");
+}
+
+#[test]
+fn test_extend_timeout_validator_only() {
+    let (mut svm, vals, miner) = setup();
+    let user = Keypair::new().pubkey();
+    do_initiate(&mut svm, &vals, &miner.pubkey(), "srctx1", &user);
+    let outsider = Keypair::new();
+    svm.airdrop(&outsider.pubkey(), 1_000_000_000).unwrap();
+    let target = swap(&svm, "srctx1").timeout_at + 300;
+    let res = send(&mut svm, extend_timeout_ix(&outsider.pubkey(), &miner.pubkey(), "srctx1", target), &outsider.pubkey(), &outsider);
+    assert!(res.is_err(), "non-validator cannot extend");
+}

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_initialize.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_initialize.rs
@@ -57,7 +57,7 @@ fn test_initialize_creates_config() {
     let cfg_acct = svm.get_account(&config_pda).expect("config exists");
     let config = Config::try_deserialize(&mut cfg_acct.data.as_slice()).unwrap();
     assert_eq!(config.admin, admin_pk);
-    assert_eq!(config.version, 6);
+    assert_eq!(config.version, 7);
     assert_eq!(config.min_collateral, 1_000_000);
     assert_eq!(config.max_collateral, 500_000_000);
     assert_eq!(config.fulfillment_timeout_secs, 12_600);


### PR DESCRIPTION
## What

Lets any validator slide a reservation's `reserved_until` or a swap's `timeout_at` **forward** while it waits on slow chain confirmation — so a correct miner isn't false-slashed when a BTC confirmation lands after a tight deadline.

Two new instructions: `extend_reservation`, `extend_timeout`. **No quorum.**

## Why it's safe without quorum

An extension moves no funds. Money only moves at `confirm_swap` / `timeout_swap`, which stay quorum-gated. So a rogue validator can at most **delay** a slash up to a fixed ceiling — never cause one, never block one past the ceiling.

Two guards carry it:
- **monotonic** — target must be later than the current deadline (can't shorten a miner's runway)
- **ceiling** — `max_extend_at`, frozen at creation = deadline + budget (can't hold a miner hostage)

No count cap / no per-extension cap: the total ceiling bounds the worst case on its own. Validators nudge adaptively as confirmations land.

## Config
- `max_total_extension_secs` — default **90 min**, admin-tunable within **[30 min, 120 min]**.
- Reset base deadlines to the intended **10 min** each side (`DEFAULT_FULFILLMENT_TIMEOUT_SECS` 4h→10m, new `DEFAULT_RESERVATION_TTL_SECS` 10m), mirroring ink!'s 50-block default. Model: tight base, extend as needed → ≤ ~100 min.
- Extensions ignore `halted` (in-flight swaps must finish).

## Tests
`test_extensions.rs`: happy path, ceiling cap, monotonic reject, validator-only, Active + Fulfilled. Bounds unit test passes; full integration run needs `build-sbf` in the dev env.

## Follow-ups (not in this PR)
Python `contract_client` methods, `optimistic_extensions.py` collapse to a single `extend` call, `event_watcher` for the 2 new events. Deployer/dev-env must pass the 10m init args.