### PR TITLE
chore(solana): Anchor.toml devnet/mainnet program entries

### DIFF
--- a/smart-contracts/solana/Anchor.toml
+++ b/smart-contracts/solana/Anchor.toml
@@ -8,6 +8,16 @@ skip-lint = false
 [programs.localnet]
 allways_swap_manager = "AKgfVK8zJVHuZwttdjU2CPykaHyTAvw5r9FUFUpM74JU"
 
+# Same program id across all clusters (persistent keypair in custody; see
+# alw-utils/dev-environment/solana/migration-runbook.md). deploy.sh drives the
+# cluster/wallet via --provider.cluster/--provider.wallet, so these are for
+# `anchor deploy --provider.cluster devnet` / IDL tooling parity.
+[programs.devnet]
+allways_swap_manager = "AKgfVK8zJVHuZwttdjU2CPykaHyTAvw5r9FUFUpM74JU"
+
+[programs.mainnet]
+allways_swap_manager = "AKgfVK8zJVHuZwttdjU2CPykaHyTAvw5r9FUFUpM74JU"
+
 [provider]
 cluster = "localnet"
 wallet = "~/.config/solana/allways-dev.json"


### PR DESCRIPTION
Adds `[programs.devnet]` and `[programs.mainnet]` entries to `smart-contracts/solana/Anchor.toml`, reusing the same program id (`AKgf…74JU`) across all clusters.

**Why:** so `anchor deploy --provider.cluster devnet|mainnet` and IDL/client tooling resolve the program address without per-cluster `declare_id!` swaps. Currently the file only has `[programs.localnet]`; the devnet/mainnet entries were missing.

Part of the local→devnet→mainnet deployment migration (deploy tooling lives in alw-utils). No code/behavior change — config only.