### PR TITLE
feat(validator): VALIDATOR_DEV_MODE (observe-only) — deprecate SOLANA_VALIDATOR_READONLY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,14 @@ MINER_BTC_ADDRESS=
 # to be prompted interactively at launch.
 MINER_BITTENSOR_COLDKEY_PASSWORD=
 
+# ─── Validator: dev / testnet mode ─────────────────────────
+# VALIDATOR_DEV_MODE=1 makes the validator observe-only: it verifies swaps and computes
+# scores but submits NO Solana consensus votes (logs "WOULD …") and does NOT set Bittensor
+# weights. Use it to stage a new validator before it can affect consensus or emissions;
+# unset / 0 for a live validator.
+# (Replaces the deprecated SOLANA_VALIDATOR_READONLY, which only gated Solana votes.)
+# VALIDATOR_DEV_MODE=0
+
 # ─── Validator: Weights & Biases ───────────────────────────
 # The validator opens a wandb run at startup that captures its console output.
 # Set WANDB_API_KEY to log online; unset runs offline (./wandb/) or pass

--- a/neurons/base/neuron.py
+++ b/neurons/base/neuron.py
@@ -1,4 +1,5 @@
 import copy
+import os
 import time
 from abc import ABC, abstractmethod
 from typing import Callable
@@ -10,6 +11,31 @@ from allways import __spec_version__ as spec_version
 from allways.constants import STALE_BLOCK_POLL_THRESHOLD
 from allways.utils.config import add_args, check_config, config
 from allways.utils.misc import ttl_get_block
+
+_dev_mode_warned = False
+
+
+def validator_dev_mode() -> bool:
+    """Dev / testnet mode: the validator observes but takes no binding actions — it does NOT
+    submit Solana consensus votes (the swap loop logs "WOULD …") and does NOT set Bittensor
+    weights. Enable with VALIDATOR_DEV_MODE=1.
+
+    SOLANA_VALIDATOR_READONLY is the deprecated alias: still honored so existing configs keep
+    working, but it only ever gated Solana votes — prefer VALIDATOR_DEV_MODE, which also skips
+    weight-setting. Emits a one-time deprecation warning.
+    """
+    global _dev_mode_warned
+    if os.environ.get('VALIDATOR_DEV_MODE', '0') == '1':
+        return True
+    if os.environ.get('SOLANA_VALIDATOR_READONLY', '0') == '1':
+        if not _dev_mode_warned:
+            bt.logging.warning(
+                'SOLANA_VALIDATOR_READONLY is deprecated; use VALIDATOR_DEV_MODE=1 '
+                '(dev mode also skips set_weights, not just Solana votes).'
+            )
+            _dev_mode_warned = True
+        return True
+    return False
 
 
 class BaseNeuron(ABC):
@@ -155,6 +181,10 @@ class BaseNeuron(ABC):
             return False
 
         if self.config.neuron.disable_set_weights:
+            return False
+
+        # Dev mode: observe-only — never set weights (mirrors the Solana vote suppression).
+        if validator_dev_mode():
             return False
 
         return (

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -47,6 +47,7 @@ from allways.validator.seam_http import maybe_start_seam
 from allways.validator.solana_swap_loop import SolanaSwapLoop
 from allways.validator.state_store import ValidatorStateStore
 from allways.validator.storage import DatabaseStorage
+from neurons.base.neuron import validator_dev_mode
 from neurons.base.validator import BaseValidatorNeuron
 
 load_dotenv()
@@ -98,8 +99,12 @@ class Validator(BaseValidatorNeuron):
         # (getProgramAccounts), decides per status, verifies both legs with
         # replay-freshness gates, and casts the on-chain consensus vote. This
         # subsumes the old substrate swap_tracker discovery + verifier.
-        # Safety hatch for staged rollout: SOLANA_VALIDATOR_READONLY=1 logs "WOULD …" without voting.
-        solana_read_only = os.environ.get('SOLANA_VALIDATOR_READONLY', '0') == '1'
+        # Dev/testnet mode (VALIDATOR_DEV_MODE=1): observe-only. The swap loop logs "WOULD …"
+        # instead of voting, and should_set_weights() suppresses weight-setting. See validator_dev_mode().
+        dev_mode = validator_dev_mode()
+        if dev_mode:
+            bt.logging.warning('VALIDATOR_DEV_MODE on — observe-only: no Solana votes, no set_weights.')
+        solana_read_only = dev_mode
         self.solana_client = AllwaysSolanaClient(solana_rpc_url, keypair=keys.load_or_create())
         self.solana_swap_loop = SolanaSwapLoop(
             self.solana_client, self.chain_providers, fee_divisor=self.fee_divisor, read_only=solana_read_only

--- a/tests/test_validator_dev_mode.py
+++ b/tests/test_validator_dev_mode.py
@@ -1,0 +1,61 @@
+"""VALIDATOR_DEV_MODE — observe-only gate for staging a validator.
+
+Dev mode makes the validator take no binding actions: the Solana swap loop logs "WOULD …"
+instead of voting, and should_set_weights() returns False so no Bittensor weights are set.
+VALIDATOR_DEV_MODE=1 is the flag; SOLANA_VALIDATOR_READONLY is the deprecated alias (still
+honored, warns once) that only ever gated Solana votes.
+"""
+
+import neurons.base.neuron as neuron
+from neurons.base.neuron import validator_dev_mode
+
+
+def _reset():
+    neuron._dev_mode_warned = False
+
+
+def test_off_by_default(monkeypatch):
+    monkeypatch.delenv('VALIDATOR_DEV_MODE', raising=False)
+    monkeypatch.delenv('SOLANA_VALIDATOR_READONLY', raising=False)
+    _reset()
+    assert validator_dev_mode() is False
+
+
+def test_dev_mode_enables(monkeypatch):
+    monkeypatch.setenv('VALIDATOR_DEV_MODE', '1')
+    monkeypatch.delenv('SOLANA_VALIDATOR_READONLY', raising=False)
+    _reset()
+    assert validator_dev_mode() is True
+
+
+def test_explicit_zero_is_off(monkeypatch):
+    monkeypatch.setenv('VALIDATOR_DEV_MODE', '0')
+    monkeypatch.delenv('SOLANA_VALIDATOR_READONLY', raising=False)
+    _reset()
+    assert validator_dev_mode() is False
+
+
+def test_deprecated_alias_still_honored_and_warns_once(monkeypatch):
+    monkeypatch.delenv('VALIDATOR_DEV_MODE', raising=False)
+    monkeypatch.setenv('SOLANA_VALIDATOR_READONLY', '1')
+    _reset()
+
+    warnings = []
+    monkeypatch.setattr(neuron.bt.logging, 'warning', lambda msg, *a, **k: warnings.append(msg))
+
+    assert validator_dev_mode() is True
+    assert validator_dev_mode() is True  # still honored on repeat calls
+    # ...but the deprecation warning fires exactly once (guarded by _dev_mode_warned).
+    assert len(warnings) == 1
+    assert 'VALIDATOR_DEV_MODE' in warnings[0]
+
+
+def test_dev_mode_takes_precedence_over_alias(monkeypatch):
+    monkeypatch.setenv('VALIDATOR_DEV_MODE', '1')
+    monkeypatch.setenv('SOLANA_VALIDATOR_READONLY', '1')
+    _reset()
+    warnings = []
+    monkeypatch.setattr(neuron.bt.logging, 'warning', lambda msg, *a, **k: warnings.append(msg))
+    assert validator_dev_mode() is True
+    # New flag wins before the alias is consulted, so no deprecation warning.
+    assert warnings == []


### PR DESCRIPTION
## Why
`SOLANA_VALIDATOR_READONLY` only gated the **Solana consensus vote** — a "read-only" validator still called `set_weights`, so it kept influencing **emissions**. That's the wrong default for staging a validator on testnet: you want it fully inert until you've watched it behave.

## What
`VALIDATOR_DEV_MODE=1` makes the validator **observe-only** — it verifies swaps and computes scores but takes no binding action:
- the Solana swap loop logs `WOULD …` instead of voting (existing read-only behavior), **and**
- `should_set_weights()` returns `False`, so **no Bittensor weights are set** (new).

`SOLANA_VALIDATOR_READONLY` is kept as a **deprecated alias** — still honored (so existing deployments don't break) but emits a one-time deprecation warning, and note it only ever gated Solana votes.

## Changes
- `neurons/base/neuron.py`: `validator_dev_mode()` helper (reads `VALIDATOR_DEV_MODE`, falls back to the deprecated `SOLANA_VALIDATOR_READONLY` with a warn-once); gate added to `should_set_weights()`.
- `neurons/validator.py`: swap loop `read_only` now driven by `validator_dev_mode()`; logs when dev mode is on.
- `.env.example`: documents `VALIDATOR_DEV_MODE`.
- `tests/test_validator_dev_mode.py`: covers off-by-default, on, explicit-0, deprecated-alias-warns-once, new-flag-precedence (5 tests, green).

## Migration
Deployments using `SOLANA_VALIDATOR_READONLY=1` keep working (with a warning). Switch them to `VALIDATOR_DEV_MODE=1` to also suppress weight-setting — I'll update the testnet server + `neuron.testnet.env.example` once this merges.