### PR TITLE
chore(deploy): mount a persistent Solana keypair into validator + miner

### DIFF
--- a/allways/solana/__init__.py
+++ b/allways/solana/__init__.py
@@ -1,8 +1,7 @@
 """Solana client for the allways_swap_manager program (B0 foundation).
 
 Hand-rolled + sync: `solders` (keys/tx primitives) + `borsh-construct` (account/arg layouts) over a
-thin JSON-RPC layer. The validator's sole on-chain client (the old ink!/Substrate client is gone). See
-smart-contracts/SOLANA_VALIDATOR_CHANGES.md (★ Validator rewrite roadmap → B0).
+thin JSON-RPC layer. The validator's sole on-chain client (the old ink!/Substrate client is gone).
 """
 
 from allways.solana.pdas import PROGRAM_ID

--- a/docker-compose.miner.yml
+++ b/docker-compose.miner.yml
@@ -11,6 +11,10 @@ services:
     volumes:
       - ${WALLET_PATH}:/root/.bittensor/wallets:ro
       - ./data/allways:/root/.allways
+      # Solana keypair (miner identity + collateral payer). Pre-provision
+      # ./data/solana/id.json and fund it; ro so a missing file errors loudly at startup
+      # instead of load_or_create silently minting a throwaway key.
+      - ./data/solana:/root/.solana:ro
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
 

--- a/docker-compose.vali.yml
+++ b/docker-compose.vali.yml
@@ -13,30 +13,13 @@ services:
     volumes:
       - ${WALLET_PATH}:/root/.bittensor/wallets:ro
       - ./data/allways:/root/.allways
+      - ./data/solana:/root/.solana:ro
     # optional: uncomment to write dashboard rows from the validator
     # (requires STORE_DB_RESULTS=true and DB_* vars in .env)
     # networks:
     #   - allways_network
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
-
-  btc-node:
-    image: bitcoin/bitcoin:28
-    container_name: aw-btc
-    restart: unless-stopped
-    mem_limit: "512m" # set to "4g" for initial BTC sync, then revert
-    # mem_limit: "4g"       # initial BTC sync — revert to 512m after sync completes
-    command:
-      - bitcoind
-      - -server
-      - -prune=5000 # keep ~5g worth of data on disk
-      - -rpcuser=${BTC_RPC_USER}
-      - -rpcpassword=${BTC_RPC_PASS}
-      - -rpcallowip=0.0.0.0/0
-      - -rpcbind=0.0.0.0
-      - -rpcport=8332
-    volumes:
-      - ./data/btc:/home/bitcoin/.bitcoin
 
   watchtower:
     image: nickfedor/watchtower


### PR DESCRIPTION
## What

Bind `./data/solana` → `/root/.solana` (read-only) in both the validator and miner compose files, mirroring how the Bittensor wallet is mounted.

## Why

The Solana keypair (`solana/keys.py`) is loaded via `load_or_create`: if the file is missing it **silently mints a new keypair and writes it to disk**. In an ephemeral container without a persisted mount, a restart regenerates a fresh pubkey — losing the miner/validator's on-chain identity, its posted collateral, and its `bind_hotkey` link.

Mounting an operator-provisioned `id.json` makes the key persistent. The `:ro` flag also turns a missing key into a loud fail-fast error at startup (the `write_text` in `load_or_create` hits a read-only FS) instead of a silent throwaway key.

## Operator step (pre-boot)

Provision and fund the key before `docker compose up`:

```bash
solana-keygen new -o ./data/solana/id.json
# fund the pubkey: rent + fees + 1.1x collateral (+ SOL-leg liquidity for miners)
```

Validator and miner must use **different** keypairs (the validator's pubkey goes in the on-chain `add_validator` whitelist; the miner's is what posts collateral and binds the hotkey).

## Also in this change

- Drop the now-unused `btc-node` service from the **validator** compose — validators run `BTC_MODE=lightweight` and don't need a local node.
- Remove a stale doc pointer in `solana/__init__.py`.

Targets `m3`.