### PR TITLE
Keep pool crank simple; handle benign resolve races

### DIFF
--- a/allways/validator/solana_swap_loop.py
+++ b/allways/validator/solana_swap_loop.py
@@ -56,6 +56,12 @@ ACTIONABLE = frozenset(
 # or we're at the ceiling) — log quietly, never propagate.
 _BENIGN_EXTEND_MARKERS = ('ExtensionNotLater', 'ExtensionExceedsCeiling')
 
+# resolve_pool is permissionless, so every validator cranks every closed pool and the contract's
+# first-wins idempotency handles the race. A loser's tx fails with one of these — a peer already
+# resolved it (NoRequests: opened_at zeroed), or the on-chain clock hasn't crossed closes_at yet
+# (PoolNotClosed, clock skew) — both expected, retried next pass. Real failures still surface.
+_BENIGN_RESOLVE_MARKERS = ('NoRequests', 'PoolNotClosed')
+
 
 def _status_name(swap: Any) -> str:
     """Borsh enum decodes to an instance whose type name is the variant (Active/Fulfilled/...)."""
@@ -70,6 +76,11 @@ def _swap_key_hex(key: Any) -> str:
 def _is_benign_extension(e: Exception) -> bool:
     """A contract ceiling hit or a lost extension race — expected, not an error."""
     return any(m in str(e) for m in _BENIGN_EXTEND_MARKERS)
+
+
+def _is_benign_resolve(e: Exception) -> bool:
+    """A lost resolve_pool race — a peer already resolved it, or the clock hasn't crossed closes_at."""
+    return any(m in str(e) for m in _BENIGN_RESOLVE_MARKERS)
 
 
 def is_tx_fresh(info: Any, floor_unix: int, grace: int = 0) -> bool:
@@ -320,13 +331,15 @@ class SolanaSwapLoop:
         return True
 
     def resolve_pools_once(self, now: int) -> List[str]:
-        """Permissionless crank: resolve every pool whose window has closed into a winner Reservation.
-        Idempotent — `resolve_pool` zeroes `opened_at` + clears requests, so a resolved pool is skipped
-        next pass. One bad pool never breaks the sweep. Returns the miners whose pools we resolved."""
+        """Permissionless crank: resolve every closed, non-empty, unresolved pool into a winner
+        Reservation. `resolve_pool` is idempotent (first-wins: it zeroes `opened_at` + clears requests),
+        so racing validators are safe — a loser's tx is a benign no-op, logged quietly. One bad pool never
+        breaks the sweep. Returns the miners whose pools we resolved. (A per-pool cranker assignment to
+        avoid the redundant losing txs is a deferred optimization — D-CRANK.)"""
         resolved: List[str] = []
         for _pubkey, pool in self.client.get_all('Pool'):
             if int(getattr(pool, 'opened_at', 0)) == 0:
-                continue  # available/empty slot
+                continue  # available/empty slot — already resolved or never opened
             if now <= int(pool.closes_at):
                 continue  # window still open
             if not getattr(pool, 'requests', None):
@@ -338,6 +351,9 @@ class SolanaSwapLoop:
             try:
                 self.client.resolve_pool(miner)
             except Exception as e:  # one bad pool must not break the pass
+                if _is_benign_resolve(e):
+                    bt.logging.debug(f'pool {miner}: resolve_pool no-op (peer won the race): {e}')
+                    continue
                 bt.logging.error(f'pool {miner}: resolve_pool failed: {e}')
                 continue
             bt.logging.success(f'pool {miner}: resolved ({len(pool.requests)} req)')

--- a/tests/test_solana_swap_loop.py
+++ b/tests/test_solana_swap_loop.py
@@ -8,7 +8,7 @@ Mocks the solana client (get_swaps / get_reservation) + chain providers; no chai
 from types import SimpleNamespace
 
 from allways.chain_providers.base import ProviderUnreachableError
-from allways.validator.solana_swap_loop import SolanaSwapLoop, SwapAction, SwapDecision
+from allways.validator.solana_swap_loop import SolanaSwapLoop, SwapAction, SwapDecision, _is_benign_resolve
 
 INITIATED_AT = 1000  # dest-freshness floor
 RESV_CREATED_AT = 1200  # source-freshness floor
@@ -485,3 +485,22 @@ def test_resolve_pools_one_failure_does_not_break_sweep():
     client = Boom([make_pool(miner='bad'), make_pool(miner='good')])
     loop = SolanaSwapLoop(client, {}, fee_divisor=100)
     assert loop.resolve_pools_once(now=500) == ['good']
+
+
+def test_is_benign_resolve_classifies_lost_race():
+    assert _is_benign_resolve(RuntimeError('custom program error: NoRequests'))
+    assert _is_benign_resolve(RuntimeError('PoolNotClosed'))
+    assert not _is_benign_resolve(RuntimeError('rpc down'))
+
+
+def test_resolve_pools_lost_race_is_not_counted_and_sweep_continues():
+    # A peer resolved the pool between our read and our tx → benign NoRequests, swallowed quietly.
+    class Raced(PoolRecordingClient):
+        def resolve_pool(self, miner):
+            if miner == 'raced':
+                raise RuntimeError('custom program error: NoRequests')
+            return super().resolve_pool(miner)
+
+    client = Raced([make_pool(miner='raced'), make_pool(miner='mine')])
+    loop = SolanaSwapLoop(client, {}, fee_divisor=100)
+    assert loop.resolve_pools_once(now=500) == ['mine']  # loser not counted, sweep unbroken


### PR DESCRIPTION
Keeps the pool crank simple and permissionless (M3 D5, reshaped).

## Decision
`resolve_pool` is already idempotent on-chain (first-wins: it zeroes `opened_at` + clears requests). The
earlier single-cranker assignment (deterministic assignee + rank-staggered fallback) was prevention for a
race the contract already handles cheaply, so it's dropped in favour of the obvious loop: **every validator
resolves every closed, unresolved pool; the loser's tx is a benign no-op.** A per-pool cranker assignment to
shave the redundant losing txs (D-CRANK) is deferred as a later optimization — not worth the machinery today.

## Change (`allways/validator/solana_swap_loop.py`)
- `resolve_pools_once` stays the simple sweep (skip `opened_at == 0` / window-open / empty-requests; per-pool
  try/except so one bad pool never breaks the pass).
- **Benign-race handling:** a lost race now classifies instead of hard-erroring. The contract rejects a
  double-resolve with `NoRequests` (a peer already zeroed `opened_at`) or `PoolNotClosed` (on-chain clock
  hasn't crossed `closes_at` yet — skew); both are logged at `debug` and skipped. Real failures still surface
  as `error`. Mirrors the existing `_is_benign_extension` pattern.

## Tests
- `_is_benign_resolve` classifies `NoRequests`/`PoolNotClosed` as benign, real errors as not.
- A lost-race pool is not counted as resolved and the sweep continues to the next pool.
- Existing coverage retained: only-closed-nonempty, read-only casts nothing, one hard failure doesn't break the sweep.

`pytest -q -m "not integration"`: green. `ruff`: clean. Stacks on D3 (#500).
