### PR TITLE
Remove set_validator_weight admin override

### DIFF
--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/admin.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/admin.rs
@@ -35,20 +35,6 @@ pub fn remove_validator(ctx: Context<AdminConfig>, validator: Pubkey) -> Result<
     Ok(())
 }
 
-/// Set a validator's draw weight (the seam a future stake oracle writes through). Consensus is
-/// count-based, so this only affects the Phase 9 lottery draw.
-pub fn set_validator_weight(ctx: Context<AdminConfig>, validator: Pubkey, weight: u64) -> Result<()> {
-    let config = &mut ctx.accounts.config;
-    let entry = config
-        .validators
-        .iter_mut()
-        .find(|v| v.key == validator)
-        .ok_or(ErrorCode::ValidatorNotFound)?;
-    entry.weight = weight;
-    msg!("validator weight: {} = {}", validator, weight);
-    Ok(())
-}
-
 pub fn set_consensus_threshold(ctx: Context<AdminConfig>, percent: u8) -> Result<()> {
     crate::validate::consensus_threshold(percent)?;
     ctx.accounts.config.consensus_threshold_percent = percent;

--- a/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
@@ -102,16 +102,6 @@ pub mod allways_swap_manager {
     pub fn set_max_total_extension(ctx: Context<AdminConfig>, secs: i64) -> Result<()> {
         admin::set_max_total_extension(ctx, secs)
     }
-    /// Set a validator's draw weight (admin bootstrap/fallback; superseded for routine use
-    /// by the consensus path below).
-    pub fn set_validator_weight(
-        ctx: Context<AdminConfig>,
-        validator: Pubkey,
-        weight: u64,
-    ) -> Result<()> {
-        admin::set_validator_weight(ctx, validator, weight)
-    }
-
     // --- Consensus-governed validator weights ---
     /// A validator submits the full weight vector (index-aligned to `Config.validators`); on quorum
     /// the weights are saved. Validators read stake off-chain and converge on one snapshot.

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
@@ -928,15 +928,6 @@ fn remove_quote_ix(m: &Pubkey, from_chain: &str, to_chain: &str) -> Instruction 
     )
 }
 
-fn set_validator_weight_ix(admin: &Pubkey, v: Pubkey, weight: u64) -> Instruction {
-    Instruction::new_with_bytes(
-        pid(),
-        &allways_swap_manager::instruction::SetValidatorWeight { validator: v, weight }.data(),
-        allways_swap_manager::accounts::AdminConfig { admin: *admin, config: config_pda() }
-            .to_account_metas(None),
-    )
-}
-
 #[test]
 #[ignore = "requires a live solana-test-validator with the program deployed"]
 fn onchain_set_quote_creates_pda() {
@@ -987,21 +978,4 @@ fn onchain_bind_hotkey() {
     assert_eq!(b.hotkey, hotkey);
     assert_eq!(b.hotkey_sig, sig);
     assert!(b.bound_at > 0, "bound_at set from on-chain clock");
-}
-
-#[test]
-#[ignore = "requires a live solana-test-validator with the program deployed"]
-fn onchain_set_validator_weight() {
-    let _ = shared();
-    let rpc = rpc();
-    let admin = admin_keypair();
-    let v = Keypair::new();
-
-    // Add a fresh validator with weight 5, then bump it to 9 via set_validator_weight.
-    send(&rpc, add_validator_ix(&admin.pubkey(), v.pubkey()), &admin.pubkey(), &admin).expect("add (weight 1)");
-    send(&rpc, set_validator_weight_ix(&admin.pubkey(), v.pubkey(), 9), &admin.pubkey(), &admin).expect("set weight");
-
-    let cfg = read_config(&rpc);
-    let w = cfg.validators.iter().find(|x| x.key == v.pubkey()).map(|x| x.weight);
-    assert_eq!(w, Some(9), "validator weight updated to 9");
 }

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_validator_weight.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_validator_weight.rs
@@ -3,7 +3,7 @@
 //
 // Weights are the stake-oracle seam consumed only by the Phase 9 lottery draw; consensus stays
 // count-based (the regression for that lives in test_consensus.rs, which now runs against the
-// ValidatorInfo shape). Here we cover add-with-weight, set_validator_weight, and the unknown-key path.
+// ValidatorInfo shape). Here we cover add-validator-with-weight and the consensus weight path.
 use {
     anchor_lang::{
         prelude::Pubkey, solana_program::clock::Clock, solana_program::instruction::Instruction,
@@ -84,15 +84,6 @@ fn add_validator_ix(program_id: &Pubkey, admin: &Pubkey, v: Pubkey, weight: u64)
     )
 }
 
-fn set_weight_ix(program_id: &Pubkey, admin: &Pubkey, v: Pubkey, weight: u64) -> Instruction {
-    Instruction::new_with_bytes(
-        *program_id,
-        &allways_swap_manager::instruction::SetValidatorWeight { validator: v, weight }.data(),
-        allways_swap_manager::accounts::AdminConfig { admin: *admin, config: config_pda(program_id) }
-            .to_account_metas(None),
-    )
-}
-
 fn weight_of(svm: &LiteSVM, program_id: &Pubkey, v: &Pubkey) -> Option<u64> {
     let a = svm.get_account(&config_pda(program_id)).unwrap();
     let cfg = Config::try_deserialize(&mut a.data.as_slice()).unwrap();
@@ -105,23 +96,6 @@ fn test_add_validator_stores_weight() {
     let v = Keypair::new();
     send(&mut svm, add_validator_ix(&program_id, &admin.pubkey(), v.pubkey(), 7), &admin.pubkey(), &admin).expect("add");
     assert_eq!(weight_of(&svm, &program_id, &v.pubkey()), Some(7));
-}
-
-#[test]
-fn test_set_validator_weight_updates() {
-    let (mut svm, program_id, admin) = setup();
-    let v = Keypair::new();
-    send(&mut svm, add_validator_ix(&program_id, &admin.pubkey(), v.pubkey(), 1), &admin.pubkey(), &admin).expect("add");
-    send(&mut svm, set_weight_ix(&program_id, &admin.pubkey(), v.pubkey(), 42), &admin.pubkey(), &admin).expect("set weight");
-    assert_eq!(weight_of(&svm, &program_id, &v.pubkey()), Some(42));
-}
-
-#[test]
-fn test_set_weight_unknown_validator_fails() {
-    let (mut svm, program_id, admin) = setup();
-    let ghost = Keypair::new();
-    let r = send(&mut svm, set_weight_ix(&program_id, &admin.pubkey(), ghost.pubkey(), 5), &admin.pubkey(), &admin);
-    assert!(r.is_err(), "setting weight on an unknown validator must fail");
 }
 
 // ─── Phase 10: consensus-governed weights (vote_set_weights) ────────────────────


### PR DESCRIPTION
## Why
`set_validator_weight` was an admin-only instruction that let the admin unilaterally rewrite any validator's lottery draw weight. That is an unnecessary centralization / skew vector on the reservation lottery. The legitimate weight surface is the consensus path (`vote_set_weights`), with `add_validator(key, weight)` setting the initial value at whitelist time. Decision (user, 2026-06-29): delete the override.

## What's removed
- `instructions/admin.rs`: the `set_validator_weight` handler.
- `lib.rs`: its `#[program]` dispatch entry.
- Its test coverage (the two set-weight LiteSVM cases in `tests/test_validator_weight.rs`; the `onchain_set_validator_weight` integration case + its `set_validator_weight_ix` builder in `tests/integration_onchain.rs`).

No event or error was defined solely for it — the handler reused `ErrorCode::ValidatorNotFound` (shared with `remove_validator`), which stays.

## What's kept (the legitimate weight surface)
- `add_validator(key, weight)` — sets a validator's initial draw weight.
- `vote_set_weights` — consensus-governed weight vector (the normal path); full coverage retained.
- `ValidatorInfo.weight` field + the Phase-9 lottery draw that consumes it — unchanged.

## Notes
- Pure instruction-surface removal. Anchor discriminators are per-instruction name-hashes, so removing one does not shift the others; all kept instructions' discriminators/layouts are unchanged.
- `Config` schema is unchanged (no field added/removed), so `CONFIG_VERSION` is **not** bumped — it tracks the Config account layout, not the instruction surface.
- Repo-wide `grep -rn set_validator_weight` returns nothing (contract + off-chain python/ts/json). No off-chain builder/layout referenced this instruction.
- `anchor build` clean; full LiteSVM unit suite green (`test_validator_weight` now 6 tests: add-with-weight + 5 `vote_set_weights` cases).

**CONTRACT CHANGE — please run a smart-contract-security review before merge.**