### PR TITLE
Extend deadlines for valid-but-unconfirmed legs

### DIFF
--- a/allways/chains.py
+++ b/allways/chains.py
@@ -2,13 +2,10 @@ import math
 from dataclasses import dataclass
 
 from allways.constants import (
-    EXTENSION_BUCKET_BLOCKS,
+    EXTENSION_BUCKET_SECONDS,
     EXTENSION_PADDING_SECONDS,
-    MAX_EXTENSION_BLOCKS,
     NUMERAIRE_CHAIN,
 )
-
-SUBTENSOR_BLOCK_SECONDS = 12
 
 
 @dataclass(frozen=True)
@@ -104,28 +101,14 @@ def canonical_pair(chain_a: str, chain_b: str) -> tuple:
     return (chain_a, chain_b) if chain_a < chain_b else (chain_b, chain_a)
 
 
-def confirmations_to_subtensor_blocks(chain_id: str) -> int:
-    """How many subtensor blocks a chain's min_confirmations take."""
-    chain = get_chain(chain_id)
-    return math.ceil(chain.min_confirmations * chain.seconds_per_block / SUBTENSOR_BLOCK_SECONDS)
+def compute_extension_target_secs(chain_id: str, confirmations: int, now_unix: int, ceiling_unix: int) -> int:
+    """Unix-seconds deadline to extend a valid-but-unconfirmed leg to.
 
-
-def compute_extension_target(
-    from_chain_id: str,
-    remaining_blocks: int,
-    current_subnet_block: int,
-) -> int:
-    """Subtensor block to extend a reservation/timeout to.
-
-    Covers ``remaining_blocks`` source-chain blocks plus a padding buffer,
-    bucket-rounded so validators converge, capped at MAX_EXTENSION_BLOCKS.
+    Covers the leg's remaining confirmations plus a padding buffer, bucket-rounded (in seconds) so
+    validators converge, then clamped to the contract ceiling (``max_extend_at``).
     """
-    chain = get_chain(from_chain_id)
-    seconds_needed = remaining_blocks * chain.seconds_per_block + EXTENSION_PADDING_SECONDS
-    blocks_needed = math.ceil(seconds_needed / SUBTENSOR_BLOCK_SECONDS)
-    blocks_needed = math.ceil(blocks_needed / EXTENSION_BUCKET_BLOCKS) * EXTENSION_BUCKET_BLOCKS
-    blocks_needed = min(blocks_needed, MAX_EXTENSION_BLOCKS)
-    # Anchor on current, not deadline: contract caps ``target - current_at_exec``
-    # at MAX_EXTENSION_BLOCKS (lib.rs:670, :1090), so a deadline anchor blows
-    # the cap whenever propose fires before the deadline.
-    return current_subnet_block + blocks_needed
+    chain = get_chain(chain_id)
+    remaining = max(0, chain.min_confirmations - confirmations)
+    target = now_unix + remaining * chain.seconds_per_block + EXTENSION_PADDING_SECONDS
+    target = math.ceil(target / EXTENSION_BUCKET_SECONDS) * EXTENSION_BUCKET_SECONDS
+    return min(target, ceiling_unix)

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -129,7 +129,11 @@ MAX_RESERVATIONS_PER_ADDRESS = 1
 # (block time, confirmations) lives in allways/chains.py; the contract enforces
 # its own MAX_EXTENSION_BLOCKS independently.
 EXTENSION_PADDING_SECONDS = 300  # safety buffer on top of confirmation time
-EXTENSION_BUCKET_BLOCKS = 30  # round target up so validator views converge
+# Validator-view convergence: extension targets snap up to this native-seconds grid so validators
+# computing `now + confirmation_runway` at slightly different wall-clock moments agree on one target_at.
+# Seconds, never blocks (the deadline axis is unix-seconds); >= the slowest chain's block time so a
+# bucket always spans at least one source block.
+EXTENSION_BUCKET_SECONDS = 600  # 10 min
 MAX_EXTENSION_BLOCKS = 250  # client-side cap, mirrors the contract's hard cap
 # Mirrors the contract's CHALLENGE_WINDOW_BLOCKS — must stay in sync with
 # smart-contracts/ink/lib.rs. Validators gate finalize calls on this locally

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -128,7 +128,7 @@ MAX_RESERVATIONS_PER_ADDRESS = 1
 # Tunables for the propose/challenge/finalize extension flow. Per-chain timing
 # (block time, confirmations) lives in allways/chains.py; the contract enforces
 # its own MAX_EXTENSION_BLOCKS independently.
-EXTENSION_PADDING_SECONDS = 300  # safety buffer on top of confirmation time
+EXTENSION_PADDING_SECONDS = 120  # safety buffer on top of confirmation time
 # Validator-view convergence: extension targets snap up to this native-seconds grid so validators
 # computing `now + confirmation_runway` at slightly different wall-clock moments agree on one target_at.
 # Seconds, never blocks (the deadline axis is unix-seconds); >= the slowest chain's block time so a

--- a/allways/miner/fulfillment.py
+++ b/allways/miner/fulfillment.py
@@ -1,8 +1,8 @@
 """Swap fulfillment engine - verifies receipt and sends funds (Solana-sourced).
 
 Fee model = Option A: the miner delivers **99% of the pinned ``to_amount``** (``apply_fee_deduction``);
-the protocol's 1% is skimmed from the miner's SOL collateral by ``confirm_swap``. The validator's
-``verify_fulfillment`` checks the dest leg delivered exactly this 99%, so the miner MUST match it. The
+the protocol's 1% is skimmed from the miner's SOL collateral by ``confirm_swap``. The validator's swap
+loop checks the dest leg delivered exactly this 99%, so the miner MUST match it. The
 fee saved on the dest leg offsets the collateral skim → the user bears the fee, the miner is a
 pass-through. ``mark_fulfilled`` records only the dest tx hash/block (``to_amount`` is pinned on-chain).
 Deadlines are unix-seconds (``Swap.timeout_at``).

--- a/allways/validator/solana_swap_loop.py
+++ b/allways/validator/solana_swap_loop.py
@@ -11,11 +11,13 @@ validator verifies the dest leg delivered `apply_fee_deduction(to_amount, FEE_DI
 """
 
 from enum import Enum
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, NamedTuple, Optional, Set, Tuple
 
 import bittensor as bt
 
 from allways.chain_providers.base import ProviderUnreachableError
+from allways.chains import compute_extension_target_secs
+from allways.constants import EXTENSION_PADDING_SECONDS
 from allways.solana import pdas
 from allways.solana.client import swap_key_from_tx_hash
 from allways.utils.rate import apply_fee_deduction, expected_swap_amounts
@@ -25,9 +27,34 @@ class SwapDecision(Enum):
     ATTEST = 'attest'  # PendingAttestation: source deposit verified -> would vote_initiate
     CONFIRM = 'confirm'  # Fulfilled: both legs verified -> would confirm_swap
     TIMEOUT = 'timeout'  # Active past its deadline -> would timeout_swap
+    EXTEND_RESERVATION = 'extend_reservation'  # source valid-but-unconfirmed near expiry -> slide reserved_until
+    EXTEND_TIMEOUT = 'extend_timeout'  # dest valid-but-unconfirmed near timeout -> slide timeout_at
     WAIT = 'wait'  # in-flight, nothing to do yet
     SKIP = 'skip'  # provider unreachable / unverifiable this round
     REJECT = 'reject'  # to_amount inconsistent with pinned rate -> never attest (terminal no-op)
+
+
+class SwapAction(NamedTuple):
+    """A decision plus the extension target it implies (``target_at`` is None for non-extend decisions)."""
+
+    decision: SwapDecision
+    target_at: Optional[int] = None
+
+
+# Decisions that drive an on-chain write this pass.
+ACTIONABLE = frozenset(
+    {
+        SwapDecision.ATTEST,
+        SwapDecision.CONFIRM,
+        SwapDecision.TIMEOUT,
+        SwapDecision.EXTEND_RESERVATION,
+        SwapDecision.EXTEND_TIMEOUT,
+    }
+)
+
+# Contract errors / lost races that make an extension a benign no-op (another validator already slid it,
+# or we're at the ceiling) — log quietly, never propagate.
+_BENIGN_EXTEND_MARKERS = ('ExtensionNotLater', 'ExtensionExceedsCeiling')
 
 
 def _status_name(swap: Any) -> str:
@@ -38,6 +65,11 @@ def _status_name(swap: Any) -> str:
 
 def _swap_key_hex(key: Any) -> str:
     return key.hex() if isinstance(key, (bytes, bytearray)) else str(key)
+
+
+def _is_benign_extension(e: Exception) -> bool:
+    """A contract ceiling hit or a lost extension race — expected, not an error."""
+    return any(m in str(e) for m in _BENIGN_EXTEND_MARKERS)
 
 
 def is_tx_fresh(info: Any, floor_unix: int, grace: int = 0) -> bool:
@@ -80,8 +112,9 @@ class SolanaSwapLoop:
     def _fetch_leg(
         self, chain: str, tx_hash: str, recipient: str, amount: int, block_hint: int = 0, sender: str = ''
     ) -> Tuple[str, Any]:
-        """Return ('ok', info) for a confirmed match, ('no', None) if absent/unconfirmed/no-provider,
-        ('down', None) if the provider was unreachable this round."""
+        """Tri-state leg status: ('ok', info) confirmed match, ('pending', info) all details match but
+        awaiting confirmations (extendable), ('no', None) absent/mismatch/no-provider (slash-eligible),
+        ('down', None) provider unreachable this round."""
         provider = self.providers.get(chain)
         if provider is None:
             bt.logging.warning(f'no chain provider for {chain}; cannot verify')
@@ -98,8 +131,10 @@ class SolanaSwapLoop:
             )
         except ProviderUnreachableError:
             return ('down', None)
-        if info is None or not info.confirmed:
+        if info is None:
             return ('no', None)
+        if not info.confirmed:
+            return ('pending', info)
         return ('ok', info)
 
     def _is_fresh(self, info: Any, floor_unix: int, chain: str, label: str) -> bool:
@@ -125,9 +160,38 @@ class SolanaSwapLoop:
             bt.logging.warning(f'reservation read failed for miner: {e}')
             return None
 
-    def verify_fulfillment(self, swap: Any) -> Optional[bool]:
-        """Verify source (user funded miner) + dest (miner delivered 99% to user, fresh). None = provider
-        down. Source freshness was gated at attestation; dest freshness (vs swap.initiated_at) is here."""
+    def _extend_target(self, chain: str, info: Any, deadline: int, ceiling: int, now: int) -> Optional[int]:
+        """Unix-seconds target to extend `deadline` to, or None when no extension is warranted. Gates
+        (shared by reservation + timeout): the deadline must be live, near expiry (within
+        EXTENSION_PADDING_SECONDS), below the contract ceiling, and the bucketed target strictly later."""
+        if deadline <= 0:
+            return None  # no live reservation/deadline
+        if deadline - now > EXTENSION_PADDING_SECONDS:
+            return None  # plenty of runway — don't extend prematurely
+        if deadline >= ceiling:
+            return None  # no room below the contract ceiling (max_extend_at)
+        target = compute_extension_target_secs(chain, int(info.confirmations), now, ceiling)
+        return target if target > deadline else None
+
+    def _extend_reservation_action(self, swap: Any, info: Any, now: int) -> SwapAction:
+        """Source leg valid-but-unconfirmed near reservation expiry → slide reserved_until, else WAIT."""
+        reservation = self._get_reservation(swap.miner)
+        if reservation is None:
+            return SwapAction(SwapDecision.WAIT)
+        target = self._extend_target(
+            swap.from_chain, info, int(reservation.reserved_until), int(reservation.max_extend_at), now
+        )
+        return SwapAction(SwapDecision.EXTEND_RESERVATION, target) if target else SwapAction(SwapDecision.WAIT)
+
+    def _extend_timeout_action(self, swap: Any, info: Any, now: int) -> SwapAction:
+        """Dest leg valid-but-unconfirmed near swap timeout → slide timeout_at, else WAIT."""
+        target = self._extend_target(swap.to_chain, info, int(swap.timeout_at), int(swap.max_extend_at), now)
+        return SwapAction(SwapDecision.EXTEND_TIMEOUT, target) if target else SwapAction(SwapDecision.WAIT)
+
+    def _decide_fulfilled(self, swap: Any, now: int, overdue: bool) -> SwapAction:
+        """Verify source (user funded miner) + dest (miner delivered 99% to user, fresh). CONFIRM when both
+        verify; EXTEND_TIMEOUT a valid-but-unconfirmed dest near timeout; TIMEOUT an overdue swap whose dest
+        is absent/mismatched (the contract slashes Fulfilled too). Source freshness was gated at attestation."""
         s_status, _ = self._fetch_leg(
             swap.from_chain,
             swap.from_tx_hash,
@@ -136,9 +200,7 @@ class SolanaSwapLoop:
             block_hint=int(getattr(swap, 'from_tx_block', 0)),
         )
         if s_status == 'down':
-            return None
-        if s_status != 'ok':
-            return False
+            return SwapAction(SwapDecision.SKIP)
         d_status, d_info = self._fetch_leg(
             swap.to_chain,
             swap.to_tx_hash,
@@ -148,13 +210,22 @@ class SolanaSwapLoop:
             sender=swap.miner_to_addr,
         )
         if d_status == 'down':
-            return None
-        if d_status != 'ok':
-            return False
+            return SwapAction(SwapDecision.SKIP)
+        if d_status == 'pending':
+            # Valid-but-unconfirmed payout near timeout → extend; if extension is exhausted/not yet due,
+            # fall through to the same overdue rule (at the ceiling + overdue still slashes).
+            action = self._extend_timeout_action(swap, d_info, now)
+            if action.decision == SwapDecision.EXTEND_TIMEOUT:
+                return action
         # Dest freshness: payout must be mined after the swap was initiated on-chain (replay defense).
-        if not self._is_fresh(d_info, int(swap.initiated_at), swap.to_chain, self._label(swap)):
-            return False
-        return True
+        elif (
+            s_status == 'ok'
+            and d_status == 'ok'
+            and self._is_fresh(d_info, int(swap.initiated_at), swap.to_chain, self._label(swap))
+        ):
+            return SwapAction(SwapDecision.CONFIRM)
+        # Unverifiable/stale dest + overdue ⇒ TIMEOUT; else wait for the leg.
+        return SwapAction(SwapDecision.TIMEOUT if overdue else SwapDecision.WAIT)
 
     def _reject_logged(self, swap: Any, expected_to: int) -> None:
         """Warn once per swap key that to_amount diverges from the pinned rate (security-relevant, greppable)."""
@@ -167,52 +238,56 @@ class SolanaSwapLoop:
             f'{swap.rate} (expected {expected_to}); refusing to attest [swap_key {key}]'
         )
 
-    def decide(self, swap: Any, now: int) -> SwapDecision:
-        """Per-status decision. Verifies legs where needed; reads chain providers + the Reservation PDA."""
-        status = _status_name(swap)
-        if status == 'PendingAttestation':
-            # Refuse to attest if to_amount is inconsistent with the pinned (unforgeable) miner rate.
-            expected_to, _ = expected_swap_amounts(swap, self.fee_divisor)
-            if expected_to == 0 or abs(int(swap.to_amount) - expected_to) > 1:
-                self._reject_logged(swap, expected_to)
-                return SwapDecision.REJECT
-            # Source deposit must exist, confirm, AND be fresh vs the Reservation before we'd attest.
-            s_status, info = self._fetch_leg(
-                swap.from_chain,
-                swap.from_tx_hash,
-                swap.miner_from_addr,
-                int(swap.from_amount),
-                block_hint=int(getattr(swap, 'from_tx_block', 0)),
-            )
-            if s_status == 'down':
-                return SwapDecision.SKIP
-            if s_status != 'ok':
-                return SwapDecision.WAIT
-            reservation = self._get_reservation(swap.miner)
-            if reservation is None:
-                bt.logging.warning(f'{self._label(swap)}: no reservation read — cannot check freshness, waiting')
-                return SwapDecision.WAIT
-            # Source freshness: deposit must be mined after the reservation was created (replay defense).
-            if not self._is_fresh(info, int(reservation.created_at), swap.from_chain, self._label(swap)):
-                return SwapDecision.WAIT  # replayed/stale deposit — never attest
-            return SwapDecision.ATTEST
-        overdue = now >= int(swap.timeout_at)
-        if status == 'Active':
-            return SwapDecision.TIMEOUT if overdue else SwapDecision.WAIT
-        if status == 'Fulfilled':
-            ok = self.verify_fulfillment(swap)
-            if ok is None:
-                return SwapDecision.SKIP
-            if ok:
-                return SwapDecision.CONFIRM
-            # Unverifiable dest + overdue ⇒ TIMEOUT (contract slashes Fulfilled too); else wait for the leg.
-            return SwapDecision.TIMEOUT if overdue else SwapDecision.WAIT
-        return SwapDecision.WAIT
+    def _decide_pending_attestation(self, swap: Any, now: int) -> SwapAction:
+        # D1: refuse to attest if to_amount is inconsistent with the pinned (unforgeable) miner rate.
+        expected_to, _ = expected_swap_amounts(swap, self.fee_divisor)
+        if expected_to == 0 or abs(int(swap.to_amount) - expected_to) > 1:
+            self._reject_logged(swap, expected_to)
+            return SwapAction(SwapDecision.REJECT)
+        # Source deposit must exist, confirm, AND be fresh vs the Reservation before we'd attest.
+        s_status, info = self._fetch_leg(
+            swap.from_chain,
+            swap.from_tx_hash,
+            swap.miner_from_addr,
+            int(swap.from_amount),
+            block_hint=int(getattr(swap, 'from_tx_block', 0)),
+        )
+        if s_status == 'down':
+            return SwapAction(SwapDecision.SKIP)
+        if s_status == 'pending':
+            # Valid-but-unconfirmed deposit near reservation expiry → extend so the honest miner isn't slashed.
+            return self._extend_reservation_action(swap, info, now)
+        if s_status != 'ok':
+            return SwapAction(SwapDecision.WAIT)
+        reservation = self._get_reservation(swap.miner)
+        if reservation is None:
+            bt.logging.warning(f'{self._label(swap)}: no reservation read — cannot check freshness, waiting')
+            return SwapAction(SwapDecision.WAIT)
+        # Source freshness: deposit must be mined after the reservation was created (replay defense).
+        if not self._is_fresh(info, int(reservation.created_at), swap.from_chain, self._label(swap)):
+            return SwapAction(SwapDecision.WAIT)  # replayed/stale deposit — never attest
+        return SwapAction(SwapDecision.ATTEST)
 
-    def _cast_vote(self, swap: Any, decision: SwapDecision) -> bool:
-        """Submit the on-chain consensus vote for an actionable decision. Pre-checks the VoteRound so we
-        don't re-submit a vote already cast; treats a lost race (swap already closed) as a no-op. Never
-        raises — one bad swap must not break the pass."""
+    def decide(self, swap: Any, now: int) -> SwapAction:
+        """Per-status decision (+extension target where applicable). Verifies legs where needed; reads
+        chain providers + the Reservation PDA."""
+        status = _status_name(swap)
+        overdue = now >= int(swap.timeout_at)
+        if status == 'PendingAttestation':
+            return self._decide_pending_attestation(swap, now)
+        if status == 'Active':
+            # Never extend: no mark_fulfilled = no broadcast evidence, so an overdue Active is slash-eligible.
+            return SwapAction(SwapDecision.TIMEOUT if overdue else SwapDecision.WAIT)
+        if status == 'Fulfilled':
+            return self._decide_fulfilled(swap, now, overdue)
+        return SwapAction(SwapDecision.WAIT)
+
+    def _cast_vote(self, swap: Any, action: SwapAction) -> bool:
+        """Submit the on-chain write for an actionable decision. Pre-checks the VoteRound so we don't
+        re-submit a vote already cast; treats a lost race (swap already closed) as a no-op. Extensions
+        tolerate the contract ceiling / lost extension races as no-ops. Never raises — one bad swap must
+        not break the pass."""
+        decision = action.decision
         swap_key = swap_key_from_tx_hash(swap.from_tx_hash)
         voter = self.client.keypair.pubkey()
         label = self._label(swap)
@@ -229,14 +304,19 @@ class SolanaSwapLoop:
                 if self.client.has_voted(pdas.REQ_TIMEOUT, swap_key, voter):
                     return False
                 self.client.timeout_swap(swap_key, swap.miner, swap.user)
-            elif decision == SwapDecision.REJECT:
-                return False  # rate-inconsistent claim: cast no vote, leave it to go stale and reap
+            elif decision == SwapDecision.EXTEND_RESERVATION:
+                self.client.extend_reservation(swap.miner, action.target_at)
+            elif decision == SwapDecision.EXTEND_TIMEOUT:
+                self.client.extend_timeout(swap_key, swap.miner, action.target_at)
             else:
-                return False
+                return False  # REJECT / non-actionable: cast nothing
         except Exception as e:
-            bt.logging.error(f'{label}: {decision.value} vote failed: {e}')
+            if decision in (SwapDecision.EXTEND_RESERVATION, SwapDecision.EXTEND_TIMEOUT) and _is_benign_extension(e):
+                bt.logging.debug(f'{label}: {decision.value} no-op ({e})')
+                return False
+            bt.logging.error(f'{label}: {decision.value} failed: {e}')
             return False
-        bt.logging.success(f'{label}: {decision.value} vote submitted')
+        bt.logging.success(f'{label}: {decision.value} submitted')
         return True
 
     def resolve_pools_once(self, now: int) -> List[str]:
@@ -271,14 +351,14 @@ class SolanaSwapLoop:
         for pubkey, swap in self.client.get_swaps():
             key = _swap_key_hex(getattr(swap, 'swap_key', pubkey))
             try:
-                decision = self.decide(swap, now)
+                action = self.decide(swap, now)
             except Exception as e:  # one bad swap must not break the pass
                 bt.logging.error(f'swap {key}: decide failed: {e}')
                 continue
-            if decision in (SwapDecision.ATTEST, SwapDecision.CONFIRM, SwapDecision.TIMEOUT):
+            if action.decision in ACTIONABLE:
                 if self.read_only:
-                    bt.logging.info(f'swap {key} [{_status_name(swap)}]: WOULD {decision.value} (read-only)')
+                    bt.logging.info(f'swap {key} [{_status_name(swap)}]: WOULD {action.decision.value} (read-only)')
                 else:
-                    self._cast_vote(swap, decision)
-            out.append((key, decision))
+                    self._cast_vote(swap, action)
+            out.append((key, action.decision))
         return out

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -1,18 +1,14 @@
-"""Tests for allways.chains — chain registry, confirmation math, safety blocks."""
+"""Tests for allways.chains — chain registry, canonical pairing, and the seconds-based extension target."""
 
 import pytest
 
 from allways.chains import (
     CHAIN_BTC,
     CHAIN_TAO,
+    EXTENSION_BUCKET_SECONDS,
     canonical_pair,
-    compute_extension_target,
-    confirmations_to_subtensor_blocks,
+    compute_extension_target_secs,
     get_chain,
-)
-from allways.constants import (
-    EXTENSION_BUCKET_BLOCKS,
-    MAX_EXTENSION_BLOCKS,
 )
 
 
@@ -57,61 +53,42 @@ class TestCanonicalPair:
         assert canonical_pair('tao', 'btc') == ('btc', 'tao')
 
 
-class TestConfirmationsToSubtensorBlocks:
-    def test_btc(self):
-        # ceil(2 * 600 / 12) = ceil(100) = 100
-        assert confirmations_to_subtensor_blocks('btc') == 100
+class TestComputeExtensionTargetSecs:
+    # Unix-seconds target = now + max(0, min_confirmations - confs) * seconds_per_block + 300s padding,
+    # bucketed up to the native 600s grid, clamped to the contract ceiling (max_extend_at).
+    NOW = 10_000
+    CEILING = 10_000_000
 
-    def test_tao(self):
-        # ceil(6 * 12 / 12) = ceil(6) = 6
-        assert confirmations_to_subtensor_blocks('tao') == 6
+    def test_btc_zero_confs(self):
+        # BTC needs 2 confs: remaining=2, raw = 10000 + 2*600 + 300 = 11500, bucket up to 12000.
+        assert compute_extension_target_secs('btc', 0, self.NOW, self.CEILING) == 12_000
 
+    def test_btc_one_conf(self):
+        # remaining=1, raw = 10000 + 600 + 300 = 10900, bucket up to 11400.
+        assert compute_extension_target_secs('btc', 1, self.NOW, self.CEILING) == 11_400
 
-class TestComputeExtensionTarget:
-    # BTC: 600s/block, padding 300s, bucket 30 blocks.
-    # Callers pass a fixed remaining (currently 4 across all tiers) sized for
-    # source-chain block-time variance plus padding.
+    def test_btc_fully_confirmed_only_padding(self):
+        # remaining clamps to 0: raw = 10000 + 300 = 10300, bucket up to 10800.
+        assert compute_extension_target_secs('btc', 5, self.NOW, self.CEILING) == 10_800
 
-    def test_btc_remaining_three(self):
-        # tier-2 at 0/3 confs: remaining=3, seconds=3*600+300=2100,
-        # blocks=ceil(2100/12)=175, bucketed=ceil(175/30)*30=180.
-        assert compute_extension_target('btc', 3, 1000) == 1000 + 180
+    def test_tao_remaining_confs(self):
+        # TAO needs 6 confs, 12s each: remaining=6, raw = 10000 + 72 + 300 = 10372, bucket up to 10800.
+        assert compute_extension_target_secs('tao', 0, self.NOW, self.CEILING) == 10_800
 
-    def test_btc_remaining_two(self):
-        # tier-2 at 1/3 confs: remaining=2, seconds=2*600+300=1500,
-        # blocks=125, bucketed=150.
-        assert compute_extension_target('btc', 2, 1000) == 1000 + 150
-
-    def test_btc_remaining_one(self):
-        # tier-1 (any chain) and tier-2 at 2/3 confs both land here:
-        # remaining=1, seconds=1*600+300=900, blocks=75, bucketed=90.
-        assert compute_extension_target('btc', 1, 1000) == 1000 + 90
-
-    def test_btc_remaining_zero(self):
-        # tier-2 at >=min confs: remaining=0, only padding remains —
-        # 300s/12 = 25 blocks, bucketed to 30.
-        assert compute_extension_target('btc', 0, 1000) == 1000 + 30
-
-    def test_tao_remaining_six(self):
-        # TAO: 12s/block. remaining=6, seconds=6*12+300=372,
-        # blocks=ceil(372/12)=31, bucketed=60.
-        assert compute_extension_target('tao', 6, 500) == 500 + 60
-
-    def test_target_is_capped_at_max_extension_blocks(self):
-        # Pretend a chain demands far more time than the cap allows: cap kicks in.
-        # BTC at remaining=3 gives 180 blocks — well under 250 — so it doesn't
-        # exercise the cap by itself. Drive the cap by reading-back the constant
-        # and confirming the function never returns more than current + cap.
-        target = compute_extension_target('btc', 3, 1000)
-        assert target - 1000 <= MAX_EXTENSION_BLOCKS
+    def test_target_is_strictly_after_now(self):
+        target = compute_extension_target_secs('btc', 0, self.NOW, self.CEILING)
+        assert target > self.NOW
 
     def test_result_is_bucket_aligned(self):
-        # Whatever the inputs, (target - current) is always a multiple of the
-        # bucket size — that's the convergence guarantee.
-        for remaining in range(0, 4):
-            target = compute_extension_target('btc', remaining, 1000)
-            assert (target - 1000) % EXTENSION_BUCKET_BLOCKS == 0
+        for confs in range(0, 4):
+            target = compute_extension_target_secs('btc', confs, self.NOW, self.CEILING)
+            assert target % EXTENSION_BUCKET_SECONDS == 0
+
+    def test_clamped_to_ceiling(self):
+        # A ceiling below the computed target wins — the contract caps target_at at max_extend_at.
+        ceiling = self.NOW + 500
+        assert compute_extension_target_secs('btc', 0, self.NOW, ceiling) == ceiling
 
     def test_unsupported_chain_raises(self):
         with pytest.raises(KeyError):
-            compute_extension_target('eth', 0, 1000)
+            compute_extension_target_secs('eth', 0, self.NOW, self.CEILING)

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -54,26 +54,26 @@ class TestCanonicalPair:
 
 
 class TestComputeExtensionTargetSecs:
-    # Unix-seconds target = now + max(0, min_confirmations - confs) * seconds_per_block + 300s padding,
+    # Unix-seconds target = now + max(0, min_confirmations - confs) * seconds_per_block + 120s padding,
     # bucketed up to the native 600s grid, clamped to the contract ceiling (max_extend_at).
     NOW = 10_000
     CEILING = 10_000_000
 
     def test_btc_zero_confs(self):
-        # BTC needs 2 confs: remaining=2, raw = 10000 + 2*600 + 300 = 11500, bucket up to 12000.
-        assert compute_extension_target_secs('btc', 0, self.NOW, self.CEILING) == 12_000
+        # BTC needs 2 confs: remaining=2, raw = 10000 + 2*600 + 120 = 11320, bucket up to 11400.
+        assert compute_extension_target_secs('btc', 0, self.NOW, self.CEILING) == 11_400
 
     def test_btc_one_conf(self):
-        # remaining=1, raw = 10000 + 600 + 300 = 10900, bucket up to 11400.
-        assert compute_extension_target_secs('btc', 1, self.NOW, self.CEILING) == 11_400
+        # remaining=1, raw = 10000 + 600 + 120 = 10720, bucket up to 10800.
+        assert compute_extension_target_secs('btc', 1, self.NOW, self.CEILING) == 10_800
 
     def test_btc_fully_confirmed_only_padding(self):
-        # remaining clamps to 0: raw = 10000 + 300 = 10300, bucket up to 10800.
-        assert compute_extension_target_secs('btc', 5, self.NOW, self.CEILING) == 10_800
+        # remaining clamps to 0: raw = 10000 + 120 = 10120, bucket up to 10200.
+        assert compute_extension_target_secs('btc', 5, self.NOW, self.CEILING) == 10_200
 
     def test_tao_remaining_confs(self):
-        # TAO needs 6 confs, 12s each: remaining=6, raw = 10000 + 72 + 300 = 10372, bucket up to 10800.
-        assert compute_extension_target_secs('tao', 0, self.NOW, self.CEILING) == 10_800
+        # TAO needs 6 confs, 12s each: remaining=6, raw = 10000 + 72 + 120 = 10192, bucket up to 10200.
+        assert compute_extension_target_secs('tao', 0, self.NOW, self.CEILING) == 10_200
 
     def test_target_is_strictly_after_now(self):
         target = compute_extension_target_secs('btc', 0, self.NOW, self.CEILING)

--- a/tests/test_solana_swap_loop.py
+++ b/tests/test_solana_swap_loop.py
@@ -1,5 +1,6 @@
-"""Unit tests for the Solana swap loop — decisions, Option-A 99% verification (B1), and the B2 replay
-freshness gates (source vs Reservation.created_at, dest vs Swap.initiated_at).
+"""Unit tests for the Solana swap loop — decisions, Option-A 99% verification (B1), the B2 replay
+freshness gates (source vs Reservation.created_at, dest vs Swap.initiated_at), and the D3 deadline
+extensions for valid-but-unconfirmed legs.
 
 Mocks the solana client (get_swaps / get_reservation) + chain providers; no chain, no votes.
 """
@@ -7,7 +8,7 @@ Mocks the solana client (get_swaps / get_reservation) + chain providers; no chai
 from types import SimpleNamespace
 
 from allways.chain_providers.base import ProviderUnreachableError
-from allways.validator.solana_swap_loop import SolanaSwapLoop, SwapDecision
+from allways.validator.solana_swap_loop import SolanaSwapLoop, SwapAction, SwapDecision
 
 INITIATED_AT = 1000  # dest-freshness floor
 RESV_CREATED_AT = 1200  # source-freshness floor
@@ -19,6 +20,7 @@ def make_swap(
     to_amount=1000,
     from_amount=500,
     timeout_at=2000,
+    max_extend_at=10_000,
     key=b'\x01' * 32,
     rate='5',
     from_chain='btc',
@@ -41,18 +43,21 @@ def make_swap(
         from_tx_block=0,
         to_tx_block=0,
         timeout_at=timeout_at,
+        max_extend_at=max_extend_at,
         initiated_at=INITIATED_AT,
     )
 
 
 class RecordingProvider:
-    """verify_transaction → confirmed-match info / None (missing) / raises (unreachable). block_time and
-    a per-chain replay_grace_secs feed the freshness checks."""
+    """verify_transaction → matched info / None (absent or detail mismatch) / raises (unreachable). result
+    True=confirmed, False=matched-but-unconfirmed (extendable), None=absent. block_time, confirmations and a
+    per-chain replay_grace_secs feed the freshness + extension-target math."""
 
-    def __init__(self, result=True, block_time=FRESH, grace=0):
+    def __init__(self, result=True, block_time=FRESH, grace=0, confirmations=0):
         self.result = result
         self.block_time = block_time
         self.grace = grace
+        self.confirmations = confirmations
         self.calls = []
 
     def get_chain(self):
@@ -63,15 +68,22 @@ class RecordingProvider:
         if self.result == 'unreachable':
             raise ProviderUnreachableError('down')
         if self.result is None:
-            return None  # tx not found
-        return SimpleNamespace(confirmed=bool(self.result), block_time=self.block_time)
+            return None  # tx not found / details mismatch
+        return SimpleNamespace(
+            confirmed=bool(self.result), block_time=self.block_time, confirmations=self.confirmations
+        )
 
 
-def loop_with(result=True, created_at=RESV_CREATED_AT):
+def make_reservation(created_at=RESV_CREATED_AT, reserved_until=0, max_extend_at=10_000):
+    return SimpleNamespace(created_at=created_at, reserved_until=reserved_until, max_extend_at=max_extend_at)
+
+
+def loop_with(result=True, created_at=RESV_CREATED_AT, reservation=None):
     providers = {'btc': RecordingProvider(result), 'sol': RecordingProvider(result)}
+    resv = reservation if reservation is not None else make_reservation(created_at=created_at)
     client = SimpleNamespace(
         get_swaps=lambda: [],
-        get_reservation=lambda miner: SimpleNamespace(created_at=created_at),
+        get_reservation=lambda miner: resv,
     )
     return SolanaSwapLoop(client, providers, fee_divisor=100), providers
 
@@ -85,7 +97,7 @@ def test_expected_user_receives_is_99_percent():
 def test_fulfilled_both_legs_ok_confirms_and_checks_99_percent_dest():
     loop, providers = loop_with(result=True)
     swap = make_swap(status='Fulfilled', to_amount=1000)
-    assert loop.decide(swap, now=1500) == SwapDecision.CONFIRM
+    assert loop.decide(swap, now=1500).decision == SwapDecision.CONFIRM
     # dest leg verified against 99% of to_amount, not the full amount
     dest_call = providers['sol'].calls[-1]
     assert dest_call.amount == 990 and dest_call.recipient == 'userSOL'
@@ -94,64 +106,64 @@ def test_fulfilled_both_legs_ok_confirms_and_checks_99_percent_dest():
     assert src_call.amount == 500 and src_call.recipient == 'minerBTC'
 
 
-def test_fulfilled_dest_unconfirmed_waits():
+def test_fulfilled_dest_pending_far_from_timeout_waits():
     loop, providers = loop_with(result=True)
-    providers['sol'].result = False  # dest not confirmed
-    assert loop.decide(make_swap(status='Fulfilled'), now=1500) == SwapDecision.WAIT
+    providers['sol'].result = False  # dest matched but unconfirmed, timeout far off
+    assert loop.decide(make_swap(status='Fulfilled'), now=1500).decision == SwapDecision.WAIT
 
 
 def test_fulfilled_stale_dest_tx_rejected_as_replay():
     loop, providers = loop_with(result=True)
     providers['sol'].block_time = INITIATED_AT - 1  # payout mined before the swap was initiated
-    assert loop.decide(make_swap(status='Fulfilled'), now=1500) == SwapDecision.WAIT
+    assert loop.decide(make_swap(status='Fulfilled'), now=1500).decision == SwapDecision.WAIT
 
 
 def test_fulfilled_dest_missing_block_time_rejected():
     loop, providers = loop_with(result=True)
     providers['sol'].block_time = None  # cannot prove freshness → fail closed
-    assert loop.decide(make_swap(status='Fulfilled'), now=1500) == SwapDecision.WAIT
+    assert loop.decide(make_swap(status='Fulfilled'), now=1500).decision == SwapDecision.WAIT
 
 
-def test_fulfilled_overdue_unverifiable_dest_times_out():
-    # Junk dest tx past the deadline must not escape the slash → TIMEOUT (contract allows Active|Fulfilled).
+def test_fulfilled_overdue_absent_dest_times_out():
+    # Absent/mismatched dest past the deadline must not escape the slash → TIMEOUT (Active|Fulfilled).
     loop, providers = loop_with(result=True)
-    providers['sol'].result = False  # dest never confirms
-    assert loop.decide(make_swap(status='Fulfilled', timeout_at=1000), now=1500) == SwapDecision.TIMEOUT
+    providers['sol'].result = None  # dest tx absent
+    assert loop.decide(make_swap(status='Fulfilled', timeout_at=1000), now=1500).decision == SwapDecision.TIMEOUT
 
 
 def test_fulfilled_overdue_but_verifiable_still_confirms():
     # Overdue is irrelevant when both legs verify — a good fulfillment still confirms.
     loop, _ = loop_with(result=True)
-    assert loop.decide(make_swap(status='Fulfilled', timeout_at=1000), now=1500) == SwapDecision.CONFIRM
+    assert loop.decide(make_swap(status='Fulfilled', timeout_at=1000), now=1500).decision == SwapDecision.CONFIRM
 
 
 def test_pending_attestation_source_ok_attests():
     loop, _ = loop_with(result=True)
-    assert loop.decide(make_swap(status='PendingAttestation'), now=1500) == SwapDecision.ATTEST
+    assert loop.decide(make_swap(status='PendingAttestation'), now=1500).decision == SwapDecision.ATTEST
 
 
 def test_pending_attestation_source_missing_waits():
     loop, _ = loop_with(result=None)
-    assert loop.decide(make_swap(status='PendingAttestation'), now=1500) == SwapDecision.WAIT
+    assert loop.decide(make_swap(status='PendingAttestation'), now=1500).decision == SwapDecision.WAIT
 
 
 def test_pending_attestation_stale_deposit_rejected_as_replay():
     loop, providers = loop_with(result=True)
     providers['btc'].block_time = RESV_CREATED_AT - 1  # deposit predates the reservation
-    assert loop.decide(make_swap(status='PendingAttestation'), now=1500) == SwapDecision.WAIT
+    assert loop.decide(make_swap(status='PendingAttestation'), now=1500).decision == SwapDecision.WAIT
 
 
 def test_pending_attestation_no_reservation_waits():
     loop, _ = loop_with(result=True)
     loop.client.get_reservation = lambda miner: None
-    assert loop.decide(make_swap(status='PendingAttestation'), now=1500) == SwapDecision.WAIT
+    assert loop.decide(make_swap(status='PendingAttestation'), now=1500).decision == SwapDecision.WAIT
 
 
 def test_pending_attestation_grace_allows_slightly_old_deposit():
     loop, providers = loop_with(result=True)
     providers['btc'].grace = 300
     providers['btc'].block_time = RESV_CREATED_AT - 100  # within grace of the floor
-    assert loop.decide(make_swap(status='PendingAttestation'), now=1500) == SwapDecision.ATTEST
+    assert loop.decide(make_swap(status='PendingAttestation'), now=1500).decision == SwapDecision.ATTEST
 
 
 def test_pending_attestation_honest_sol_to_btc_attests():
@@ -160,39 +172,39 @@ def test_pending_attestation_honest_sol_to_btc_attests():
     swap = make_swap(
         status='PendingAttestation', from_chain='sol', to_chain='btc', from_amount=1_000_000_000, to_amount=500_000_000
     )
-    assert loop.decide(swap, now=1500) == SwapDecision.ATTEST
+    assert loop.decide(swap, now=1500).decision == SwapDecision.ATTEST
 
 
 def test_pending_attestation_honest_btc_to_sol_reverse_attests():
     loop, _ = loop_with(result=True)
-    assert loop.decide(make_swap(status='PendingAttestation', to_amount=1000), now=1500) == SwapDecision.ATTEST
+    assert loop.decide(make_swap(status='PendingAttestation', to_amount=1000), now=1500).decision == SwapDecision.ATTEST
 
 
 def test_pending_attestation_absurd_to_amount_rejected():
     loop, _ = loop_with(result=True)
     swap = make_swap(status='PendingAttestation', to_amount=1000 * 10_000)  # expected 1000
-    assert loop.decide(swap, now=1500) == SwapDecision.REJECT
+    assert loop.decide(swap, now=1500).decision == SwapDecision.REJECT
 
 
 def test_pending_attestation_to_amount_off_by_two_rejected():
     loop, _ = loop_with(result=True)
-    assert loop.decide(make_swap(status='PendingAttestation', to_amount=1002), now=1500) == SwapDecision.REJECT
+    assert loop.decide(make_swap(status='PendingAttestation', to_amount=1002), now=1500).decision == SwapDecision.REJECT
 
 
 def test_pending_attestation_to_amount_off_by_one_attests():
     loop, _ = loop_with(result=True)
-    assert loop.decide(make_swap(status='PendingAttestation', to_amount=1001), now=1500) == SwapDecision.ATTEST
+    assert loop.decide(make_swap(status='PendingAttestation', to_amount=1001), now=1500).decision == SwapDecision.ATTEST
 
 
 def test_pending_attestation_garbage_rate_zero_expected_rejected():
     loop, _ = loop_with(result=True)
     swap = make_swap(status='PendingAttestation', rate='0', to_amount=1000)  # expected_to == 0
-    assert loop.decide(swap, now=1500) == SwapDecision.REJECT
+    assert loop.decide(swap, now=1500).decision == SwapDecision.REJECT
 
 
 def test_pending_attestation_zero_to_amount_rejected():
     loop, _ = loop_with(result=True)
-    assert loop.decide(make_swap(status='PendingAttestation', to_amount=0), now=1500) == SwapDecision.REJECT
+    assert loop.decide(make_swap(status='PendingAttestation', to_amount=0), now=1500).decision == SwapDecision.REJECT
 
 
 def test_reject_casts_no_vote():
@@ -202,19 +214,151 @@ def test_reject_casts_no_vote():
     loop = SolanaSwapLoop(client, providers, fee_divisor=100)
     loop.run_once(now=1500)
     assert client.calls == []  # rate-inconsistent claim → no on-chain vote
-    assert loop._cast_vote(swaps[0][1], SwapDecision.REJECT) is False
+    assert loop._cast_vote(swaps[0][1], SwapAction(SwapDecision.REJECT)) is False
     assert client.calls == []
 
 
 def test_active_timed_out_vs_waiting():
     loop, _ = loop_with()
-    assert loop.decide(make_swap(status='Active', timeout_at=1000), now=1500) == SwapDecision.TIMEOUT
-    assert loop.decide(make_swap(status='Active', timeout_at=2000), now=1500) == SwapDecision.WAIT
+    assert loop.decide(make_swap(status='Active', timeout_at=1000), now=1500).decision == SwapDecision.TIMEOUT
+    assert loop.decide(make_swap(status='Active', timeout_at=2000), now=1500).decision == SwapDecision.WAIT
+
+
+def test_active_overdue_never_extends():
+    # Active has no mark_fulfilled = no broadcast evidence → overdue must slash, never extend.
+    loop, providers = loop_with(result=False)  # even a pending-looking source can't save an Active
+    swap = make_swap(status='Active', timeout_at=1000, max_extend_at=10_000)
+    assert loop.decide(swap, now=1500).decision == SwapDecision.TIMEOUT
 
 
 def test_provider_unreachable_skips():
     loop, _ = loop_with(result='unreachable')
-    assert loop.decide(make_swap(status='Fulfilled'), now=1500) == SwapDecision.SKIP
+    assert loop.decide(make_swap(status='Fulfilled'), now=1500).decision == SwapDecision.SKIP
+
+
+# ─── D3: deadline extensions for valid-but-unconfirmed legs ───
+
+
+def test_fetch_leg_tristate():
+    # confirmed→ok, matched-unconfirmed→pending, absent/mismatch→no, unreachable→down.
+    loop, _ = loop_with()
+    loop.providers = {'btc': RecordingProvider(True)}
+    assert loop._fetch_leg('btc', 'tx', 'r', 1)[0] == 'ok'
+    loop.providers = {'btc': RecordingProvider(False)}
+    status, info = loop._fetch_leg('btc', 'tx', 'r', 1)
+    assert status == 'pending' and info is not None
+    loop.providers = {'btc': RecordingProvider(None)}
+    assert loop._fetch_leg('btc', 'tx', 'r', 1) == ('no', None)
+    loop.providers = {'btc': RecordingProvider('unreachable')}
+    assert loop._fetch_leg('btc', 'tx', 'r', 1) == ('down', None)
+
+
+def test_source_pending_near_expiry_extends_reservation():
+    # BTC source pending at 0/2 confs: target = now + 2*600 + 300 = 3000 → 600s bucket lands on 3000.
+    resv = make_reservation(reserved_until=1600, max_extend_at=10_000)
+    loop, _ = loop_with(result=False, reservation=resv)
+    action = loop.decide(make_swap(status='PendingAttestation'), now=1500)
+    assert action.decision == SwapDecision.EXTEND_RESERVATION
+    assert action.target_at == 3000
+
+
+def test_source_pending_with_time_left_waits():
+    resv = make_reservation(reserved_until=5000, max_extend_at=10_000)  # 3500s of runway > padding
+    loop, _ = loop_with(result=False, reservation=resv)
+    assert loop.decide(make_swap(status='PendingAttestation'), now=1500).decision == SwapDecision.WAIT
+
+
+def test_source_pending_at_ceiling_no_extend():
+    resv = make_reservation(reserved_until=1600, max_extend_at=1600)  # no room below ceiling
+    loop, _ = loop_with(result=False, reservation=resv)
+    assert loop.decide(make_swap(status='PendingAttestation'), now=1500).decision == SwapDecision.WAIT
+
+
+def test_source_pending_no_reservation_waits():
+    loop, _ = loop_with(result=False, reservation=None)
+    loop.client.get_reservation = lambda miner: None
+    assert loop.decide(make_swap(status='PendingAttestation'), now=1500).decision == SwapDecision.WAIT
+
+
+def test_dest_pending_near_timeout_extends_timeout():
+    # SOL dest pending at 0/32 confs: target = now + 32*1 + 300 = 1832 → 600s bucket up to 2400 (<ceiling).
+    loop, providers = loop_with(result=True)
+    providers['sol'].result = False
+    swap = make_swap(status='Fulfilled', timeout_at=1600, max_extend_at=10_000)
+    action = loop.decide(swap, now=1500)
+    assert action.decision == SwapDecision.EXTEND_TIMEOUT
+    assert action.target_at == 2400
+
+
+def test_dest_pending_far_from_timeout_waits():
+    loop, providers = loop_with(result=True)
+    providers['sol'].result = False
+    swap = make_swap(status='Fulfilled', timeout_at=5000, max_extend_at=10_000)
+    assert loop.decide(swap, now=1500).decision == SwapDecision.WAIT
+
+
+def test_dest_pending_at_ceiling_overdue_times_out():
+    # Extensions exhausted (timeout_at == max_extend_at) and overdue → slash, don't wait forever.
+    loop, providers = loop_with(result=True)
+    providers['sol'].result = False
+    swap = make_swap(status='Fulfilled', timeout_at=1000, max_extend_at=1000)
+    assert loop.decide(swap, now=1500).decision == SwapDecision.TIMEOUT
+
+
+def test_dest_absent_overdue_times_out_not_extended():
+    loop, providers = loop_with(result=True)
+    providers['sol'].result = None  # dest absent, not merely unconfirmed
+    swap = make_swap(status='Fulfilled', timeout_at=1000, max_extend_at=10_000)
+    assert loop.decide(swap, now=1500).decision == SwapDecision.TIMEOUT
+
+
+def test_extension_target_clamped_to_ceiling():
+    # A tight ceiling caps target_at at max_extend_at; still strictly past the deadline.
+    resv = make_reservation(reserved_until=1600, max_extend_at=1800)
+    loop, _ = loop_with(result=False, reservation=resv)
+    action = loop.decide(make_swap(status='PendingAttestation'), now=1500)
+    assert action.decision == SwapDecision.EXTEND_RESERVATION
+    assert action.target_at == 1800  # clamped down from the bucketed 3000
+    assert action.target_at > 1600
+
+
+class ExtendRecordingClient:
+    """Captures extend calls; raisers simulate the contract ceiling / lost-race rejections."""
+
+    def __init__(self, reservation_exc=None, timeout_exc=None):
+        self.reservation_exc = reservation_exc
+        self.timeout_exc = timeout_exc
+        self.calls = []
+        self.keypair = SimpleNamespace(pubkey=lambda: 'VALIDATOR')
+
+    def extend_reservation(self, miner, target_at):
+        self.calls.append(('extend_reservation', miner, target_at))
+        if self.reservation_exc:
+            raise self.reservation_exc
+
+    def extend_timeout(self, swap_key, miner, target_at):
+        self.calls.append(('extend_timeout', swap_key, miner, target_at))
+        if self.timeout_exc:
+            raise self.timeout_exc
+
+
+def test_cast_extend_reservation_calls_client():
+    client = ExtendRecordingClient()
+    loop = SolanaSwapLoop(client, {}, fee_divisor=100)
+    assert loop._cast_vote(make_swap(), SwapAction(SwapDecision.EXTEND_RESERVATION, 3240)) is True
+    assert client.calls == [('extend_reservation', 'minerPK', 3240)]
+
+
+def test_cast_extend_tolerates_not_later_as_noop():
+    client = ExtendRecordingClient(reservation_exc=RuntimeError('ExtensionNotLater: already slid'))
+    loop = SolanaSwapLoop(client, {}, fee_divisor=100)
+    assert loop._cast_vote(make_swap(), SwapAction(SwapDecision.EXTEND_RESERVATION, 3240)) is False  # no raise
+
+
+def test_cast_extend_tolerates_exceeds_ceiling_as_noop():
+    client = ExtendRecordingClient(timeout_exc=RuntimeError('ExtensionExceedsCeiling'))
+    loop = SolanaSwapLoop(client, {}, fee_divisor=100)
+    assert loop._cast_vote(make_swap(), SwapAction(SwapDecision.EXTEND_TIMEOUT, 2160)) is False  # no raise
 
 
 def test_run_once_discovers_and_decides_mix():
@@ -225,7 +369,7 @@ def test_run_once_discovers_and_decides_mix():
     providers = {'btc': RecordingProvider(True), 'sol': RecordingProvider(True)}
     client = SimpleNamespace(
         get_swaps=lambda: swaps,
-        get_reservation=lambda miner: SimpleNamespace(created_at=RESV_CREATED_AT),
+        get_reservation=lambda miner: make_reservation(),
     )
     loop = SolanaSwapLoop(client, providers, fee_divisor=100, read_only=True)
     out = dict(loop.run_once(now=1500))
@@ -246,7 +390,7 @@ class VoteRecordingClient:
         return self._swaps
 
     def get_reservation(self, miner):
-        return SimpleNamespace(created_at=RESV_CREATED_AT)
+        return make_reservation()
 
     def has_voted(self, req_type, target, voter):
         return self.already_voted

--- a/tests/test_solana_swap_loop.py
+++ b/tests/test_solana_swap_loop.py
@@ -254,7 +254,7 @@ def test_fetch_leg_tristate():
 
 
 def test_source_pending_near_expiry_extends_reservation():
-    # BTC source pending at 0/2 confs: target = now + 2*600 + 300 = 3000 → 600s bucket lands on 3000.
+    # BTC source pending at 0/2 confs: raw = now + 2*600 + 120 = 2820 → 600s bucket lands on 3000.
     resv = make_reservation(reserved_until=1600, max_extend_at=10_000)
     loop, _ = loop_with(result=False, reservation=resv)
     action = loop.decide(make_swap(status='PendingAttestation'), now=1500)
@@ -281,13 +281,13 @@ def test_source_pending_no_reservation_waits():
 
 
 def test_dest_pending_near_timeout_extends_timeout():
-    # SOL dest pending at 0/32 confs: target = now + 32*1 + 300 = 1832 → 600s bucket up to 2400 (<ceiling).
+    # SOL dest pending at 0/32 confs: raw = now + 32*1 + 120 = 1652 → 600s bucket up to 1800 (<ceiling).
     loop, providers = loop_with(result=True)
     providers['sol'].result = False
     swap = make_swap(status='Fulfilled', timeout_at=1600, max_extend_at=10_000)
     action = loop.decide(swap, now=1500)
     assert action.decision == SwapDecision.EXTEND_TIMEOUT
-    assert action.target_at == 2400
+    assert action.target_at == 1800
 
 
 def test_dest_pending_far_from_timeout_waits():


### PR DESCRIPTION
## What

D3 — deadline extensions. Protects honest miners from a false slash when a swap leg is broadcast-and-valid but just slow to reach its required confirmations.

## The false slash this fixes

The contract slashes a miner whose leg is on-chain and matches every detail (recipient, amount, sender) but still sits below `min_confirmations` when the deadline passes. The validator loop never called the extension builders, so a slow source/dest confirm turned into a false slash.

## Trigger — valid-but-unconfirmed only

`_fetch_leg` is now tri-state: `('no')` absent/mismatch (slash-eligible), `('pending', info)` matched-but-unconfirmed (the new extendable case), `('ok', info)` confirmed, `('down')` unreachable. `verify_transaction(require_confirmed=False)` already returned the matched info while unconfirmed; the only blocker was `_fetch_leg` collapsing `not info.confirmed` into `'no'`.

`decide()` extends only on `pending`, only near the deadline (`(deadline - now) <= EXTENSION_PADDING_SECONDS`), only with room below the contract ceiling (`max_extend_at`):
- PendingAttestation source pending → `EXTEND_RESERVATION`
- Fulfilled dest pending → `EXTEND_TIMEOUT` (at ceiling + overdue → TIMEOUT)
- Active never extends (no `mark_fulfilled` = no broadcast evidence → overdue slashes)
- dest absent/mismatch + overdue → TIMEOUT

The contract ceiling is the only bound — no client-side extension counters. `decide()` returns a `(decision, target_at)` `SwapAction` so `_cast_vote` casts `extend_reservation`/`extend_timeout` with the computed target. Extension casts tolerate `ExtensionNotLater` / `ExtensionExceedsCeiling` / lost races as no-ops.

## Seconds-based target replacing block rot

`chains.py`'s `compute_extension_target` returned subtensor *blocks* and cited deleted ink! `lib.rs` lines. Replaced with `compute_extension_target_secs` (unix seconds): `now + max(0, min_confirmations - confs) * seconds_per_block + EXTENSION_PADDING_SECONDS`, bucketed on a seconds grid derived from existing constants (`EXTENSION_BUCKET_BLOCKS * SUBTENSOR_BLOCK_SECONDS`), clamped to `max_extend_at`. The block-based `compute_extension_target` and `confirmations_to_subtensor_blocks` were dead in production (tests only) and are removed.

## Notes

- Stacks on D1 (`m3-d1-attestation-rate-check`) — both edit `decide()`/`SwapDecision`/`_cast_vote`. Base is D1; retarget to `m3` once D1 merges.
- Per-chain numbers (`seconds_per_block`, `min_confirmations`) come from `chains.py` — no scattered literals.
- `MAX_EXTENSIONS_PER_*` constants left untouched (miner cache sizing references them).
- 546 unit tests green; ruff clean.