### PR TITLE
Expose remaining admin setters and config views

### DIFF
--- a/allways/cli/swap_commands/admin.py
+++ b/allways/cli/swap_commands/admin.py
@@ -183,29 +183,6 @@ def set_max_extension(secs: int):
     )
 
 
-@admin_group.command('set-halted', show_disclaimer=True)
-@click.argument('state', type=click.Choice(['on', 'off'], case_sensitive=False))
-def set_halted(state: str):
-    """Halt (on) or resume (off) value entry — blocks new deposits, activations, and reservation pools.
-
-    [dim]Existing in-flight swaps continue through their lifecycle.
-
-    Examples:
-        $ alw admin set-halted on
-        $ alw admin set-halted off[/dim]
-    """
-    halted = state.lower() == 'on'
-    _run_setter(
-        title='Halt System' if halted else 'Resume System',
-        getter=lambda c: c.get_config().halted,
-        setter=lambda c: c.set_halted(halted),
-        noun='halt state',
-        format_current=lambda v: 'halted' if v else 'running',
-        new_display='halted' if halted else 'running',
-        success_msg='System is now halted' if halted else 'System resumed',
-    )
-
-
 @admin_group.command('set-min-collateral', show_disclaimer=True)
 @click.argument('amount_sol', type=float)
 def set_min_collateral(amount_sol: float):

--- a/allways/cli/swap_commands/admin.py
+++ b/allways/cli/swap_commands/admin.py
@@ -9,13 +9,10 @@ from allways.cli.swap_commands.helpers import (
     from_lamports,
     get_solana_cli_context,
     loading,
+    secs_str,
     to_lamports,
 )
 from allways.solana.client import SolanaClientError
-
-
-def _secs_str(secs: int) -> str:
-    return f'{secs}s (~{secs // 60}m)'
 
 
 def _parse_pubkey(s: str):
@@ -69,9 +66,9 @@ def set_timeout(secs: int):
         getter=lambda c: c.get_config().fulfillment_timeout_secs,
         setter=lambda c: c.set_fulfillment_timeout(secs),
         noun='fulfillment timeout',
-        format_current=lambda v: _secs_str(v),
-        new_display=_secs_str(secs),
-        success_msg=f'Fulfillment timeout set to {_secs_str(secs)}',
+        format_current=lambda v: secs_str(v),
+        new_display=secs_str(secs),
+        success_msg=f'Fulfillment timeout set to {secs_str(secs)}',
     )
 
 
@@ -91,9 +88,121 @@ def set_reservation_ttl(secs: int):
         getter=lambda c: c.get_config().reservation_ttl_secs,
         setter=lambda c: c.set_reservation_ttl(secs),
         noun='reservation TTL',
-        format_current=lambda v: _secs_str(v),
-        new_display=_secs_str(secs),
-        success_msg=f'Reservation TTL set to {_secs_str(secs)}',
+        format_current=lambda v: secs_str(v),
+        new_display=secs_str(secs),
+        success_msg=f'Reservation TTL set to {secs_str(secs)}',
+    )
+
+
+@admin_group.command('set-reservation-fee', show_disclaimer=True)
+@click.argument('amount_sol', type=float)
+def set_reservation_fee(amount_sol: float):
+    """Set the flat per-request reservation fee (in SOL).
+
+    [dim]Examples:
+        $ alw admin set-reservation-fee 0.001[/dim]
+    """
+    if amount_sol < 0:
+        console.print('[red]Amount must be non-negative[/red]')
+        return
+    lamports = to_lamports(amount_sol)
+    _run_setter(
+        title='Set Reservation Fee',
+        getter=lambda c: c.get_config().reservation_fee_lamports,
+        setter=lambda c: c.set_reservation_fee(lamports),
+        noun='reservation fee',
+        format_current=lambda v: f'{from_lamports(v):.6f} SOL',
+        new_display=f'{amount_sol:.6f} SOL',
+        success_msg=f'Reservation fee set to {amount_sol:.6f} SOL',
+    )
+
+
+@admin_group.command('set-pool-window', show_disclaimer=True)
+@click.argument('secs', type=int)
+def set_pool_window(secs: int):
+    """Set the reservation-pool window in seconds (how long a pool collects requests before the draw).
+
+    [dim]Examples:
+        $ alw admin set-pool-window 60[/dim]
+    """
+    if secs <= 0:
+        console.print('[red]Seconds must be positive[/red]')
+        return
+    _run_setter(
+        title='Set Pool Window',
+        getter=lambda c: c.get_config().pool_window_secs,
+        setter=lambda c: c.set_pool_window(secs),
+        noun='pool window',
+        format_current=lambda v: secs_str(v),
+        new_display=secs_str(secs),
+        success_msg=f'Pool window set to {secs_str(secs)}',
+    )
+
+
+@admin_group.command('set-weights-interval', show_disclaimer=True)
+@click.argument('secs', type=int)
+def set_weights_interval(secs: int):
+    """Set the minimum interval between validator weight updates (seconds).
+
+    [dim]Examples:
+        $ alw admin set-weights-interval 1200[/dim]
+    """
+    if secs <= 0:
+        console.print('[red]Seconds must be positive[/red]')
+        return
+    _run_setter(
+        title='Set Weights Update Interval',
+        getter=lambda c: c.get_config().weights_update_min_interval_secs,
+        setter=lambda c: c.set_weights_update_min_interval(secs),
+        noun='weights update interval',
+        format_current=lambda v: secs_str(v),
+        new_display=secs_str(secs),
+        success_msg=f'Weights update interval set to {secs_str(secs)}',
+    )
+
+
+@admin_group.command('set-max-extension', show_disclaimer=True)
+@click.argument('secs', type=int)
+def set_max_extension(secs: int):
+    """Set the max total timeout/reservation extension a single swap may accrue (seconds).
+
+    [dim]Examples:
+        $ alw admin set-max-extension 3600[/dim]
+    """
+    if secs < 0:
+        console.print('[red]Seconds must be non-negative[/red]')
+        return
+    _run_setter(
+        title='Set Max Total Extension',
+        getter=lambda c: c.get_config().max_total_extension_secs,
+        setter=lambda c: c.set_max_total_extension(secs),
+        noun='max total extension',
+        format_current=lambda v: secs_str(v),
+        new_display=secs_str(secs),
+        success_msg=f'Max total extension set to {secs_str(secs)}',
+    )
+
+
+@admin_group.command('set-halted', show_disclaimer=True)
+@click.argument('state', type=click.Choice(['on', 'off'], case_sensitive=False))
+def set_halted(state: str):
+    """Halt (on) or resume (off) value entry — blocks new deposits, activations, and reservation pools.
+
+    [dim]Existing in-flight swaps continue through their lifecycle.
+
+    Examples:
+        $ alw admin set-halted on
+        $ alw admin set-halted off[/dim]
+    """
+    halted = state.lower() == 'on'
+    _run_setter(
+        title='Halt System' if halted else 'Resume System',
+        getter=lambda c: c.get_config().halted,
+        setter=lambda c: c.set_halted(halted),
+        noun='halt state',
+        format_current=lambda v: 'halted' if v else 'running',
+        new_display='halted' if halted else 'running',
+        success_msg='System is now halted' if halted else 'System resumed',
     )
 
 

--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -276,6 +276,11 @@ def from_lamports(amount_lamports: int) -> float:
     return amount_lamports / LAMPORTS_PER_SOL
 
 
+def secs_str(secs: int) -> str:
+    """Render a seconds duration as `<n>s (~<m>m)` — shared by admin setters and view dumps."""
+    return f'{secs}s (~{secs // 60}m)'
+
+
 def get_solana_cli_context(need_keypair: bool = True):
     """Solana CLI setup for the B4-repointed miner/admin commands → (config, solana_client).
 

--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -1,14 +1,21 @@
-"""alw view - Inspect miners, rates, swaps, validators, and reservations.
+"""alw view - Inspect miners, rates, swaps, validators, config, and reservations.
 
-Stub: every view read drew miner quotes/reservations/swaps from the old ink!
-contract surface. Their Solana-backed taker views (MinerQuote aggregation, on-chain
-swaps/Config/Reservation) are not wired yet, so each subcommand is stubbed. The group
-+ subcommands are kept so `alw view --help` and command registration are unchanged."""
+`view config` and `view validators` read the on-chain Config directly. The taker aggregation
+views (miners/rates/swaps/reservation) still drew from the old ink! contract surface and need a
+Solana-backed re-port (MinerQuote aggregation, on-chain swaps/reservations), so they stay stubbed."""
 
 import click
+from solders.pubkey import Pubkey
 
 from allways.cli.help import StyledGroup
-from allways.cli.swap_commands.helpers import taker_view_unavailable
+from allways.cli.swap_commands.helpers import (
+    console,
+    from_lamports,
+    get_solana_cli_context,
+    secs_str,
+    taker_view_unavailable,
+)
+from allways.solana.client import SolanaClientError
 
 MINER_SORT_FIELDS = ['uid', 'rate', 'capacity', 'status']
 MINER_STATUS_CHOICES = ['available', 'offline', 'in-swap', 'reserved', 'cooldown']
@@ -97,16 +104,61 @@ def view_swap(swap_id: int, watch: bool):
     taker_view_unavailable('`view swap`')
 
 
-@view_group.command('contract')
-def view_contract():
-    """Show contract config (bounds, fees, timeouts)."""
-    taker_view_unavailable('`view contract`')
+def _read_config():
+    """Read the on-chain program Config (read-only — no keypair needed). None if unreadable/uninitialized."""
+    _, client = get_solana_cli_context(need_keypair=False)
+    try:
+        cfg = client.get_config()
+    except SolanaClientError as e:
+        console.print(f'[red]Failed to read config: {e}[/red]')
+        return None
+    if cfg is None:
+        console.print('[yellow]Program is not initialized (no Config account).[/yellow]')
+    return cfg
+
+
+def _sol_or(amount: int, zero_label: str) -> str:
+    return f'{from_lamports(amount):.4f} SOL' + (f' ({zero_label})' if amount == 0 else '')
+
+
+@view_group.command('config')
+def view_config():
+    """Show the current on-chain program Config (bounds, fees, windows, threshold). Read-only."""
+    cfg = _read_config()
+    if cfg is None:
+        return
+    console.print('\n[bold]Program Config[/bold]\n')
+    console.print(f'  Admin:                {cfg.admin}')
+    console.print(f'  Version:              {cfg.version}')
+    console.print(f'  Halted:               {"yes" if cfg.halted else "no"}')
+    console.print(f'  Consensus threshold:  {cfg.consensus_threshold_percent}%')
+    console.print(f'  Reservation fee:      {from_lamports(cfg.reservation_fee_lamports):.6f} SOL')
+    console.print(f'  Min collateral:       {from_lamports(cfg.min_collateral):.4f} SOL')
+    console.print(f'  Max collateral:       {_sol_or(cfg.max_collateral, "unlimited")}')
+    console.print(f'  Min swap amount:      {_sol_or(cfg.min_swap_amount, "no minimum")}')
+    console.print(f'  Max swap amount:      {_sol_or(cfg.max_swap_amount, "no maximum")}')
+    console.print(f'  Fulfillment timeout:  {secs_str(cfg.fulfillment_timeout_secs)}')
+    console.print(f'  Reservation TTL:      {secs_str(cfg.reservation_ttl_secs)}')
+    console.print(f'  Pool window:          {secs_str(cfg.pool_window_secs)}')
+    console.print(f'  Weights interval:     {secs_str(cfg.weights_update_min_interval_secs)}')
+    console.print(f'  Max total extension:  {secs_str(cfg.max_total_extension_secs)}')
+    console.print(f'  Validators:           {len(cfg.validators)}\n')
 
 
 @view_group.command('validators')
 def view_validators():
-    """List the registered validators and their weights."""
-    taker_view_unavailable('`view validators`')
+    """List the registered validators with their lottery weights and the consensus threshold."""
+    cfg = _read_config()
+    if cfg is None:
+        return
+    console.print('\n[bold]Validators[/bold]\n')
+    console.print(f'  Consensus threshold: {cfg.consensus_threshold_percent}%\n')
+    if not cfg.validators:
+        console.print('  [yellow]No validators registered.[/yellow]\n')
+        return
+    for v in cfg.validators:
+        console.print(f'  {Pubkey.from_bytes(bytes(v.key))}  weight={v.weight}')
+    console.print()
 
 
 @view_group.command('reservation')

--- a/allways/solana/client.py
+++ b/allways/solana/client.py
@@ -300,6 +300,18 @@ class AllwaysSolanaClient:
     def set_reservation_ttl(self, secs: int) -> str:
         return self._admin_config('set_reservation_ttl', layouts.IX_I64_ARGS.build({'value': secs}))
 
+    def set_reservation_fee(self, lamports: int) -> str:
+        return self._admin_config('set_reservation_fee', layouts.IX_AMOUNT_ARGS.build({'amount': lamports}))
+
+    def set_pool_window(self, secs: int) -> str:
+        return self._admin_config('set_pool_window', layouts.IX_I64_ARGS.build({'value': secs}))
+
+    def set_weights_update_min_interval(self, secs: int) -> str:
+        return self._admin_config('set_weights_update_min_interval', layouts.IX_I64_ARGS.build({'value': secs}))
+
+    def set_max_total_extension(self, secs: int) -> str:
+        return self._admin_config('set_max_total_extension', layouts.IX_I64_ARGS.build({'value': secs}))
+
     def withdraw_treasury(self, recipient, amount: int) -> str:
         """Admin: move accrued protocol fees from the Treasury PDA to `recipient`."""
         admin = self.keypair.pubkey()

--- a/allways/solana/layouts.py
+++ b/allways/solana/layouts.py
@@ -229,6 +229,11 @@ IX_DISCRIMINATORS = {
     'set_min_swap_amount': bytes([189, 59, 139, 62, 167, 12, 58, 88]),
     'set_reservation_ttl': bytes([108, 189, 90, 167, 113, 34, 82, 140]),
     'withdraw_treasury': bytes([40, 63, 122, 158, 144, 216, 83, 96]),
+    # D6 — remaining admin levers (single scalar each, reusing IX_AMOUNT_ARGS u64 / IX_I64_ARGS i64).
+    'set_reservation_fee': bytes([58, 32, 204, 143, 35, 61, 70, 115]),
+    'set_pool_window': bytes([250, 90, 55, 0, 118, 48, 94, 204]),
+    'set_weights_update_min_interval': bytes([185, 134, 117, 75, 73, 184, 80, 123]),
+    'set_max_total_extension': bytes([185, 183, 148, 252, 204, 128, 7, 24]),
     # Phase 9 — swap intake (reservation-lottery pool).
     'open_or_request': bytes([174, 133, 208, 178, 0, 117, 73, 12]),
     'resolve_pool': bytes([191, 164, 190, 142, 178, 198, 162, 249]),  # no args (empty body)

--- a/tests/test_cli_admin_solana.py
+++ b/tests/test_cli_admin_solana.py
@@ -89,28 +89,6 @@ def test_halt_skips_when_already_halted(monkeypatch):
     client.set_halted.assert_not_called()
 
 
-def test_set_halted_on_calls_set_halted_true(monkeypatch):
-    client = MagicMock()
-    client.get_config.return_value = _config(halted=False)
-    _patch_client(monkeypatch, client)
-
-    result = CliRunner().invoke(admin.admin_group, ['set-halted', 'on'], input='y\n')
-
-    assert result.exit_code == 0, result.output
-    client.set_halted.assert_called_once_with(True)
-
-
-def test_set_halted_off_calls_set_halted_false(monkeypatch):
-    client = MagicMock()
-    client.get_config.return_value = _config(halted=True)
-    _patch_client(monkeypatch, client)
-
-    result = CliRunner().invoke(admin.admin_group, ['set-halted', 'off'], input='y\n')
-
-    assert result.exit_code == 0, result.output
-    client.set_halted.assert_called_once_with(False)
-
-
 def test_set_reservation_fee_converts_sol_to_lamports(monkeypatch):
     client = MagicMock()
     client.get_config.return_value = _config(reservation_fee_lamports=0)

--- a/tests/test_cli_admin_solana.py
+++ b/tests/test_cli_admin_solana.py
@@ -19,6 +19,10 @@ def _config(**over):
         min_swap_amount=0,
         max_swap_amount=0,
         halted=False,
+        reservation_fee_lamports=0,
+        pool_window_secs=60,
+        weights_update_min_interval_secs=1200,
+        max_total_extension_secs=3600,
         validators=[],
     )
     fields.update(over)
@@ -83,3 +87,69 @@ def test_halt_skips_when_already_halted(monkeypatch):
     assert result.exit_code == 0
     assert 'already halted' in result.output
     client.set_halted.assert_not_called()
+
+
+def test_set_halted_on_calls_set_halted_true(monkeypatch):
+    client = MagicMock()
+    client.get_config.return_value = _config(halted=False)
+    _patch_client(monkeypatch, client)
+
+    result = CliRunner().invoke(admin.admin_group, ['set-halted', 'on'], input='y\n')
+
+    assert result.exit_code == 0, result.output
+    client.set_halted.assert_called_once_with(True)
+
+
+def test_set_halted_off_calls_set_halted_false(monkeypatch):
+    client = MagicMock()
+    client.get_config.return_value = _config(halted=True)
+    _patch_client(monkeypatch, client)
+
+    result = CliRunner().invoke(admin.admin_group, ['set-halted', 'off'], input='y\n')
+
+    assert result.exit_code == 0, result.output
+    client.set_halted.assert_called_once_with(False)
+
+
+def test_set_reservation_fee_converts_sol_to_lamports(monkeypatch):
+    client = MagicMock()
+    client.get_config.return_value = _config(reservation_fee_lamports=0)
+    _patch_client(monkeypatch, client)
+
+    result = CliRunner().invoke(admin.admin_group, ['set-reservation-fee', '0.001'], input='y\n')
+
+    assert result.exit_code == 0, result.output
+    client.set_reservation_fee.assert_called_once_with(1_000_000)
+
+
+def test_set_pool_window_passes_seconds(monkeypatch):
+    client = MagicMock()
+    client.get_config.return_value = _config(pool_window_secs=60)
+    _patch_client(monkeypatch, client)
+
+    result = CliRunner().invoke(admin.admin_group, ['set-pool-window', '120'], input='y\n')
+
+    assert result.exit_code == 0, result.output
+    client.set_pool_window.assert_called_once_with(120)
+
+
+def test_set_weights_interval_passes_seconds(monkeypatch):
+    client = MagicMock()
+    client.get_config.return_value = _config(weights_update_min_interval_secs=1200)
+    _patch_client(monkeypatch, client)
+
+    result = CliRunner().invoke(admin.admin_group, ['set-weights-interval', '900'], input='y\n')
+
+    assert result.exit_code == 0, result.output
+    client.set_weights_update_min_interval.assert_called_once_with(900)
+
+
+def test_set_max_extension_passes_seconds(monkeypatch):
+    client = MagicMock()
+    client.get_config.return_value = _config(max_total_extension_secs=3600)
+    _patch_client(monkeypatch, client)
+
+    result = CliRunner().invoke(admin.admin_group, ['set-max-extension', '7200'], input='y\n')
+
+    assert result.exit_code == 0, result.output
+    client.set_max_total_extension.assert_called_once_with(7200)

--- a/tests/test_cli_view_solana.py
+++ b/tests/test_cli_view_solana.py
@@ -1,0 +1,86 @@
+"""D6 — `alw view config` / `alw view validators` render the on-chain Config (mocked, no chain)."""
+
+import types
+from unittest.mock import MagicMock
+
+from click.testing import CliRunner
+from solders.keypair import Keypair
+
+from allways.cli.swap_commands import view
+
+
+def _config(**over):
+    fields = dict(
+        admin=Keypair().pubkey(),
+        version=1,
+        consensus_threshold_percent=51,
+        fulfillment_timeout_secs=600,
+        reservation_ttl_secs=600,
+        min_collateral=2_000_000_000,
+        max_collateral=0,
+        min_swap_amount=0,
+        max_swap_amount=0,
+        halted=False,
+        reservation_fee_lamports=1_000_000,
+        pool_window_secs=60,
+        weights_update_min_interval_secs=1200,
+        max_total_extension_secs=3600,
+        validators=[],
+    )
+    fields.update(over)
+    return types.SimpleNamespace(**fields)
+
+
+def _patch_client(monkeypatch, client):
+    monkeypatch.setattr(view, 'get_solana_cli_context', lambda need_keypair=True: ({}, client))
+
+
+def test_view_config_renders_every_field(monkeypatch):
+    client = MagicMock()
+    client.get_config.return_value = _config()
+    _patch_client(monkeypatch, client)
+
+    result = CliRunner().invoke(view.view_group, ['config'])
+
+    assert result.exit_code == 0, result.output
+    for label in ('Halted:', 'Consensus threshold:', 'Reservation fee:', 'Pool window:', 'Max total extension:'):
+        assert label in result.output
+    assert '51%' in result.output
+    assert '0.001000 SOL' in result.output  # reservation fee in SOL
+
+
+def test_view_config_reports_uninitialized(monkeypatch):
+    client = MagicMock()
+    client.get_config.return_value = None
+    _patch_client(monkeypatch, client)
+
+    result = CliRunner().invoke(view.view_group, ['config'])
+
+    assert result.exit_code == 0, result.output
+    assert 'not initialized' in result.output
+
+
+def test_view_validators_lists_pubkeys_and_weights(monkeypatch):
+    v = Keypair().pubkey()
+    vinfo = types.SimpleNamespace(key=bytes(v), weight=3)
+    client = MagicMock()
+    client.get_config.return_value = _config(validators=[vinfo], consensus_threshold_percent=67)
+    _patch_client(monkeypatch, client)
+
+    result = CliRunner().invoke(view.view_group, ['validators'])
+
+    assert result.exit_code == 0, result.output
+    assert str(v) in result.output
+    assert 'weight=3' in result.output
+    assert '67%' in result.output
+
+
+def test_view_validators_handles_empty_set(monkeypatch):
+    client = MagicMock()
+    client.get_config.return_value = _config(validators=[])
+    _patch_client(monkeypatch, client)
+
+    result = CliRunner().invoke(view.view_group, ['validators'])
+
+    assert result.exit_code == 0, result.output
+    assert 'No validators registered' in result.output

--- a/tests/test_solana_d6_builders.py
+++ b/tests/test_solana_d6_builders.py
@@ -1,0 +1,78 @@
+"""D6 — unit tests for the remaining admin-lever builders (set_reservation_fee/pool_window/
+weights_update_min_interval/max_total_extension). Same approach as test_solana_b4_builders: no chain —
+`_send` is stubbed, each discriminator is independently recomputed via sha256("global:<name>")[:8], and the
+Context<AdminConfig> meta order (admin signer + config mut) must match instructions/admin.rs.
+"""
+
+import hashlib
+
+import pytest
+from solders.keypair import Keypair
+
+from allways.solana import layouts, pdas
+from allways.solana.client import AllwaysSolanaClient
+
+PID = pdas.PROGRAM_ID
+
+
+def _global_disc(name: str) -> bytes:
+    return hashlib.sha256(f'global:{name}'.encode()).digest()[:8]
+
+
+@pytest.fixture
+def client():
+    c = AllwaysSolanaClient('http://localhost:9', keypair=Keypair())
+    cap = {}
+
+    def fake_send(ixs, **kw):
+        cap['ixs'] = ixs
+        return 'SIG'
+
+    c._send = fake_send
+    c._cap = cap
+    return c
+
+
+def test_d6_discriminators_match_anchor_global_formula():
+    for name in (
+        'set_reservation_fee',
+        'set_pool_window',
+        'set_weights_update_min_interval',
+        'set_max_total_extension',
+    ):
+        assert layouts.IX_DISCRIMINATORS[name] == _global_disc(name), f'{name} ix discriminator mismatch'
+
+
+@pytest.mark.parametrize(
+    'call, ix_name, body',
+    [
+        (
+            lambda c: c.set_reservation_fee(5_000),
+            'set_reservation_fee',
+            layouts.IX_AMOUNT_ARGS.build({'amount': 5_000}),
+        ),
+        (lambda c: c.set_pool_window(60), 'set_pool_window', layouts.IX_I64_ARGS.build({'value': 60})),
+        (
+            lambda c: c.set_weights_update_min_interval(1_200),
+            'set_weights_update_min_interval',
+            layouts.IX_I64_ARGS.build({'value': 1_200}),
+        ),
+        (
+            lambda c: c.set_max_total_extension(3_600),
+            'set_max_total_extension',
+            layouts.IX_I64_ARGS.build({'value': 3_600}),
+        ),
+    ],
+)
+def test_d6_admin_setters(client, call, ix_name, body):
+    call(client)
+    ixs = client._cap['ixs']
+    assert len(ixs) == 1
+    ix = ixs[0]
+    admin = client.keypair.pubkey()
+    assert ix.data[:8] == layouts.IX_DISCRIMINATORS[ix_name]
+    assert bytes(ix.data[8:]) == body
+    assert [(m.pubkey, m.is_signer, m.is_writable) for m in ix.accounts] == [
+        (admin, True, False),
+        (pdas.config_pda(PID), False, True),
+    ]


### PR DESCRIPTION
Closes the admin-setter parity gap between the Solana contract and the SDK/CLI (M3 D6).

## Client builders (allways/solana/client.py + layouts.py)
Four new `Context<AdminConfig>` setters, mirroring the existing `set_*` builders and reusing `IX_AMOUNT_ARGS` (u64) / `IX_I64_ARGS` (i64):
- `set_reservation_fee(lamports: u64)`
- `set_pool_window(secs: i64)`
- `set_weights_update_min_interval(secs: i64)`
- `set_max_total_extension(secs: i64)`

Discriminators via `sha256("global:<name>")[:8]` (formula verified against an existing setter).

## CLI setters (allways/cli/swap_commands/admin.py)
Four commands via the existing `_run_setter` + `@admin_group.command(show_disclaimer=True)` pattern:
- `set-reservation-fee <amount_sol>` (SOL float -> lamports)
- `set-pool-window <secs>`
- `set-weights-interval <secs>`
- `set-max-extension <secs>`

## Read-views (allways/cli/swap_commands/view.py)
- `alw view config` — dumps every current `Config` field. Replaces the now-redundant `view contract` stub (single source of truth for the config dump).
- `alw view validators` — each validator pubkey + lottery weight + consensus threshold.

The seconds formatter moved to `helpers.secs_str` so admin setters and view dumps share one source.

## Notes
- **Halt is not re-surfaced here.** It already exists as `alw admin danger halt` / `danger resume` (richer confirm/UX); a second `set-halted` command would be a duplicate halt surface, so it was dropped to keep one source of truth.
- `set_validator_weight` is **intentionally absent** — it is being removed from the contract in D9.
- Independent of other M3 items (client/CLI only; no contract changes).

## Tests
- `tests/test_solana_d6_builders.py` — discriminator + arg encoding + meta order for the 4 builders.
- `tests/test_cli_admin_solana.py` — the 4 new setters pass through correct units.
- `tests/test_cli_view_solana.py` — `view config`/`view validators` render against a mocked Config.

`pytest -q -m "not integration"`: green. `ruff format` + `ruff check`: clean.
