### PR TITLE
feat(cli): per-chain network config + quote churn-fee visibility

### DIFF
--- a/allways/cli/main.py
+++ b/allways/cli/main.py
@@ -50,7 +50,20 @@ load_dotenv(find_dotenv(usecwd=True), override=False)
 load_dotenv(Path.home() / '.allways' / '.env', override=False)
 
 from allways.cli.help import StyledAliasGroup, StyledGroup  # noqa: E402
-from allways.cli.swap_commands.helpers import ALLWAYS_DIR, CONFIG_FILE, apply_global_flags, console  # noqa: E402
+from allways.cli.swap_commands.helpers import (  # noqa: E402
+    ALLWAYS_DIR,
+    BTC_NETWORKS,
+    CONFIG_FILE,
+    ENV_BUNDLES,
+    SOLANA_NETWORKS,
+    apply_btc_network_env,
+    apply_global_flags,
+    console,
+    get_effective_config,
+)
+
+# Feed a configured btc-network into the BTC provider (which reads BTC_NETWORK from env; a real env wins).
+apply_btc_network_env(get_effective_config())
 
 # Restore original argv now that bittensor has been imported
 _sys.argv = _saved_argv
@@ -112,7 +125,18 @@ KNOWN_NETWORKS = {
     'local': 'ws://127.0.0.1:9944',
 }
 
-VALID_CONFIG_KEYS = ('wallet', 'hotkey', 'network', 'netuid', 'contract-address', 'program-id', 'solana-rpc')
+VALID_CONFIG_KEYS = (
+    'wallet',
+    'hotkey',
+    'network',
+    'netuid',
+    'contract-address',
+    'program-id',
+    'solana-rpc',
+    'solana-network',
+    'btc-network',
+    'env',
+)
 
 
 @config_group.command('set')
@@ -122,25 +146,28 @@ def config_set(key: str, value: str):
     """Set a configuration value.
 
     [dim]Valid keys:
-        wallet              Wallet name
-        hotkey              Hotkey name
-        contract-address    Substrate contract address (legacy taker/reserve path)
+        env                 One-liner bundle: sets network + solana-network + btc-network + netuid
+        wallet              Bittensor wallet name
+        hotkey              Bittensor hotkey name
+        network             Bittensor network name (test/finney/local) or ws:// endpoint
+        netuid              Subnet UID
+        solana-network      Solana network name (devnet/mainnet/localnet) → RPC resolved in code
+        solana-rpc          Custom Solana RPC URL (escape hatch; SOLANA_RPC_URL env wins)
+        btc-network         Bitcoin network name (mainnet/testnet4/testnet/signet)
         program-id          Solana program ID (miner/admin commands)
-        solana-rpc          Solana RPC URL (overridden by SOLANA_RPC_URL env)
-        network             Network name or endpoint URL
-        netuid              Subnet UID[/dim]
+        contract-address    Legacy substrate contract address (old taker/reserve path)[/dim]
 
-    [dim]Networks:
-        finney              Production  (wss://entrypoint-finney.opentensor.ai:443)
-        test                Test        (wss://test.finney.opentensor.ai:443)
-        local               Local dev   (ws://127.0.0.1:9944)
-        ws://...            Custom endpoint[/dim]
+    [dim]Networks per chain:
+        env:            testnet | mainnet   (sets all three chains at once)
+        network:        finney | test | local | ws://...
+        solana-network: devnet | mainnet | localnet   (or set a custom solana-rpc URL)
+        btc-network:    mainnet | testnet4 | testnet | signet[/dim]
 
     [dim]Examples:
+        $ alw config set env testnet          # bittensor test + solana devnet + btc testnet4 + netuid 19
         $ alw config set wallet alice
-        $ alw config set contract-address 5Cxxx...
-        $ alw config set network finney
-        $ alw config set network local[/dim]
+        $ alw config set solana-network devnet
+        $ alw config set network finney[/dim]
     """
     ALLWAYS_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -150,6 +177,27 @@ def config_set(key: str, value: str):
             config = json.loads(CONFIG_FILE.read_text())
         except json.JSONDecodeError:
             console.print('[yellow]Warning: Existing config was invalid, starting fresh[/yellow]')
+
+    # env bundle: expand one name into all three chains' networks + netuid in a single write.
+    if key == 'env':
+        bundle = ENV_BUNDLES.get(value)
+        if not bundle:
+            console.print(f'[red]Unknown env {value!r}; expected {list(ENV_BUNDLES)}.[/red]')
+            return
+        config.update(bundle)
+        CONFIG_FILE.write_text(json.dumps(config, indent=2))
+        console.print(
+            f'[green]Set env {value}:[/green] ' + ', '.join(f'{k}={v}' for k, v in bundle.items())
+        )
+        return
+
+    # Validate name-based network keys — the raw-URL escape hatches are solana-rpc / SOLANA_RPC_URL.
+    if key == 'solana-network' and value not in SOLANA_NETWORKS:
+        console.print(f'[red]Unknown solana-network {value!r}; expected {list(SOLANA_NETWORKS)} (or set a custom solana-rpc).[/red]')
+        return
+    if key == 'btc-network' and value not in BTC_NETWORKS:
+        console.print(f'[red]Unknown btc-network {value!r}; expected {list(BTC_NETWORKS)}.[/red]')
+        return
 
     # Normalize network: reverse-map known endpoints to names
     if key == 'network':

--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -18,6 +18,60 @@ ALLWAYS_DIR = Path.home() / '.allways'
 CONFIG_FILE = ALLWAYS_DIR / 'config.json'
 PENDING_SWAP_FILE = ALLWAYS_DIR / 'pending_swap.json'
 
+# ─── Per-chain network resolution ────────────────────────────────────────────
+# Each chain takes a simple network NAME (alw config set solana-network devnet); the code
+# maps it to an endpoint so operators never hand-copy RPC URLs. Raw-URL escape hatches still
+# win for paid/custom RPCs (SOLANA_RPC_URL env / solana-rpc config; BTC_ESPLORA_URLS env).
+SOLANA_NETWORKS = {
+    'devnet': 'https://api.devnet.solana.com',
+    'mainnet': 'https://api.mainnet-beta.solana.com',
+    'localnet': 'http://127.0.0.1:8899',
+}
+# Names the BTC provider (BTC_NETWORK env) accepts; endpoints default to public esplora per network.
+BTC_NETWORKS = ('mainnet', 'testnet', 'testnet4', 'signet')
+# One-liner env bundle: `alw config set env testnet|mainnet` sets all three chains' networks + netuid.
+ENV_BUNDLES = {
+    'testnet': {'network': 'test', 'solana-network': 'devnet', 'btc-network': 'testnet4', 'netuid': '19'},
+    'mainnet': {'network': 'finney', 'solana-network': 'mainnet', 'btc-network': 'mainnet', 'netuid': '7'},
+}
+
+
+def resolve_solana_rpc(config: dict) -> str:
+    """Solana RPC precedence: SOLANA_RPC_URL env / solana-rpc config (raw URL — paid/custom) win;
+    else the solana-network name resolves to a public endpoint; else localnet default."""
+    raw = os.environ.get('SOLANA_RPC_URL') or config.get('solana-rpc')
+    if raw:
+        return raw
+    name = config.get('solana-network')
+    if name:
+        url = SOLANA_NETWORKS.get(name)
+        if url:
+            return url
+        console.print(
+            f'[yellow]Unknown solana-network {name!r} (expected {list(SOLANA_NETWORKS)}); using localnet.[/yellow]'
+        )
+    return 'http://127.0.0.1:8899'
+
+
+def apply_btc_network_env(config: dict) -> None:
+    """Feed btc-network config into the BTC provider, which reads BTC_NETWORK from the env.
+    A real BTC_NETWORK env wins (explicit override); otherwise the configured name is applied."""
+    if not os.environ.get('BTC_NETWORK') and config.get('btc-network'):
+        os.environ['BTC_NETWORK'] = config['btc-network']
+
+
+# Quote-update churn fee tiers — mirror smart-contracts/…/constants.rs quote_update_fee().
+QUOTE_UPDATE_FEE_TIERS = ((300, 10_000_000), (600, 1_000_000))  # (elapsed < secs, lamports); else free
+
+
+def quote_update_fee_lamports(elapsed_secs: int) -> int:
+    """Churn fee (lamports) to re-quote a direction ``elapsed_secs`` after its last update: 0.01 SOL
+    under 5 min, 0.001 SOL at 5–10 min, free after 10 min. Creation is free. Mirrors the contract."""
+    for below, fee in QUOTE_UPDATE_FEE_TIERS:
+        if elapsed_secs < below:
+            return fee
+    return 0
+
 console = Console()
 
 
@@ -294,7 +348,7 @@ def get_solana_cli_context(need_keypair: bool = True):
     from allways.solana.client import AllwaysSolanaClient
 
     config = get_effective_config()
-    rpc_url = os.environ.get('SOLANA_RPC_URL') or config.get('solana-rpc') or 'http://127.0.0.1:8899'
+    rpc_url = resolve_solana_rpc(config)
     program_id = pdas.PROGRAM_ID
     configured = config.get('program-id') or config.get('contract')
     if configured:

--- a/allways/cli/swap_commands/numeraire.py
+++ b/allways/cli/swap_commands/numeraire.py
@@ -11,13 +11,20 @@ An optional symmetric `spread_bps` gives the miner margin both ways (sol→X pos
 high); `spread_bps=0` posts the zero-margin mid.
 """
 
+import time
 from dataclasses import dataclass
 from typing import Dict, List, Tuple
 
 import click
 
 from allways.cli.help import StyledCommand
-from allways.cli.swap_commands.helpers import console, get_cli_context, get_solana_cli_context, loading
+from allways.cli.swap_commands.helpers import (
+    console,
+    get_cli_context,
+    get_solana_cli_context,
+    loading,
+    quote_update_fee_lamports,
+)
 from allways.cli.swap_commands.pair import write_rate_posted_flag
 from allways.constants import NUMERAIRE_CHAIN, RATE_PRECISION
 from allways.solana.client import SolanaClientError
@@ -60,8 +67,9 @@ def derive_sol_numeraire_quotes(
 @click.option('--tao-price', type=float, default=None, help='TAO per 1 SOL (0/omit to skip TAO).')
 @click.option('--tao-address', default=None, help='Your TAO address.')
 @click.option('--spread', 'spread_bps', type=int, default=0, help='Symmetric margin in bps (0 = mid).')
+@click.option('--dry-run', 'dry_run', is_flag=True, help='Preview quotes + churn fees; post nothing.')
 @click.option('--yes', 'yes', is_flag=True, help='Skip confirmation.')
-def quotes_command(sol_address, btc_price, btc_address, tao_price, tao_address, spread_bps, yes):
+def quotes_command(sol_address, btc_price, btc_address, tao_price, tao_address, spread_bps, dry_run, yes):
     """Publish all SOL pairs from one price per chain (the 'X per 1 SOL' convention).
 
     \b
@@ -87,16 +95,48 @@ def quotes_command(sol_address, btc_price, btc_address, tao_price, tao_address, 
         console.print('[red]--sol-address is required.[/red]')
         return
 
+    _, wallet, _, _ = get_cli_context(need_client=False)
+    _, client = get_solana_cli_context()
+    miner = client.keypair.pubkey()
+    now = int(time.time())
+
     specs = derive_sol_numeraire_quotes(sol_address, chain_specs, spread_bps)
-    console.print('\n[bold]Publishing SOL-numéraire quotes[/bold]  [dim](X per 1 SOL)[/dim]\n')
+
+    # Show each direction's current rate + the churn fee this update will incur (per-direction,
+    # keyed on that quote's own updated_at). Creation is free; the fee decays to 0 over 10 min.
+    console.print('\n[bold]SOL-numéraire quotes[/bold]  [dim](X per 1 SOL)[/dim]\n')
+    total_fee = 0
     for sp in specs:
-        console.print(f'  {sp.from_chain.upper()} → {sp.to_chain.upper()}: [green]{sp.rate:g}[/green]')
-    if not yes and not click.confirm('\nConfirm publishing these quotes?'):
+        cur = client.get_quote(miner, sp.from_chain, sp.to_chain)
+        if cur is None:
+            note = '[dim]new — free[/dim]'
+        else:
+            age = now - int(cur.updated_at)
+            fee = quote_update_fee_lamports(age)
+            total_fee += fee
+            was = int(cur.rate) / RATE_PRECISION
+            if fee:
+                note = (
+                    f'[yellow]churn fee {fee / 1e9:g} SOL[/yellow] '
+                    f'[dim](was {was:g}, set {age}s ago; free to update in {max(0, 600 - age)}s)[/dim]'
+                )
+            else:
+                note = f'[dim]free (was {was:g})[/dim]'
+        console.print(f'  {sp.from_chain.upper()} → {sp.to_chain.upper()}: [green]{sp.rate:g}[/green]   {note}')
+
+    if total_fee:
+        console.print(
+            f'\n[yellow]Total churn fee: {total_fee / 1e9:g} SOL[/yellow] '
+            '[dim](→ treasury; each direction is free again 10 min after its last update)[/dim]'
+        )
+
+    if dry_run:
+        console.print('\n[dim]--dry-run: nothing posted.[/dim]')
+        return
+    if not yes and not click.confirm('\nPublish these quotes?'):
         console.print('[yellow]Cancelled[/yellow]')
         return
 
-    _, wallet, _, _ = get_cli_context(need_client=False)
-    _, client = get_solana_cli_context()
     posted = 0
     for sp in specs:
         try:

--- a/allways/cli/swap_commands/pair.py
+++ b/allways/cli/swap_commands/pair.py
@@ -1,10 +1,18 @@
 """alw post - Publish a trading pair as on-chain Solana quotes."""
 
+import time
+
 import click
 
 from allways.chains import SUPPORTED_CHAINS, canonical_pair
 from allways.cli.help import StyledCommand
-from allways.cli.swap_commands.helpers import console, get_cli_context, get_solana_cli_context, loading
+from allways.cli.swap_commands.helpers import (
+    console,
+    get_cli_context,
+    get_solana_cli_context,
+    loading,
+    quote_update_fee_lamports,
+)
 from allways.constants import RATE_PRECISION
 from allways.solana.client import SolanaClientError
 
@@ -63,6 +71,7 @@ def prompt_rates(canon_from: str, canon_to: str) -> tuple:
 @click.argument('dst_addr', required=False, default=None, type=str)
 @click.argument('rate', required=False, default=None, type=float)
 @click.argument('counter_rate', required=False, default=None, type=float)
+@click.option('--dry-run', 'dry_run', is_flag=True, help='Preview quotes + churn fees; post nothing.')
 @click.option('--yes', '-y', is_flag=True, help='Skip confirmation prompt')
 def post_pair(
     src_chain: str | None,
@@ -72,6 +81,7 @@ def post_pair(
     rate: float | None,
     counter_rate: float | None,
     yes: bool,
+    dry_run: bool,
 ):
     """Post a trading pair to chain via commitment.
 
@@ -175,6 +185,25 @@ def post_pair(
             console.print(f'  {dst_up} → {src_up}: [yellow]not offered[/yellow]')
     console.print(f'  Pubkey:     [dim]{client.keypair.pubkey()}[/dim]\n')
 
+    # Per-direction churn fee for updating an existing quote (creation is free); keyed on each
+    # quote's own updated_at. Total shown before the confirm so the fee is never a surprise.
+    now = int(time.time())
+    miner = client.keypair.pubkey()
+    to_post = ([(src_chain, dst_chain)] if rate > 0 else []) + ([(dst_chain, src_chain)] if counter_rate > 0 else [])
+    total_fee = 0
+    for from_c, to_c in to_post:
+        cur = client.get_quote(miner, from_c, to_c)
+        if cur is not None:
+            total_fee += quote_update_fee_lamports(now - int(cur.updated_at))
+    if total_fee:
+        console.print(
+            f'  [yellow]Churn fee: {total_fee / 1e9:g} SOL[/yellow] '
+            "[dim](updating existing quote(s); free 10 min after each direction's last change)[/dim]\n"
+        )
+
+    if dry_run:
+        console.print('[dim]--dry-run: nothing posted.[/dim]')
+        return
     if not yes and not click.confirm('Confirm publishing this pair?'):
         console.print('[yellow]Cancelled[/yellow]')
         return

--- a/tests/test_network_config.py
+++ b/tests/test_network_config.py
@@ -1,0 +1,65 @@
+"""Per-chain network config — each chain takes a network NAME resolved to an endpoint in code.
+
+Raw-URL escape hatches (SOLANA_RPC_URL env / solana-rpc config, BTC_NETWORK env) win for
+paid/custom endpoints; otherwise the name maps to a public default. `env` is a one-liner bundle
+that sets all three chains' networks + netuid at once.
+"""
+
+from allways.cli.swap_commands.helpers import (
+    BTC_NETWORKS,
+    ENV_BUNDLES,
+    SOLANA_NETWORKS,
+    apply_btc_network_env,
+    resolve_solana_rpc,
+)
+
+
+def test_solana_name_resolves_to_endpoint(monkeypatch):
+    monkeypatch.delenv('SOLANA_RPC_URL', raising=False)
+    assert resolve_solana_rpc({'solana-network': 'devnet'}) == SOLANA_NETWORKS['devnet']
+    assert resolve_solana_rpc({'solana-network': 'mainnet'}) == SOLANA_NETWORKS['mainnet']
+
+
+def test_solana_rpc_config_is_escape_hatch(monkeypatch):
+    monkeypatch.delenv('SOLANA_RPC_URL', raising=False)
+    # A custom/paid URL in solana-rpc wins over the network name.
+    assert resolve_solana_rpc({'solana-rpc': 'https://paid.rpc/x', 'solana-network': 'devnet'}) == 'https://paid.rpc/x'
+
+
+def test_solana_env_wins_over_everything(monkeypatch):
+    monkeypatch.setenv('SOLANA_RPC_URL', 'https://env.rpc/x')
+    assert resolve_solana_rpc({'solana-rpc': 'https://paid.rpc/x', 'solana-network': 'mainnet'}) == 'https://env.rpc/x'
+
+
+def test_solana_unset_defaults_localnet(monkeypatch):
+    monkeypatch.delenv('SOLANA_RPC_URL', raising=False)
+    assert resolve_solana_rpc({}) == 'http://127.0.0.1:8899'
+
+
+def test_solana_unknown_name_falls_back_localnet(monkeypatch):
+    monkeypatch.delenv('SOLANA_RPC_URL', raising=False)
+    assert resolve_solana_rpc({'solana-network': 'nope'}) == 'http://127.0.0.1:8899'
+
+
+def test_env_bundles_cover_all_three_chains():
+    for name in ('testnet', 'mainnet'):
+        b = ENV_BUNDLES[name]
+        assert set(b) == {'network', 'solana-network', 'btc-network', 'netuid'}
+        assert b['solana-network'] in SOLANA_NETWORKS
+        assert b['btc-network'] in BTC_NETWORKS
+
+
+def test_btc_shim_sets_env_when_unset(monkeypatch):
+    monkeypatch.delenv('BTC_NETWORK', raising=False)
+    apply_btc_network_env({'btc-network': 'testnet4'})
+    import os
+
+    assert os.environ.get('BTC_NETWORK') == 'testnet4'
+
+
+def test_btc_shim_respects_real_env(monkeypatch):
+    monkeypatch.setenv('BTC_NETWORK', 'mainnet')
+    apply_btc_network_env({'btc-network': 'testnet4'})
+    import os
+
+    assert os.environ['BTC_NETWORK'] == 'mainnet'  # explicit env wins


### PR DESCRIPTION
Makes each chain resolve its network from a **name** (no hand-copied RPC URLs) and surfaces the quote churn fee before it's charged. Requested by Alex; **@landyndev please review — this touches the `alw` CLI (your lane).**

## Config — per-chain network names
- **`solana-network`** (devnet/mainnet/localnet) → RPC resolved in code (`SOLANA_NETWORKS`). Precedence: `SOLANA_RPC_URL` env → `solana-rpc` config → `solana-network` name → localnet. **Fixes a real footgun:** before, setting only `network` (Bittensor) left Solana silently defaulting to `localhost:8899`.
- **`btc-network`** (mainnet/testnet4/testnet/signet) → fed to the BTC provider's `BTC_NETWORK` env (a real env wins).
- **`env` one-liner:** `alw config set env testnet|mainnet` sets all three chains' networks + netuid at once.
- **Escape hatches preserved:** `solana-rpc`/`SOLANA_RPC_URL`/`BTC_ESPLORA_URLS` still win for paid/custom RPCs.

## CLI UX — `alw miner quotes`
- Before charging, shows each direction's **current rate + the per-direction churn fee** this update incurs (0.01 SOL <5 min / 0.001 at 5–10 min / free after 10 min) + the total, then confirms. Added **`--dry-run`** to preview without posting.

## Tests
`tests/test_network_config.py` (8) covers RPC precedence, escape hatches, env bundle, BTC shim — all green (+ existing dev-mode tests).

## Follow-ups
- `alw pair` could get the same fee-visibility treatment (this PR does the canonical `alw miner quotes`).
- Live-verify on the mineros miner after a rebuild.