### PR TITLE
Reject attestation when to_amount diverges from pinned rate

### DIFF
--- a/allways/validator/solana_swap_loop.py
+++ b/allways/validator/solana_swap_loop.py
@@ -158,7 +158,7 @@ class SolanaSwapLoop:
 
     def _reject_logged(self, swap: Any, expected_to: int) -> None:
         """Warn once per swap key that to_amount diverges from the pinned rate (security-relevant, greppable)."""
-        key = self._swap_key(swap)
+        key = _swap_key_hex(swap.swap_key)
         if key in self.reject_warned:
             return
         self.reject_warned.add(key)
@@ -166,12 +166,6 @@ class SolanaSwapLoop:
             f'{self._label(swap)}: REJECT — to_amount {swap.to_amount} inconsistent with pinned rate '
             f'{swap.rate} (expected {expected_to}); refusing to attest [swap_key {key}]'
         )
-
-    def _swap_key(self, swap: Any) -> str:
-        try:
-            return swap_key_from_tx_hash(swap.from_tx_hash).hex()
-        except Exception:
-            return '?'
 
     def decide(self, swap: Any, now: int) -> SwapDecision:
         """Per-status decision. Verifies legs where needed; reads chain providers + the Reservation PDA."""

--- a/allways/validator/solana_swap_loop.py
+++ b/allways/validator/solana_swap_loop.py
@@ -11,14 +11,14 @@ validator verifies the dest leg delivered `apply_fee_deduction(to_amount, FEE_DI
 """
 
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import bittensor as bt
 
 from allways.chain_providers.base import ProviderUnreachableError
 from allways.solana import pdas
 from allways.solana.client import swap_key_from_tx_hash
-from allways.utils.rate import apply_fee_deduction
+from allways.utils.rate import apply_fee_deduction, expected_swap_amounts
 
 
 class SwapDecision(Enum):
@@ -27,6 +27,7 @@ class SwapDecision(Enum):
     TIMEOUT = 'timeout'  # Active past its deadline -> would timeout_swap
     WAIT = 'wait'  # in-flight, nothing to do yet
     SKIP = 'skip'  # provider unreachable / unverifiable this round
+    REJECT = 'reject'  # to_amount inconsistent with pinned rate -> never attest (terminal no-op)
 
 
 def _status_name(swap: Any) -> str:
@@ -63,6 +64,7 @@ class SolanaSwapLoop:
         self.providers = chain_providers
         self.fee_divisor = fee_divisor
         self.read_only = read_only
+        self.reject_warned: Set[str] = set()  # dedupe rate-reject warnings, one per swap key
 
     def expected_user_receives(self, swap: Any) -> int:
         """Dest amount the miner must deliver = 99% of the pinned to_amount (Option A)."""
@@ -154,10 +156,32 @@ class SolanaSwapLoop:
             return False
         return True
 
+    def _reject_logged(self, swap: Any, expected_to: int) -> None:
+        """Warn once per swap key that to_amount diverges from the pinned rate (security-relevant, greppable)."""
+        key = self._swap_key(swap)
+        if key in self.reject_warned:
+            return
+        self.reject_warned.add(key)
+        bt.logging.warning(
+            f'{self._label(swap)}: REJECT — to_amount {swap.to_amount} inconsistent with pinned rate '
+            f'{swap.rate} (expected {expected_to}); refusing to attest [swap_key {key}]'
+        )
+
+    def _swap_key(self, swap: Any) -> str:
+        try:
+            return swap_key_from_tx_hash(swap.from_tx_hash).hex()
+        except Exception:
+            return '?'
+
     def decide(self, swap: Any, now: int) -> SwapDecision:
         """Per-status decision. Verifies legs where needed; reads chain providers + the Reservation PDA."""
         status = _status_name(swap)
         if status == 'PendingAttestation':
+            # Refuse to attest if to_amount is inconsistent with the pinned (unforgeable) miner rate.
+            expected_to, _ = expected_swap_amounts(swap, self.fee_divisor)
+            if expected_to == 0 or abs(int(swap.to_amount) - expected_to) > 1:
+                self._reject_logged(swap, expected_to)
+                return SwapDecision.REJECT
             # Source deposit must exist, confirm, AND be fresh vs the Reservation before we'd attest.
             s_status, info = self._fetch_leg(
                 swap.from_chain,
@@ -211,6 +235,8 @@ class SolanaSwapLoop:
                 if self.client.has_voted(pdas.REQ_TIMEOUT, swap_key, voter):
                     return False
                 self.client.timeout_swap(swap_key, swap.miner, swap.user)
+            elif decision == SwapDecision.REJECT:
+                return False  # rate-inconsistent claim: cast no vote, leave it to go stale and reap
             else:
                 return False
         except Exception as e:

--- a/tests/test_solana_swap_loop.py
+++ b/tests/test_solana_swap_loop.py
@@ -14,13 +14,22 @@ RESV_CREATED_AT = 1200  # source-freshness floor
 FRESH = 5000  # block_time comfortably after both floors
 
 
-def make_swap(status='Fulfilled', to_amount=1000, from_amount=500, timeout_at=2000, key=b'\x01' * 32):
+def make_swap(
+    status='Fulfilled',
+    to_amount=1000,
+    from_amount=500,
+    timeout_at=2000,
+    key=b'\x01' * 32,
+    rate='5',
+    from_chain='btc',
+    to_chain='sol',
+):
     return SimpleNamespace(
         swap_key=key,
         miner='minerPK',
         status=status,
-        from_chain='btc',
-        to_chain='sol',
+        from_chain=from_chain,
+        to_chain=to_chain,
         from_tx_hash='srctx',
         to_tx_hash='dsttx',
         miner_from_addr='minerBTC',
@@ -28,6 +37,7 @@ def make_swap(status='Fulfilled', to_amount=1000, from_amount=500, timeout_at=20
         user_to_addr='userSOL',
         from_amount=from_amount,
         to_amount=to_amount,
+        rate=rate,
         from_tx_block=0,
         to_tx_block=0,
         timeout_at=timeout_at,
@@ -142,6 +152,58 @@ def test_pending_attestation_grace_allows_slightly_old_deposit():
     providers['btc'].grace = 300
     providers['btc'].block_time = RESV_CREATED_AT - 100  # within grace of the floor
     assert loop.decide(make_swap(status='PendingAttestation'), now=1500) == SwapDecision.ATTEST
+
+
+def test_pending_attestation_honest_sol_to_btc_attests():
+    # Forward direction (is_reverse=False): rate 5 → 1 SOL (1e9 lamports) maps to 5e8 sats.
+    loop, _ = loop_with(result=True)
+    swap = make_swap(
+        status='PendingAttestation', from_chain='sol', to_chain='btc', from_amount=1_000_000_000, to_amount=500_000_000
+    )
+    assert loop.decide(swap, now=1500) == SwapDecision.ATTEST
+
+
+def test_pending_attestation_honest_btc_to_sol_reverse_attests():
+    loop, _ = loop_with(result=True)
+    assert loop.decide(make_swap(status='PendingAttestation', to_amount=1000), now=1500) == SwapDecision.ATTEST
+
+
+def test_pending_attestation_absurd_to_amount_rejected():
+    loop, _ = loop_with(result=True)
+    swap = make_swap(status='PendingAttestation', to_amount=1000 * 10_000)  # expected 1000
+    assert loop.decide(swap, now=1500) == SwapDecision.REJECT
+
+
+def test_pending_attestation_to_amount_off_by_two_rejected():
+    loop, _ = loop_with(result=True)
+    assert loop.decide(make_swap(status='PendingAttestation', to_amount=1002), now=1500) == SwapDecision.REJECT
+
+
+def test_pending_attestation_to_amount_off_by_one_attests():
+    loop, _ = loop_with(result=True)
+    assert loop.decide(make_swap(status='PendingAttestation', to_amount=1001), now=1500) == SwapDecision.ATTEST
+
+
+def test_pending_attestation_garbage_rate_zero_expected_rejected():
+    loop, _ = loop_with(result=True)
+    swap = make_swap(status='PendingAttestation', rate='0', to_amount=1000)  # expected_to == 0
+    assert loop.decide(swap, now=1500) == SwapDecision.REJECT
+
+
+def test_pending_attestation_zero_to_amount_rejected():
+    loop, _ = loop_with(result=True)
+    assert loop.decide(make_swap(status='PendingAttestation', to_amount=0), now=1500) == SwapDecision.REJECT
+
+
+def test_reject_casts_no_vote():
+    swaps = [('pk1', make_swap(status='PendingAttestation', to_amount=1000 * 10_000, key=b'\x07' * 32))]
+    providers = {'btc': RecordingProvider(True), 'sol': RecordingProvider(True)}
+    client = VoteRecordingClient(swaps)
+    loop = SolanaSwapLoop(client, providers, fee_divisor=100)
+    loop.run_once(now=1500)
+    assert client.calls == []  # rate-inconsistent claim → no on-chain vote
+    assert loop._cast_vote(swaps[0][1], SwapDecision.REJECT) is False
+    assert client.calls == []
 
 
 def test_active_timed_out_vs_waiting():


### PR DESCRIPTION
Closes the permissionless-pool grief-drain / 2-strike elimination attack: a malicious router wins a quiet miner's pool and pins an absurd `to_amount` for a fair `sol_amount`, sends real source funds so validators attest, then the miner can't profitably deliver the pinned amount and gets slashed (refunded to the attacker) — two strikes eliminate the miner.

Mechanism: at the top of the PendingAttestation branch in `SolanaSwapLoop.decide()`, each validator recomputes the expected `to_amount` from the pinned (unforgeable) miner rate via `expected_swap_amounts` (one source of truth) and refuses to attest on mismatch (`expected_to == 0` or off by more than 1 smallest unit). REJECT casts no on-chain vote; the claim goes stale and reaps. Quorum of honest validators enforces it.

Spec: contract-v2/m3-specs/D1-attestation-rate-check.md