### PR TITLE
Drop legacy B3.5 swap_outcomes schema at init

### DIFF
--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -515,9 +515,7 @@ class ValidatorStateStore:
     def init_db(self) -> None:
         with self.lock:
             conn = self.require_connection()
-            # The pre-B3.5 scoring ledger used the swap_outcomes name with a different shape
-            # (swap_id/completed/resolved_block). CREATE IF NOT EXISTS silently keeps it, so a
-            # long-lived state.db breaks the seam's outcome lookups — drop the dead schema first.
+            # The pre-B3.5 scoring ledger squatted this name; IF NOT EXISTS keeps its dead schema.
             cols = [row[1] for row in conn.execute('PRAGMA table_info(swap_outcomes)')]
             if cols and 'outcome' not in cols:
                 conn.execute('DROP TABLE swap_outcomes')

--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -515,6 +515,12 @@ class ValidatorStateStore:
     def init_db(self) -> None:
         with self.lock:
             conn = self.require_connection()
+            # The pre-B3.5 scoring ledger used the swap_outcomes name with a different shape
+            # (swap_id/completed/resolved_block). CREATE IF NOT EXISTS silently keeps it, so a
+            # long-lived state.db breaks the seam's outcome lookups — drop the dead schema first.
+            cols = [row[1] for row in conn.execute('PRAGMA table_info(swap_outcomes)')]
+            if cols and 'outcome' not in cols:
+                conn.execute('DROP TABLE swap_outcomes')
             conn.executescript(
                 """
                 CREATE TABLE IF NOT EXISTS rate_events (

--- a/tests/test_event_index.py
+++ b/tests/test_event_index.py
@@ -385,6 +385,23 @@ class TestIngestSwapOutcomes:
         assert store.get_swap_outcome(key.hex()) == 'timed_out'
         store.close()
 
+    def test_legacy_b35_table_is_dropped_and_recreated(self, tmp_path: Path):
+        # A long-lived state.db still carries the pre-B3.5 scoring ledger under the same name;
+        # CREATE IF NOT EXISTS keeps it and every outcome lookup dies on 'no such column: outcome'.
+        import sqlite3
+
+        db = tmp_path / 'state.db'
+        conn = sqlite3.connect(db)
+        conn.execute(
+            'CREATE TABLE swap_outcomes (swap_id INTEGER, miner_hotkey TEXT, completed INTEGER, resolved_block INTEGER)'
+        )
+        conn.commit()
+        conn.close()
+        store = ValidatorStateStore(db_path=db)
+        store.record_swap_outcome('ab' * 32, 'timed_out', 100)
+        assert store.get_swap_outcome('ab' * 32) == 'timed_out'
+        store.close()
+
     def test_prune_drops_old_outcomes(self, tmp_path: Path):
         store = make_store(tmp_path)
         old, recent = b'\x01' * 32, b'\x02' * 32

--- a/tests/test_event_index.py
+++ b/tests/test_event_index.py
@@ -386,17 +386,12 @@ class TestIngestSwapOutcomes:
         store.close()
 
     def test_legacy_b35_table_is_dropped_and_recreated(self, tmp_path: Path):
-        # A long-lived state.db still carries the pre-B3.5 scoring ledger under the same name;
-        # CREATE IF NOT EXISTS keeps it and every outcome lookup dies on 'no such column: outcome'.
+        # The pre-B3.5 scoring ledger squatted the swap_outcomes name in long-lived state DBs.
         import sqlite3
 
         db = tmp_path / 'state.db'
-        conn = sqlite3.connect(db)
-        conn.execute(
-            'CREATE TABLE swap_outcomes (swap_id INTEGER, miner_hotkey TEXT, completed INTEGER, resolved_block INTEGER)'
-        )
-        conn.commit()
-        conn.close()
+        with sqlite3.connect(db) as conn:
+            conn.execute('CREATE TABLE swap_outcomes (swap_id INTEGER, completed INTEGER, resolved_block INTEGER)')
         store = ValidatorStateStore(db_path=db)
         store.record_swap_outcome('ab' * 32, 'timed_out', 100)
         assert store.get_swap_outcome('ab' * 32) == 'timed_out'


### PR DESCRIPTION
Wave-2 live gate caught this: a long-lived validator state.db still carries the pre-B3.5 scoring ledger under the swap_outcomes name (swap_id/completed/resolved_block). CREATE TABLE IF NOT EXISTS keeps it, so every seam outcome lookup 500s with 'no such column: outcome' — ventura holds rows correctly but nothing ever resolves. Fix: init_db drops the dead-schema table (that ledger was deleted with B3.5) before the schema script recreates the new shape. Regression test creates the legacy table first, then asserts record/get work. 610 tests pass.