### PR TITLE
refactor(validator): remove SOLANA_VALIDATOR_READONLY entirely

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,7 +64,6 @@ MINER_BITTENSOR_COLDKEY_PASSWORD=
 # scores but submits NO Solana consensus votes (logs "WOULD …") and does NOT set Bittensor
 # weights. Use it to stage a new validator before it can affect consensus or emissions;
 # unset / 0 for a live validator.
-# (Replaces the deprecated SOLANA_VALIDATOR_READONLY, which only gated Solana votes.)
 # VALIDATOR_DEV_MODE=0
 
 # ─── Validator: Weights & Biases ───────────────────────────

--- a/neurons/base/neuron.py
+++ b/neurons/base/neuron.py
@@ -12,30 +12,12 @@ from allways.constants import STALE_BLOCK_POLL_THRESHOLD
 from allways.utils.config import add_args, check_config, config
 from allways.utils.misc import ttl_get_block
 
-_dev_mode_warned = False
-
-
 def validator_dev_mode() -> bool:
     """Dev / testnet mode: the validator observes but takes no binding actions — it does NOT
     submit Solana consensus votes (the swap loop logs "WOULD …") and does NOT set Bittensor
     weights. Enable with VALIDATOR_DEV_MODE=1.
-
-    SOLANA_VALIDATOR_READONLY is the deprecated alias: still honored so existing configs keep
-    working, but it only ever gated Solana votes — prefer VALIDATOR_DEV_MODE, which also skips
-    weight-setting. Emits a one-time deprecation warning.
     """
-    global _dev_mode_warned
-    if os.environ.get('VALIDATOR_DEV_MODE', '0') == '1':
-        return True
-    if os.environ.get('SOLANA_VALIDATOR_READONLY', '0') == '1':
-        if not _dev_mode_warned:
-            bt.logging.warning(
-                'SOLANA_VALIDATOR_READONLY is deprecated; use VALIDATOR_DEV_MODE=1 '
-                '(dev mode also skips set_weights, not just Solana votes).'
-            )
-            _dev_mode_warned = True
-        return True
-    return False
+    return os.environ.get('VALIDATOR_DEV_MODE', '0') == '1'
 
 
 class BaseNeuron(ABC):

--- a/tests/test_validator_dev_mode.py
+++ b/tests/test_validator_dev_mode.py
@@ -2,60 +2,28 @@
 
 Dev mode makes the validator take no binding actions: the Solana swap loop logs "WOULD …"
 instead of voting, and should_set_weights() returns False so no Bittensor weights are set.
-VALIDATOR_DEV_MODE=1 is the flag; SOLANA_VALIDATOR_READONLY is the deprecated alias (still
-honored, warns once) that only ever gated Solana votes.
+Enable with VALIDATOR_DEV_MODE=1.
 """
 
-import neurons.base.neuron as neuron
 from neurons.base.neuron import validator_dev_mode
-
-
-def _reset():
-    neuron._dev_mode_warned = False
 
 
 def test_off_by_default(monkeypatch):
     monkeypatch.delenv('VALIDATOR_DEV_MODE', raising=False)
-    monkeypatch.delenv('SOLANA_VALIDATOR_READONLY', raising=False)
-    _reset()
     assert validator_dev_mode() is False
 
 
 def test_dev_mode_enables(monkeypatch):
     monkeypatch.setenv('VALIDATOR_DEV_MODE', '1')
-    monkeypatch.delenv('SOLANA_VALIDATOR_READONLY', raising=False)
-    _reset()
     assert validator_dev_mode() is True
 
 
 def test_explicit_zero_is_off(monkeypatch):
     monkeypatch.setenv('VALIDATOR_DEV_MODE', '0')
-    monkeypatch.delenv('SOLANA_VALIDATOR_READONLY', raising=False)
-    _reset()
     assert validator_dev_mode() is False
 
 
-def test_deprecated_alias_still_honored_and_warns_once(monkeypatch):
-    monkeypatch.delenv('VALIDATOR_DEV_MODE', raising=False)
-    monkeypatch.setenv('SOLANA_VALIDATOR_READONLY', '1')
-    _reset()
-
-    warnings = []
-    monkeypatch.setattr(neuron.bt.logging, 'warning', lambda msg, *a, **k: warnings.append(msg))
-
-    assert validator_dev_mode() is True
-    assert validator_dev_mode() is True  # still honored on repeat calls
-    # ...but the deprecation warning fires exactly once (guarded by _dev_mode_warned).
-    assert len(warnings) == 1
-    assert 'VALIDATOR_DEV_MODE' in warnings[0]
-
-
-def test_dev_mode_takes_precedence_over_alias(monkeypatch):
-    monkeypatch.setenv('VALIDATOR_DEV_MODE', '1')
-    monkeypatch.setenv('SOLANA_VALIDATOR_READONLY', '1')
-    _reset()
-    warnings = []
-    monkeypatch.setattr(neuron.bt.logging, 'warning', lambda msg, *a, **k: warnings.append(msg))
-    assert validator_dev_mode() is True
-    # New flag wins before the alias is consulted, so no deprecation warning.
-    assert warnings == []
+def test_arbitrary_value_is_off(monkeypatch):
+    # Only an exact "1" enables it — no accidental truthiness.
+    monkeypatch.setenv('VALIDATOR_DEV_MODE', 'true')
+    assert validator_dev_mode() is False


### PR DESCRIPTION
Follow-up to #511. That PR kept `SOLANA_VALIDATOR_READONLY` as a deprecated alias; this removes it **completely** so there's only one flag.

- `validator_dev_mode()` now reads **only** `VALIDATOR_DEV_MODE` — no fallback, no warn-once state.
- Dropped the alias unit tests; kept off-by-default / on / explicit-0 / non-"1"-is-off (4, green).
- Removed the `.env.example` reference to the old var.

**Migration:** any deployment still setting `SOLANA_VALIDATOR_READONLY` is now inert — set `VALIDATOR_DEV_MODE=1` instead. (I'm updating the testnet server as part of this.)