### PR TITLE
refactor(solana): store miner rate as u128 fixed-point (drop rate string)

### DIFF
--- a/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
@@ -70,8 +70,14 @@ pub const SLOT_MS: u64 = 400;
 /// Bounded max lengths for stored strings.
 pub const MAX_ADDR_LEN: usize = 80;
 pub const MAX_CHAIN_LEN: usize = 16;
-pub const MAX_RATE_LEN: usize = 32;
 pub const MAX_TX_LEN: usize = 128;
+
+/// Fixed-point scale for the miner rate: the stored `rate` integer = display_rate × RATE_PRECISION
+/// (e.g. "345" TAO/BTC → `345 × 1e18`). Matches the off-chain `RATE_PRECISION`, so the stored value
+/// IS the off-chain `rate_fixed` — no decimal-string parse on either side (replaces the old free-form
+/// `rate: String`, which let an unparseable-but-lucrative rate score yet never reserve). The contract
+/// only stores/copies the value; routability/validity is judged off-chain (`is_executable_rate`).
+pub const RATE_PRECISION: u128 = 1_000_000_000_000_000_000; // 1e18
 
 /// Basis-points denominator (10_000 bps = 1.00×). Shared by every ×-multiplier below.
 pub const BPS_DENOMINATOR: u64 = 10_000;

--- a/smart-contracts/solana/programs/allways_swap_manager/src/events.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/events.rs
@@ -96,7 +96,8 @@ pub struct QuoteSet {
     pub miner: Pubkey,
     pub from_chain: String,
     pub to_chain: String,
-    pub rate: String,
+    /// Fixed-point rate = display_rate × RATE_PRECISION (1e18).
+    pub rate: u128,
     pub liquidity: u128,
     pub updated_at: i64,
     /// Anti-flashing churn fee paid into the treasury this call (lamports); 0 on first creation

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/open_or_request.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/open_or_request.rs
@@ -178,7 +178,7 @@ pub fn handler(
         let (mfrom, mto, rate) = (
             q.miner_from_addr.clone(),
             q.miner_to_addr.clone(),
-            q.rate.clone(),
+            q.rate,
         );
         let window = ctx.accounts.config.pool_window_secs;
         let seed_slot = clock

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/resolve_pool.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/resolve_pool.rs
@@ -130,7 +130,7 @@ pub fn handler(ctx: Context<ResolvePool>) -> Result<()> {
             p.to_chain.clone(),
             p.miner_from_addr.clone(),
             p.miner_to_addr.clone(),
-            p.rate.clone(),
+            p.rate,
         )
     };
 

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/set_quote.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/set_quote.rs
@@ -1,7 +1,7 @@
 use anchor_lang::prelude::*;
 use anchor_lang::system_program::{transfer, Transfer};
 
-use crate::constants::{quote_update_fee, MAX_ADDR_LEN, MAX_CHAIN_LEN, MAX_RATE_LEN, QUOTE_SEED, TREASURY_SEED};
+use crate::constants::{quote_update_fee, MAX_ADDR_LEN, MAX_CHAIN_LEN, QUOTE_SEED, TREASURY_SEED};
 use crate::error::ErrorCode;
 use crate::events::QuoteSet;
 use crate::state::{MinerQuote, Treasury};
@@ -41,16 +41,18 @@ pub fn handler(
     to_chain: String,
     miner_from_addr: String,
     miner_to_addr: String,
-    rate: String,
+    rate: u128,
     liquidity: u128,
 ) -> Result<()> {
-    // Mechanical sanity only — chains are opaque bounded strings; validity is the off-chain layer's call.
+    // Mechanical sanity only — chains/addrs are opaque bounded strings. The rate is an opaque
+    // fixed-point integer (display × RATE_PRECISION); the contract stores whatever the miner posts
+    // and never computes with it — routability/validity is the off-chain layer's call
+    // (`is_executable_rate`), so there is deliberately no on-chain rate check.
     require!(
         !from_chain.is_empty()
             && !to_chain.is_empty()
             && !miner_from_addr.is_empty()
-            && !miner_to_addr.is_empty()
-            && !rate.is_empty(),
+            && !miner_to_addr.is_empty(),
         ErrorCode::EmptyField
     );
     require!(
@@ -61,7 +63,6 @@ pub fn handler(
         miner_from_addr.len() <= MAX_ADDR_LEN && miner_to_addr.len() <= MAX_ADDR_LEN,
         ErrorCode::StringTooLong
     );
-    require!(rate.len() <= MAX_RATE_LEN, ErrorCode::StringTooLong);
     require!(from_chain != to_chain, ErrorCode::SameChain);
 
     let now = Clock::get()?.unix_timestamp;
@@ -100,7 +101,7 @@ pub fn handler(
     quote.to_chain = to_chain.clone();
     quote.miner_from_addr = miner_from_addr;
     quote.miner_to_addr = miner_to_addr;
-    quote.rate = rate.clone();
+    quote.rate = rate;
     quote.liquidity = liquidity;
     quote.updated_at = now;
     quote.bump = bump;

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/vote_initiate.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/vote_initiate.rs
@@ -143,7 +143,7 @@ pub fn handler(
                 r.to_chain.clone(),
                 r.miner_from_addr.clone(),
                 r.miner_to_addr.clone(),
-                r.rate.clone(),
+                r.rate,
                 r.sol_amount,
                 r.from_amount,
                 r.to_amount,

--- a/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
@@ -236,7 +236,7 @@ pub mod allways_swap_manager {
         to_chain: String,
         miner_from_addr: String,
         miner_to_addr: String,
-        rate: String,
+        rate: u128,
         liquidity: u128,
     ) -> Result<()> {
         set_quote::handler(

--- a/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 
-use crate::constants::{MAX_ADDR_LEN, MAX_CHAIN_LEN, MAX_RATE_LEN, MAX_TX_LEN, MAX_VALIDATORS};
+use crate::constants::{MAX_ADDR_LEN, MAX_CHAIN_LEN, MAX_TX_LEN, MAX_VALIDATORS};
 
 /// A whitelisted validator and its draw weight. `weight` (default 1, admin-set) is the
 /// stake-weight seam consumed ONLY by the reservation-lottery draw; consensus stays count-based.
@@ -143,8 +143,8 @@ pub struct Reservation {
     pub miner_from_addr: String,
     #[max_len(MAX_ADDR_LEN)]
     pub miner_to_addr: String,
-    #[max_len(MAX_RATE_LEN)]
-    pub rate: String,
+    /// Fixed-point rate = display_rate × RATE_PRECISION (1e18); see constants::RATE_PRECISION.
+    pub rate: u128,
     /// Expiry, unix seconds (0 = empty).
     pub reserved_until: i64,
     /// Absolute ceiling `reserved_until` may be extended to (unix seconds). Frozen at creation =
@@ -182,8 +182,8 @@ pub struct Swap {
     pub miner_from_addr: String,
     #[max_len(MAX_ADDR_LEN)]
     pub miner_to_addr: String,
-    #[max_len(MAX_RATE_LEN)]
-    pub rate: String,
+    /// Fixed-point rate = display_rate × RATE_PRECISION (1e18); see constants::RATE_PRECISION.
+    pub rate: u128,
     /// Collateral-backed swap size (SOL lamports) — fee/slash basis.
     pub sol_amount: u64,
     pub from_amount: u128,
@@ -235,9 +235,9 @@ pub struct MinerQuote {
     /// Where the miner sends the destination asset (on `to_chain`).
     #[max_len(MAX_ADDR_LEN)]
     pub miner_to_addr: String,
-    /// Offered rate, dest per 1 source, for THIS direction (string for exact sig-fig precision).
-    #[max_len(MAX_RATE_LEN)]
-    pub rate: String,
+    /// Offered rate, dest per 1 source, for THIS direction. Fixed-point = display_rate ×
+    /// RATE_PRECISION (1e18) — exact, no string parse; see constants::RATE_PRECISION.
+    pub rate: u128,
     /// Advertised depth in the asset's own units (u128 to cover wei-scale).
     pub liquidity: u128,
     /// Unix timestamp of the last write (staleness signal for off-chain consumers).
@@ -283,8 +283,8 @@ pub struct Pool {
     pub miner_from_addr: String,
     #[max_len(MAX_ADDR_LEN)]
     pub miner_to_addr: String,
-    #[max_len(MAX_RATE_LEN)]
-    pub rate: String,
+    /// Fixed-point rate = display_rate × RATE_PRECISION (1e18); see constants::RATE_PRECISION.
+    pub rate: u128,
     /// Unix seconds the pool opened (0 = available/empty slot).
     pub opened_at: i64,
     /// Unix seconds the request window closes; `resolve_pool` is callable after this.

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
@@ -64,7 +64,7 @@ const FROM_CHAIN: &str = "BTC";
 const TO_CHAIN: &str = "SOL";
 const MINER_FROM: &str = "minerBTCaddr";
 const MINER_TO: &str = "minerSOLaddr";
-const RATE: &str = "1.5";
+const RATE: u128 = 1_500_000_000_000_000_000; // 1.5 × RATE_PRECISION (1e18)
 
 // ─── PDA helpers (mirror the unit tests) ────────────────────────────────────────
 fn pid() -> Pubkey {
@@ -858,7 +858,7 @@ fn quote_pda(m: &Pubkey, from_chain: &str, to_chain: &str) -> Pubkey {
     .0
 }
 
-fn set_quote_ix(m: &Pubkey, from_chain: &str, to_chain: &str, rate: &str) -> Instruction {
+fn set_quote_ix(m: &Pubkey, from_chain: &str, to_chain: &str, rate: u128) -> Instruction {
     Instruction::new_with_bytes(
         pid(),
         &allways_swap_manager::instruction::SetQuote {
@@ -866,7 +866,7 @@ fn set_quote_ix(m: &Pubkey, from_chain: &str, to_chain: &str, rate: &str) -> Ins
             to_chain: to_chain.to_string(),
             miner_from_addr: MINER_FROM.to_string(),
             miner_to_addr: MINER_TO.to_string(),
-            rate: rate.to_string(),
+            rate,
             liquidity: 1_000,
         }
         .data(),
@@ -914,7 +914,7 @@ fn onchain_set_quote_creates_pda() {
     let rpc = rpc();
     let miner = funded_keypair(&rpc, 10 * LAMPORTS_PER_SOL);
 
-    send(&rpc, set_quote_ix(&miner.pubkey(), "BTC", "SOL", "1.5"), &miner.pubkey(), &miner)
+    send(&rpc, set_quote_ix(&miner.pubkey(), "BTC", "SOL", RATE), &miner.pubkey(), &miner)
         .expect("set_quote");
 
     let a = rpc.get_account(&quote_pda(&miner.pubkey(), "BTC", "SOL")).expect("quote account");
@@ -922,7 +922,7 @@ fn onchain_set_quote_creates_pda() {
     assert_eq!(q.miner, miner.pubkey());
     assert_eq!(q.from_chain, "BTC");
     assert_eq!(q.to_chain, "SOL");
-    assert_eq!(q.rate, "1.5");
+    assert_eq!(q.rate, RATE);
     assert!(q.updated_at > 0, "updated_at set from on-chain clock");
 }
 
@@ -933,7 +933,7 @@ fn onchain_remove_quote_closes_pda() {
     let rpc = rpc();
     let miner = funded_keypair(&rpc, 10 * LAMPORTS_PER_SOL);
 
-    send(&rpc, set_quote_ix(&miner.pubkey(), "BTC", "SOL", "1.5"), &miner.pubkey(), &miner).expect("set");
+    send(&rpc, set_quote_ix(&miner.pubkey(), "BTC", "SOL", RATE), &miner.pubkey(), &miner).expect("set");
     assert!(account_exists(&rpc, &quote_pda(&miner.pubkey(), "BTC", "SOL")), "quote exists after set");
 
     send(&rpc, remove_quote_ix(&miner.pubkey(), "BTC", "SOL"), &miner.pubkey(), &miner).expect("remove");

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_extensions.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_extensions.rs
@@ -34,7 +34,7 @@ const FROM_CHAIN: &str = "BTC";
 const TO_CHAIN: &str = "SOL";
 const MINER_FROM: &str = "minerBTCaddr";
 const MINER_TO: &str = "minerSOLaddr";
-const RATE: &str = "1.5";
+const RATE: u128 = 1_500_000_000_000_000_000; // 1.5 × RATE_PRECISION (1e18)
 
 fn pid() -> Pubkey {
     allways_swap_manager::id()
@@ -153,7 +153,7 @@ fn set_quote_ix(miner: &Pubkey) -> Instruction {
             to_chain: TO_CHAIN.to_string(),
             miner_from_addr: MINER_FROM.to_string(),
             miner_to_addr: MINER_TO.to_string(),
-            rate: RATE.to_string(),
+            rate: RATE,
             liquidity: 1_000,
         }
         .data(),

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_quote.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_quote.rs
@@ -14,7 +14,7 @@ use {
     allways_swap_manager::state::{MinerQuote, Treasury},
     allways_swap_manager::constants::{
         QUOTE_UPDATE_FEE_TIER1_LAMPORTS, QUOTE_UPDATE_FEE_TIER1_MAX_SECS,
-        QUOTE_UPDATE_FEE_TIER2_LAMPORTS, QUOTE_UPDATE_FEE_TIER2_MAX_SECS,
+        QUOTE_UPDATE_FEE_TIER2_LAMPORTS, QUOTE_UPDATE_FEE_TIER2_MAX_SECS, RATE_PRECISION,
     },
     litesvm::LiteSVM,
     solana_keypair::Keypair,
@@ -86,7 +86,7 @@ fn set_quote_ix(
     to_chain: &str,
     miner_from_addr: &str,
     miner_to_addr: &str,
-    rate: &str,
+    rate: u128,
     liquidity: u128,
 ) -> Instruction {
     Instruction::new_with_bytes(
@@ -96,7 +96,7 @@ fn set_quote_ix(
             to_chain: to_chain.to_string(),
             miner_from_addr: miner_from_addr.to_string(),
             miner_to_addr: miner_to_addr.to_string(),
-            rate: rate.to_string(),
+            rate,
             liquidity,
         }
         .data(),
@@ -157,7 +157,7 @@ fn test_set_quote_creates_pda() {
 
     send(
         &mut svm,
-        set_quote_ix(&program_id, &miner.pubkey(), "btc", "tao", "bc1qsrc", "5Cdst", "340", 100),
+        set_quote_ix(&program_id, &miner.pubkey(), "btc", "tao", "bc1qsrc", "5Cdst", 340 * RATE_PRECISION, 100),
         &miner.pubkey(),
         &miner,
     )
@@ -169,7 +169,7 @@ fn test_set_quote_creates_pda() {
     assert_eq!(q.to_chain, "tao");
     assert_eq!(q.miner_from_addr, "bc1qsrc");
     assert_eq!(q.miner_to_addr, "5Cdst");
-    assert_eq!(q.rate, "340");
+    assert_eq!(q.rate, 340 * RATE_PRECISION);
     assert_eq!(q.liquidity, 100);
     assert!(q.updated_at >= 0);
 }
@@ -180,11 +180,11 @@ fn test_set_quote_overwrites_in_place() {
     let miner = Keypair::new();
     svm.airdrop(&miner.pubkey(), 10_000_000_000).unwrap();
 
-    send(&mut svm, set_quote_ix(&program_id, &miner.pubkey(), "btc", "tao", "a", "b", "340", 100), &miner.pubkey(), &miner).expect("set1");
-    send(&mut svm, set_quote_ix(&program_id, &miner.pubkey(), "btc", "tao", "a", "b", "355", 200), &miner.pubkey(), &miner).expect("set2 overwrite");
+    send(&mut svm, set_quote_ix(&program_id, &miner.pubkey(), "btc", "tao", "a", "b", 340 * RATE_PRECISION, 100), &miner.pubkey(), &miner).expect("set1");
+    send(&mut svm, set_quote_ix(&program_id, &miner.pubkey(), "btc", "tao", "a", "b", 355 * RATE_PRECISION, 200), &miner.pubkey(), &miner).expect("set2 overwrite");
 
     let q = read_quote(&svm, &program_id, &miner.pubkey(), "btc", "tao");
-    assert_eq!(q.rate, "355", "rate updated in place");
+    assert_eq!(q.rate, 355 * RATE_PRECISION, "rate updated in place");
     assert_eq!(q.liquidity, 200, "liquidity updated in place");
 }
 
@@ -196,14 +196,14 @@ fn test_multiple_pairs_and_directions_coexist() {
     let m = miner.pubkey();
 
     // Whole book: btc->tao, tao->btc (reverse direction), sol->btc.
-    send(&mut svm, set_quote_ix(&program_id, &m, "btc", "tao", "a", "b", "340", 1), &m, &miner).expect("btc->tao");
-    send(&mut svm, set_quote_ix(&program_id, &m, "tao", "btc", "c", "d", "0.0029", 2), &m, &miner).expect("tao->btc");
-    send(&mut svm, set_quote_ix(&program_id, &m, "sol", "btc", "e", "f", "0.0011", 3), &m, &miner).expect("sol->btc");
+    send(&mut svm, set_quote_ix(&program_id, &m, "btc", "tao", "a", "b", 340 * RATE_PRECISION, 1), &m, &miner).expect("btc->tao");
+    send(&mut svm, set_quote_ix(&program_id, &m, "tao", "btc", "c", "d", 29 * RATE_PRECISION / 10_000, 2), &m, &miner).expect("tao->btc");
+    send(&mut svm, set_quote_ix(&program_id, &m, "sol", "btc", "e", "f", 11 * RATE_PRECISION / 10_000, 3), &m, &miner).expect("sol->btc");
 
     // Each is its own PDA with its own rate; no collision.
-    assert_eq!(read_quote(&svm, &program_id, &m, "btc", "tao").rate, "340");
-    assert_eq!(read_quote(&svm, &program_id, &m, "tao", "btc").rate, "0.0029");
-    assert_eq!(read_quote(&svm, &program_id, &m, "sol", "btc").rate, "0.0011");
+    assert_eq!(read_quote(&svm, &program_id, &m, "btc", "tao").rate, 340 * RATE_PRECISION);
+    assert_eq!(read_quote(&svm, &program_id, &m, "tao", "btc").rate, 29 * RATE_PRECISION / 10_000);
+    assert_eq!(read_quote(&svm, &program_id, &m, "sol", "btc").rate, 11 * RATE_PRECISION / 10_000);
 }
 
 #[test]
@@ -211,7 +211,7 @@ fn test_same_chain_rejected() {
     let (mut svm, program_id) = setup();
     let miner = Keypair::new();
     svm.airdrop(&miner.pubkey(), 10_000_000_000).unwrap();
-    let r = send(&mut svm, set_quote_ix(&program_id, &miner.pubkey(), "btc", "btc", "a", "b", "1", 1), &miner.pubkey(), &miner);
+    let r = send(&mut svm, set_quote_ix(&program_id, &miner.pubkey(), "btc", "btc", "a", "b", RATE_PRECISION, 1), &miner.pubkey(), &miner);
     assert!(r.is_err(), "from_chain == to_chain must be rejected");
 }
 
@@ -220,7 +220,7 @@ fn test_empty_field_rejected() {
     let (mut svm, program_id) = setup();
     let miner = Keypair::new();
     svm.airdrop(&miner.pubkey(), 10_000_000_000).unwrap();
-    let r = send(&mut svm, set_quote_ix(&program_id, &miner.pubkey(), "btc", "tao", "", "b", "1", 1), &miner.pubkey(), &miner);
+    let r = send(&mut svm, set_quote_ix(&program_id, &miner.pubkey(), "btc", "tao", "", "b", RATE_PRECISION, 1), &miner.pubkey(), &miner);
     assert!(r.is_err(), "empty miner_from_addr must be rejected");
 }
 
@@ -230,7 +230,7 @@ fn test_oversized_string_rejected() {
     let miner = Keypair::new();
     svm.airdrop(&miner.pubkey(), 10_000_000_000).unwrap();
     let long_addr = "x".repeat(81); // MAX_ADDR_LEN = 80
-    let r = send(&mut svm, set_quote_ix(&program_id, &miner.pubkey(), "btc", "tao", &long_addr, "b", "1", 1), &miner.pubkey(), &miner);
+    let r = send(&mut svm, set_quote_ix(&program_id, &miner.pubkey(), "btc", "tao", &long_addr, "b", RATE_PRECISION, 1), &miner.pubkey(), &miner);
     assert!(r.is_err(), "address over MAX_ADDR_LEN must be rejected");
 }
 
@@ -242,7 +242,7 @@ fn test_remove_quote_closes_and_refunds() {
     let m = miner.pubkey();
 
     set_clock(&mut svm, 2_000_000);
-    send(&mut svm, set_quote_ix(&program_id, &m, "btc", "tao", "a", "b", "340", 1), &m, &miner).expect("set");
+    send(&mut svm, set_quote_ix(&program_id, &m, "btc", "tao", "a", "b", 340 * RATE_PRECISION, 1), &m, &miner).expect("set");
     let before = svm.get_account(&m).unwrap().lamports;
     assert!(svm.get_account(&quote_pda(&program_id, &m, "btc", "tao")).map(|a| a.lamports > 0).unwrap_or(false));
 
@@ -267,17 +267,17 @@ fn test_quote_update_fee_decays() {
     set_clock(&mut svm, 1_000_000); // a real (nonzero) wall clock
 
     // 1) Creation → free.
-    send(&mut svm, set_quote_ix(&program_id, &m, "btc", "tao", "a", "b", "340", 1), &m, &miner).expect("create");
+    send(&mut svm, set_quote_ix(&program_id, &m, "btc", "tao", "a", "b", 340 * RATE_PRECISION, 1), &m, &miner).expect("create");
     assert_eq!(treasury(&svm, &program_id), 0, "creation is free");
 
     // 2) Immediate update (elapsed 0 < 5 min) → tier-1.
-    send(&mut svm, set_quote_ix(&program_id, &m, "btc", "tao", "a", "b", "341", 1), &m, &miner).expect("rapid update");
+    send(&mut svm, set_quote_ix(&program_id, &m, "btc", "tao", "a", "b", 341 * RATE_PRECISION, 1), &m, &miner).expect("rapid update");
     let after_t1 = treasury(&svm, &program_id);
     assert_eq!(after_t1, QUOTE_UPDATE_FEE_TIER1_LAMPORTS, "rapid update charges tier-1");
 
     // 3) Update just past the 5-min window → tier-2.
     set_clock(&mut svm, 1_000_000 + QUOTE_UPDATE_FEE_TIER1_MAX_SECS + 1);
-    send(&mut svm, set_quote_ix(&program_id, &m, "btc", "tao", "a", "b", "342", 1), &m, &miner).expect("tier2 update");
+    send(&mut svm, set_quote_ix(&program_id, &m, "btc", "tao", "a", "b", 342 * RATE_PRECISION, 1), &m, &miner).expect("tier2 update");
     let after_t2 = treasury(&svm, &program_id);
     assert_eq!(after_t2, after_t1 + QUOTE_UPDATE_FEE_TIER2_LAMPORTS, "5–10 min update charges tier-2");
 
@@ -286,7 +286,7 @@ fn test_quote_update_fee_decays() {
         &mut svm,
         1_000_000 + QUOTE_UPDATE_FEE_TIER1_MAX_SECS + 1 + QUOTE_UPDATE_FEE_TIER2_MAX_SECS + 1,
     );
-    send(&mut svm, set_quote_ix(&program_id, &m, "btc", "tao", "a", "b", "343", 1), &m, &miner).expect("free update");
+    send(&mut svm, set_quote_ix(&program_id, &m, "btc", "tao", "a", "b", 343 * RATE_PRECISION, 1), &m, &miner).expect("free update");
     assert_eq!(treasury(&svm, &program_id), after_t2, "long-standing quote updates for free");
 }
 
@@ -301,13 +301,13 @@ fn test_remove_quote_charges_churn_fee() {
     set_clock(&mut svm, 1_000_000);
 
     // Fresh quote (btc/tao), removed immediately → tier-1.
-    send(&mut svm, set_quote_ix(&program_id, &m, "btc", "tao", "a", "b", "340", 1), &m, &miner).expect("create fresh");
+    send(&mut svm, set_quote_ix(&program_id, &m, "btc", "tao", "a", "b", 340 * RATE_PRECISION, 1), &m, &miner).expect("create fresh");
     assert_eq!(treasury(&svm, &program_id), 0, "creation free");
     send(&mut svm, remove_quote_ix(&program_id, &m, "btc", "tao"), &m, &miner).expect("remove fresh");
     assert_eq!(treasury(&svm, &program_id), QUOTE_UPDATE_FEE_TIER1_LAMPORTS, "removing a fresh quote charges tier-1");
 
     // A different quote (btc/sol) left to stand past the decay window → removes free (treasury unchanged).
-    send(&mut svm, set_quote_ix(&program_id, &m, "btc", "sol", "a", "b", "341", 1), &m, &miner).expect("create stale");
+    send(&mut svm, set_quote_ix(&program_id, &m, "btc", "sol", "a", "b", 341 * RATE_PRECISION, 1), &m, &miner).expect("create stale");
     set_clock(&mut svm, 1_000_000 + QUOTE_UPDATE_FEE_TIER2_MAX_SECS + 1);
     send(&mut svm, remove_quote_ix(&program_id, &m, "btc", "sol"), &m, &miner).expect("remove stale");
     assert_eq!(treasury(&svm, &program_id), QUOTE_UPDATE_FEE_TIER1_LAMPORTS, "a long-standing quote removes free");
@@ -321,10 +321,10 @@ fn test_set_quote_is_permissionless() {
     svm.airdrop(&anyone.pubkey(), 10_000_000_000).unwrap();
     send(
         &mut svm,
-        set_quote_ix(&program_id, &anyone.pubkey(), "btc", "tao", "a", "b", "340", 1),
+        set_quote_ix(&program_id, &anyone.pubkey(), "btc", "tao", "a", "b", 340 * RATE_PRECISION, 1),
         &anyone.pubkey(),
         &anyone,
     )
     .expect("permissionless set_quote");
-    assert_eq!(read_quote(&svm, &program_id, &anyone.pubkey(), "btc", "tao").rate, "340");
+    assert_eq!(read_quote(&svm, &program_id, &anyone.pubkey(), "btc", "tao").rate, 340 * RATE_PRECISION);
 }

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_reservation.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_reservation.rs
@@ -28,7 +28,7 @@ const TTL: i64 = 1_800;
 // Default pinned quote (matches the pair the tests open on).
 const MFROM: &str = "minerBTCaddr";
 const MTO: &str = "minerSOLaddr";
-const RATE: &str = "1.5";
+const RATE: u128 = 1_500_000_000_000_000_000; // 1.5 × RATE_PRECISION (1e18)
 
 fn pid() -> Pubkey {
     allways_swap_manager::id()
@@ -131,7 +131,7 @@ fn vote_activate_ix(validator: &Pubkey, miner: &Pubkey) -> Instruction {
         .to_account_metas(None),
     )
 }
-fn set_quote_ix(miner: &Pubkey, f: &str, t: &str, mfrom: &str, mto: &str, rate: &str) -> Instruction {
+fn set_quote_ix(miner: &Pubkey, f: &str, t: &str, mfrom: &str, mto: &str, rate: u128) -> Instruction {
     Instruction::new_with_bytes(
         pid(),
         &allways_swap_manager::instruction::SetQuote {
@@ -139,7 +139,7 @@ fn set_quote_ix(miner: &Pubkey, f: &str, t: &str, mfrom: &str, mto: &str, rate: 
             to_chain: t.to_string(),
             miner_from_addr: mfrom.to_string(),
             miner_to_addr: mto.to_string(),
-            rate: rate.to_string(),
+            rate,
             liquidity: 1_000,
         }
         .data(),
@@ -320,7 +320,7 @@ fn test_validator_can_update_request() {
 fn test_pair_mismatch_rejected() {
     let (mut svm, _admin, vals, miner) = setup(0, 0);
     // Miner also quotes BTC→TAO so that quote account exists for the join attempt.
-    send(&mut svm, set_quote_ix(&miner.pubkey(), "BTC", "TAO", MFROM, "minerTAOaddr", "2.0"), &miner.pubkey(), &miner).expect("quote2");
+    send(&mut svm, set_quote_ix(&miner.pubkey(), "BTC", "TAO", MFROM, "minerTAOaddr", 2_000_000_000_000_000_000), &miner.pubkey(), &miner).expect("quote2");
     let user = Keypair::new().pubkey();
     send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL", &user, "u1", "uSOL", 1, 1, 0), &vals[0].pubkey(), &vals[0]).expect("open BTC/SOL");
     let mism = send(&mut svm, open_ix(&vals[1].pubkey(), &miner.pubkey(), "BTC", "TAO", &user, "u2", "uTAO", 1, 1, 0), &vals[1].pubkey(), &vals[1]);

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_swap.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_swap.rs
@@ -33,7 +33,7 @@ const FROM_CHAIN: &str = "BTC";
 const TO_CHAIN: &str = "SOL";
 const MINER_FROM: &str = "minerBTCaddr";
 const MINER_TO: &str = "minerSOLaddr";
-const RATE: &str = "1.5";
+const RATE: u128 = 1_500_000_000_000_000_000; // 1.5 × RATE_PRECISION (1e18)
 
 fn pid() -> Pubkey {
     allways_swap_manager::id()
@@ -152,7 +152,7 @@ fn set_quote_ix(miner: &Pubkey) -> Instruction {
             to_chain: TO_CHAIN.to_string(),
             miner_from_addr: MINER_FROM.to_string(),
             miner_to_addr: MINER_TO.to_string(),
-            rate: RATE.to_string(),
+            rate: RATE,
             liquidity: 1_000,
         }
         .data(),

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_treasury.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_treasury.rs
@@ -140,7 +140,7 @@ fn setup_with_fee() -> (LiteSVM, Keypair, u64) {
 
     // Reservation via the lottery (set quote → open → warp past window → resolve; sole entrant wins).
     send(&mut svm, Instruction::new_with_bytes(pid(),
-        &allways_swap_manager::instruction::SetQuote { from_chain: "BTC".to_string(), to_chain: "SOL".to_string(), miner_from_addr: "mBTC".to_string(), miner_to_addr: "mSOL".to_string(), rate: "1".to_string(), liquidity: 1 }.data(),
+        &allways_swap_manager::instruction::SetQuote { from_chain: "BTC".to_string(), to_chain: "SOL".to_string(), miner_from_addr: "mBTC".to_string(), miner_to_addr: "mSOL".to_string(), rate: 1_000_000_000_000_000_000, liquidity: 1 }.data(),
         allways_swap_manager::accounts::SetQuote { miner: miner.pubkey(), quote: quote_pda(&miner.pubkey(), "BTC", "SOL"), treasury: treasury_pda(), system_program: SYS }.to_account_metas(None),
     ), &miner.pubkey(), &miner).expect("set_quote");
     let pool_user = Keypair::new().pubkey();


### PR DESCRIPTION
rate `String` → `u128` fixed-point (`display × 1e18` = the off-chain `rate_fixed` scale).

Kills the stringly-typed parse-bug class (rate that scores but won't reserve) — no parser left to diverge, exact integer math.

**Pure representation change, no on-chain policy:** the contract never computes with `rate`, only stores/copies it. Validity/routability stays off-chain in `is_executable_rate` (already gates scoring + reservation). `set_quote` stores whatever the miner posts — a `u128` can't be junk — so no new rate check. Decimals unaffected (orthogonal, done in the amount math).

Files: state (4 rate fields), events (QuoteSet), set_quote (drop empty/len checks), constants (MAX_RATE_LEN → RATE_PRECISION), lib, open_or_request/resolve_pool/vote_initiate (copy), + tests. cargo check + lib tests green; LiteSVM tests updated (no local build-sbf, CI verifies).