### PR TITLE
Forfeit crown for busy miners via activity states

### DIFF
--- a/allways/classes.py
+++ b/allways/classes.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from enum import IntEnum
+from typing import Optional
 
 
 class SwapStatus(IntEnum):
@@ -7,6 +8,47 @@ class SwapStatus(IntEnum):
     FULFILLED = 1
     COMPLETED = 2
     TIMED_OUT = 3
+
+
+class MinerActivity(IntEnum):
+    """A miner's per-instant availability for the crown, reduced from its
+    activity-transition timeline. ``REWARD_MINER_STATES`` decides which states
+    earn — by default only AVAILABLE (a busy miner isn't takeable)."""
+
+    AVAILABLE = 0
+    RESERVED = 1
+    FULFILLING = 2
+
+
+class ActivityTransition(IntEnum):
+    """Edges of the ``MinerActivity`` machine. Values double as the coincident-
+    instant tiebreak: at one block a swap closes before a re-reservation opens,
+    which opens before its initiation, and a reservation lapse applies last so an
+    in-flight swap survives its synthetic ``RESERVE_EXPIRE``."""
+
+    FULFILL_END = 0  # SwapCompleted / SwapTimedOut
+    RESERVE_START = 1  # PoolResolved
+    FULFILL_START = 2  # SwapInitiated
+    RESERVE_EXPIRE = 3  # synthetic, at reserve block_time + reservation_ttl_secs
+
+
+# Guarded transitions; an undefined (state, transition) pair returns None so the
+# caller holds state (and can warn once). The RESERVE_EXPIRE no-ops are explicit
+# (not warned): a swap consumes the reservation, so its synthetic expiry fires
+# later while FULFILLING, or after the swap already closed (AVAILABLE).
+_ACTIVITY_TRANSITIONS = {
+    (MinerActivity.AVAILABLE, ActivityTransition.RESERVE_START): MinerActivity.RESERVED,
+    (MinerActivity.AVAILABLE, ActivityTransition.RESERVE_EXPIRE): MinerActivity.AVAILABLE,
+    (MinerActivity.RESERVED, ActivityTransition.FULFILL_START): MinerActivity.FULFILLING,
+    (MinerActivity.RESERVED, ActivityTransition.RESERVE_EXPIRE): MinerActivity.AVAILABLE,
+    (MinerActivity.FULFILLING, ActivityTransition.RESERVE_EXPIRE): MinerActivity.FULFILLING,
+    (MinerActivity.FULFILLING, ActivityTransition.FULFILL_END): MinerActivity.AVAILABLE,
+}
+
+
+def next_activity(state: MinerActivity, transition: ActivityTransition) -> Optional[MinerActivity]:
+    """Next state, or ``None`` for an unexpected (undefined) transition."""
+    return _ACTIVITY_TRANSITIONS.get((state, transition))
 
 
 @dataclass

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -1,5 +1,7 @@
 import os
 
+from allways.classes import MinerActivity
+
 # ─── Network ───────────────────────────────────────────────
 NETUID_FINNEY = 7
 NETUID_LOCAL = 2
@@ -53,6 +55,10 @@ SCORING_WINDOW_BLOCKS = 300  # ~1 hour at 12s/block — scoring cadence and wind
 SCORING_WINDOW_SECS = 3600  # ~1 hour — crown replay window width
 MAX_SCORING_BACKFILL_SECS = 2 * SCORING_WINDOW_SECS  # ~2 hours — backfill cap after a stall
 SCORING_EMA_ALPHA = 1.0  # Instantaneous — no smoothing across passes
+# Crown reward-state policy (D4): the only place that decides which MinerActivity
+# states earn crown. "All busy forfeits" = only AVAILABLE; add MinerActivity.FULFILLING
+# here to reward in-flight miners, with no other logic change.
+REWARD_MINER_STATES: frozenset[MinerActivity] = frozenset({MinerActivity.AVAILABLE})
 # Numéraire / hub asset: the subnet is hub-and-spoke — every launch pair is hub↔spoke, so a rate reads
 # uniformly as 'dest per 1 hub'. SOL by construction (the contract lives on Solana: collateral, fee, and the
 # sol_amount notional are all SOL). Referenced wherever code needs "is this the hub", instead of a literal.

--- a/allways/solana/events.py
+++ b/allways/solana/events.py
@@ -2,14 +2,14 @@
 
 Anchor self-CPI events are emitted as base64 `Program data:` log lines = 8-byte event discriminator +
 borsh(body). Discriminators + field order copied verbatim from target/idl/allways_swap_manager.json. The
-validator replays these to reconstruct per-instant miner state (collateral, busy, rate, active) for the
+validator replays these to reconstruct per-instant miner state (collateral, activity, rate, active) for the
 crown — replacing the old substrate event_watcher. Only the crown-relevant events are decoded here.
 """
 
 from dataclasses import dataclass
 from typing import Any, List, Optional, Tuple
 
-from borsh_construct import I64, U64, U128, CStruct, String
+from borsh_construct import I64, U8, U64, U128, CStruct, String
 from solders.pubkey import Pubkey
 
 from allways.solana.layouts import Hash32, Pubkey32
@@ -25,6 +25,7 @@ EVENT_DISCRIMINATORS = {
     'QuoteRemoved': bytes([52, 211, 141, 65, 95, 43, 64, 32]),
     'MinerActivated': bytes([203, 75, 131, 151, 24, 167, 159, 19]),
     'MinerDeactivated': bytes([31, 67, 233, 59, 174, 101, 245, 122]),
+    'PoolResolved': bytes([37, 148, 82, 156, 128, 131, 201, 171]),
 }
 
 # Borsh bodies (post-discriminator), field order locked to events.rs.
@@ -64,6 +65,8 @@ EVENT_LAYOUTS = {
     'QuoteRemoved': CStruct('miner' / Pubkey32, 'from_chain' / String, 'to_chain' / String, 'remove_fee' / U64),
     'MinerActivated': CStruct('miner' / Pubkey32, 'at' / I64),
     'MinerDeactivated': CStruct('miner' / Pubkey32, 'at' / I64),
+    # The reserved miner is `miner` (not `winner`, the router). Drives RESERVE_START.
+    'PoolResolved': CStruct('miner' / Pubkey32, 'winner' / Pubkey32, 'user' / Pubkey32, 'requests' / U8),
 }
 
 # Fields to convert from raw 32 bytes → solders Pubkey after parse.
@@ -77,6 +80,7 @@ EVENT_PUBKEY_FIELDS = {
     'QuoteRemoved': ['miner'],
     'MinerActivated': ['miner'],
     'MinerDeactivated': ['miner'],
+    'PoolResolved': ['miner', 'winner', 'user'],
 }
 
 _BY_DISC = {disc: name for name, disc in EVENT_DISCRIMINATORS.items()}

--- a/allways/validator/bounds_cache.py
+++ b/allways/validator/bounds_cache.py
@@ -48,6 +48,9 @@ class SolanaConfigCache:
     def fulfillment_timeout_secs(self) -> int:
         return int(self._fresh_config().fulfillment_timeout_secs)
 
+    def reservation_ttl_secs(self) -> int:
+        return int(self._fresh_config().reservation_ttl_secs)
+
     def halted(self) -> bool:
         """Shorter-TTL halt read. Fails open to last-known (or False) so a
         flaky RPC can't zero every miner's reward — matches

--- a/allways/validator/event_index.py
+++ b/allways/validator/event_index.py
@@ -1,6 +1,6 @@
 """SolanaEventIndex — crown-time miner state sourced from Solana program events (B3.4).
 
-The crown algorithm in ``scoring.py`` reads per-instant miner state (active set, busy counts, posted
+The crown algorithm in ``scoring.py`` reads per-instant miner state (active set, activity state, posted
 collateral, quoted rate) through a small read interface. B1/B2 fed that interface from the substrate
 ``ContractEventWatcher``; B3.4 swaps the *writer*: ``SolanaEventIngest`` (B3.1) decodes program events and
 this index persists them into the ``state_store`` event tables, attributing each on-chain Solana pubkey to
@@ -10,32 +10,40 @@ persists its realized legs into ``clearing_rates`` (C-rev), the per-swap history
 is built from.
 
 The axis is unix ``blockTime`` seconds (the ``block_num``/``block`` columns are repurposed), not substrate
-blocks. Reservation pins are gone in the Solana model (the swap rate is pinned on-chain and a reserved miner
-is busy-gated out of the crown), so no pin stream is written.
+blocks. Reservation + swap lifecycle drive a per-miner ``MinerActivity`` machine (D4): ``PoolResolved``
+opens a RESERVE_START plus a synthetic RESERVE_EXPIRE at ``block_time + reservation_ttl_secs``, and the swap
+events drive FULFILL_START/END. The crown credits a miner only while its activity ∈ ``REWARD_MINER_STATES``.
 """
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Set
+from typing import Callable, Dict, List, Optional, Set
 
 import bittensor as bt
 
+from allways.classes import ActivityTransition, MinerActivity
 from allways.constants import RATE_PRECISION
 from allways.solana.events import EventRecord
 from allways.validator.state_store import ValidatorStateStore
 
-# Busy delta per swap-lifecycle event: a miner is busy (excluded from crown) while the running sum is > 0.
-# Reservation-busy (the pool window's busy_until) has no per-instant event and is intentionally not ingested
-# here — swap-lifecycle busy only (B3.4 decision; PoolResolved→busy-start deferred).
-_BUSY_DELTA = {'SwapInitiated': +1, 'SwapCompleted': -1, 'SwapTimedOut': -1}
+# Swap-lifecycle events → MinerActivity edges. A reserved miner enters FULFILLING on
+# SwapInitiated and returns to AVAILABLE on completion/timeout (see classes.MinerActivity).
+_FULFILL_TRANSITIONS = {
+    'SwapInitiated': ActivityTransition.FULFILL_START,
+    'SwapCompleted': ActivityTransition.FULFILL_END,
+    'SwapTimedOut': ActivityTransition.FULFILL_END,
+}
 
 
 class SolanaEventIndex:
     """Persists decoded Solana program events into the validator state store and exposes the crown's
-    per-instant read interface over them. One instance per validator; backed by ``ValidatorStateStore``."""
+    per-instant read interface over them. One instance per validator; backed by ``ValidatorStateStore``.
+    ``reservation_ttl_fn`` (the solana config cache getter) supplies the TTL used to synthesize each
+    reservation's RESERVE_EXPIRE, since ``reserved_until`` isn't carried on the ``PoolResolved`` event."""
 
-    def __init__(self, state_store: ValidatorStateStore):
+    def __init__(self, state_store: ValidatorStateStore, reservation_ttl_fn: Optional[Callable[[], int]] = None):
         self.state_store = state_store
+        self._reservation_ttl_fn = reservation_ttl_fn
 
     # ─── write path ─────────────────────────────────────────────────────
 
@@ -65,11 +73,13 @@ class SolanaEventIndex:
         if name in ('MinerActivated', 'MinerDeactivated'):
             self.state_store.insert_active_event(block_time, hotkey, name == 'MinerActivated')
             return True
-        if name in _BUSY_DELTA:
-            self.state_store.insert_busy_event(block_time, hotkey, _BUSY_DELTA[name])
-            # SwapCompleted is the only busy event carrying realized legs — persist
+        if name == 'PoolResolved':
+            return self._apply_reservation(hotkey, block_time)
+        if name in _FULFILL_TRANSITIONS:
+            self.state_store.insert_activity_event(block_time, hotkey, _FULFILL_TRANSITIONS[name])
+            # SwapCompleted is the only swap event carrying realized legs — persist
             # them as a clearing-rate sample for the C-rev quality reference, in
-            # addition to closing the busy interval above.
+            # addition to closing the fulfillment above.
             if name == 'SwapCompleted':
                 self.state_store.insert_clearing_rate(
                     block_time,
@@ -98,6 +108,29 @@ class SolanaEventIndex:
             return True
         return False  # not a crown-relevant event
 
+    def _apply_reservation(self, hotkey: str, block_time: int) -> bool:
+        """PoolResolved → RESERVE_START now + a synthetic RESERVE_EXPIRE at
+        ``block_time + reservation_ttl_secs`` (``reserved_until`` isn't on the
+        event). Dropped if no TTL source is wired, so the reservation never opens
+        without its matching expiry."""
+        ttl = self._reservation_ttl()
+        if ttl is None:
+            bt.logging.warning('SolanaEventIndex: no reservation_ttl; dropping PoolResolved')
+            return False
+        self.state_store.insert_activity_event(block_time, hotkey, ActivityTransition.RESERVE_START)
+        self.state_store.insert_activity_event(block_time + ttl, hotkey, ActivityTransition.RESERVE_EXPIRE)
+        return True
+
+    def _reservation_ttl(self) -> Optional[int]:
+        if self._reservation_ttl_fn is None:
+            return None
+        try:
+            ttl = int(self._reservation_ttl_fn())
+        except Exception as e:
+            bt.logging.warning(f'SolanaEventIndex: reservation_ttl read failed: {e}')
+            return None
+        return ttl if ttl > 0 else None
+
     @staticmethod
     def _miner_str(rec: EventRecord) -> Optional[str]:
         try:
@@ -115,8 +148,8 @@ class SolanaEventIndex:
     def get_active_miners_at(self, at_time: int) -> Set[str]:
         return self.state_store.get_active_state_at(at_time)
 
-    def get_busy_miners_at(self, at_time: int) -> Dict[str, int]:
-        return self.state_store.get_busy_counts_at(at_time)
+    def get_activity_state_at(self, at_time: int) -> Dict[str, MinerActivity]:
+        return self.state_store.get_activity_state_at(at_time)
 
     def get_miner_collaterals_at(self, at_time: int) -> Dict[str, int]:
         return self.state_store.get_collaterals_at(at_time)
@@ -124,8 +157,8 @@ class SolanaEventIndex:
     def get_active_events_in_range(self, start_time: int, end_time: int) -> List[dict]:
         return self.state_store.get_active_events_in_range(start_time, end_time)
 
-    def get_busy_events_in_range(self, start_time: int, end_time: int) -> List[dict]:
-        return self.state_store.get_busy_events_in_range(start_time, end_time)
+    def get_activity_events_in_range(self, start_time: int, end_time: int) -> List[dict]:
+        return self.state_store.get_activity_events_in_range(start_time, end_time)
 
     def get_collateral_events_in_range(self, start_time: int, end_time: int) -> List[dict]:
         return self.state_store.get_collateral_events_in_range(start_time, end_time)

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -78,7 +78,7 @@ def clear_provider_caches(self: Validator) -> None:
 
 def ingest_solana_events(self: Validator) -> None:
     """Poll program events newer than the stored cursor and fold them into the
-    crown ``SolanaEventIndex`` (active/busy/collateral/rate tables), attributing
+    crown ``SolanaEventIndex`` (active/activity/collateral/rate tables), attributing
     each event's miner Solana pubkey → bound hotkey via the sr25519 binding. The
     cursor advances only after a successful poll, so a transient RPC failure
     re-reads the same window next step instead of skipping events."""

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -27,6 +27,7 @@ import bittensor as bt
 import numpy as np
 
 from allways.chains import canonical_pair, get_chain
+from allways.classes import ActivityTransition, MinerActivity, next_activity
 from allways.constants import (
     DIRECTION_POOLS,
     MAX_FAILED_SWAPS,
@@ -40,6 +41,7 @@ from allways.constants import (
     RATE_REFERENCE_TRIM_FRAC,
     RATE_REFERENCE_WINDOW_SECS,
     RECYCLE_UID,
+    REWARD_MINER_STATES,
     REWARD_WEIGHT_CROWN,
     REWARD_WEIGHT_QUALITY_VOLUME,
     SCORING_WINDOW_BLOCKS,
@@ -160,14 +162,14 @@ def build_halted_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
 def prune_crown_events(self: Validator, current_time: int) -> None:
     """Trim the crown-time event tables to one trailing window. The Solana
     event tables are keyed by unix blockTime, so the cutoff is on that axis;
-    this also takes over the active/busy/collateral pruning the deleted
+    this also takes over the active/activity/collateral pruning the deleted
     substrate event_watcher used to own (each preserves a per-hotkey anchor)."""
     cutoff = current_time - SCORING_WINDOW_SECS
     if cutoff <= 0:
         return
     self.state_store.prune_events_older_than(cutoff)
     self.state_store.prune_active_events(cutoff)
-    self.state_store.prune_busy_events(cutoff)
+    self.state_store.prune_activity_events(cutoff)
     self.state_store.prune_collateral_events(cutoff)
     # clearing_rates feeds the rate-quality reference over a wider (24h) window,
     # so it has its own, later horizon — pruning it at the 1h crown cutoff would
@@ -437,7 +439,7 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
     # A miner's *current* active flag is irrelevant to whether they earned
     # crown during the replay window. The only at-scoring-time check is
     # metagraph membership, because a dereg'd miner has no UID to credit.
-    # Active, rate, and busy are all evaluated per-block via event replay
+    # Active, rate, and activity are all evaluated per-block via event replay
     # inside replay_crown_time_window. Collateral-floor invariants are
     # trusted to the contract's active flag.
     rewardable_hotkeys: Set[str] = set(self.metagraph.hotkeys)
@@ -693,19 +695,15 @@ class EventKind(IntEnum):
     """Ordering of coincident-instant transitions in the crown-time replay.
 
     ACTIVE applies first because the on-chain active flag is the per-miner
-    tell-all. Then BUSY (busy ends crown for that miner). RATE comes after so
-    a same-instant rate update lands once the qualification gates are set.
-    COLLATERAL is last — it's independent of qualification, only scaling an
-    interval's credit, so a same-instant post is observable as soon as it
-    lands.
-
-    Reservation pins are gone in the Solana model (the swap rate is pinned
-    on-chain and a reserved miner is busy-gated out of the crown), so there
-    are no RESERVED transitions.
+    tell-all. Then ACTIVITY (the MinerActivity machine — a reserved/fulfilling
+    miner forfeits crown). RATE comes after so a same-instant rate update lands
+    once the qualification gates are set. COLLATERAL is last — it's independent
+    of qualification, only scaling an interval's credit, so a same-instant post
+    is observable as soon as it lands.
     """
 
     ACTIVE = 0
-    BUSY = 1
+    ACTIVITY = 1
     RATE = 2
     COLLATERAL = 3
 
@@ -713,8 +711,8 @@ class EventKind(IntEnum):
 @dataclass
 class ReplayEvent:
     """One transition in the chronological replay stream. ``value`` is
-    polymorphic on ``kind``: rate as float, busy delta of ±1, or active as
-    0/1."""
+    polymorphic on ``kind``: rate as float, active as 0/1, or an
+    ``ActivityTransition`` value for ACTIVITY."""
 
     block: int
     hotkey: str
@@ -722,8 +720,23 @@ class ReplayEvent:
     value: float
 
     @property
-    def sort_key(self) -> Tuple[int, int]:
-        return (self.block, int(self.kind))
+    def sort_key(self) -> Tuple[int, int, int]:
+        # ActivityTransition values double as the within-instant tiebreak so a
+        # swap's FULFILL_* applies before its reservation's RESERVE_EXPIRE.
+        sub = int(self.value) if self.kind is EventKind.ACTIVITY else 0
+        return (self.block, int(self.kind), sub)
+
+
+_warned_activity_transitions: Set[Tuple[MinerActivity, ActivityTransition]] = set()
+
+
+def warn_unexpected_activity(state: MinerActivity, transition: ActivityTransition) -> None:
+    """One-time warn per (state, transition) the machine has no edge for —
+    defensive only; the state is held unchanged."""
+    key = (state, transition)
+    if key not in _warned_activity_transitions:
+        _warned_activity_transitions.add(key)
+        bt.logging.warning(f'crown replay: unexpected activity transition {transition.name} in {state.name}')
 
 
 def reconstruct_window_start_state(
@@ -733,12 +746,14 @@ def reconstruct_window_start_state(
     to_chain: str,
     window_start: int,
     rewardable_hotkeys: Set[str],
-) -> Tuple[Dict[str, float], Dict[str, int], Set[str], Dict[str, int]]:
-    """Snapshot rates, busy counts, active set, and posted collateral as they
-    stood at window_start. Rate read is one batched query per direction (N
-    rewardable hotkeys would otherwise be N point lookups, runs every forward
-    step from snapshot_current_crown_holders)."""
-    busy_count: Dict[str, int] = dict(event_index.get_busy_miners_at(window_start))
+) -> Tuple[Dict[str, float], Dict[str, MinerActivity], Set[str], Dict[str, int]]:
+    """Snapshot rates, per-miner activity, active set, and posted collateral as
+    they stood at window_start. ``activity`` holds only non-AVAILABLE miners (a
+    reservation/swap open before the window shows RESERVED/FULFILLING at the
+    edge); absent hotkeys default to AVAILABLE. Rate read is one batched query
+    per direction (N rewardable hotkeys would otherwise be N point lookups, runs
+    every forward step from snapshot_current_crown_holders)."""
+    activity: Dict[str, MinerActivity] = dict(event_index.get_activity_state_at(window_start))
     active_set: Set[str] = set(event_index.get_active_miners_at(window_start))
 
     all_latest = store.get_latest_rates_before(from_chain, to_chain, window_start)
@@ -746,7 +761,7 @@ def reconstruct_window_start_state(
 
     collaterals: Dict[str, int] = dict(event_index.get_miner_collaterals_at(window_start))
 
-    return rates, busy_count, active_set, collaterals
+    return rates, activity, active_set, collaterals
 
 
 def merge_replay_events(
@@ -757,8 +772,8 @@ def merge_replay_events(
     window_start: int,
     window_end: int,
 ) -> List[ReplayEvent]:
-    """Merge in-window active, busy, rate, and collateral transitions into one
-    chronologically-sorted stream."""
+    """Merge in-window active, activity, rate, and collateral transitions into
+    one chronologically-sorted stream (incl. the synthetic RESERVE_EXPIRE)."""
     events: List[ReplayEvent] = []
 
     for e in event_index.get_active_events_in_range(window_start, window_end):
@@ -766,8 +781,10 @@ def merge_replay_events(
             ReplayEvent(block=e['block'], hotkey=e['hotkey'], kind=EventKind.ACTIVE, value=1.0 if e['active'] else 0.0)
         )
 
-    for e in event_index.get_busy_events_in_range(window_start, window_end):
-        events.append(ReplayEvent(block=e['block'], hotkey=e['hotkey'], kind=EventKind.BUSY, value=float(e['delta'])))
+    for e in event_index.get_activity_events_in_range(window_start, window_end):
+        events.append(
+            ReplayEvent(block=e['block'], hotkey=e['hotkey'], kind=EventKind.ACTIVITY, value=float(e['kind']))
+        )
 
     for e in store.get_rate_events_in_range(from_chain, to_chain, window_start, window_end):
         events.append(ReplayEvent(block=e['block'], hotkey=e['hotkey'], kind=EventKind.RATE, value=float(e['rate'])))
@@ -833,9 +850,10 @@ def replay_crown_time_window(
     """Walk the merged event stream, return ``{hotkey: crown_blocks_float}``.
     Ties at the same rate split credit evenly. A miner qualifies for crown
     at an instant iff they are on the current metagraph, were active at
-    that instant, not busy, had a positive rate posted, and their rate is
-    executable under the current contract swap bounds. Active/rate/busy/
-    collateral are evaluated per-block via the replay — a miner's status at
+    that instant, in a rewardable activity state (∈ REWARD_MINER_STATES — a
+    reserved/fulfilling miner forfeits), had a positive rate posted, and their
+    rate is executable under the current contract swap bounds. Active/rate/
+    activity/collateral are evaluated per-block via the replay — a miner's status at
     scoring time is irrelevant other than metagraph membership (used to
     credit the UID). The collateral-floor activation gate is still trusted
     to the contract's active flag; halt state is handled at
@@ -849,7 +867,7 @@ def replay_crown_time_window(
     interval's split by ``capacity_factor(collateral_at_block, max_swap_lamports)``
     so a post-window collateral boost cannot retroactively scale credit
     already earned (closes #409)."""
-    rates, busy_count, active_set, collaterals = reconstruct_window_start_state(
+    rates, activity, active_set, collaterals = reconstruct_window_start_state(
         store, event_index, from_chain, to_chain, window_start, rewardable_hotkeys
     )
     replay_events = merge_replay_events(store, event_index, from_chain, to_chain, window_start, window_end)
@@ -874,12 +892,14 @@ def replay_crown_time_window(
         duration = interval_end - interval_start
         if duration <= 0:
             return
-        busy_set = {hk for hk, c in busy_count.items() if c > 0}
+        rewardable_by_state = {
+            hk for hk in rewardable_hotkeys if activity.get(hk, MinerActivity.AVAILABLE) in REWARD_MINER_STATES
+        }
         rates_for_instant = rates
         holders = crown_holders_at_instant(
             rates_for_instant,
             rewardable_hotkeys,
-            busy=busy_set,
+            rewardable_by_state=rewardable_by_state,
             active=active_set,
             lower_rate_wins=lower_rate_wins,
             executable_rate_check=executable_check,
@@ -905,12 +925,16 @@ def replay_crown_time_window(
     def apply_event(event: ReplayEvent) -> None:
         if event.kind is EventKind.RATE:
             rates[event.hotkey] = event.value
-        elif event.kind is EventKind.BUSY:
-            new_count = busy_count.get(event.hotkey, 0) + int(event.value)
-            if new_count > 0:
-                busy_count[event.hotkey] = new_count
+        elif event.kind is EventKind.ACTIVITY:
+            cur = activity.get(event.hotkey, MinerActivity.AVAILABLE)
+            nxt = next_activity(cur, ActivityTransition(int(event.value)))
+            if nxt is None:
+                warn_unexpected_activity(cur, ActivityTransition(int(event.value)))
+                nxt = cur
+            if nxt is MinerActivity.AVAILABLE:
+                activity.pop(event.hotkey, None)
             else:
-                busy_count.pop(event.hotkey, None)
+                activity[event.hotkey] = nxt
         elif event.kind is EventKind.COLLATERAL:
             collaterals[event.hotkey] = max(0, int(event.value))
         else:  # ACTIVE
@@ -938,7 +962,7 @@ def snapshot_current_crown_holders(
     """Cheap "who holds the crown right now" per direction. Used by the
     per-forward-step live-crown writer.
 
-    Reconstructs rates/busy/active at the current block and evaluates
+    Reconstructs rates/activity/active at the current block and evaluates
     ``crown_holders_at_instant`` once per direction — no event-stream walk,
     so cost is O(rewardable_hotkeys) per direction, sub-millisecond in
     practice. Returns rows in ``DatabaseStorage.upsert_current_crown_snapshot``
@@ -969,7 +993,7 @@ def snapshot_current_crown_holders(
     rows_by_direction: Dict[Tuple[str, str], List[Tuple[str, str, str, float, float, int]]] = {}
     bounds_set = min_swap_amount > 0 or max_swap_amount > 0
     for from_chain, to_chain in DIRECTION_POOLS:
-        rates, busy_count, active_set, collaterals = reconstruct_window_start_state(
+        rates, activity, active_set, collaterals = reconstruct_window_start_state(
             self.state_store,
             self.event_index,
             from_chain,
@@ -979,7 +1003,9 @@ def snapshot_current_crown_holders(
         )
         canon_from, _ = canonical_pair(from_chain, to_chain)
         lower_rate_wins = from_chain != canon_from
-        busy_set = {hk for hk, c in busy_count.items() if c > 0}
+        rewardable_by_state = {
+            hk for hk in rewardable_hotkeys if activity.get(hk, MinerActivity.AVAILABLE) in REWARD_MINER_STATES
+        }
 
         # Same predicates the scoring replay uses, so the live table never
         # credits a holder the ledger drops. Built per direction so each
@@ -991,7 +1017,7 @@ def snapshot_current_crown_holders(
         holders = crown_holders_at_instant(
             rates,
             rewardable_hotkeys,
-            busy=busy_set,
+            rewardable_by_state=rewardable_by_state,
             active=active_set,
             lower_rate_wins=lower_rate_wins,
             executable_rate_check=executable_check,
@@ -1032,16 +1058,16 @@ def expand_intervals_to_crown_rows(
 def crown_holders_at_instant(
     rates: Dict[str, float],
     rewardable: Set[str],
-    busy: Optional[Set[str]] = None,
+    rewardable_by_state: Optional[Set[str]] = None,
     active: Optional[Set[str]] = None,
     lower_rate_wins: bool = False,
     executable_rate_check: Optional[Callable[[float], bool]] = None,
     can_fund_at_rate: Optional[Callable[[str, float], bool]] = None,
 ) -> List[str]:
     """Take the miners posting the best rate, but only if they satisfy every
-    other condition (rewardable, active, not busy, rate > 0, executable).
-    If the best rate has no qualified miner, fall through to the next-best
-    rate.
+    other condition (rewardable, active, activity ∈ REWARD_MINER_STATES, rate >
+    0, executable). If the best rate has no qualified miner, fall through to the
+    next-best rate.
 
     ``lower_rate_wins`` flips the sort: rates are stored as canonical_dest
     per canonical_source (TAO per BTC), so higher-is-better only holds in
@@ -1062,12 +1088,17 @@ def crown_holders_at_instant(
     case. Halt state is handled at ``score_and_reward_miners`` entry, not
     in this helper.
 
+    ``rewardable_by_state`` (optional) is the set whose activity ∈
+    REWARD_MINER_STATES — a miner outside it (reserved/fulfilling) forfeits the
+    crown. None skips the state gate (tests that don't model activity).
+
     ``active`` defaults to None for tests that don't care about the
     historical active flag; replay callers pass the reconstructed set."""
-    busy = busy or set()
 
     def qualifies(hotkey: str) -> bool:
         if active is not None and hotkey not in active:
+            return False
+        if rewardable_by_state is not None and hotkey not in rewardable_by_state:
             return False
         rate = rates.get(hotkey, 0)
         if rate <= 0:
@@ -1076,7 +1107,7 @@ def crown_holders_at_instant(
             return False
         if can_fund_at_rate is not None and not can_fund_at_rate(hotkey, rate):
             return False
-        return hotkey in rewardable and hotkey not in busy
+        return hotkey in rewardable
 
     by_rate: Dict[float, List[str]] = {}
     for hotkey, rate in rates.items():

--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -372,15 +372,16 @@ class ValidatorStateStore:
     def prune_activity_events(self, cutoff_block: int) -> None:
         """Drop activity transitions older than ``cutoff_block`` except for hotkeys
         still mid-reservation/swap (reduced state != AVAILABLE) — their full
-        timeline is kept so a later FULFILL_END / RESERVE_EXPIRE isn't orphaned."""
+        timeline is kept so a later FULFILL_END / RESERVE_EXPIRE isn't orphaned.
+        Read + reduce + delete under one lock so no writer interleaves."""
         if cutoff_block <= 0:
             return
-        all_rows = self._fetchall(
-            'SELECT block_num, hotkey, kind FROM activity_events ORDER BY block_num ASC, kind ASC, id ASC'
-        )
-        open_hotkeys = set(self._reduce_activity(all_rows))
         with self.lock:
             conn = self.require_connection()
+            all_rows = conn.execute(
+                'SELECT block_num, hotkey, kind FROM activity_events ORDER BY block_num ASC, kind ASC, id ASC'
+            ).fetchall()
+            open_hotkeys = set(self._reduce_activity(all_rows))
             if open_hotkeys:
                 placeholders = ','.join('?' * len(open_hotkeys))
                 conn.execute(

--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -1,6 +1,6 @@
 """SQLite-backed store for all validator-local state.
 
-Tables: ``rate_events`` + ``active_events`` + ``busy_events`` +
+Tables: ``rate_events`` + ``active_events`` + ``activity_events`` +
 ``collateral_events`` (the crown-time event series, sourced from Solana program
 events via ``SolanaEventIndex`` and keyed by unix ``blockTime``),
 ``clearing_rates`` (per-swap realized history from ``SwapCompleted``, backing the
@@ -14,7 +14,9 @@ locked" — the local dev env runs two validators against the same file.
 import sqlite3
 import threading
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Set, Tuple
+from typing import Callable, Dict, List, Optional, Sequence, Set, Tuple
+
+from allways.classes import ActivityTransition, MinerActivity, next_activity
 
 
 class ValidatorStateStore:
@@ -144,24 +146,21 @@ class ValidatorStateStore:
             (block_num, hotkey, 1 if active else 0),
         )
 
-    def insert_busy_event(self, block_num: int, hotkey: str, delta: int, swap_id: Optional[int] = None) -> None:
+    def insert_activity_event(self, block_num: int, hotkey: str, transition: ActivityTransition) -> None:
+        """Record one edge of a miner's ``MinerActivity`` machine (RESERVE_START,
+        FULFILL_START, FULFILL_END, or the synthetic RESERVE_EXPIRE)."""
         self._execute(
-            'INSERT INTO busy_events (block_num, hotkey, delta, swap_id) VALUES (?, ?, ?, ?)',
-            (block_num, hotkey, delta, swap_id),
+            'INSERT INTO activity_events (block_num, hotkey, kind) VALUES (?, ?, ?)',
+            (block_num, hotkey, int(transition)),
         )
 
     def load_all_active_events(self) -> List[dict]:
         rows = self._fetchall('SELECT block_num, hotkey, active FROM active_events ORDER BY block_num ASC, id ASC')
         return [{'block_num': r['block_num'], 'hotkey': r['hotkey'], 'active': bool(r['active'])} for r in rows]
 
-    def load_all_busy_events(self) -> List[dict]:
-        rows = self._fetchall(
-            'SELECT block_num, hotkey, delta, swap_id FROM busy_events ORDER BY block_num ASC, id ASC'
-        )
-        return [
-            {'block_num': r['block_num'], 'hotkey': r['hotkey'], 'delta': r['delta'], 'swap_id': r['swap_id']}
-            for r in rows
-        ]
+    def load_all_activity_events(self) -> List[dict]:
+        rows = self._fetchall('SELECT block_num, hotkey, kind FROM activity_events ORDER BY block_num ASC, id ASC')
+        return [{'block_num': r['block_num'], 'hotkey': r['hotkey'], 'kind': r['kind']} for r in rows]
 
     def insert_collateral_event(self, block_num: int, hotkey: str, collateral_rao: int) -> None:
         self._execute(
@@ -180,7 +179,7 @@ class ValidatorStateStore:
 
     # ─── crown read interface (B3.4 SolanaEventIndex) ───────────────────
     #
-    # At-time + in-range queries over the active/busy/collateral event tables,
+    # At-time + in-range queries over the active/activity/collateral event tables,
     # the SQL twins of the rate_events readers above. ``block_num`` here is a
     # unix ``blockTime`` (seconds), not a substrate block — the Solana crown
     # axis. ``SolanaEventIndex`` wraps these into the read interface scoring's
@@ -213,30 +212,45 @@ class ValidatorStateStore:
         )
         return {r['hotkey'] for r in rows if r['active']}
 
-    def get_busy_events_in_range(self, start_time: int, end_time: int) -> List[dict]:
-        """Busy ±1 deltas in ``(start_time, end_time]``, oldest first."""
+    def get_activity_events_in_range(self, start_time: int, end_time: int) -> List[dict]:
+        """Activity transitions in ``(start_time, end_time]``. Ordered ``block_num,
+        kind`` so coincident-instant edges replay in machine-precedence order
+        (closers/openers before a reservation lapse)."""
         rows = self._fetchall(
             """
-            SELECT id, block_num, hotkey, delta FROM busy_events
+            SELECT id, block_num, hotkey, kind FROM activity_events
             WHERE block_num > ? AND block_num <= ?
-            ORDER BY block_num ASC, id ASC
+            ORDER BY block_num ASC, kind ASC, id ASC
             """,
             (start_time, end_time),
         )
-        return [{'hotkey': r['hotkey'], 'delta': r['delta'], 'block': r['block_num']} for r in rows]
+        return [{'hotkey': r['hotkey'], 'kind': r['kind'], 'block': r['block_num']} for r in rows]
 
-    def get_busy_counts_at(self, at_time: int) -> Dict[str, int]:
-        """Per-hotkey open-swap count at ``at_time`` (running sum of deltas),
-        keeping only hotkeys still busy (sum > 0)."""
+    def get_activity_state_at(self, at_time: int) -> Dict[str, MinerActivity]:
+        """Per-hotkey ``MinerActivity`` at ``at_time``, reduced over each miner's
+        transition timeline. Only non-AVAILABLE miners are returned (callers
+        default the rest to AVAILABLE)."""
         rows = self._fetchall(
             """
-            SELECT hotkey, SUM(delta) AS total FROM busy_events
+            SELECT block_num, hotkey, kind FROM activity_events
             WHERE block_num <= ?
-            GROUP BY hotkey HAVING total > 0
+            ORDER BY block_num ASC, kind ASC, id ASC
             """,
             (at_time,),
         )
-        return {r['hotkey']: int(r['total']) for r in rows}
+        return self._reduce_activity(rows)
+
+    @staticmethod
+    def _reduce_activity(rows: Sequence[sqlite3.Row]) -> Dict[str, MinerActivity]:
+        """Fold ordered transition rows into ``{hotkey: state}`` for non-AVAILABLE
+        miners. An undefined transition holds the current state (defensive)."""
+        states: Dict[str, MinerActivity] = {}
+        for r in rows:
+            hk = r['hotkey']
+            cur = states.get(hk, MinerActivity.AVAILABLE)
+            nxt = next_activity(cur, ActivityTransition(r['kind']))
+            states[hk] = cur if nxt is None else nxt
+        return {hk: st for hk, st in states.items() if st is not MinerActivity.AVAILABLE}
 
     def get_collateral_events_in_range(self, start_time: int, end_time: int) -> List[dict]:
         """Collateral transitions in ``(start_time, end_time]``, oldest first.
@@ -355,20 +369,27 @@ class ValidatorStateStore:
             (cutoff_block,),
         )
 
-    def prune_busy_events(self, cutoff_block: int) -> None:
-        """Drop busy events older than ``cutoff_block`` except for hotkeys whose
-        SUM(delta) > 0 — those still have an open swap, so we keep their full
-        +1/-1 history so a future SwapCompleted's -1 isn't orphaned."""
+    def prune_activity_events(self, cutoff_block: int) -> None:
+        """Drop activity transitions older than ``cutoff_block`` except for hotkeys
+        still mid-reservation/swap (reduced state != AVAILABLE) — their full
+        timeline is kept so a later FULFILL_END / RESERVE_EXPIRE isn't orphaned."""
         if cutoff_block <= 0:
             return
-        self._execute(
-            """
-            DELETE FROM busy_events
-            WHERE block_num < ?
-              AND hotkey NOT IN (SELECT hotkey FROM busy_events GROUP BY hotkey HAVING SUM(delta) > 0)
-            """,
-            (cutoff_block,),
+        all_rows = self._fetchall(
+            'SELECT block_num, hotkey, kind FROM activity_events ORDER BY block_num ASC, kind ASC, id ASC'
         )
+        open_hotkeys = set(self._reduce_activity(all_rows))
+        with self.lock:
+            conn = self.require_connection()
+            if open_hotkeys:
+                placeholders = ','.join('?' * len(open_hotkeys))
+                conn.execute(
+                    f'DELETE FROM activity_events WHERE block_num < ? AND hotkey NOT IN ({placeholders})',
+                    (cutoff_block, *open_hotkeys),
+                )
+            else:
+                conn.execute('DELETE FROM activity_events WHERE block_num < ?', (cutoff_block,))
+            conn.commit()
 
     def prune_collateral_events(self, cutoff_block: int) -> None:
         """Drop collateral events older than ``cutoff_block``, preserving the
@@ -495,17 +516,19 @@ class ValidatorStateStore:
                 CREATE INDEX IF NOT EXISTS idx_active_events_hotkey
                     ON active_events(hotkey);
 
-                CREATE TABLE IF NOT EXISTS busy_events (
+                -- MinerActivity transitions (D4): kind is an ActivityTransition
+                -- value; the crown replay reduces these into per-instant state so
+                -- a reserved/fulfilling miner forfeits crown (REWARD_MINER_STATES).
+                CREATE TABLE IF NOT EXISTS activity_events (
                     id          INTEGER PRIMARY KEY AUTOINCREMENT,
                     block_num   INTEGER NOT NULL,
                     hotkey      TEXT NOT NULL,
-                    delta       INTEGER NOT NULL,
-                    swap_id     INTEGER
+                    kind        INTEGER NOT NULL
                 );
-                CREATE INDEX IF NOT EXISTS idx_busy_events_block
-                    ON busy_events(block_num);
-                CREATE INDEX IF NOT EXISTS idx_busy_events_hotkey
-                    ON busy_events(hotkey);
+                CREATE INDEX IF NOT EXISTS idx_activity_events_block
+                    ON activity_events(block_num);
+                CREATE INDEX IF NOT EXISTS idx_activity_events_hotkey
+                    ON activity_events(hotkey);
 
                 CREATE TABLE IF NOT EXISTS collateral_events (
                     id              INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -105,8 +105,10 @@ class Validator(BaseValidatorNeuron):
         # tables, and scoring replays those tables. `solana_config_cache` serves
         # swap bounds + halt off the Config account (replacing substrate reads).
         self.event_ingest = SolanaEventIngest(self.solana_client)
-        self.event_index = SolanaEventIndex(self.state_store)
         self.solana_config_cache = SolanaConfigCache(self.solana_client)
+        # event_index synthesizes each reservation's RESERVE_EXPIRE at
+        # block_time + reservation_ttl_secs, read off the config cache (D4).
+        self.event_index = SolanaEventIndex(self.state_store, self.solana_config_cache.reservation_ttl_secs)
 
         # Forces one scoring pass per fresh process so a mid-window restart
         # doesn't leave self.scores stale until the next scoring boundary

--- a/tests/test_event_index.py
+++ b/tests/test_event_index.py
@@ -4,6 +4,7 @@ bound hotkey at write time."""
 
 from pathlib import Path
 
+from allways.classes import MinerActivity
 from allways.constants import RATE_PRECISION
 from allways.solana.events import EventRecord
 from allways.validator.event_index import SolanaEventIndex
@@ -12,6 +13,7 @@ from allways.validator.state_store import ValidatorStateStore
 
 # pubkey str -> hotkey ss58 (what binding.build_attribution returns).
 ATTR = {'pk_a': 'hk_a', 'pk_b': 'hk_b'}
+RESERVATION_TTL = 300
 
 
 def rec(name: str, *, miner: str = 'pk_a', block_time, slot: int = 0, **fields) -> EventRecord:
@@ -21,6 +23,12 @@ def rec(name: str, *, miner: str = 'pk_a', block_time, slot: int = 0, **fields) 
 
 def make_store(tmp_path: Path) -> ValidatorStateStore:
     return ValidatorStateStore(db_path=tmp_path / 'state.db')
+
+
+def make_index(store: ValidatorStateStore, ttl: int = RESERVATION_TTL) -> SolanaEventIndex:
+    """Index wired with a constant reservation TTL (the config-cache getter in
+    production) so PoolResolved can synthesize RESERVE_EXPIRE."""
+    return SolanaEventIndex(store, reservation_ttl_fn=lambda: ttl)
 
 
 class TestIngestActive:
@@ -44,13 +52,14 @@ class TestIngestActive:
         store.close()
 
 
-class TestIngestBusy:
-    def test_swap_lifecycle_drives_busy(self, tmp_path: Path):
+class TestIngestActivity:
+    def test_reservation_then_swap_lifecycle_drives_activity(self, tmp_path: Path):
         store = make_store(tmp_path)
-        idx = SolanaEventIndex(store)
+        idx = make_index(store, ttl=1000)
         idx.ingest(
             [
-                rec('SwapInitiated', miner='pk_a', block_time=200),
+                rec('PoolResolved', miner='pk_a', block_time=200, winner='pk_router', user='pk_user', requests=1),
+                rec('SwapInitiated', miner='pk_a', block_time=250),
                 rec(
                     'SwapCompleted',
                     miner='pk_a',
@@ -60,18 +69,53 @@ class TestIngestBusy:
                     from_amount=100_000,
                     to_amount=500_000_000,
                 ),
-                rec('SwapInitiated', miner='pk_a', block_time=600),
-                rec('SwapTimedOut', miner='pk_a', block_time=900),
             ],
             ATTR,
         )
-        assert idx.get_busy_miners_at(100) == {}
-        assert idx.get_busy_miners_at(200) == {'hk_a': 1}
-        assert idx.get_busy_miners_at(400) == {}  # completed nets to 0
-        assert idx.get_busy_miners_at(600) == {'hk_a': 1}
-        assert idx.get_busy_miners_at(900) == {}  # timed out nets to 0
-        deltas = [(e['block'], e['delta']) for e in idx.get_busy_events_in_range(0, 1000)]
-        assert deltas == [(200, 1), (400, -1), (600, 1), (900, -1)]
+        assert idx.get_activity_state_at(100) == {}  # AVAILABLE before the reservation
+        assert idx.get_activity_state_at(200) == {'hk_a': MinerActivity.RESERVED}
+        assert idx.get_activity_state_at(250) == {'hk_a': MinerActivity.FULFILLING}
+        assert idx.get_activity_state_at(400) == {}  # completed → AVAILABLE
+        store.close()
+
+    def test_pool_resolved_synthesizes_reserve_expire(self, tmp_path: Path):
+        """A reservation with no swap forfeits the crown until block_time + ttl,
+        then RESERVE_EXPIRE returns the miner to AVAILABLE."""
+        store = make_store(tmp_path)
+        idx = make_index(store, ttl=300)
+        idx.ingest(
+            [rec('PoolResolved', miner='pk_a', block_time=200, winner='pk_router', user='pk_user', requests=1)],
+            ATTR,
+        )
+        assert idx.get_activity_state_at(200) == {'hk_a': MinerActivity.RESERVED}
+        assert idx.get_activity_state_at(499) == {'hk_a': MinerActivity.RESERVED}
+        assert idx.get_activity_state_at(500) == {}  # 200 + 300 ttl → AVAILABLE
+        kinds = [e['kind'] for e in idx.get_activity_events_in_range(0, 1000)]
+        assert kinds == [1, 3]  # RESERVE_START then synthetic RESERVE_EXPIRE
+        store.close()
+
+    def test_busy_miner_is_the_reserved_miner_not_the_router(self, tmp_path: Path):
+        """PoolResolved.miner (not .winner, the router) is busy-gated."""
+        store = make_store(tmp_path)
+        idx = make_index(store)
+        idx.ingest(
+            [rec('PoolResolved', miner='pk_a', block_time=200, winner='pk_b', user='pk_user', requests=1)],
+            ATTR,
+        )
+        assert idx.get_activity_state_at(250) == {'hk_a': MinerActivity.RESERVED}  # not hk_b
+        store.close()
+
+    def test_pool_resolved_dropped_without_ttl_source(self, tmp_path: Path):
+        """No TTL getter wired → PoolResolved is dropped (a reservation never
+        opens without its matching expiry)."""
+        store = make_store(tmp_path)
+        idx = SolanaEventIndex(store)  # no reservation_ttl_fn
+        n = idx.ingest(
+            [rec('PoolResolved', miner='pk_a', block_time=200, winner='pk_b', user='pk_user', requests=1)],
+            ATTR,
+        )
+        assert n == 0
+        assert idx.get_activity_state_at(250) == {}
         store.close()
 
 
@@ -162,11 +206,12 @@ class TestIngestRate:
 
 
 class TestIngestClearingRate:
-    def test_swap_completed_persists_clearing_rate_and_busy(self, tmp_path: Path):
+    def test_swap_completed_persists_clearing_rate_and_activity(self, tmp_path: Path):
         store = make_store(tmp_path)
-        idx = SolanaEventIndex(store)
+        idx = make_index(store, ttl=1000)
         idx.ingest(
             [
+                rec('PoolResolved', miner='pk_a', block_time=150, winner='pk_router', user='pk_user', requests=1),
                 rec('SwapInitiated', miner='pk_a', block_time=200),
                 rec(
                     'SwapCompleted',
@@ -180,8 +225,8 @@ class TestIngestClearingRate:
             ],
             ATTR,
         )
-        # Both effects fire: the busy interval closes AND a clearing-rate sample lands.
-        assert idx.get_busy_miners_at(400) == {}
+        # Both effects fire: FULFILL_END returns AVAILABLE AND a clearing-rate sample lands.
+        assert idx.get_activity_state_at(400) == {}
         rows = store.get_clearing_rates_in_range('btc', 'tao', 0, 1000)
         assert rows == [{'hotkey': 'hk_a', 'from_amount': 100_000, 'to_amount': 500_000_000, 'block': 400}]
         store.close()
@@ -310,8 +355,8 @@ class TestAttributionAndSkips:
 
     def test_unknown_event_name_is_ignored(self, tmp_path: Path):
         store = make_store(tmp_path)
-        idx = SolanaEventIndex(store)
-        n = idx.ingest([rec('PoolResolved', miner='pk_a', block_time=100)], ATTR)
+        idx = make_index(store)
+        n = idx.ingest([rec('ValidatorWeightsUpdated', miner='pk_a', block_time=100)], ATTR)
         assert n == 0
         store.close()
 
@@ -335,7 +380,7 @@ class TestIngestEndToEndCrown:
         """The full B3.4 path: decode-shaped records → index persistence →
         scoring's crown replay credits the active, funded, best-rate miner."""
         store = make_store(tmp_path)
-        idx = SolanaEventIndex(store)
+        idx = make_index(store, ttl=1000)
         idx.ingest(
             [
                 # Both miners active + funded from t=0; btc→tao (higher rate wins).
@@ -361,7 +406,8 @@ class TestIngestEndToEndCrown:
                     rate=200 * RATE_PRECISION,
                     liquidity=0,
                 ),
-                # A takes a swap mid-window — crown flips to B while busy.
+                # A is reserved then takes a swap mid-window — crown flips to B while busy.
+                rec('PoolResolved', miner='pk_a', block_time=400, winner='pk_router', user='pk_user', requests=1),
                 rec('SwapInitiated', miner='pk_a', block_time=400),
                 rec(
                     'SwapCompleted',

--- a/tests/test_rate_state.py
+++ b/tests/test_rate_state.py
@@ -16,7 +16,7 @@ class TestValidatorStateStoreSchema:
         conn = store.require_connection()
 
         tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
-        assert {'rate_events', 'active_events', 'busy_events', 'collateral_events'}.issubset(tables)
+        assert {'rate_events', 'active_events', 'activity_events', 'collateral_events'}.issubset(tables)
 
         indexes = {
             row[0]

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import numpy as np
 import pytest
 
+from allways.classes import ActivityTransition, MinerActivity
 from allways.constants import (
     DIRECTION_POOLS,
     MAX_FAILED_SWAPS,
@@ -122,23 +123,36 @@ class CrownSeeder:
         if name in ('MinerActivated', 'MinerDeactivated'):
             active = fields.get('active', name == 'MinerActivated')
             self.state_store.insert_active_event(block, miner, bool(active))
+        elif name == 'PoolResolved':
+            # RESERVE_START now + RESERVE_EXPIRE at block+ttl (default beyond any
+            # test window, so a swap's FULFILL_END is what returns to AVAILABLE).
+            ttl = fields.get('ttl', 10**9)
+            self.state_store.insert_activity_event(block, miner, ActivityTransition.RESERVE_START)
+            self.state_store.insert_activity_event(block + ttl, miner, ActivityTransition.RESERVE_EXPIRE)
         elif name == 'SwapInitiated':
-            self.state_store.insert_busy_event(block, miner, +1)
+            self.state_store.insert_activity_event(block, miner, ActivityTransition.FULFILL_START)
         elif name in ('SwapCompleted', 'SwapTimedOut'):
-            self.state_store.insert_busy_event(block, miner, -1)
+            self.state_store.insert_activity_event(block, miner, ActivityTransition.FULFILL_END)
         elif name in ('CollateralPosted', 'CollateralWithdrawn'):
             self.state_store.insert_collateral_event(block, miner, int(fields['total']))
         else:
             raise ValueError(f'CrownSeeder: unsupported event {name}')
 
-    def apply_busy_delta(self, block: int, hotkey: str, delta: int) -> None:
-        self.state_store.insert_busy_event(block, hotkey, delta)
+    def reserve_then_swap(
+        self, miner: str, reserve_block: int, init_block: int, end_block: int, end='SwapCompleted', ttl: int = 10**9
+    ):
+        """Realistic busy span: PoolResolved → SwapInitiated → completion. The
+        reservation's RESERVE_EXPIRE is parked at reserve_block + ttl (default
+        beyond the window)."""
+        self.apply_event(reserve_block, 'PoolResolved', {'miner': miner, 'ttl': ttl})
+        self.apply_event(init_block, 'SwapInitiated', {'miner': miner})
+        self.apply_event(end_block, end, {'miner': miner})
 
     def get_active_miners_at(self, at_time: int) -> set[str]:
         return self.state_store.get_active_state_at(at_time)
 
-    def get_busy_miners_at(self, at_time: int) -> dict[str, int]:
-        return self.state_store.get_busy_counts_at(at_time)
+    def get_activity_state_at(self, at_time: int) -> dict[str, MinerActivity]:
+        return self.state_store.get_activity_state_at(at_time)
 
     def get_miner_collaterals_at(self, at_time: int) -> dict[str, int]:
         return self.state_store.get_collaterals_at(at_time)
@@ -362,25 +376,26 @@ class TestCrownHoldersHelper:
         assert holders == {'a', 'b'}
 
     def test_busy_best_rate_loses_to_idle_runner_up(self):
-        """Miner A has the best rate but is mid-swap — crown goes to B."""
+        """Miner A has the best rate but is mid-swap (not in the rewardable-by-
+        state set) — crown goes to B."""
         rates = {'a': 0.00030, 'b': 0.00020}
-        holders = crown_holders_at_instant(rates, {'a', 'b'}, busy={'a'})
+        holders = crown_holders_at_instant(rates, {'a', 'b'}, rewardable_by_state={'b'})
         assert holders == ['b']
 
     def test_all_busy_returns_empty(self):
-        """Every eligible miner is busy → no crown → pool recycles."""
+        """No miner is in a rewardable state → no crown → pool recycles."""
         rates = {'a': 0.00030, 'b': 0.00020}
-        holders = crown_holders_at_instant(rates, {'a', 'b'}, busy={'a', 'b'})
+        holders = crown_holders_at_instant(rates, {'a', 'b'}, rewardable_by_state=set())
         assert holders == []
 
     def test_lower_rate_wins_flips_sort(self):
         """For tao→btc the rate is TAO per BTC and lower = better. The
         helper picks the smallest qualifying rate, falling through to the
-        next-smallest when the smallest is busy."""
+        next-smallest when the smallest isn't rewardable."""
         rates = {'a': 250.0, 'b': 251.0}
         assert crown_holders_at_instant(rates, {'a', 'b'}, lower_rate_wins=True) == ['a']
         # Smallest miner is busy → next-smallest takes the crown.
-        assert crown_holders_at_instant(rates, {'a', 'b'}, busy={'a'}, lower_rate_wins=True) == ['b']
+        assert crown_holders_at_instant(rates, {'a', 'b'}, rewardable_by_state={'b'}, lower_rate_wins=True) == ['b']
 
     def test_executable_check_drops_sentinel_and_falls_through(self):
         """Regression for #392: a miner posting 1e10 TAO/BTC wins the rate
@@ -784,8 +799,8 @@ class TestReplayCrownTime:
         store.close()
 
     def test_best_rate_miner_goes_busy_credit_flows_to_runner_up(self, tmp_path: Path):
-        """A holds the best rate but takes a swap at block 400 that resolves
-        at block 800. During [400, 800] the crown flips to idle runner-up B."""
+        """A holds the best rate but is reserved+swapping over [400, 800]. During
+        that span A is FULFILLING (forfeits crown) and it flips to runner-up B."""
         store = ValidatorStateStore(db_path=tmp_path / 'state.db')
         watcher = make_watcher(store, active={'hk_a', 'hk_b'})
         conn = store.require_connection()
@@ -799,9 +814,8 @@ class TestReplayCrownTime:
             )
         conn.commit()
 
-        # A goes busy with a swap at 400, completes at 800.
-        watcher.apply_event(400, 'SwapInitiated', {'swap_id': 1, 'miner': 'hk_a'})
-        watcher.apply_event(800, 'SwapCompleted', {'swap_id': 1, 'miner': 'hk_a'})
+        # A is reserved then initiates a swap at 400, completing at 800.
+        watcher.reserve_then_swap('hk_a', reserve_block=400, init_block=400, end_block=800)
 
         crown = replay_crown_time_window(
             store=store,
@@ -829,8 +843,7 @@ class TestReplayCrownTime:
         )
         conn.commit()
 
-        watcher.apply_event(400, 'SwapInitiated', {'swap_id': 1, 'miner': 'hk_a'})
-        watcher.apply_event(900, 'SwapTimedOut', {'swap_id': 1, 'miner': 'hk_a'})
+        watcher.reserve_then_swap('hk_a', reserve_block=400, init_block=400, end_block=900, end='SwapTimedOut')
 
         crown = replay_crown_time_window(
             store=store,
@@ -848,8 +861,9 @@ class TestReplayCrownTime:
         store.close()
 
     def test_busy_state_at_window_start_is_reconstructed(self, tmp_path: Path):
-        """Miner A's SwapInitiated fires before window_start and doesn't
-        resolve until mid-window — replay must see A as busy from the start."""
+        """Miner A's reservation+swap opens before window_start and doesn't
+        resolve until mid-window — reconstruction must see A as FULFILLING at the
+        window edge."""
         store = ValidatorStateStore(db_path=tmp_path / 'state.db')
         watcher = make_watcher(store, active={'hk_a', 'hk_b'})
         conn = store.require_connection()
@@ -864,9 +878,10 @@ class TestReplayCrownTime:
         conn.commit()
 
         # A's swap started BEFORE the window opens and completes inside it.
-        watcher.apply_event(50, 'SwapInitiated', {'swap_id': 1, 'miner': 'hk_a'})
-        watcher.apply_event(500, 'SwapCompleted', {'swap_id': 1, 'miner': 'hk_a'})
+        watcher.reserve_then_swap('hk_a', reserve_block=50, init_block=50, end_block=500)
 
+        # Window-start state shows A FULFILLING (open swap spans the edge).
+        assert store.get_activity_state_at(100) == {'hk_a': MinerActivity.FULFILLING}
         crown = replay_crown_time_window(
             store=store,
             event_index=SolanaEventIndex(store),
@@ -877,8 +892,116 @@ class TestReplayCrownTime:
             rewardable_hotkeys={'hk_a', 'hk_b'},
         )
         # From window_start=100 A is already busy (reconstructed from pre-window
-        # SwapInitiated). B earns (100,500] = 400; A earns (500,1100] = 600.
+        # swap). B earns (100,500] = 400; A earns (500,1100] = 600.
         assert crown == {'hk_b': 400.0, 'hk_a': 600.0}
+        store.close()
+
+
+class TestCrownRewardStates:
+    """D4 — a reserved/fulfilling miner forfeits crown (activity ∉
+    REWARD_MINER_STATES), on top of the existing active/rate/executable gates."""
+
+    def _seed_solo(self, tmp_path: Path, rate: float = 300.0):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active={'hk_a'})
+        conn = store.require_connection()
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_a', 'sol', 'btc', rate, 0),
+        )
+        conn.commit()
+        return store, watcher
+
+    def _replay(self, store, **kw):
+        return replay_crown_time_window(
+            store=store,
+            event_index=SolanaEventIndex(store),
+            from_chain='sol',
+            to_chain='btc',
+            window_start=100,
+            window_end=1100,
+            **kw,
+        )
+
+    def test_reserved_not_initiated_forfeits_then_earns_after_expiry(self, tmp_path: Path):
+        """A bare reservation (no swap) forfeits crown for [resolve, resolve+ttl],
+        then RESERVE_EXPIRE returns the miner to AVAILABLE and it earns again."""
+        store, watcher = self._seed_solo(tmp_path)
+        watcher.apply_event(300, 'PoolResolved', {'miner': 'hk_a', 'ttl': 400})  # expire @ 700
+        crown = self._replay(store, rewardable_hotkeys={'hk_a'})
+        # AVAILABLE (100,300]=200 + (700,1100]=400 = 600; RESERVED (300,700] forfeited (solo → recycles).
+        assert crown == {'hk_a': 600.0}
+        store.close()
+
+    def test_reserved_then_initiated_then_completed_forfeits_whole_span(self, tmp_path: Path):
+        """A is reserved at 300 and the swap runs to 800 — the entire
+        [300, 800] span (RESERVED then FULFILLING) forfeits to runner-up B."""
+        store, watcher = self._seed_solo(tmp_path)
+        conn = store.require_connection()
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_b', 'sol', 'btc', 200.0, 0),
+        )
+        conn.commit()
+        seed_active(watcher, 'hk_b', active=True, block=0)
+        watcher.reserve_then_swap('hk_a', reserve_block=300, init_block=350, end_block=800)
+        crown = self._replay(store, rewardable_hotkeys={'hk_a', 'hk_b'})
+        # A: (100,300]=200 + (800,1100]=300 = 500. B holds the forfeited (300,800]=500.
+        assert crown == {'hk_a': 500.0, 'hk_b': 500.0}
+        store.close()
+
+    def test_swap_completes_before_reserved_until_has_no_false_tail(self, tmp_path: Path):
+        """The interval model's win over the old delta tail: a swap completing
+        before the reservation's TTL returns the miner to AVAILABLE immediately —
+        no forfeited tail out to reserved_until."""
+        store, watcher = self._seed_solo(tmp_path)
+        # Reserved @300 with ttl 600 (reserved_until = 900), but the swap completes @500.
+        watcher.reserve_then_swap('hk_a', reserve_block=300, init_block=350, end_block=500, ttl=600)
+        # Mid-span between completion and the original reserved_until: AVAILABLE, not RESERVED.
+        assert store.get_activity_state_at(700) == {}
+        crown = self._replay(store, rewardable_hotkeys={'hk_a'})
+        # Forfeits only (300,500]=200; earns (100,300]=200 + (500,1100]=600 = 800. No tail to 900.
+        assert crown == {'hk_a': 800.0}
+        store.close()
+
+    def test_window_start_reconstruction_shows_reserved_at_edge(self, tmp_path: Path):
+        """A reservation open before window_start shows RESERVED at the edge."""
+        store, watcher = self._seed_solo(tmp_path)
+        watcher.apply_event(50, 'PoolResolved', {'miner': 'hk_a', 'ttl': 400})  # expire @ 450
+        assert store.get_activity_state_at(100) == {'hk_a': MinerActivity.RESERVED}
+        crown = self._replay(store, rewardable_hotkeys={'hk_a'})
+        # RESERVED (100,450] forfeited (solo); earns (450,1100] = 650.
+        assert crown == {'hk_a': 650.0}
+        store.close()
+
+    def test_reserve_expire_during_fulfilling_is_a_no_op(self, tmp_path: Path):
+        """RESERVE_EXPIRE landing mid-swap is a no-op — the miner stays FULFILLING
+        until FULFILL_END, forfeiting the whole swap span."""
+        store, watcher = self._seed_solo(tmp_path)
+        # ttl 100 → RESERVE_EXPIRE @ 400, but the swap runs 350..800.
+        watcher.reserve_then_swap('hk_a', reserve_block=300, init_block=350, end_block=800, ttl=100)
+        assert store.get_activity_state_at(500) == {'hk_a': MinerActivity.FULFILLING}  # past the expire, still busy
+        crown = self._replay(store, rewardable_hotkeys={'hk_a'})
+        # Forfeits (300,800]; earns (100,300]=200 + (800,1100]=300 = 500.
+        assert crown == {'hk_a': 500.0}
+        store.close()
+
+    def test_reward_states_set_is_the_only_policy_knob(self, tmp_path: Path, monkeypatch):
+        """Flipping REWARD_MINER_STATES to include FULFILLING makes a fulfilling
+        miner earn — with no other change. RESERVED still forfeits, proving the
+        frozenset is the sole policy lever."""
+        store, watcher = self._seed_solo(tmp_path)
+        watcher.reserve_then_swap('hk_a', reserve_block=300, init_block=350, end_block=800)
+        # Default: only AVAILABLE earns. RESERVED (300,350] + FULFILLING (350,800] forfeit.
+        base = self._replay(store, rewardable_hotkeys={'hk_a'})
+        assert base == {'hk_a': 500.0}  # (100,300]=200 + (800,1100]=300
+
+        monkeypatch.setattr(
+            scoring_mod, 'REWARD_MINER_STATES', frozenset({MinerActivity.AVAILABLE, MinerActivity.FULFILLING})
+        )
+        flipped = self._replay(store, rewardable_hotkeys={'hk_a'})
+        # FULFILLING (350,800]=450 now earns; RESERVED (300,350]=50 still forfeits.
+        assert flipped == {'hk_a': 950.0}
         store.close()
 
 
@@ -1410,8 +1533,8 @@ class TestHistoricalActiveState:
         holders = crown_holders_at_instant(rates, rewardable={'a', 'b'}, active=set())
         assert holders == []
 
-    def test_active_transition_plus_busy_transition_at_same_block(self, tmp_path: Path):
-        """ACTIVE (kind=0) orders before BUSY (kind=1). A deactivates and
+    def test_active_transition_plus_activity_transition_at_same_block(self, tmp_path: Path):
+        """ACTIVE (kind=0) orders before ACTIVITY (kind=1). A deactivates and
         goes busy at the same block — the interval ending at that block
         included A. After the block, A is out both ways."""
         store = ValidatorStateStore(db_path=tmp_path / 'state.db')
@@ -1423,12 +1546,11 @@ class TestHistoricalActiveState:
                 (hk, 'sol', 'btc', rate, 0),
             )
         conn.commit()
-        # At block 500: A both deactivates and picks up a swap. Both events
-        # apply; both end A's crown credit. A remains out until deactivation
-        # reverses (it doesn't).
+        # At block 500: A both deactivates and picks up a reserved swap. Both
+        # events apply; both end A's crown credit. A remains out until
+        # deactivation reverses (it doesn't).
         watcher.apply_event(500, 'MinerActivated', {'miner': 'hk_a', 'active': False})
-        watcher.apply_event(500, 'SwapInitiated', {'swap_id': 1, 'miner': 'hk_a'})
-        watcher.apply_event(800, 'SwapCompleted', {'swap_id': 1, 'miner': 'hk_a'})
+        watcher.reserve_then_swap('hk_a', reserve_block=500, init_block=500, end_block=800)
 
         crown = replay_crown_time_window(
             store=store,
@@ -1477,13 +1599,13 @@ class TestEventKindOrdering:
     now that the crown reads the state_store event tables directly."""
 
     def test_event_kind_ordering_at_same_block(self, tmp_path: Path):
-        """ACTIVE < BUSY < RATE. At a shared block the credit_interval
+        """ACTIVE < ACTIVITY < RATE. At a shared block the credit_interval
         *ending* at that block is evaluated before any of these transitions
         applies. Ordering matters: active-flag flip at block N must gate
         block N+1 regardless of any other same-block transition."""
         from allways.validator.scoring import EventKind
 
-        assert int(EventKind.ACTIVE) < int(EventKind.BUSY) < int(EventKind.RATE)
+        assert int(EventKind.ACTIVE) < int(EventKind.ACTIVITY) < int(EventKind.RATE)
 
 
 class TestHaltShortCircuit:
@@ -1974,13 +2096,11 @@ class TestVolumeWeighting:
             ('hk_b', 'sol', 'btc', 150.0, 0),
         )
         conn.commit()
-        # Window is (9700, 10000]. A busy block 9_800..9_860 (60 blocks within
-        # the window) so B holds crown 20% of window. We can't use a
-        # SwapCompleted event here because the direction lookup needs an
-        # active swap entry in the tracker — easier to just record the
-        # outcome and the busy delta directly.
-        v.event_watcher.apply_busy_delta(9_800, 'hk_a', +1)
-        v.event_watcher.apply_busy_delta(9_860, 'hk_a', -1)
+        # Window is (9700, 10000]. A is reserved 9_800..9_860 (60 blocks within
+        # the window) so B holds crown 20% of window. A bare PoolResolved (no
+        # swap) with a 60s TTL forfeits the crown for exactly the reserved span,
+        # then RESERVE_EXPIRE returns A to AVAILABLE.
+        v.event_watcher.apply_event(9_800, 'PoolResolved', {'miner': 'hk_a', 'ttl': 60})
         self.insert_volume(v, 'hk_a', tao_amount=200_000_000, swap_id=1, from_chain='sol', to_chain='btc')
         self.insert_volume(v, 'hk_b', tao_amount=800_000_000, swap_id=2, from_chain='sol', to_chain='btc')
         rewards, _ = calculate_miner_rewards(v, v.block)


### PR DESCRIPTION
## D4 — Crown reward-states

Replaces the implicit busy-sum (`_BUSY_DELTA`/`busy_events`) with an explicit per-instant **`MinerActivity`** state machine (`AVAILABLE`/`RESERVED`/`FULFILLING`) and a declarative **`REWARD_MINER_STATES = frozenset({AVAILABLE})`**. The crown credits a miner only when its activity ∈ `REWARD_MINER_STATES`, on top of the unchanged active + rate-positive + executable gates.

### The gap this closes
The crown rewards best-rate *presence*, but a busy miner isn't takeable. The old delta model only forfeited during the **active-swap** window; the **reservation** window (`PoolResolved → reserved_until`) was intentionally never ingested. Now **all busy forfeits**: `PoolResolved` is ingested as `RESERVE_START` plus a synthetic `RESERVE_EXPIRE` at `block_time + reservation_ttl_secs` (TTL read off the solana config cache, since `reserved_until` isn't on the event). The busy miner is `PoolResolved.miner` (the reserved miner), not `winner` (the router).

### Design
- `classes.py`: `MinerActivity` + `ActivityTransition` enums and a single `next_activity(state, transition)` reducer. Transition values double as the coincident-instant tiebreak (a swap closes/opens before a reservation lapse).
- `constants.py`: `REWARD_MINER_STATES` — the **only** place that decides which states earn. Add `FULFILLING` to reward in-flight miners with no other logic change (proven by a test).
- State machine: `AVAILABLE+RESERVE_START→RESERVED`; `RESERVED+FULFILL_START→FULFILLING`; `RESERVED+RESERVE_EXPIRE→AVAILABLE`; `FULFILLING+RESERVE_EXPIRE→FULFILLING` (no-op); `FULFILLING+FULFILL_END→AVAILABLE`. `AVAILABLE+RESERVE_EXPIRE` is an explicit no-op (residual expiry after a swap closed before its TTL). Undefined edges hold state + warn once.
- `scoring.py`: `reconstruct_window_start_state` / `merge_replay_events` / `apply_event` now drive the machine; `credit_interval` rewardable set = `{hk : activity ∈ REWARD_MINER_STATES}`; `crown_holders_at_instant`'s `busy` exclusion param is replaced by a `rewardable_by_state` inclusion param.
- Storage: `busy_events` is replaced by a clean `activity_events` table (kind = `ActivityTransition`). No parallel dead `busy_events`. `SwapCompleted`'s clearing-rate sampling is untouched.

### No false tail
Because state is interval-derived, a swap completing before its original `reserved_until` returns the miner to `AVAILABLE` **immediately** — the old delta approach's over-exclusion tail is gone. Asserted explicitly.

### Already covered
Active-swap busy was the only case the old model handled; it still forfeits (regression test retained, now reservation→swap).

### Tests
Extends the crown-replay suite: reserved-not-initiated forfeits then earns after expiry; reserved→initiated→completed forfeits the whole span; no-false-tail; window-start reconstruction shows RESERVED/FULFILLING at the edge; RESERVE_EXPIRE during FULFILLING is a no-op; flipping `REWARD_MINER_STATES` to include FULFILLING makes a fulfilling miner earn; active-swap regression. `pytest -q -m "not integration"` green (535 passed); `ruff format` + `ruff check` clean.