### PR TITLE
Remove dead slippage surface

### DIFF
--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -59,17 +59,6 @@ def _poll_reservation(client, miner, timeout_secs: int):
 @click.option('--auto', 'auto_select', is_flag=True, help='Auto-select best rate miner')
 @click.option('--yes', 'skip_confirm', is_flag=True, help='Skip confirmation prompts')
 @click.option(
-    '--slippage',
-    'slippage',
-    type=float,
-    default=2.0,
-    help=(
-        'Maximum rate slippage as a percent (e.g. 2.0 means 2%) between your quote and '
-        "the reservation. The reservation is rejected if the miner's current rate would "
-        'give you more than this percentage less than your quoted amount. Default: 2.0%.'
-    ),
-)
-@click.option(
     '--btc-fee-rate',
     'btc_fee_rate_opt',
     type=click.IntRange(min=1),
@@ -90,7 +79,6 @@ def swap_now_command(
     from_tx_hash_opt: Optional[str],
     auto_select: bool,
     skip_confirm: bool,
-    slippage: float,
     btc_fee_rate_opt: Optional[int],
 ):
     """Originate a swap: reserve a miner on-chain, then send source funds.
@@ -139,7 +127,7 @@ def swap_now_command(
 
     console.print(
         f'\n  Swap [cyan]{amount_opt} {from_chain.upper()}[/cyan] -> ~[cyan]{recv:.8g} {to_chain.upper()}[/cyan]'
-        f'  (miner [dim]{str(cand.miner)[:8]}…[/dim], rate {cand.rate_display} per SOL, slippage {slippage}%)\n'
+        f'  (miner [dim]{str(cand.miner)[:8]}…[/dim], rate {cand.rate_display} per SOL)\n'
     )
     if not skip_confirm and not click.confirm('  Reserve this miner on-chain?', default=False):
         return

--- a/allways/cli/validator_rejections.py
+++ b/allways/cli/validator_rejections.py
@@ -94,15 +94,6 @@ _RULES: list[_Rule] = [
         ),
     ),
     (
-        'rate_moved',
-        'quoted amount is below your slippage band',
-        True,
-        lambda ctx: (
-            f'Miner UID {_ctx_get(ctx, "miner_uid")} changed its rate after you got your quote. '
-            'Re-run the swap to get a fresh quote at the current rate, then retry.'
-        ),
-    ),
-    (
         'wrong_direction',
         'miner does not support this swap direction',
         True,

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -119,8 +119,6 @@ COLLATERAL_REQUIREMENT_BPS = 11_000
 RECYCLE_UID = 53  # Subnet owner UID
 
 # ─── Reservation ─────────────────────────────────────────
-RESERVE_SLIPPAGE_DEFAULT_BPS = 200  # 2% — applied when the synapse omits slippage
-RESERVE_SLIPPAGE_MAX_BPS = 2_500  # 25% — clamp ceiling; ≥10_000 turns the rate gate into a no-op
 RESERVATION_COOLDOWN_BLOCKS = 150  # ~30 min base cooldown on failed reservation
 RESERVATION_COOLDOWN_MULTIPLIER = 2  # 150 → 300 → 600 ...
 MAX_RESERVATIONS_PER_ADDRESS = 1

--- a/allways/synapses.py
+++ b/allways/synapses.py
@@ -10,8 +10,6 @@ from typing import Optional
 
 import bittensor as bt
 
-from allways.constants import RESERVE_SLIPPAGE_DEFAULT_BPS
-
 
 class MinerActivateSynapse(bt.Synapse):
     """Miner broadcasts activation request to all validators.
@@ -47,7 +45,6 @@ class SwapReserveSynapse(bt.Synapse):
     block_anchor: int
     from_chain: str = ''  # User's source chain (for bilateral pair support)
     to_chain: str = ''  # User's dest chain
-    slippage_bps: int = RESERVE_SLIPPAGE_DEFAULT_BPS
 
     # Response fields (validator fills)
     accepted: Optional[bool] = None

--- a/allways/utils/rate.py
+++ b/allways/utils/rate.py
@@ -92,20 +92,6 @@ def apply_fee_deduction(to_amount: int, fee_divisor: int) -> int:
     return to_amount - to_amount // fee_divisor
 
 
-def quote_within_slippage(quoted: int, recomputed: int, slippage_bps: int) -> bool:
-    """True if `recomputed` is no more than `slippage_bps` below `quoted`.
-
-    One-sided (DEX 'minimum received'): a favorable move — recomputed >= quoted —
-    always passes. Pure integer math for determinism across validators. When
-    slippage_bps >= 10_000 the threshold is non-positive, so it always passes.
-    """
-    if quoted <= 0 or recomputed <= 0:
-        return False
-    if recomputed >= quoted:
-        return True
-    return recomputed * 10_000 >= quoted * (10_000 - slippage_bps)
-
-
 def is_executable_rate(
     rate: float,
     from_chain: str,

--- a/tests/test_validator_rejections.py
+++ b/tests/test_validator_rejections.py
@@ -96,21 +96,6 @@ def test_address_cooldown_includes_raw_reason():
     assert info.headline.lower().count('address on cooldown') == 0
 
 
-def test_rate_moved_translates():
-    raw = 'Quoted amount is below your slippage band — the miner rate moved, re-quote and retry'
-    info = render_and_aggregate(
-        _silent_console(),
-        [FakeResp(accepted=False, rejection_reason=raw)],
-        context={'miner_uid': 7},
-    )
-    assert info.category == 'rate_moved'
-    # Deterministic: retrying with the same stale quote cannot succeed — the
-    # user must re-quote first.
-    assert info.deterministic is True
-    assert 'UID 7' in info.headline
-    assert 'rate' in info.headline.lower()
-
-
 def test_miner_busy_is_not_deterministic():
     info = render_and_aggregate(
         _silent_console(),


### PR DESCRIPTION
Slippage is deprecated: the validator locks the miner rate at pool-open (`open_or_request` pins `pool.rate`) and D1 makes `to_amount` follow that locked rate exactly, so a slippage band has nothing to do. The whole surface has no live consumer (the FCFS `handle_swap_reserve` stub ignores `slippage_bps`).

Pure dead-code deletion: constants, the reserve synapse field, the `--slippage` CLI option, the slippage-band rejection entry, and the unused `quote_within_slippage` helper (plus its test).

Spec: `contract-v2/m3-specs/D2-deprecate-slippage.md`