### PR TITLE
Map StaleClaimClosed to terminal expired outcome

### DIFF
--- a/allways/validator/event_index.py
+++ b/allways/validator/event_index.py
@@ -37,10 +37,12 @@ _FULFILL_TRANSITIONS = {
 
 # Terminal events → per-swap outcome persisted for the seam (reserve_engine._swap_stage):
 # terminal swap PDAs close on-chain, so this index is what disambiguates a slash from a
-# completion once the account is gone.
+# completion once the account is gone. ``expired`` is a claim reaped stale before attestation
+# (close_stale_claim closes the Swap PDA) — the user never completed, so it's terminal too.
 _OUTCOME_BY_EVENT = {
     'SwapCompleted': 'completed',
     'SwapTimedOut': 'timed_out',
+    'StaleClaimClosed': 'expired',
 }
 
 
@@ -101,6 +103,12 @@ class SolanaEventIndex:
                     int(rec.fields['from_amount']),
                     int(rec.fields['to_amount']),
                 )
+            return True
+        if name == 'StaleClaimClosed':
+            # A PendingAttestation claim reaped stale: the Swap PDA is gone, so record the terminal
+            # 'expired' outcome for the seam. No activity edge — the miner never entered FULFILLING;
+            # its synthetic RESERVE_EXPIRE already returns it to AVAILABLE.
+            self.state_store.record_swap_outcome(bytes(rec.fields['swap_key']).hex(), _OUTCOME_BY_EVENT[name], block_time)
             return True
         if name in ('CollateralPosted', 'CollateralWithdrawn'):
             total = int(rec.fields['total'])

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -265,9 +265,11 @@ class SwapStatus:
     """Seam ``/status`` payload. ``stage`` is the offering-facing lifecycle enum:
 
     none → reserved → claimed → active → fulfilled → { completed | timed_out }
+    (a claim reaped stale before attestation ends at the terminal ``expired`` instead)
 
-    ``completed`` and ``timed_out`` are terminal; ``timed_out`` means the miner was slashed.
-    Both are sourced from the live PDA status or, after the terminal PDA closes on-chain, from
+    ``completed``, ``timed_out``, and ``expired`` are terminal; ``timed_out`` means the miner was
+    slashed, ``expired`` means the claim went stale pre-attestation (no funds moved, the Swap PDA
+    was closed by ``close_stale_claim``). They are sourced from the live PDA status or, after the terminal PDA closes on-chain, from
     the validator's ``swap_outcomes`` event index. A closed PDA whose outcome isn't recorded
     yet reports ``fulfilled`` — transient, normally resolving within ~one forward step once the
     terminal event is ingested. Consumers keep polling on ``fulfilled`` and should apply their
@@ -280,7 +282,7 @@ class SwapStatus:
     moment it goes ``active``. Without ``swap_key``, resolution walks the miner's reservation
     and only the pre-attestation stages (``none``/``reserved``/``claimed``) are reliably visible."""
 
-    stage: str  # none | reserved | claimed | active | fulfilled | completed | timed_out
+    stage: str  # none | reserved | claimed | active | fulfilled | completed | timed_out | expired
     reserved_until: int = 0
     user: str = ''
     swap_key: str = ''
@@ -352,8 +354,8 @@ _STAGE_BY_NAME = {
 def _swap_stage(validator, swap, swap_key: bytes) -> str:
     """Stage for a claimed swap. A closed PDA is terminal, but Completed and TimedOut swaps both
     close on-chain, so the on-chain account alone can't tell a completion from a slash — the
-    validator's own event index (``swap_outcomes``, written on SwapCompleted/SwapTimedOut ingest)
-    disambiguates. On an outcome miss, fall back NON-terminal to ``fulfilled``: the miss is
+    validator's own event index (``swap_outcomes``, written on SwapCompleted/SwapTimedOut/
+    StaleClaimClosed ingest) disambiguates. On an outcome miss, fall back NON-terminal to ``fulfilled``: the miss is
     normally ingest lag (another validator's quorum closed the PDA since our last forward-step
     ingest) and self-corrects at the next ingest, whereas a terminal guess would stop the
     consumer polling on a wrong answer — for a slash, exactly the bug this index exists to fix."""

--- a/tests/test_event_index.py
+++ b/tests/test_event_index.py
@@ -374,6 +374,14 @@ class TestIngestSwapOutcomes:
         assert store.get_swap_outcome(DEFAULT_SWAP_KEY.hex()) is None  # only the event's key lands
         store.close()
 
+    def test_stale_claim_closed_records_expired_outcome(self, tmp_path: Path):
+        store = make_store(tmp_path)
+        idx = SolanaEventIndex(store)
+        key = bytes(range(32))
+        idx.ingest([rec('StaleClaimClosed', miner='pk_a', block_time=400, swap_key=key)], ATTR)
+        assert store.get_swap_outcome(key.hex()) == 'expired'
+        store.close()
+
     def test_reingest_of_same_event_is_a_noop_upsert(self, tmp_path: Path):
         """A cursor reset can replay history — the outcome row upserts instead of erroring."""
         store = make_store(tmp_path)


### PR DESCRIPTION
W4-C. A pre-attestation claim reaped by `close_stale_claim` closes the Swap PDA with no funds moved. The seam previously read those swaps as non-terminal `fulfilled` forever; record an `expired` outcome so consumers see terminal truth.

- `event_index`: `StaleClaimClosed` → `expired` in `_OUTCOME_BY_EVENT` (outcome-only; no activity edge — the synthetic RESERVE_EXPIRE already frees the miner)
- `reserve_engine`: `expired` documented as a terminal stage
- New test: stale-claim ingest records the expired outcome
- 614 tests pass, ruff clean

Pairs with ventura `w4c-expired-outcome`.