### PR TITLE
Slash truth at the seam + dashboard DB reconnect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ data/
 CLAUDE.md
 
 # Local tooling / scratch
+.full-e2e/
 .mcp.json
 *.md
 .vouch/

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -112,6 +112,11 @@ RATE_REFERENCE_TRIM_FRAC = 0.10  # drop the top & bottom 10% of weight before av
 RATE_REFERENCE_MINER_CAP_FRAC = 0.25  # cap any single miner at 25% of total reference weight
 RATE_REFERENCE_MIN_SWAPS = 5  # fewer positive-weight samples in-window ⇒ reference undefined ⇒ neutral
 
+# ─── Swap outcome retention ──────────────────────────────
+# Terminal completed/timed_out rows (seam stage truth after the swap PDA closes). Rows are
+# tiny and only queried while an offering still polls a finished swap — 7 days is generous.
+SWAP_OUTCOME_RETENTION_SECS = 7 * 86400
+
 # ─── Collateral ──────────────────────────────────────────
 # Collateral a miner must post to back a swap = sol_amount × this/10_000. Mirrors the contract's
 # COLLATERAL_REQUIREMENT_BPS (constants.rs) — keep in sync. 11_000 = 1.10×.

--- a/allways/validator/event_index.py
+++ b/allways/validator/event_index.py
@@ -7,7 +7,8 @@ this index persists them into the ``state_store`` event tables, attributing each
 its bound Bittensor hotkey at write time (B3.2). The crown math is unchanged — it consumes the same
 ``get_*_at`` / ``get_*_in_range`` shapes ``ContractEventWatcher`` exposed. ``SwapCompleted`` additionally
 persists its realized legs into ``clearing_rates`` (C-rev), the per-swap history the rate-quality reference
-is built from.
+is built from. ``SwapCompleted``/``SwapTimedOut`` also record the swap's terminal outcome into
+``swap_outcomes``, the seam's post-close completed-vs-slashed truth (terminal swap PDAs are closed on-chain).
 
 The axis is unix ``blockTime`` seconds (the ``block_num``/``block`` columns are repurposed), not substrate
 blocks. Reservation + swap lifecycle drive a per-miner ``MinerActivity`` machine (D4): ``PoolResolved``
@@ -32,6 +33,14 @@ _FULFILL_TRANSITIONS = {
     'SwapInitiated': ActivityTransition.FULFILL_START,
     'SwapCompleted': ActivityTransition.FULFILL_END,
     'SwapTimedOut': ActivityTransition.FULFILL_END,
+}
+
+# Terminal events → per-swap outcome persisted for the seam (reserve_engine._swap_stage):
+# terminal swap PDAs close on-chain, so this index is what disambiguates a slash from a
+# completion once the account is gone.
+_OUTCOME_BY_EVENT = {
+    'SwapCompleted': 'completed',
+    'SwapTimedOut': 'timed_out',
 }
 
 
@@ -77,6 +86,9 @@ class SolanaEventIndex:
             return self._apply_reservation(hotkey, block_time)
         if name in _FULFILL_TRANSITIONS:
             self.state_store.insert_activity_event(block_time, hotkey, _FULFILL_TRANSITIONS[name])
+            outcome = _OUTCOME_BY_EVENT.get(name)
+            if outcome is not None:
+                self.state_store.record_swap_outcome(bytes(rec.fields['swap_key']).hex(), outcome, block_time)
             # SwapCompleted is the only swap event carrying realized legs — persist
             # them as a clearing-rate sample for the C-rev quality reference, in
             # addition to closing the fulfillment above.

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -272,7 +272,13 @@ class SwapStatus:
     yet reports ``fulfilled`` — transient, normally resolving within ~one forward step once the
     terminal event is ingested. Consumers keep polling on ``fulfilled`` and should apply their
     own reconcile deadline: in the wiped-state.db + RPC-pruned edge the outcome never lands, and
-    the validator won't guess terminal truth it hasn't ingested (see ``_swap_stage``)."""
+    the validator won't guess terminal truth it hasn't ingested (see ``_swap_stage``).
+
+    Resolution: the consumer passes the ``swap_key`` it persisted at claim time to resolve the
+    swap directly — required for post-attestation stages, because ``vote_initiate`` consumes
+    the reservation at attestation quorum, so the reservation stops referencing the swap the
+    moment it goes ``active``. Without ``swap_key``, resolution walks the miner's reservation
+    and only the pre-attestation stages (``none``/``reserved``/``claimed``) are reliably visible."""
 
     stage: str  # none | reserved | claimed | active | fulfilled | completed | timed_out
     reserved_until: int = 0
@@ -281,8 +287,13 @@ class SwapStatus:
     detail: dict = field(default_factory=dict)
 
 
-def swap_status(validator, miner_hotkey: str) -> SwapStatus:
-    """Current lifecycle stage for a miner's live reservation/swap — the offering polls this."""
+def swap_status(validator, miner_hotkey: str, swap_key_hex: str = '') -> SwapStatus:
+    """Current lifecycle stage for a reservation/swap — the offering polls this.
+
+    With ``swap_key_hex`` the swap resolves by key (survives the reservation being consumed at
+    attestation quorum); without it, via the miner's live reservation (pre-attestation stages)."""
+    if swap_key_hex:
+        return _swap_status_by_key(validator, swap_key_hex)
     client = validator.solana_client
     miner_pk = resolve_miner_pubkey(validator, miner_hotkey)
     if miner_pk is None:
@@ -304,6 +315,28 @@ def swap_status(validator, miner_hotkey: str) -> SwapStatus:
     swap = client.get_swap(swap_key)
     stage = _swap_stage(validator, swap, swap_key)
     return SwapStatus(stage, reservation.reserved_until, str(reservation.user), swap_key.hex(), detail)
+
+
+def _swap_status_by_key(validator, swap_key_hex: str) -> SwapStatus:
+    """Resolve directly by swap_key: a live PDA's status maps as usual; a closed PDA goes through
+    the ``swap_outcomes`` disambiguation. ``reserved_until`` is 0 here — the reservation is
+    already consumed (or irrelevant) once the consumer polls by key."""
+    swap_key = bytes.fromhex(swap_key_hex)  # bad hex raises ValueError → seam answers 400
+    if len(swap_key) != 32:
+        raise ValueError('swap_key must be 32 bytes hex')
+    swap = validator.solana_client.get_swap(swap_key)
+    stage = _swap_stage(validator, swap, swap_key)
+    if swap is None:
+        return SwapStatus(stage, swap_key=swap_key_hex)
+    # Same detail shape as the reservation path — the Swap PDA carries the full legs.
+    detail = {
+        'from_chain': swap.from_chain,
+        'to_chain': swap.to_chain,
+        'from_amount': int(swap.from_amount),
+        'to_amount': int(swap.to_amount),
+        'miner_from_addr': swap.miner_from_addr,
+    }
+    return SwapStatus(stage, 0, str(swap.user), swap_key_hex, detail)
 
 
 # On-chain Swap.status is a borsh enum object; map by its variant name (not int()).

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -266,10 +266,13 @@ class SwapStatus:
 
     none → reserved → claimed → active → fulfilled → { completed | timed_out }
 
-    ``completed`` and ``timed_out`` are terminal. ``timed_out`` means the miner was slashed;
-    it is sourced from the live PDA status or, after the terminal PDA closes, from the
-    validator's ``swap_outcomes`` event index. A closed PDA whose swap_key is absent from
-    that index degrades to ``completed`` (see ``_swap_stage``)."""
+    ``completed`` and ``timed_out`` are terminal; ``timed_out`` means the miner was slashed.
+    Both are sourced from the live PDA status or, after the terminal PDA closes on-chain, from
+    the validator's ``swap_outcomes`` event index. A closed PDA whose outcome isn't recorded
+    yet reports ``fulfilled`` — transient, normally resolving within ~one forward step once the
+    terminal event is ingested. Consumers keep polling on ``fulfilled`` and should apply their
+    own reconcile deadline: in the wiped-state.db + RPC-pruned edge the outcome never lands, and
+    the validator won't guess terminal truth it hasn't ingested (see ``_swap_stage``)."""
 
     stage: str  # none | reserved | claimed | active | fulfilled | completed | timed_out
     reserved_until: int = 0
@@ -317,10 +320,11 @@ def _swap_stage(validator, swap, swap_key: bytes) -> str:
     """Stage for a claimed swap. A closed PDA is terminal, but Completed and TimedOut swaps both
     close on-chain, so the on-chain account alone can't tell a completion from a slash — the
     validator's own event index (``swap_outcomes``, written on SwapCompleted/SwapTimedOut ingest)
-    disambiguates. An unknown swap_key (validator restarted with no local history and the RPC
-    pruned the signatures before ingest) falls back to ``completed``: the overwhelmingly common
-    terminal outcome, and the seam must return *some* terminal stage so the offering stops polling."""
+    disambiguates. On an outcome miss, fall back NON-terminal to ``fulfilled``: the miss is
+    normally ingest lag (another validator's quorum closed the PDA since our last forward-step
+    ingest) and self-corrects at the next ingest, whereas a terminal guess would stop the
+    consumer polling on a wrong answer — for a slash, exactly the bug this index exists to fix."""
     if swap is None:
         outcome = validator.state_store.get_swap_outcome(swap_key.hex())
-        return outcome or 'completed'
+        return outcome or 'fulfilled'
     return _STAGE_BY_NAME.get(type(getattr(swap, 'status', None)).__name__, 'claimed')

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -262,6 +262,15 @@ def _miner_hotkey_for(validator, miner_pk) -> Optional[str]:
 
 @dataclass
 class SwapStatus:
+    """Seam ``/status`` payload. ``stage`` is the offering-facing lifecycle enum:
+
+    none → reserved → claimed → active → fulfilled → { completed | timed_out }
+
+    ``completed`` and ``timed_out`` are terminal. ``timed_out`` means the miner was slashed;
+    it is sourced from the live PDA status or, after the terminal PDA closes, from the
+    validator's ``swap_outcomes`` event index. A closed PDA whose swap_key is absent from
+    that index degrades to ``completed`` (see ``_swap_stage``)."""
+
     stage: str  # none | reserved | claimed | active | fulfilled | completed | timed_out
     reserved_until: int = 0
     user: str = ''
@@ -290,7 +299,8 @@ def swap_status(validator, miner_hotkey: str) -> SwapStatus:
     if swap_key == EMPTY_SWAP_KEY:
         return SwapStatus('reserved', reservation.reserved_until, str(reservation.user), detail=detail)
     swap = client.get_swap(swap_key)
-    return SwapStatus(_swap_stage(swap), reservation.reserved_until, str(reservation.user), swap_key.hex(), detail)
+    stage = _swap_stage(validator, swap, swap_key)
+    return SwapStatus(stage, reservation.reserved_until, str(reservation.user), swap_key.hex(), detail)
 
 
 # On-chain Swap.status is a borsh enum object; map by its variant name (not int()).
@@ -303,9 +313,14 @@ _STAGE_BY_NAME = {
 }
 
 
-def _swap_stage(swap) -> str:
-    # A claimed swap whose PDA has closed is terminal — treat as completed (happy path; slash/timeout
-    # disambiguation via miner counters is a later refinement).
+def _swap_stage(validator, swap, swap_key: bytes) -> str:
+    """Stage for a claimed swap. A closed PDA is terminal, but Completed and TimedOut swaps both
+    close on-chain, so the on-chain account alone can't tell a completion from a slash — the
+    validator's own event index (``swap_outcomes``, written on SwapCompleted/SwapTimedOut ingest)
+    disambiguates. An unknown swap_key (validator restarted with no local history and the RPC
+    pruned the signatures before ingest) falls back to ``completed``: the overwhelmingly common
+    terminal outcome, and the seam must return *some* terminal stage so the offering stops polling."""
     if swap is None:
-        return 'completed'
+        outcome = validator.state_store.get_swap_outcome(swap_key.hex())
+        return outcome or 'completed'
     return _STAGE_BY_NAME.get(type(getattr(swap, 'status', None)).__name__, 'claimed')

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -46,6 +46,7 @@ from allways.constants import (
     REWARD_WEIGHT_QUALITY_VOLUME,
     SCORING_WINDOW_BLOCKS,
     SCORING_WINDOW_SECS,
+    SWAP_OUTCOME_RETENTION_SECS,
     VOLUME_WEIGHT_ALPHA,
 )
 from allways.utils.rate import is_executable_rate, min_executable_sol_leg
@@ -175,6 +176,7 @@ def prune_crown_events(self: Validator, current_time: int) -> None:
     # so it has its own, later horizon — pruning it at the 1h crown cutoff would
     # starve the reference.
     self.state_store.prune_clearing_rates(current_time - RATE_REFERENCE_WINDOW_SECS)
+    self.state_store.prune_swap_outcomes(current_time - SWAP_OUTCOME_RETENTION_SECS)
 
 
 def is_eligible(miner_state) -> bool:
@@ -1025,9 +1027,7 @@ def snapshot_current_crown_holders(
         if holders:
             share = 1.0 / len(holders)
             rate = rates.get(holders[0], 0.0)
-            rows_by_direction[(from_chain, to_chain)] = [
-                (from_chain, to_chain, hk, share, rate, ts) for hk in holders
-            ]
+            rows_by_direction[(from_chain, to_chain)] = [(from_chain, to_chain, hk, share, rate, ts) for hk in holders]
         else:
             rows_by_direction[(from_chain, to_chain)] = []
     return rows_by_direction

--- a/allways/validator/seam_http.py
+++ b/allways/validator/seam_http.py
@@ -53,7 +53,10 @@ def _make_handler(validator, secret: str):
                         return self._send(404, {'error': 'no executable quote for that pair/amount'})
                     return self._send(200, bq.__dict__)
                 if url.path == '/status':
-                    return self._send(200, swap_status(validator, q['miner_hotkey']).__dict__)
+                    # Optional swap_key (hex, persisted by the consumer at claim time) resolves the
+                    # swap directly — the only route to post-attestation stages, since vote_initiate
+                    # consumes the reservation at quorum.
+                    return self._send(200, swap_status(validator, q['miner_hotkey'], q.get('swap_key', '')).__dict__)
                 if url.path == '/health':
                     return self._send(200, {'ok': True})
             except (KeyError, ValueError) as e:

--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -4,7 +4,9 @@ Tables: ``rate_events`` + ``active_events`` + ``activity_events`` +
 ``collateral_events`` (the crown-time event series, sourced from Solana program
 events via ``SolanaEventIndex`` and keyed by unix ``blockTime``),
 ``clearing_rates`` (per-swap realized history from ``SwapCompleted``, backing the
-C-rev rate-quality reference), and ``solana_event_meta`` (the event-ingest cursor).
+C-rev rate-quality reference), ``swap_outcomes`` (terminal completed/timed_out
+truth per swap_key, backing the seam's stage disambiguation after the swap PDA
+closes), and ``solana_event_meta`` (the event-ingest cursor).
 Single connection guarded by one lock; opened with ``check_same_thread=False``.
 ``busy_timeout`` is set before ``journal_mode=WAL`` because the WAL flip takes a
 brief exclusive lock that concurrent openers would otherwise hit as "database is
@@ -339,6 +341,30 @@ class ValidatorStateStore:
             return
         self._execute('DELETE FROM clearing_rates WHERE block_num < ?', (cutoff_block,))
 
+    # ─── swap_outcomes (terminal per-swap truth for the seam) ───────────
+
+    def record_swap_outcome(self, swap_key: str, outcome: str, block_time: int) -> None:
+        """Persist a swap's terminal outcome (``completed`` | ``timed_out``) keyed by
+        swap_key hex. Upsert: a cursor-reset re-ingest of the same event is a no-op."""
+        self._execute(
+            """
+            INSERT INTO swap_outcomes (swap_key, outcome, block_time) VALUES (?, ?, ?)
+            ON CONFLICT(swap_key) DO UPDATE SET outcome = excluded.outcome, block_time = excluded.block_time
+            """,
+            (swap_key, outcome, block_time),
+        )
+
+    def get_swap_outcome(self, swap_key: str) -> Optional[str]:
+        row = self._fetchone('SELECT outcome FROM swap_outcomes WHERE swap_key = ?', (swap_key,))
+        return row['outcome'] if row is not None else None
+
+    def prune_swap_outcomes(self, cutoff_block: int) -> None:
+        """Drop outcome rows older than ``cutoff_block``. No anchor row — each row is
+        an independent terminal fact, only queried while the offering still polls."""
+        if cutoff_block <= 0:
+            return
+        self._execute('DELETE FROM swap_outcomes WHERE block_time < ?', (cutoff_block,))
+
     def get_solana_event_cursor(self) -> Optional[str]:
         """Last ingested Solana tx signature (the SolanaEventIngest cursor).
         ``None`` on a fresh DB so the first poll starts from the prune horizon."""
@@ -558,6 +584,16 @@ class ValidatorStateStore:
                 );
                 CREATE INDEX IF NOT EXISTS idx_clearing_rates_dir_block
                     ON clearing_rates(from_chain, to_chain, block_num);
+
+                -- Terminal outcome per swap (SwapCompleted | SwapTimedOut), keyed by
+                -- swap_key hex. Terminal swap PDAs are closed on-chain, so this is the
+                -- seam's only way to tell a slash from a completion after close. Not
+                -- the old B3.5 scoring ledger — scoring reads on-chain counters.
+                CREATE TABLE IF NOT EXISTS swap_outcomes (
+                    swap_key    TEXT PRIMARY KEY,
+                    outcome     TEXT NOT NULL,
+                    block_time  INTEGER NOT NULL
+                );
 
                 CREATE TABLE IF NOT EXISTS solana_event_meta (
                     key     TEXT PRIMARY KEY,

--- a/allways/validator/storage/database.py
+++ b/allways/validator/storage/database.py
@@ -19,10 +19,20 @@ except ImportError:
 # statement_timeout cancels anything that blocks past this.
 STATEMENT_TIMEOUT_MS = 2000
 # Single connect attempt with the same 2s ceiling. If Postgres isn't
-# reachable at validator boot, storage stays disabled for the lifetime of
-# the process; caller (DatabaseStorage.__init__) logs the outcome and
-# proceeds with writes disabled.
+# reachable, this attempt fails fast; DatabaseStorage retries lazily on a
+# later write (rate-limited), so a slow-booting or restarted aw-db only
+# pauses dashboard writes instead of disabling them for the process.
 CONNECT_TIMEOUT_SEC = 2
+
+# psycopg exception class names that mean the connection itself is dead or unusable
+# (server restart, network drop, closed connection) — DatabaseStorage drops and lazily
+# reconnects on these. Matched by MRO class name rather than isinstance so the check
+# (and its tests) work even where psycopg isn't importable.
+_CONNECTION_ERROR_NAMES = frozenset({'OperationalError', 'InterfaceError'})
+
+
+def is_connection_failure(ex: Exception) -> bool:
+    return any(c.__name__ in _CONNECTION_ERROR_NAMES for c in type(ex).__mro__)
 
 
 def create_database_connection() -> Optional[Any]:

--- a/allways/validator/storage/storage.py
+++ b/allways/validator/storage/storage.py
@@ -6,13 +6,19 @@ disabled-state result.
 """
 
 import os
+import time
 from dataclasses import dataclass, field
 from typing import Dict, List, Tuple
 
 import bittensor as bt
 
-from .database import create_database_connection
+from .database import create_database_connection, is_connection_failure
 from .repository import Repository
+
+# Floor between reconnect attempts after a dropped/failed connection. Each attempt can
+# stall up to CONNECT_TIMEOUT_SEC, so a down aw-db costs one bounded stall per interval,
+# not one per write. The warning is rate-limited by the same clock.
+RECONNECT_MIN_INTERVAL_SEC = 30.0
 
 
 @dataclass
@@ -28,7 +34,9 @@ def _flag_enabled() -> bool:
 
 class DatabaseStorage:
     """Single connection per validator instance; one transactional flush per
-    scoring round. Caller decides what to pass in.
+    scoring round. Caller decides what to pass in. A dead connection (aw-db
+    restart, boot-order race) is dropped and lazily re-established on a later
+    write — failures are logged, never raised into the forward loop.
 
     Methods accept already-shaped row tuples — the validator's scoring code
     is responsible for producing them, not this class. That keeps the
@@ -39,23 +47,70 @@ class DatabaseStorage:
         self.logger = bt.logging
         self.db_connection = None
         self.repo = None
+        self._enabled = _flag_enabled()
+        self._last_reconnect_attempt = 0.0
 
-        if not _flag_enabled():
+        if not self._enabled:
             bt.logging.info('STORE_DB_RESULTS not set — validator DB storage disabled')
             return
 
         bt.logging.info('STORE_DB_RESULTS=1 — connecting to Postgres for dashboard writes')
-        self.db_connection = create_database_connection()
-        if self.db_connection is not None:
-            self.repo = Repository(self.db_connection)
+        if self._connect():
             bt.logging.success('Validator DB storage enabled')
         else:
             bt.logging.error(
-                'STORE_DB_RESULTS=1 but Postgres connection failed — dashboard writes disabled for this process'
+                'STORE_DB_RESULTS=1 but Postgres connection failed — dashboard writes paused until reconnect'
             )
 
     def is_enabled(self) -> bool:
         return self.db_connection is not None and self.repo is not None
+
+    def _connect(self) -> bool:
+        self.db_connection = create_database_connection()
+        self.repo = Repository(self.db_connection) if self.db_connection is not None else None
+        return self.is_enabled()
+
+    def _ensure_connection(self) -> bool:
+        """Lazy reconnect for a dropped (or never-established) connection, at most once per
+        RECONNECT_MIN_INTERVAL_SEC. Called at the top of every write so a restarted aw-db
+        heals without a validator restart."""
+        if not self._enabled:
+            return False
+        if self.is_enabled():
+            return True
+        now = time.monotonic()
+        if now - self._last_reconnect_attempt < RECONNECT_MIN_INTERVAL_SEC:
+            return False
+        self._last_reconnect_attempt = now
+        bt.logging.warning('Dashboard DB connection is down — attempting reconnect')
+        if self._connect():
+            bt.logging.success('Dashboard DB connection re-established')
+            return True
+        return False
+
+    def _drop_connection(self) -> None:
+        try:
+            if self.db_connection is not None:
+                self.db_connection.close()
+        except Exception:
+            pass
+        self.db_connection = None
+        self.repo = None
+
+    def _handle_write_failure(self, ex: Exception, context: str) -> str:
+        """Best-effort rollback, then drop the connection on connection-class failures so the
+        next write reconnects. Never raises — dashboard writes must not kill the forward loop."""
+        if self.db_connection is not None:
+            try:
+                self.db_connection.rollback()
+                self.db_connection.autocommit = True
+            except Exception:
+                pass
+        if is_connection_failure(ex):
+            self._drop_connection()
+        msg = f'{context}: {ex}'
+        self.logger.error(msg)
+        return msg
 
     def flush_scoring_window(
         self,
@@ -78,7 +133,7 @@ class DatabaseStorage:
         Failure on any write rolls back the whole window — the cursor is
         never left ahead of (or behind) the rows it describes.
         """
-        if not self.is_enabled():
+        if not self._ensure_connection():
             return StorageResult(success=False, errors=['Validator DB storage not enabled'])
 
         result = StorageResult(success=True)
@@ -105,13 +160,8 @@ class DatabaseStorage:
             self.db_connection.autocommit = True
 
         except Exception as ex:
-            if self.db_connection is not None:
-                self.db_connection.rollback()
-                self.db_connection.autocommit = True
-            error_msg = f'Failed to flush scoring window to DB: {ex}'
             result.success = False
-            result.errors.append(error_msg)
-            self.logger.error(error_msg)
+            result.errors.append(self._handle_write_failure(ex, 'Failed to flush scoring window to DB'))
 
         return result
 
@@ -136,7 +186,7 @@ class DatabaseStorage:
         ``[window_start, window_end)`` is the unix-second range to clear per
         direction. ``max_ts`` advances both sync_cursor watermarks.
         """
-        if not self.is_enabled():
+        if not self._ensure_connection():
             return StorageResult(success=False, errors=['Validator DB storage not enabled'])
 
         result = StorageResult(success=True)
@@ -154,16 +204,8 @@ class DatabaseStorage:
             self.db_connection.autocommit = True
 
         except Exception as ex:
-            if self.db_connection is not None:
-                try:
-                    self.db_connection.rollback()
-                except Exception:
-                    pass
-                self.db_connection.autocommit = True
-            error_msg = f'Failed to flush halt window to DB: {ex}'
             result.success = False
-            result.errors.append(error_msg)
-            self.logger.error(error_msg)
+            result.errors.append(self._handle_write_failure(ex, 'Failed to flush halt window to DB'))
 
         return result
 
@@ -182,7 +224,7 @@ class DatabaseStorage:
         rate, ts)``. Empty list for a direction means "no qualifying
         holder right now" — that direction's rows are cleared.
         """
-        if not self.is_enabled():
+        if not self._ensure_connection():
             return StorageResult(success=False, errors=['Validator DB storage not enabled'])
 
         result = StorageResult(success=True)
@@ -194,16 +236,8 @@ class DatabaseStorage:
             self.db_connection.autocommit = True
             result.stored_counts['current_crown_holders'] = count
         except Exception as ex:
-            if self.db_connection is not None:
-                try:
-                    self.db_connection.rollback()
-                except Exception:
-                    pass
-                self.db_connection.autocommit = True
-            error_msg = f'Failed to upsert current_crown_holders: {ex}'
             result.success = False
-            result.errors.append(error_msg)
-            self.logger.error(error_msg)
+            result.errors.append(self._handle_write_failure(ex, 'Failed to upsert current_crown_holders'))
 
         return result
 

--- a/allways/validator/storage/storage.py
+++ b/allways/validator/storage/storage.py
@@ -63,12 +63,18 @@ class DatabaseStorage:
             )
 
     def is_enabled(self) -> bool:
+        """Storage is configured (STORE_DB_RESULTS set) — the callers' gate. Deliberately NOT
+        "connection currently live": the write methods own connection state (drop + lazy
+        redial), so a dead connection must still reach them or reconnect would be unreachable."""
+        return self._enabled
+
+    def _connected(self) -> bool:
         return self.db_connection is not None and self.repo is not None
 
     def _connect(self) -> bool:
         self.db_connection = create_database_connection()
         self.repo = Repository(self.db_connection) if self.db_connection is not None else None
-        return self.is_enabled()
+        return self._connected()
 
     def _ensure_connection(self) -> bool:
         """Lazy reconnect for a dropped (or never-established) connection, at most once per
@@ -76,7 +82,7 @@ class DatabaseStorage:
         heals without a validator restart."""
         if not self._enabled:
             return False
-        if self.is_enabled():
+        if self._connected():
             return True
         now = time.monotonic()
         if now - self._last_reconnect_attempt < RECONNECT_MIN_INTERVAL_SEC:

--- a/tests/test_event_index.py
+++ b/tests/test_event_index.py
@@ -16,8 +16,13 @@ ATTR = {'pk_a': 'hk_a', 'pk_b': 'hk_b'}
 RESERVATION_TTL = 300
 
 
+DEFAULT_SWAP_KEY = b'\x2a' * 32
+
+
 def rec(name: str, *, miner: str = 'pk_a', block_time, slot: int = 0, **fields) -> EventRecord:
-    fields = {'miner': miner, **fields}
+    # swap_key defaults so swap-lifecycle recs match the on-chain layouts (Hash32); harmless extra
+    # field on events that don't carry one.
+    fields = {'miner': miner, 'swap_key': DEFAULT_SWAP_KEY, **fields}
     return EventRecord(name=name, fields=fields, slot=slot, block_time=block_time, signature=f'sig{slot}')
 
 
@@ -331,6 +336,63 @@ class TestIngestClearingRate:
         store.prune_clearing_rates(500)
         blocks = [r['block'] for r in store.get_clearing_rates_in_range('btc', 'tao', 0, 1000)]
         assert blocks == [900]  # no anchor preservation — old sample is gone
+        store.close()
+
+
+class TestIngestSwapOutcomes:
+    def test_swap_completed_records_completed_outcome(self, tmp_path: Path):
+        store = make_store(tmp_path)
+        idx = SolanaEventIndex(store)
+        key = bytes(range(32))
+        idx.ingest(
+            [
+                rec(
+                    'SwapCompleted',
+                    miner='pk_a',
+                    block_time=400,
+                    swap_key=key,
+                    from_chain='btc',
+                    to_chain='tao',
+                    from_amount=100_000,
+                    to_amount=500_000_000,
+                )
+            ],
+            ATTR,
+        )
+        assert store.get_swap_outcome(key.hex()) == 'completed'
+        store.close()
+
+    def test_swap_timed_out_records_timed_out_outcome(self, tmp_path: Path):
+        store = make_store(tmp_path)
+        idx = SolanaEventIndex(store)
+        key = bytes(range(32))
+        idx.ingest(
+            [rec('SwapTimedOut', miner='pk_a', block_time=400, swap_key=key, sol_amount=10, slash=1)],
+            ATTR,
+        )
+        assert store.get_swap_outcome(key.hex()) == 'timed_out'
+        assert store.get_swap_outcome(DEFAULT_SWAP_KEY.hex()) is None  # only the event's key lands
+        store.close()
+
+    def test_reingest_of_same_event_is_a_noop_upsert(self, tmp_path: Path):
+        """A cursor reset can replay history — the outcome row upserts instead of erroring."""
+        store = make_store(tmp_path)
+        idx = SolanaEventIndex(store)
+        key = bytes(range(32))
+        event = rec('SwapTimedOut', miner='pk_a', block_time=400, swap_key=key, sol_amount=10, slash=1)
+        idx.ingest([event], ATTR)
+        idx.ingest([event], ATTR)
+        assert store.get_swap_outcome(key.hex()) == 'timed_out'
+        store.close()
+
+    def test_prune_drops_old_outcomes(self, tmp_path: Path):
+        store = make_store(tmp_path)
+        old, recent = b'\x01' * 32, b'\x02' * 32
+        store.record_swap_outcome(old.hex(), 'completed', 100)
+        store.record_swap_outcome(recent.hex(), 'timed_out', 900)
+        store.prune_swap_outcomes(500)
+        assert store.get_swap_outcome(old.hex()) is None
+        assert store.get_swap_outcome(recent.hex()) == 'timed_out'
         store.close()
 
 

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -185,13 +185,15 @@ def test_closed_pda_with_recorded_completion_reports_completed(tmp_path):
     store.close()
 
 
-def test_closed_pda_with_unknown_key_falls_back_to_completed(tmp_path):
-    # Validator restarted with no local history + RPC pruned before ingest: the seam
-    # still returns a terminal stage so the offering stops polling.
+def test_closed_pda_with_unrecorded_outcome_reports_fulfilled(tmp_path):
+    # Ingest lag: another validator's quorum closed the PDA but this validator hasn't
+    # ingested the terminal event yet. The fallback must be NON-terminal so the consumer
+    # keeps polling and picks up the real outcome next ingest — a 'completed' guess for a
+    # fresh slash would resurrect the original bug through a one-forward-step window.
     from allways.validator.reserve_engine import _swap_stage
 
     validator, store = _stage_validator(tmp_path)
-    assert _swap_stage(validator, None, b'\x03' * 32) == 'completed'
+    assert _swap_stage(validator, None, b'\x03' * 32) == 'fulfilled'
     store.close()
 
 

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -208,3 +208,97 @@ def test_live_pda_status_maps_by_variant_name(tmp_path):
         swap = SimpleNamespace(status=type(variant, (), {})())
         assert _swap_stage(validator, swap, key) == stage
     store.close()
+
+
+# ─── swap_status by swap_key (post-attestation resolution) ──────────────────
+# vote_initiate consumes the reservation at attestation quorum (reserved_until=0,
+# claimed_swap_key cleared), so post-attestation stages are only reachable by key —
+# the consumer persists the swap_key from /confirm and polls /status with it.
+
+
+class StatusClient:
+    """Minimal client for the status paths: swap-by-key + reservation + a valid binding."""
+
+    def __init__(self, swap=None, reservation=None):
+        self._swap = swap
+        self._reservation = reservation
+        self.swap_keys_queried = []
+
+    def get_swap(self, swap_key):
+        self.swap_keys_queried.append(swap_key)
+        return self._swap
+
+    def get_reservation(self, miner):
+        return self._reservation
+
+    def get_hotkey_binding(self, hotkey_bytes):
+        return SimpleNamespace(miner=MINER_PK)
+
+    def get_binding(self, miner):
+        return SimpleNamespace(miner=MINER_PK, hotkey=HOTKEY_BYTES, hotkey_sig=BINDING_SIG)
+
+
+def _live_swap(variant: str):
+    return SimpleNamespace(
+        status=type(variant, (), {})(),
+        user='userSOLpk',
+        from_chain='sol',
+        to_chain='btc',
+        from_amount=1_000_000_000,
+        to_amount=210_000,
+        miner_from_addr='minerSOLaddr',
+    )
+
+
+def _status_validator(tmp_path, client):
+    validator, store = _stage_validator(tmp_path)
+    validator.solana_client = client
+    return validator, store
+
+
+def test_initiated_swap_resolves_by_key_after_reservation_consumed(tmp_path):
+    from allways.validator.reserve_engine import swap_status
+
+    key = b'\x05' * 32
+    consumed = SimpleNamespace(reserved_until=0)  # vote_initiate zeroed it at quorum
+    client = StatusClient(swap=_live_swap('Active'), reservation=consumed)
+    validator, store = _status_validator(tmp_path, client)
+    assert swap_status(validator, HOTKEY).stage == 'none'  # reservation path is blind post-attestation
+    s = swap_status(validator, HOTKEY, key.hex())
+    assert s.stage == 'active' and s.swap_key == key.hex() and s.reserved_until == 0
+    assert s.detail['from_chain'] == 'sol' and s.detail['to_amount'] == 210_000
+    assert client.swap_keys_queried == [key]
+    store.close()
+
+
+def test_closed_pda_by_key_with_recorded_slash_reports_timed_out(tmp_path):
+    from allways.validator.reserve_engine import swap_status
+
+    key = b'\x06' * 32
+    validator, store = _status_validator(tmp_path, StatusClient(swap=None))
+    store.record_swap_outcome(key.hex(), 'timed_out', 100)
+    s = swap_status(validator, HOTKEY, key.hex())
+    assert s.stage == 'timed_out' and s.swap_key == key.hex() and s.detail == {}
+    store.close()
+
+
+def test_closed_pda_by_key_with_unrecorded_outcome_reports_fulfilled(tmp_path):
+    from allways.validator.reserve_engine import swap_status
+
+    validator, store = _status_validator(tmp_path, StatusClient(swap=None))
+    assert swap_status(validator, HOTKEY, (b'\x07' * 32).hex()).stage == 'fulfilled'
+    store.close()
+
+
+def test_malformed_swap_key_raises_value_error(tmp_path):
+    # Non-hex or wrong-length keys must raise ValueError (seam maps it to a 400).
+    from allways.validator.reserve_engine import swap_status
+
+    validator, store = _status_validator(tmp_path, StatusClient())
+    for bad in ('zz', 'abcd'):
+        try:
+            swap_status(validator, HOTKEY, bad)
+            assert False, f'expected ValueError for swap_key={bad!r}'
+        except ValueError:
+            pass
+    store.close()

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -104,8 +104,8 @@ def test_contract_rejection_returns_reject_not_raise():
 
     def _raise(*_a, **_k):
         raise RuntimeError(
-            "send failed: AnchorError ... Error Code: MinerReserved. Error Number: 6022. "
-            "Error Message: Miner already has an active reservation. custom program error: 0x1786"
+            'send failed: AnchorError ... Error Code: MinerReserved. Error Number: 6022. '
+            'Error Message: Miner already has an active reservation. custom program error: 0x1786'
         )
 
     client.open_or_request = _raise
@@ -150,3 +150,59 @@ def test_join_uses_pinned_pool_rate_not_live_quote():
     _, sol_amount, _, to_amount, _, _, _ = client.calls[0]
     # to_amount derived from pinned 0.0021 (≈ 0.0021 BTC for 1 SOL = 210000 sat), not the 0.0099 live quote.
     assert to_amount == 210_000
+
+
+# ─── _swap_stage: closed-PDA terminal disambiguation ────────────────────────
+# Terminal swaps (Completed AND TimedOut) close their PDA on-chain, so a None swap
+# account alone can't tell a completion from a slash — the validator's own
+# swap_outcomes index (written on SwapCompleted/SwapTimedOut ingest) must.
+
+
+def _stage_validator(tmp_path):
+    from allways.validator.state_store import ValidatorStateStore
+
+    store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+    return SimpleNamespace(state_store=store), store
+
+
+def test_closed_pda_with_recorded_slash_reports_timed_out(tmp_path):
+    from allways.validator.reserve_engine import _swap_stage
+
+    validator, store = _stage_validator(tmp_path)
+    key = b'\x01' * 32
+    store.record_swap_outcome(key.hex(), 'timed_out', 100)
+    assert _swap_stage(validator, None, key) == 'timed_out'
+    store.close()
+
+
+def test_closed_pda_with_recorded_completion_reports_completed(tmp_path):
+    from allways.validator.reserve_engine import _swap_stage
+
+    validator, store = _stage_validator(tmp_path)
+    key = b'\x02' * 32
+    store.record_swap_outcome(key.hex(), 'completed', 100)
+    assert _swap_stage(validator, None, key) == 'completed'
+    store.close()
+
+
+def test_closed_pda_with_unknown_key_falls_back_to_completed(tmp_path):
+    # Validator restarted with no local history + RPC pruned before ingest: the seam
+    # still returns a terminal stage so the offering stops polling.
+    from allways.validator.reserve_engine import _swap_stage
+
+    validator, store = _stage_validator(tmp_path)
+    assert _swap_stage(validator, None, b'\x03' * 32) == 'completed'
+    store.close()
+
+
+def test_live_pda_status_maps_by_variant_name(tmp_path):
+    # A still-open PDA never consults the outcome index — the borsh status variant wins.
+    from allways.validator.reserve_engine import _swap_stage
+
+    validator, store = _stage_validator(tmp_path)
+    key = b'\x04' * 32
+    store.record_swap_outcome(key.hex(), 'completed', 100)  # must be ignored while the PDA is live
+    for variant, stage in [('Active', 'active'), ('Fulfilled', 'fulfilled'), ('TimedOut', 'timed_out')]:
+        swap = SimpleNamespace(status=type(variant, (), {})())
+        assert _swap_stage(validator, swap, key) == stage
+    store.close()

--- a/tests/test_seam_http.py
+++ b/tests/test_seam_http.py
@@ -101,3 +101,20 @@ def test_rate(server):
 def test_status(server):
     code, payload = _req(server, 'GET', '/status?miner_hotkey=hk')
     assert code == 200 and payload['stage'] == 'reserved'
+
+
+def test_status_forwards_optional_swap_key(server, monkeypatch):
+    """swap_key drives by-key resolution in the engine — the seam must pass it through
+    (and default it to '' when absent, preserving the reservation-path behavior)."""
+    seen = []
+
+    def fake_status(validator, miner_hotkey, swap_key_hex=''):
+        seen.append((miner_hotkey, swap_key_hex))
+        return SwapStatus('timed_out', 0, '', swap_key_hex)
+
+    monkeypatch.setattr(seam_http, 'swap_status', fake_status)
+    key = 'ab' * 32
+    code, payload = _req(server, 'GET', f'/status?miner_hotkey=hk&swap_key={key}')
+    assert code == 200 and payload['stage'] == 'timed_out' and payload['swap_key'] == key
+    _req(server, 'GET', '/status?miner_hotkey=hk')
+    assert seen == [('hk', key), ('hk', '')]

--- a/tests/test_validator_storage.py
+++ b/tests/test_validator_storage.py
@@ -1,0 +1,135 @@
+"""TODO-14 — DatabaseStorage reconnect-on-failure.
+
+A slow-booting or restarted aw-db must pause dashboard writes, not disable them for the
+process lifetime: a connection-class failure drops the connection and a later write lazily
+reconnects (rate-limited). Writes stay non-fatal to the forward loop throughout.
+
+Mocks the psycopg layer entirely (psycopg isn't a test dependency): failures are raised as a
+test-local ``OperationalError``, which ``is_connection_failure`` matches by class name.
+"""
+
+from allways.validator.storage import storage as storage_mod
+from allways.validator.storage.database import is_connection_failure
+from allways.validator.storage.storage import DatabaseStorage
+
+
+class OperationalError(Exception):
+    """Name-matched by is_connection_failure, same as psycopg's."""
+
+
+class FakeConnection:
+    def __init__(self):
+        self.autocommit = True
+        self.failing = False
+        self.closed = False
+        self.commits = 0
+
+    def _maybe_fail(self):
+        if self.failing:
+            raise OperationalError('server closed the connection unexpectedly')
+
+    def commit(self):
+        self._maybe_fail()
+        self.commits += 1
+
+    def rollback(self):
+        self._maybe_fail()
+
+    def close(self):
+        self.closed = True
+
+
+class FakeRepo:
+    def __init__(self, conn):
+        self.conn = conn
+
+    def replace_current_crown(self, rows_by_direction, commit=False):
+        self.conn._maybe_fail()
+        return len(rows_by_direction)
+
+
+def make_storage(monkeypatch, connections):
+    """DatabaseStorage wired to pop successive connections from ``connections``
+    (None = a failed connect attempt) instead of dialing Postgres."""
+    monkeypatch.setenv('STORE_DB_RESULTS', '1')
+    monkeypatch.setattr(storage_mod, 'create_database_connection', lambda: connections.pop(0))
+    monkeypatch.setattr(storage_mod, 'Repository', FakeRepo)
+    return DatabaseStorage()
+
+
+def force_retry_window(storage):
+    """Rewind the reconnect rate limiter so the next write is allowed to redial."""
+    storage._last_reconnect_attempt = 0.0
+
+
+def test_is_connection_failure_matches_by_class_name():
+    assert is_connection_failure(OperationalError('boom'))
+    assert not is_connection_failure(ValueError('boom'))
+
+
+def test_write_failure_does_not_raise_and_drops_connection(monkeypatch):
+    conn = FakeConnection()
+    storage = make_storage(monkeypatch, [conn])
+    assert storage.is_enabled()
+
+    conn.failing = True  # aw-db restarted: repo call AND the rollback both raise
+    result = storage.upsert_current_crown_snapshot({})  # must not propagate into the forward loop
+    assert not result.success and result.errors
+    assert conn.closed and not storage.is_enabled()
+
+
+def test_reconnects_on_next_write_after_drop(monkeypatch):
+    dead, fresh = FakeConnection(), FakeConnection()
+    storage = make_storage(monkeypatch, [dead, fresh])
+    dead.failing = True
+    assert not storage.upsert_current_crown_snapshot({}).success
+
+    force_retry_window(storage)
+    result = storage.upsert_current_crown_snapshot({('sol', 'btc'): []})
+    assert result.success and result.stored_counts['current_crown_holders'] == 1
+    assert storage.db_connection is fresh and fresh.commits == 1
+
+
+def test_reconnect_attempts_are_rate_limited(monkeypatch):
+    dead = FakeConnection()
+    connections = [dead, None]  # a third pop would raise IndexError — proves no extra redial
+    storage = make_storage(monkeypatch, connections)
+    dead.failing = True
+    assert not storage.upsert_current_crown_snapshot({}).success  # drops the connection
+    assert not storage.upsert_current_crown_snapshot({}).success  # first redial (fails: None)
+
+    # Within the rate-limit window after a failed redial: degrades to not-enabled without dialing.
+    result = storage.upsert_current_crown_snapshot({})
+    assert not result.success and 'not enabled' in result.errors[0]
+
+
+def test_boot_time_connect_failure_heals_on_later_write(monkeypatch):
+    # The full-e2e boot-order landmine: aw-db up after the validator.
+    fresh = FakeConnection()
+    storage = make_storage(monkeypatch, [None, fresh])
+    assert not storage.is_enabled()
+
+    force_retry_window(storage)
+    assert storage.upsert_current_crown_snapshot({}).success
+    assert storage.is_enabled() and storage.db_connection is fresh
+
+
+def test_non_connection_failure_keeps_connection(monkeypatch):
+    conn = FakeConnection()
+    storage = make_storage(monkeypatch, [conn])
+
+    def raise_value_error(rows_by_direction, commit=False):
+        raise ValueError('bad row shape')
+
+    storage.repo.replace_current_crown = raise_value_error
+    result = storage.upsert_current_crown_snapshot({})
+    assert not result.success
+    assert storage.is_enabled() and storage.db_connection is conn  # only connection-class errors drop
+
+
+def test_disabled_flag_never_dials(monkeypatch):
+    monkeypatch.delenv('STORE_DB_RESULTS', raising=False)
+    monkeypatch.setattr(storage_mod, 'create_database_connection', lambda: FakeConnection())
+    storage = DatabaseStorage()
+    assert not storage.is_enabled()
+    assert not storage.upsert_current_crown_snapshot({}).success

--- a/tests/test_validator_storage.py
+++ b/tests/test_validator_storage.py
@@ -4,9 +4,15 @@ A slow-booting or restarted aw-db must pause dashboard writes, not disable them 
 process lifetime: a connection-class failure drops the connection and a later write lazily
 reconnects (rate-limited). Writes stay non-fatal to the forward loop throughout.
 
+``is_enabled()`` is the callers' gate and means "configured", not "connection live" — otherwise
+the gates in forward.py/scoring.py would make the reconnect unreachable (the review finding).
+
 Mocks the psycopg layer entirely (psycopg isn't a test dependency): failures are raised as a
 test-local ``OperationalError``, which ``is_connection_failure`` matches by class name.
 """
+
+import contextlib
+from types import SimpleNamespace
 
 from allways.validator.storage import storage as storage_mod
 from allways.validator.storage.database import is_connection_failure
@@ -35,6 +41,10 @@ class FakeConnection:
     def rollback(self):
         self._maybe_fail()
 
+    def pipeline(self):
+        self._maybe_fail()
+        return contextlib.nullcontext()
+
     def close(self):
         self.closed = True
 
@@ -46,6 +56,12 @@ class FakeRepo:
     def replace_current_crown(self, rows_by_direction, commit=False):
         self.conn._maybe_fail()
         return len(rows_by_direction)
+
+    def delete_crown_in_range(self, from_chain, to_chain, lo, hi, commit=False):
+        self.conn._maybe_fail()
+
+    def set_sync_cursor(self, key, value, commit=False):
+        self.conn._maybe_fail()
 
 
 def make_storage(monkeypatch, connections):
@@ -75,7 +91,8 @@ def test_write_failure_does_not_raise_and_drops_connection(monkeypatch):
     conn.failing = True  # aw-db restarted: repo call AND the rollback both raise
     result = storage.upsert_current_crown_snapshot({})  # must not propagate into the forward loop
     assert not result.success and result.errors
-    assert conn.closed and not storage.is_enabled()
+    assert conn.closed and storage.db_connection is None
+    assert storage.is_enabled()  # still configured — the callers' gate must stay open to reach the redial
 
 
 def test_reconnects_on_next_write_after_drop(monkeypatch):
@@ -107,11 +124,11 @@ def test_boot_time_connect_failure_heals_on_later_write(monkeypatch):
     # The full-e2e boot-order landmine: aw-db up after the validator.
     fresh = FakeConnection()
     storage = make_storage(monkeypatch, [None, fresh])
-    assert not storage.is_enabled()
+    assert storage.is_enabled() and storage.db_connection is None  # configured, not yet connected
 
     force_retry_window(storage)
     assert storage.upsert_current_crown_snapshot({}).success
-    assert storage.is_enabled() and storage.db_connection is fresh
+    assert storage.db_connection is fresh
 
 
 def test_non_connection_failure_keeps_connection(monkeypatch):
@@ -124,7 +141,7 @@ def test_non_connection_failure_keeps_connection(monkeypatch):
     storage.repo.replace_current_crown = raise_value_error
     result = storage.upsert_current_crown_snapshot({})
     assert not result.success
-    assert storage.is_enabled() and storage.db_connection is conn  # only connection-class errors drop
+    assert storage.db_connection is conn  # only connection-class errors drop
 
 
 def test_disabled_flag_never_dials(monkeypatch):
@@ -133,3 +150,18 @@ def test_disabled_flag_never_dials(monkeypatch):
     storage = DatabaseStorage()
     assert not storage.is_enabled()
     assert not storage.upsert_current_crown_snapshot({}).success
+
+
+def test_gated_caller_path_reaches_the_redial(monkeypatch):
+    """Through a REAL caller (scoring._flush_halt_window, same is_enabled() gate as forward.py):
+    with the connection dead, the gate must still pass so the write methods — which own
+    connection state — get to redial. Regression for the unreachable-reconnect review finding."""
+    from allways.validator.scoring import _flush_halt_window
+
+    fresh = FakeConnection()
+    storage = make_storage(monkeypatch, [None, fresh])  # aw-db down at validator boot
+    force_retry_window(storage)
+
+    _flush_halt_window(SimpleNamespace(database_storage=storage), current_time=1_000_000)
+    assert storage.db_connection is fresh
+    assert fresh.commits == 2  # flush_halt_window + upsert_current_crown_snapshot both landed


### PR DESCRIPTION
W2-B. Three items:

**Seam reports slashed swaps as completed (TODO-5).** Terminal swap PDAs are closed on-chain — Completed and TimedOut both just disappear — so `_swap_stage` returned `completed` for slashes. Fix: `SwapCompleted`/`SwapTimedOut` ingest now records the terminal outcome into a new `swap_outcomes` table (`swap_key` hex PK, `outcome`, `block_time`); a closed PDA looks its swap_key up there. Pruned at 7 days (`SWAP_OUTCOME_RETENTION_SECS`) in the same `prune_crown_events` pass as the other tables.

Additionally, `vote_initiate` consumes the reservation at attestation quorum (`reserved_until = 0`, `claimed_swap_key` cleared), so reservation-based `/status` goes blind (`none`) the moment a swap turns Active — post-attestation stages were unreachable. `/status` now takes an optional `swap_key` query param (hex, persisted by the consumer at claim time from `/confirm`) that resolves the swap directly by key.

**Seam `/status` stage contract** (for the W2-C ventura consumer):

```
GET /status?miner_hotkey=<ss58>[&swap_key=<64-char hex>]

stage ∈ none | reserved | claimed | active | fulfilled | completed | timed_out
none      — hotkey unbound, or no live reservation (reservation path only)
reserved  — reservation open, no claimed swap yet
claimed   — deposit claim submitted, pending attestation
active    — attested, awaiting miner fulfillment
fulfilled — miner marked fulfilled, awaiting validator confirmation
completed — terminal success
timed_out — terminal slash
```

Resolution:
- `swap_key` present → resolve the Swap PDA by key. Live PDA maps its status (`claimed`/`active`/`fulfilled`/`completed`/`timed_out`); closed PDA → `swap_outcomes` lookup → `completed`/`timed_out`; outcome miss → `fulfilled` (non-terminal). This is the ONLY route to post-attestation stages — pass it once you have it. `reserved_until` is 0 and `detail` carries the same shape as the reservation path (`from_chain`, `to_chain`, `from_amount`, `to_amount`, `miner_from_addr`), sourced from the Swap PDA while live, `{}` after close. Malformed `swap_key` (non-hex or ≠32 bytes) → 400.
- `swap_key` absent → resolve via the miner's reservation; only pre-attestation stages (`none`/`reserved`/`claimed`) are reliably visible — a consumed reservation reports `none`.

`completed`/`timed_out` are terminal — stop polling on either. Closed PDA + no recorded outcome → **`fulfilled`** (non-terminal): normally just ingest lag — another validator's quorum closed the PDA since this validator's last forward-step ingest — and it resolves to the real terminal stage within ~one forward step. Consumers keep polling on `fulfilled` and apply their own reconcile deadline rather than trust a terminal guess; edges that never resolve include wiped-state.db + RPC-pruned history, and a never-attested claim closed by `close_stale_claim` (no terminal event for the swap).

**Dashboard DB writes never reconnect (TODO-14).** `DatabaseStorage` connected once at boot; a slow or restarted aw-db left crown/rate persistence silently dead for the process (the full-e2e boot-order landmine). Now: OperationalError/InterfaceError-class failures drop the connection, and the next write lazily redials (rate-limited to one attempt per 30s so a down DB costs one bounded 2s stall per interval, not per write). `is_enabled()` now means "configured" (STORE_DB_RESULTS set), not "connection live" — the callers' gates (forward.py, scoring.py) stay open so the write methods, which own connection state, are reachable to redial. Writes stay non-fatal to the forward loop — the previously unguarded rollback in `flush_scoring_window`'s error path could itself raise on a dead connection; guarded now.

**Rider:** `.full-e2e/` gitignored (untracked dev keypair sat there).

Tests: outcome written on SwapCompleted + SwapTimedOut ingest, re-ingest upsert, prune; `_swap_stage` timed_out/completed/miss-reports-fulfilled/live-PDA-precedence; by-key resolution (active swap resolvable after reservation consumed, closed+recorded → timed_out, closed+miss → fulfilled, malformed key → ValueError, seam forwards the param); storage reconnect, rate limiting, boot-failure heal, non-connection errors keep the connection, forward-facing call never raises, real-caller-path regression through the `is_enabled()` gate. `ruff format` + `ruff check` clean, 609 passed.