### PR TITLE
Un-stub the CLI taker path and make the whole CLI script-safe

### DIFF
--- a/allways/cli/main.py
+++ b/allways/cli/main.py
@@ -5,8 +5,8 @@ Usage:
     alw config              - Show/set CLI configuration
     alw miner post          - Post a trading pair
     alw collateral          - Manage collateral
-    alw swap now        - Execute a swap (guided interactive)
-    alw swap post-tx    - Submit tx hash for pending swap
+    alw swap quote          - Preview miner rates for a swap
+    alw swap now            - Originate a swap (flag-driven)
     alw view                - View swaps, miners, rates
 """
 
@@ -108,6 +108,8 @@ def show_config():
         table.add_column('Value', style='green')
 
         for key, value in config.items():
+            if key in HIDDEN_CONFIG_KEYS:
+                continue  # legacy substrate key, dead on Solana — hidden but tolerated in the file
             table.add_row(key, str(value))
 
         console.print(table)
@@ -130,13 +132,15 @@ VALID_CONFIG_KEYS = (
     'hotkey',
     'network',
     'netuid',
-    'contract-address',
     'program-id',
     'solana-rpc',
     'solana-network',
     'btc-network',
     'env',
 )
+
+# Legacy keys still tolerated in an existing config file but never shown or settable (dead on Solana).
+HIDDEN_CONFIG_KEYS = ('contract-address', 'contract')
 
 
 @config_group.command('set')
@@ -154,8 +158,7 @@ def config_set(key: str, value: str):
         solana-network      Solana network name (devnet/mainnet/localnet) → RPC resolved in code
         solana-rpc          Custom Solana RPC URL (escape hatch; SOLANA_RPC_URL env wins)
         btc-network         Bitcoin network name (mainnet/testnet4/testnet/signet)
-        program-id          Solana program ID (miner/admin commands)
-        contract-address    Legacy substrate contract address (old taker/reserve path)[/dim]
+        program-id          Solana program ID (miner/admin commands)[/dim]
 
     [dim]Networks per chain:
         env:            testnet | mainnet   (sets all three chains at once)
@@ -186,14 +189,14 @@ def config_set(key: str, value: str):
             return
         config.update(bundle)
         CONFIG_FILE.write_text(json.dumps(config, indent=2))
-        console.print(
-            f'[green]Set env {value}:[/green] ' + ', '.join(f'{k}={v}' for k, v in bundle.items())
-        )
+        console.print(f'[green]Set env {value}:[/green] ' + ', '.join(f'{k}={v}' for k, v in bundle.items()))
         return
 
     # Validate name-based network keys — the raw-URL escape hatches are solana-rpc / SOLANA_RPC_URL.
     if key == 'solana-network' and value not in SOLANA_NETWORKS:
-        console.print(f'[red]Unknown solana-network {value!r}; expected {list(SOLANA_NETWORKS)} (or set a custom solana-rpc).[/red]')
+        console.print(
+            f'[red]Unknown solana-network {value!r}; expected {list(SOLANA_NETWORKS)} (or set a custom solana-rpc).[/red]'
+        )
         return
     if key == 'btc-network' and value not in BTC_NETWORKS:
         console.print(f'[red]Unknown btc-network {value!r}; expected {list(BTC_NETWORKS)}.[/red]')

--- a/allways/cli/swap_commands/admin.py
+++ b/allways/cli/swap_commands/admin.py
@@ -6,6 +6,7 @@ from solders.pubkey import Pubkey
 from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
     console,
+    fail,
     from_lamports,
     get_solana_cli_context,
     loading,
@@ -19,8 +20,7 @@ def _parse_pubkey(s: str):
     try:
         return Pubkey.from_string(s)
     except Exception:
-        console.print(f'[red]Not a valid Solana pubkey: {s}[/red]')
-        return None
+        fail(f'Not a valid Solana pubkey: {s}')
 
 
 def _run_setter(title, getter, setter, noun, format_current, new_display, success_msg):
@@ -28,8 +28,7 @@ def _run_setter(title, getter, setter, noun, format_current, new_display, succes
     try:
         current = getter(client)
     except SolanaClientError as e:
-        console.print(f'[red]Failed to read {noun}: {e}[/red]')
-        return
+        fail(f'Failed to read {noun}: {e}')
     console.print(f'\n[bold]{title}[/bold]\n')
     console.print(f'  Current: {format_current(current)}')
     console.print(f'  New:     {new_display}\n')
@@ -41,7 +40,7 @@ def _run_setter(title, getter, setter, noun, format_current, new_display, succes
             setter(client)
         console.print(f'[green]{success_msg}[/green]\n')
     except SolanaClientError as e:
-        console.print(f'[red]Failed to set {noun}: {e}[/red]')
+        fail(f'Failed to set {noun}: {e}')
 
 
 @click.group('admin', cls=StyledGroup, show_disclaimer=True)
@@ -59,8 +58,7 @@ def set_timeout(secs: int):
         $ alw admin set-timeout 600[/dim]
     """
     if secs < 60:
-        console.print('[red]Seconds must be >= 60[/red]')
-        return
+        fail('Seconds must be >= 60')
     _run_setter(
         title='Set Fulfillment Timeout',
         getter=lambda c: c.get_config().fulfillment_timeout_secs,
@@ -81,8 +79,7 @@ def set_reservation_ttl(secs: int):
         $ alw admin set-reservation-ttl 600[/dim]
     """
     if secs <= 0:
-        console.print('[red]Seconds must be positive[/red]')
-        return
+        fail('Seconds must be positive')
     _run_setter(
         title='Set Reservation TTL',
         getter=lambda c: c.get_config().reservation_ttl_secs,
@@ -103,8 +100,7 @@ def set_reservation_fee(amount_sol: float):
         $ alw admin set-reservation-fee 0.001[/dim]
     """
     if amount_sol < 0:
-        console.print('[red]Amount must be non-negative[/red]')
-        return
+        fail('Amount must be non-negative')
     lamports = to_lamports(amount_sol)
     _run_setter(
         title='Set Reservation Fee',
@@ -126,8 +122,7 @@ def set_pool_window(secs: int):
         $ alw admin set-pool-window 60[/dim]
     """
     if secs <= 0:
-        console.print('[red]Seconds must be positive[/red]')
-        return
+        fail('Seconds must be positive')
     _run_setter(
         title='Set Pool Window',
         getter=lambda c: c.get_config().pool_window_secs,
@@ -148,8 +143,7 @@ def set_weights_interval(secs: int):
         $ alw admin set-weights-interval 1200[/dim]
     """
     if secs <= 0:
-        console.print('[red]Seconds must be positive[/red]')
-        return
+        fail('Seconds must be positive')
     _run_setter(
         title='Set Weights Update Interval',
         getter=lambda c: c.get_config().weights_update_min_interval_secs,
@@ -170,8 +164,7 @@ def set_max_extension(secs: int):
         $ alw admin set-max-extension 3600[/dim]
     """
     if secs < 0:
-        console.print('[red]Seconds must be non-negative[/red]')
-        return
+        fail('Seconds must be non-negative')
     _run_setter(
         title='Set Max Total Extension',
         getter=lambda c: c.get_config().max_total_extension_secs,
@@ -192,8 +185,7 @@ def set_min_collateral(amount_sol: float):
         $ alw admin set-min-collateral 2.0[/dim]
     """
     if amount_sol <= 0:
-        console.print('[red]Amount must be positive[/red]')
-        return
+        fail('Amount must be positive')
     lamports = to_lamports(amount_sol)
     _run_setter(
         title='Set Minimum Collateral',
@@ -216,8 +208,7 @@ def set_max_collateral(amount_sol: float):
         $ alw admin set-max-collateral 0[/dim]
     """
     if amount_sol < 0:
-        console.print('[red]Amount must be non-negative[/red]')
-        return
+        fail('Amount must be non-negative')
     lamports = to_lamports(amount_sol)
     _run_setter(
         title='Set Maximum Collateral',
@@ -240,8 +231,7 @@ def set_min_swap(amount_sol: float):
         $ alw admin set-min-swap 0[/dim]
     """
     if amount_sol < 0:
-        console.print('[red]Amount must be non-negative[/red]')
-        return
+        fail('Amount must be non-negative')
     lamports = to_lamports(amount_sol)
     _run_setter(
         title='Set Minimum Swap Amount',
@@ -264,8 +254,7 @@ def set_max_swap(amount_sol: float):
         $ alw admin set-max-swap 0[/dim]
     """
     if amount_sol < 0:
-        console.print('[red]Amount must be non-negative[/red]')
-        return
+        fail('Amount must be non-negative')
     lamports = to_lamports(amount_sol)
     _run_setter(
         title='Set Maximum Swap Amount',
@@ -287,8 +276,7 @@ def set_threshold(percent: int):
         $ alw admin set-threshold 67[/dim]
     """
     if percent <= 0 or percent > 100:
-        console.print('[red]Threshold must be 1-100[/red]')
-        return
+        fail('Threshold must be 1-100')
     _run_setter(
         title='Set Consensus Threshold',
         getter=lambda c: c.get_config().consensus_threshold_percent,
@@ -315,15 +303,12 @@ def add_vali(pubkey: str, weight: int):
         $ alw admin add-vali <pubkey> --weight 1[/dim]
     """
     pk = _parse_pubkey(pubkey)
-    if pk is None:
-        return
     _, client = get_solana_cli_context()
 
     try:
         already = _is_validator(client.get_config(), pk)
     except SolanaClientError as e:
-        console.print(f'[red]Failed to read validator set: {e}[/red]')
-        return
+        fail(f'Failed to read validator set: {e}')
 
     console.print('\n[bold]Add Validator[/bold]\n')
     console.print(f'  Pubkey: {pk}')
@@ -341,7 +326,7 @@ def add_vali(pubkey: str, weight: int):
             client.add_validator(pk, weight)
         console.print(f'[green]Validator {pk} added[/green]\n')
     except SolanaClientError as e:
-        console.print(f'[red]Failed to add validator: {e}[/red]')
+        fail(f'Failed to add validator: {e}')
 
 
 @admin_group.command('remove-vali', show_disclaimer=True)
@@ -353,15 +338,12 @@ def remove_vali(pubkey: str):
         $ alw admin remove-vali <pubkey>[/dim]
     """
     pk = _parse_pubkey(pubkey)
-    if pk is None:
-        return
     _, client = get_solana_cli_context()
 
     try:
         registered = _is_validator(client.get_config(), pk)
     except SolanaClientError as e:
-        console.print(f'[red]Failed to read validator set: {e}[/red]')
-        return
+        fail(f'Failed to read validator set: {e}')
 
     console.print('\n[bold]Remove Validator[/bold]\n')
     console.print(f'  Pubkey: {pk}')
@@ -378,7 +360,7 @@ def remove_vali(pubkey: str):
             client.remove_validator(pk)
         console.print(f'[green]Validator {pk} removed[/green]\n')
     except SolanaClientError as e:
-        console.print(f'[red]Failed to remove validator: {e}[/red]')
+        fail(f'Failed to remove validator: {e}')
 
 
 @admin_group.command('withdraw-treasury', show_disclaimer=True)
@@ -395,15 +377,12 @@ def withdraw_treasury(recipient: str, amount: float | None, yes: bool):
         $ alw admin withdraw-treasury <pubkey> --amount 1.5[/dim]
     """
     pk = _parse_pubkey(recipient)
-    if pk is None:
-        return
     _, client = get_solana_cli_context()
 
     try:
         treasury = client.get_treasury()
     except SolanaClientError as e:
-        console.print(f'[red]Failed to read treasury: {e}[/red]')
-        return
+        fail(f'Failed to read treasury: {e}')
     total = treasury.total if treasury is not None else 0
 
     lamports = to_lamports(amount) if amount is not None else total
@@ -413,11 +392,9 @@ def withdraw_treasury(recipient: str, amount: float | None, yes: bool):
     console.print(f'  Recipient: {pk}\n')
 
     if lamports <= 0:
-        console.print('[yellow]Nothing to withdraw.[/yellow]')
-        return
+        fail('Nothing to withdraw (treasury is empty or amount is zero).')
     if lamports > total:
-        console.print('[red]Requested amount exceeds the accrued treasury balance.[/red]')
-        return
+        fail('Requested amount exceeds the accrued treasury balance.')
 
     if not yes and not click.confirm('Confirm withdrawing treasury fees?'):
         console.print('[yellow]Cancelled[/yellow]')
@@ -428,7 +405,7 @@ def withdraw_treasury(recipient: str, amount: float | None, yes: bool):
             client.withdraw_treasury(pk, lamports)
         console.print(f'[green]Withdrew {from_lamports(lamports):.6f} SOL to {pk}[/green]\n')
     except SolanaClientError as e:
-        console.print(f'[red]Failed to withdraw treasury: {e}[/red]')
+        fail(f'Failed to withdraw treasury: {e}')
 
 
 @click.group('danger', cls=StyledGroup, show_disclaimer=True)
@@ -453,8 +430,7 @@ def halt_system():
             console.print('[yellow]System is already halted[/yellow]')
             return
     except SolanaClientError as e:
-        console.print(f'[red]Failed to read halt status: {e}[/red]')
-        return
+        fail(f'Failed to read halt status: {e}')
 
     console.print('\n[bold red]Halt System[/bold red]\n')
     console.print('  This blocks new deposits / activations / reservation pools.')
@@ -469,7 +445,7 @@ def halt_system():
             client.set_halted(True)
         console.print('[red]System is now halted[/red]\n')
     except SolanaClientError as e:
-        console.print(f'[red]Failed to halt system: {e}[/red]')
+        fail(f'Failed to halt system: {e}')
 
 
 @danger_group.command('resume', show_disclaimer=True)
@@ -486,8 +462,7 @@ def resume_system():
             console.print('[yellow]System is not halted[/yellow]')
             return
     except SolanaClientError as e:
-        console.print(f'[red]Failed to read halt status: {e}[/red]')
-        return
+        fail(f'Failed to read halt status: {e}')
 
     console.print('\n[bold]Resume System[/bold]\n')
     console.print('  This allows new deposits / activations / pools again.\n')
@@ -501,7 +476,7 @@ def resume_system():
             client.set_halted(False)
         console.print('[green]System resumed[/green]\n')
     except SolanaClientError as e:
-        console.print(f'[red]Failed to resume system: {e}[/red]')
+        fail(f'Failed to resume system: {e}')
 
 
 admin_group.add_command(danger_group)

--- a/allways/cli/swap_commands/admin.py
+++ b/allways/cli/swap_commands/admin.py
@@ -1,10 +1,13 @@
 """alw admin - Program administration commands (admin-only, signed by the Solana keypair)."""
 
+import os
+
 import click
 from solders.pubkey import Pubkey
 
 from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
+    FINITE_FLOAT,
     console,
     fail,
     from_lamports,
@@ -23,6 +26,15 @@ def _parse_pubkey(s: str):
         fail(f'Not a valid Solana pubkey: {s}')
 
 
+def _confirm(prompt: str) -> bool:
+    """Confirm interactively, unless a group-level `admin --yes` (or ALW_ASSUME_YES env) opts out — this
+    is what makes the admin commands scriptable/headless without dropping the interactive safety prompt."""
+    ctx = click.get_current_context(silent=True)
+    if (ctx is not None and ctx.obj and ctx.obj.get('yes')) or os.environ.get('ALW_ASSUME_YES'):
+        return True
+    return click.confirm(prompt)
+
+
 def _run_setter(title, getter, setter, noun, format_current, new_display, success_msg):
     _, client = get_solana_cli_context()
     try:
@@ -32,7 +44,7 @@ def _run_setter(title, getter, setter, noun, format_current, new_display, succes
     console.print(f'\n[bold]{title}[/bold]\n')
     console.print(f'  Current: {format_current(current)}')
     console.print(f'  New:     {new_display}\n')
-    if not click.confirm(f'Confirm updating {noun}?'):
+    if not _confirm(f'Confirm updating {noun}?'):
         console.print('[yellow]Cancelled[/yellow]')
         return
     try:
@@ -44,9 +56,14 @@ def _run_setter(title, getter, setter, noun, format_current, new_display, succes
 
 
 @click.group('admin', cls=StyledGroup, show_disclaimer=True)
-def admin_group():
-    """Program administration commands (admin-only)."""
-    pass
+@click.option('--yes', '-y', 'assume_yes', is_flag=True, help='Skip confirmation prompts (for scripting).')
+@click.pass_context
+def admin_group(ctx, assume_yes):
+    """Program administration commands (admin-only).
+
+    [dim]Pass --yes before the subcommand (e.g. `alw admin --yes set-max-swap 50`) or set
+    ALW_ASSUME_YES=1 to run headless.[/dim]"""
+    ctx.obj = {'yes': assume_yes}
 
 
 @admin_group.command('set-timeout', show_disclaimer=True)
@@ -92,7 +109,7 @@ def set_reservation_ttl(secs: int):
 
 
 @admin_group.command('set-reservation-fee', show_disclaimer=True)
-@click.argument('amount_sol', type=float)
+@click.argument('amount_sol', type=FINITE_FLOAT)
 def set_reservation_fee(amount_sol: float):
     """Set the flat per-request reservation fee (in SOL).
 
@@ -177,7 +194,7 @@ def set_max_extension(secs: int):
 
 
 @admin_group.command('set-min-collateral', show_disclaimer=True)
-@click.argument('amount_sol', type=float)
+@click.argument('amount_sol', type=FINITE_FLOAT)
 def set_min_collateral(amount_sol: float):
     """Set the minimum collateral amount (in SOL).
 
@@ -199,7 +216,7 @@ def set_min_collateral(amount_sol: float):
 
 
 @admin_group.command('set-max-collateral', show_disclaimer=True)
-@click.argument('amount_sol', type=float)
+@click.argument('amount_sol', type=FINITE_FLOAT)
 def set_max_collateral(amount_sol: float):
     """Set the maximum collateral amount (in SOL). Use 0 to remove the cap.
 
@@ -222,7 +239,7 @@ def set_max_collateral(amount_sol: float):
 
 
 @admin_group.command('set-min-swap', show_disclaimer=True)
-@click.argument('amount_sol', type=float)
+@click.argument('amount_sol', type=FINITE_FLOAT)
 def set_min_swap(amount_sol: float):
     """Set the minimum swap amount in SOL (SOL-denominated swap size). Use 0 to remove.
 
@@ -245,7 +262,7 @@ def set_min_swap(amount_sol: float):
 
 
 @admin_group.command('set-max-swap', show_disclaimer=True)
-@click.argument('amount_sol', type=float)
+@click.argument('amount_sol', type=FINITE_FLOAT)
 def set_max_swap(amount_sol: float):
     """Set the maximum swap amount in SOL (SOL-denominated swap size). Use 0 to remove.
 
@@ -317,7 +334,7 @@ def add_vali(pubkey: str, weight: int):
         console.print('  [yellow]Warning: this pubkey is already a registered validator[/yellow]')
     console.print()
 
-    if not click.confirm('Confirm adding validator?'):
+    if not _confirm('Confirm adding validator?'):
         console.print('[yellow]Cancelled[/yellow]')
         return
 
@@ -351,7 +368,7 @@ def remove_vali(pubkey: str):
         console.print('  [yellow]Warning: this pubkey is not a registered validator[/yellow]')
     console.print()
 
-    if not click.confirm('Confirm removing validator?'):
+    if not _confirm('Confirm removing validator?'):
         console.print('[yellow]Cancelled[/yellow]')
         return
 
@@ -365,7 +382,7 @@ def remove_vali(pubkey: str):
 
 @admin_group.command('withdraw-treasury', show_disclaimer=True)
 @click.argument('recipient', type=str)
-@click.option('--amount', default=None, type=float, help='Amount in SOL (default: withdraw the full balance)')
+@click.option('--amount', default=None, type=FINITE_FLOAT, help='Amount in SOL (default: withdraw the full balance)')
 @click.option('--yes', '-y', is_flag=True, help='Skip confirmation prompt')
 def withdraw_treasury(recipient: str, amount: float | None, yes: bool):
     """Withdraw accrued protocol fees from the treasury to a recipient.
@@ -396,7 +413,7 @@ def withdraw_treasury(recipient: str, amount: float | None, yes: bool):
     if lamports > total:
         fail('Requested amount exceeds the accrued treasury balance.')
 
-    if not yes and not click.confirm('Confirm withdrawing treasury fees?'):
+    if not yes and not _confirm('Confirm withdrawing treasury fees?'):
         console.print('[yellow]Cancelled[/yellow]')
         return
 
@@ -436,7 +453,7 @@ def halt_system():
     console.print('  This blocks new deposits / activations / reservation pools.')
     console.print('  Existing swaps continue to completion.\n')
 
-    if not click.confirm('Confirm halting the system?'):
+    if not _confirm('Confirm halting the system?'):
         console.print('[yellow]Cancelled[/yellow]')
         return
 
@@ -467,7 +484,7 @@ def resume_system():
     console.print('\n[bold]Resume System[/bold]\n')
     console.print('  This allows new deposits / activations / pools again.\n')
 
-    if not click.confirm('Confirm resuming the system?'):
+    if not _confirm('Confirm resuming the system?'):
         console.print('[yellow]Cancelled[/yellow]')
         return
 

--- a/allways/cli/swap_commands/claim.py
+++ b/allways/cli/swap_commands/claim.py
@@ -1,12 +1,12 @@
 """alw claim - Claim a pending slash payout for a timed-out swap.
 
-Stub: the slash/refund payout flow moves on-chain to Solana with the
-reservation pool; its Solana-backed re-port is pending (`alw swap now` origination is live)."""
+Deferred: the slash/refund payout needs source-chain verification of the failed swap (a chain-provider check
+the CLI taker path does not do yet). Exits non-zero; use the browser flow."""
 
 import click
 
 from allways.cli.help import StyledCommand
-from allways.cli.swap_commands.helpers import taker_view_unavailable
+from allways.cli.swap_commands.helpers import not_implemented
 
 
 @click.command('claim', cls=StyledCommand, show_disclaimer=True)
@@ -22,4 +22,4 @@ def claim_command(swap_id: int, yes: bool):
     [dim]Examples:
         $ alw claim 42[/dim]
     """
-    taker_view_unavailable('Slash claim')
+    not_implemented('Slash claim (CLI fund relay)')

--- a/allways/cli/swap_commands/claim.py
+++ b/allways/cli/swap_commands/claim.py
@@ -10,16 +10,12 @@ from allways.cli.swap_commands.helpers import not_implemented
 
 
 @click.command('claim', cls=StyledCommand, show_disclaimer=True)
-@click.argument('swap_id', type=int)
-@click.option('--yes', '-y', is_flag=True, help='Skip confirmation prompt')
-def claim_command(swap_id: int, yes: bool):
-    """Claim a pending slash payout for a timed-out swap.
+@click.argument('swap_key', type=str, required=False, default=None)
+def claim_command(swap_key):
+    """Claim a slash payout for a timed-out swap (not yet available from the CLI).
 
-    [dim]If a miner failed to fulfill your swap before the timeout,
-    you can claim a slash payout from their collateral.
-    Only the original swap user can claim.[/dim]
-
-    [dim]Examples:
-        $ alw claim 42[/dim]
+    [dim]When a miner fails to fulfill before the timeout, the user is owed a slash payout from the
+    miner's collateral. Settling it needs source-chain verification the CLI taker path does not do
+    yet — use the browser swap flow. Inspect a swap with `alw view swap <swap_key>`.[/dim]
     """
     not_implemented('Slash claim (CLI fund relay)')

--- a/allways/cli/swap_commands/collateral.py
+++ b/allways/cli/swap_commands/collateral.py
@@ -8,12 +8,14 @@ from rich.table import Table
 from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
     console,
+    fail,
     from_lamports,
     from_rao,
     get_cli_context,
     get_solana_cli_context,
     is_valid_ss58,
     loading,
+    secs_str,
     to_lamports,
     to_rao,
 )
@@ -51,8 +53,7 @@ def collateral_deposit(amount: float | None, yes: bool):
         amount = click.prompt('Amount to deposit (SOL)', type=float)
 
     if amount <= 0:
-        console.print('[red]Amount must be positive[/red]')
-        return
+        fail('Amount must be positive')
 
     amount_lamports = to_lamports(amount)
 
@@ -68,21 +69,19 @@ def collateral_deposit(amount: float | None, yes: bool):
         if config is not None and config.max_collateral > 0:
             current = client.get_collateral_lamports(pubkey) or 0
             if current + amount_lamports > config.max_collateral:
-                console.print(
-                    f'[red]This would exceed the max collateral limit ({from_lamports(config.max_collateral):.4f} SOL). '
-                    f'Current: {from_lamports(current):.4f} SOL, posting: {amount} SOL.[/red]'
+                fail(
+                    f'This would exceed the max collateral limit ({from_lamports(config.max_collateral):.4f} SOL). '
+                    f'Current: {from_lamports(current):.4f} SOL, posting: {amount} SOL.'
                 )
-                return
 
         free = client.rpc.get_account_lamports(pubkey) or 0
         required = amount_lamports + SOLANA_FEE_BUFFER_LAMPORTS
         if free < required:
-            console.print(
-                f'[red]Insufficient keypair balance. Free: {from_lamports(free):.4f} SOL, '
-                f'need: {from_lamports(required):.4f} SOL (amount + gas buffer).[/red]'
-            )
             console.print(f'[dim]Fund the Solana keypair: solana transfer {pubkey} <sol>[/dim]')
-            return
+            fail(
+                f'Insufficient keypair balance. Free: {from_lamports(free):.4f} SOL, '
+                f'need: {from_lamports(required):.4f} SOL (amount + gas buffer).'
+            )
     except SolanaClientError as e:
         console.print(f'[yellow]Warning: pre-flight check failed ({e}), proceeding anyway[/yellow]')
     except Exception as e:
@@ -97,7 +96,7 @@ def collateral_deposit(amount: float | None, yes: bool):
             client.post_collateral(amount_lamports)
         console.print(f'[green]Successfully deposited {amount} SOL collateral![/green]')
     except SolanaClientError as e:
-        console.print(f'[red]Failed to deposit collateral: {e}[/red]')
+        fail(f'Failed to deposit collateral: {e}')
 
 
 @collateral_group.command('withdraw', show_disclaimer=True)
@@ -116,8 +115,7 @@ def collateral_withdraw(amount: float | None, yes: bool):
         amount = click.prompt('Amount to withdraw (SOL)', type=float)
 
     if amount <= 0:
-        console.print('[red]Amount must be positive[/red]')
-        return
+        fail('Amount must be positive')
 
     amount_lamports = to_lamports(amount)
 
@@ -132,20 +130,16 @@ def collateral_withdraw(amount: float | None, yes: bool):
         now = int(time.time())
         ms = client.get_miner_state(pubkey)
         if ms is None:
-            console.print('[red]No miner state found for this keypair (no collateral posted).[/red]')
-            return
+            fail('No miner state found for this keypair (no collateral posted).')
 
         if ms.active:
-            console.print('[red]Cannot withdraw while miner is active. Run `alw miner deactivate` first.[/red]')
-            return
+            fail('Cannot withdraw while miner is active. Run `alw miner deactivate` first.')
 
         if ms.has_active_swap:
-            console.print('[red]Cannot withdraw while miner has an active swap.[/red]')
-            return
+            fail('Cannot withdraw while miner has an active swap.')
 
         if ms.busy_until > now:
-            console.print('[red]Cannot withdraw while miner is busy (open pool / held reservation).[/red]')
-            return
+            fail('Cannot withdraw while miner is busy (open pool / held reservation).')
 
         if ms.deactivation_at > 0:
             config = client.get_config()
@@ -153,18 +147,11 @@ def collateral_withdraw(amount: float | None, yes: bool):
             cooldown_end = ms.deactivation_at + (timeout_secs * 2)
             if now < cooldown_end:
                 remaining = cooldown_end - now
-                console.print(
-                    f'[red]Withdrawal cooldown active. ~{remaining}s (~{remaining // 60} min) remaining.[/red]'
-                )
-                return
+                fail(f'Withdrawal cooldown active. {secs_str(remaining)} remaining.')
 
         current = client.get_collateral_lamports(pubkey) or 0
         if amount_lamports > current:
-            console.print(
-                f'[red]Insufficient collateral. Current: {from_lamports(current):.4f} SOL, '
-                f'requested: {amount} SOL.[/red]'
-            )
-            return
+            fail(f'Insufficient collateral. Current: {from_lamports(current):.4f} SOL, requested: {amount} SOL.')
     except SolanaClientError as e:
         console.print(f'[yellow]Warning: pre-flight check failed ({e}), proceeding anyway[/yellow]')
     except Exception as e:
@@ -179,7 +166,7 @@ def collateral_withdraw(amount: float | None, yes: bool):
             client.withdraw_collateral(amount_lamports)
         console.print(f'[green]Successfully withdrew {amount} SOL collateral![/green]')
     except SolanaClientError as e:
-        console.print(f'[red]Failed to withdraw collateral: {e}[/red]')
+        fail(f'Failed to withdraw collateral: {e}')
 
 
 @collateral_group.command('recover-from-hotkey', show_disclaimer=True)
@@ -208,8 +195,7 @@ def collateral_recover_from_hotkey(dest: str | None, amount: float | None, yes: 
     if dest is None:
         dest = wallet.coldkeypub.ss58_address
     elif not is_valid_ss58(dest):
-        console.print(f'[red]Invalid destination ss58 address: {dest}[/red]')
-        return
+        fail(f'Invalid destination ss58 address: {dest}')
 
     keypair = wallet.hotkey
     src = keypair.ss58_address
@@ -219,8 +205,7 @@ def collateral_recover_from_hotkey(dest: str | None, amount: float | None, yes: 
         account_data = account_info.value if hasattr(account_info, 'value') else account_info
         free_rao = int(account_data.get('data', {}).get('free', 0))
     except Exception as e:
-        console.print(f'[red]Failed to read hotkey balance: {e}[/red]')
-        return
+        fail(f'Failed to read hotkey balance: {e}')
 
     sweep = amount is None
     amount_rao = 0
@@ -228,17 +213,15 @@ def collateral_recover_from_hotkey(dest: str | None, amount: float | None, yes: 
         action = 'Sweep entire free balance (minus tx fee)'
     else:
         if amount <= 0:
-            console.print('[red]Amount must be positive[/red]')
-            return
+            fail('Amount must be positive')
         amount_rao = to_rao(amount)
         required = amount_rao + MIN_BALANCE_FOR_TX_RAO
         if required > free_rao:
-            console.print(
-                f'[red]Insufficient hotkey balance. Free: {from_rao(free_rao):.4f} TAO, '
+            fail(
+                f'Insufficient hotkey balance. Free: {from_rao(free_rao):.4f} TAO, '
                 f'need: {from_rao(required):.4f} TAO (amount + {from_rao(MIN_BALANCE_FOR_TX_RAO):.2f} TAO gas buffer). '
-                f'Omit --amount to sweep everything.[/red]'
+                f'Omit --amount to sweep everything.'
             )
-            return
         action = f'Transfer {amount} TAO'
 
     console.print('\n[bold]Recovering Hotkey Balance[/bold]\n')
@@ -275,8 +258,7 @@ def collateral_recover_from_hotkey(dest: str | None, amount: float | None, yes: 
         with loading('Submitting transaction...'):
             receipt = substrate.submit_extrinsic(extrinsic, wait_for_inclusion=True)
     except Exception as e:
-        console.print(f'[red]Failed to submit transfer: {e}[/red]')
-        return
+        fail(f'Failed to submit transfer: {e}')
 
     try:
         succeeded = receipt.is_success
@@ -293,7 +275,7 @@ def collateral_recover_from_hotkey(dest: str | None, amount: float | None, yes: 
         console.print(f'[green]Recovered hotkey balance to {dest}.[/green]')
         console.print(f'[dim]Block hash: {receipt.block_hash}[/dim]')
     else:
-        console.print(f'[red]Transfer failed: {receipt.error_message}[/red]')
+        fail(f'Transfer failed: {receipt.error_message}')
 
 
 @collateral_group.command('view')
@@ -315,8 +297,7 @@ def collateral_view(pubkey: str):
             ms = client.get_miner_state(target)
             config = client.get_config()
     except SolanaClientError as e:
-        console.print(f'[red]Failed to read collateral: {e}[/red]')
-        return
+        fail(f'Failed to read collateral: {e}')
 
     is_active = bool(ms and ms.active)
     min_required = config.min_collateral if config is not None else 0

--- a/allways/cli/swap_commands/collateral.py
+++ b/allways/cli/swap_commands/collateral.py
@@ -7,6 +7,7 @@ from rich.table import Table
 
 from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
+    FINITE_FLOAT,
     console,
     fail,
     from_lamports,
@@ -38,7 +39,7 @@ def collateral_group():
 
 
 @collateral_group.command('deposit', show_disclaimer=True)
-@click.option('--amount', default=None, type=float, help='Amount in SOL')
+@click.option('--amount', default=None, type=FINITE_FLOAT, help='Amount in SOL')
 @click.option('--yes', '-y', is_flag=True, help='Skip confirmation prompt')
 def collateral_deposit(amount: float | None, yes: bool):
     """Deposit SOL collateral to the swap program.
@@ -50,7 +51,7 @@ def collateral_deposit(amount: float | None, yes: bool):
         $ alw collateral deposit  (prompts interactively)[/dim]
     """
     if amount is None:
-        amount = click.prompt('Amount to deposit (SOL)', type=float)
+        amount = click.prompt('Amount to deposit (SOL)', type=FINITE_FLOAT)
 
     if amount <= 0:
         fail('Amount must be positive')
@@ -100,7 +101,7 @@ def collateral_deposit(amount: float | None, yes: bool):
 
 
 @collateral_group.command('withdraw', show_disclaimer=True)
-@click.option('--amount', default=None, type=float, help='Amount in SOL')
+@click.option('--amount', default=None, type=FINITE_FLOAT, help='Amount in SOL')
 @click.option('--yes', '-y', is_flag=True, help='Skip confirmation prompt')
 def collateral_withdraw(amount: float | None, yes: bool):
     """Withdraw SOL collateral from the swap program.
@@ -112,7 +113,7 @@ def collateral_withdraw(amount: float | None, yes: bool):
         $ alw collateral withdraw  (prompts interactively)[/dim]
     """
     if amount is None:
-        amount = click.prompt('Amount to withdraw (SOL)', type=float)
+        amount = click.prompt('Amount to withdraw (SOL)', type=FINITE_FLOAT)
 
     if amount <= 0:
         fail('Amount must be positive')
@@ -171,7 +172,9 @@ def collateral_withdraw(amount: float | None, yes: bool):
 
 @collateral_group.command('recover-from-hotkey', show_disclaimer=True)
 @click.option('--dest', default=None, help='Destination ss58 (default: your coldkey)')
-@click.option('--amount', default=None, type=float, help='Amount in TAO to recover (default: sweep all free balance)')
+@click.option(
+    '--amount', default=None, type=FINITE_FLOAT, help='Amount in TAO to recover (default: sweep all free balance)'
+)
 @click.option('--yes', '-y', is_flag=True, help='Skip confirmation prompt')
 def collateral_recover_from_hotkey(dest: str | None, amount: float | None, yes: bool):
     """Move a hotkey's free TAO balance back to your coldkey.

--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -1,4 +1,5 @@
 import json
+import math
 import os
 import sys
 import time
@@ -88,19 +89,57 @@ class CliError(Exception):
     """Local CLI/Solana error type — replaces the deleted ink! contract error."""
 
 
+# NOT_IMPLEMENTED_EXIT: distinct from Click's usage-error code (2) so a script can tell "deferred CLI
+# path" apart from "you passed bad args". EX_UNAVAILABLE (sysexits.h) = 69.
+NOT_IMPLEMENTED_EXIT = 69
+
+# When a --json command is running, errors must stay machine-readable — `fail()` emits `{"error": ...}`
+# instead of Rich text so a consumer piping --json never chokes on a plain-text error. Set per command.
+_JSON_OUTPUT = False
+
+
+def set_json_output(enabled: bool) -> None:
+    """Mark the current command as JSON-mode so `fail()` (and thus `safe_read`) emit JSON errors."""
+    global _JSON_OUTPUT
+    _JSON_OUTPUT = bool(enabled)
+
+
+class FiniteFloatType(click.ParamType):
+    """A float option that rejects nan/inf at parse time with a clean Click usage error — so
+    user-supplied `--amount nan/inf/1e999` never reaches an `int()` cast and dumps a traceback."""
+
+    name = 'number'
+
+    def convert(self, value, param, ctx):
+        try:
+            f = float(value)
+        except (TypeError, ValueError):
+            self.fail(f'{value!r} is not a number', param, ctx)
+        if not math.isfinite(f):
+            self.fail(f'{value!r} must be a finite number (not nan/inf)', param, ctx)
+        return f
+
+
+FINITE_FLOAT = FiniteFloatType()
+
+
 def fail(message: str, code: int = 1) -> None:
-    """Single error-exit path: print the message in red and exit non-zero so `$?` reflects failure.
+    """Single error-exit path: exit non-zero so `$?` reflects failure. In JSON mode emits
+    `{"error": ...}`; otherwise prints the message in red.
 
     Every command rejection/error across the CLI routes through here — that is what makes the CLI script-safe."""
-    console.print(f'[red]{message}[/red]')
+    if _JSON_OUTPUT:
+        click.echo(json.dumps({'error': message}))
+    else:
+        console.print(f'[red]{message}[/red]')
     raise SystemExit(code)
 
 
-def not_implemented(what: str, code: int = 2) -> None:
+def not_implemented(what: str, code: int = NOT_IMPLEMENTED_EXIT) -> None:
     """Honest exit for the fund-moving relays (post-tx / claim / resume) that need chain-provider verification.
 
-    Points at the working browser flow and exits non-zero (code 2 = not implemented) so scripts don't mistake
-    a deferred path for success. This is NOT a read view — the read views are all live on Solana now."""
+    Points at the working browser flow and exits with EX_UNAVAILABLE (69, not Click's usage-error 2) so
+    scripts can tell a deferred path apart from bad args. The read views are all live on Solana now."""
     console.print(
         f'[yellow]{what} is not available from the CLI yet.[/yellow]\n'
         f'[dim]This step verifies your deposit against the source chain, which the CLI taker path does not do '
@@ -115,6 +154,21 @@ def print_json(data) -> None:
     click.echo(json.dumps(data, indent=2, default=str))
 
 
+def effective_rate(from_chain: str, to_chain: str, rate_display: str) -> str:
+    """Directional 'to per 1 from' rate for display. Stored quotes are canonical 'dest per 1 hub', which
+    reads backwards for a spoke→hub direction (BTC→SOL stored 0.0021 really means ~476 SOL per BTC).
+    Return the reciprocal for spoke→hub so `amount × shown-rate ≈ you receive` always reconciles."""
+    from allways.constants import NUMERAIRE_CHAIN
+
+    try:
+        r = float(rate_display)
+    except (TypeError, ValueError):
+        return rate_display
+    if to_chain == NUMERAIRE_CHAIN and r > 0:
+        r = 1.0 / r
+    return f'{r:.8g}'
+
+
 def safe_read(fn: Callable, what: str = 'read from Solana'):
     """Run a client read, converting any RPC/decode/transport failure into a clean non-zero `fail`.
 
@@ -125,8 +179,8 @@ def safe_read(fn: Callable, what: str = 'read from Solana'):
         return fn()
     except (SolanaClientError, SolanaRpcError) as e:
         fail(f'Failed to {what}: {e}')
-    except requests.RequestException as e:
-        fail(f'Could not reach the Solana RPC ({what}): {e}')
+    except requests.RequestException:
+        fail(f'Could not reach the Solana RPC to {what}. Is the node up at the configured solana-rpc?')
 
 
 ZERO_SWAP_KEY = bytes(32)

--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -2,8 +2,9 @@ import json
 import os
 import sys
 import time
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Callable, List, Optional, Tuple
 
 import bittensor as bt
 import click
@@ -13,6 +14,8 @@ from rich.text import Text
 
 from allways.classes import SwapStatus
 from allways.constants import NETUID_FINNEY, TAO_TO_RAO
+from allways.solana.client import SolanaClientError
+from allways.solana.rpc import SolanaRpcError
 
 ALLWAYS_DIR = Path.home() / '.allways'
 CONFIG_FILE = ALLWAYS_DIR / 'config.json'
@@ -72,23 +75,129 @@ def quote_update_fee_lamports(elapsed_secs: int) -> int:
             return fee
     return 0
 
+
 console = Console()
+
+# The taker fund-relay path (post-tx / claim / resume) verifies deposits against a chain provider before it
+# can advance a swap; that verification isn't wired into the CLI yet. Until it is, those commands point at the
+# working browser flow. Keep this URL in one place so every pointer agrees.
+BROWSER_SWAP_URL = 'http://localhost:9090'
 
 
 class CliError(Exception):
     """Local CLI/Solana error type — replaces the deleted ink! contract error."""
 
 
-def taker_view_unavailable(what: str) -> None:
-    """Stub for the taker READ/relay views (preview, dashboard, resume, post-tx) still on the old ink! surface.
+def fail(message: str, code: int = 1) -> None:
+    """Single error-exit path: print the message in red and exit non-zero so `$?` reflects failure.
 
-    Swap origination (`alw swap now`) is live on Solana. What remains stubbed are the read-only aggregation
-    views that drew from the ink! contract surface and need a Solana MinerQuote/Reservation-backed re-port."""
+    Every command rejection/error across the CLI routes through here — that is what makes the CLI script-safe."""
+    console.print(f'[red]{message}[/red]')
+    raise SystemExit(code)
+
+
+def not_implemented(what: str, code: int = 2) -> None:
+    """Honest exit for the fund-moving relays (post-tx / claim / resume) that need chain-provider verification.
+
+    Points at the working browser flow and exits non-zero (code 2 = not implemented) so scripts don't mistake
+    a deferred path for success. This is NOT a read view — the read views are all live on Solana now."""
     console.print(
-        f'[yellow]{what} is not available yet.[/yellow]\n'
-        '[dim]Swap origination (`alw swap now`) is live on Solana; this read/relay view still needs its '
-        'Solana-backed re-port (MinerQuote aggregation, on-chain swaps/reservations).[/dim]'
+        f'[yellow]{what} is not available from the CLI yet.[/yellow]\n'
+        f'[dim]This step verifies your deposit against the source chain, which the CLI taker path does not do '
+        f'yet. Use the browser swap flow at {BROWSER_SWAP_URL} to complete a swap end-to-end; '
+        f'`alw swap now` originates a reservation on-chain.[/dim]'
     )
+    raise SystemExit(code)
+
+
+def print_json(data) -> None:
+    """Emit a value as pretty JSON (str fallback for non-serializable types like Pubkey)."""
+    click.echo(json.dumps(data, indent=2, default=str))
+
+
+def safe_read(fn: Callable, what: str = 'read from Solana'):
+    """Run a client read, converting any RPC/decode/transport failure into a clean non-zero `fail`.
+
+    Reads raise `SolanaClientError` (decode), `SolanaRpcError` (RPC-level error), or a bare
+    `requests` transport error (unreachable RPC). All three must surface as a script-safe failure,
+    never a stacktrace."""
+    try:
+        return fn()
+    except (SolanaClientError, SolanaRpcError) as e:
+        fail(f'Failed to {what}: {e}')
+    except requests.RequestException as e:
+        fail(f'Could not reach the Solana RPC ({what}): {e}')
+
+
+ZERO_SWAP_KEY = bytes(32)
+
+
+@dataclass
+class MinerBookEntry:
+    """One miner's aggregated on-chain view: its posted quotes (one per direction) plus runtime state.
+
+    Taker views key by the Solana miner pubkey (a miner has no bittensor uid here), so `miner` is the identity."""
+
+    miner: object  # solders Pubkey
+    quotes: List[object] = field(default_factory=list)  # MinerQuote rows, one per direction
+    collateral: int = 0  # lamports
+    state: Optional[object] = None  # MinerState | None
+    reservation: Optional[object] = None  # Reservation | None
+
+    @property
+    def pubkey_str(self) -> str:
+        return str(self.miner)
+
+
+def load_miner_book(client, with_reservation: bool = True) -> List[MinerBookEntry]:
+    """Group all on-chain MinerQuote rows by miner and attach collateral + state (+ reservation).
+
+    One `MinerBookEntry` per distinct miner pubkey; `quotes` holds its per-direction rows. Any read failure
+    routes through `safe_read` (clean non-zero exit)."""
+    rows = safe_read(lambda: client.get_all('MinerQuote'), what='read miner quotes')
+    by_miner: dict = {}
+    for _pk, q in rows:
+        by_miner.setdefault(bytes(q.miner), MinerBookEntry(miner=q.miner)).quotes.append(q)
+    book = list(by_miner.values())
+    for entry in book:
+        entry.collateral = (
+            safe_read(lambda m=entry.miner: client.get_collateral_lamports(m), what='read collateral') or 0
+        )
+        entry.state = safe_read(lambda m=entry.miner: client.get_miner_state(m), what='read miner state')
+        if with_reservation:
+            entry.reservation = safe_read(lambda m=entry.miner: client.get_reservation(m), what='read reservation')
+    return book
+
+
+def miner_runtime_status(state, reservation, now: int) -> str:
+    """Collapse on-chain miner state into one runtime label the taker views sort/filter on.
+
+    offline (not registered / inactive) → in-swap → reserved (live reservation, no deposit claimed yet) →
+    cooldown (busy) → available."""
+    if state is None or not state.active:
+        return 'offline'
+    if state.has_active_swap:
+        return 'in-swap'
+    if (
+        reservation is not None
+        and int(getattr(reservation, 'reserved_until', 0)) > now
+        and bytes(getattr(reservation, 'claimed_swap_key', ZERO_SWAP_KEY)) == ZERO_SWAP_KEY
+    ):
+        return 'reserved'
+    if int(getattr(state, 'busy_until', 0)) > now:
+        return 'cooldown'
+    return 'available'
+
+
+STATUS_STYLES = {
+    'available': 'green',
+    'reserved': 'cyan',
+    'in-swap': 'yellow',
+    'cooldown': 'magenta',
+    'offline': 'dim',
+}
+# Deterministic sort order for `--sort status`: most-available first.
+STATUS_SORT_ORDER = ['available', 'reserved', 'in-swap', 'cooldown', 'offline']
 
 
 # --- Miner reliability (swap success rate) -------------------------------
@@ -331,7 +440,9 @@ def from_lamports(amount_lamports: int) -> float:
 
 
 def secs_str(secs: int) -> str:
-    """Render a seconds duration as `<n>s (~<m>m)` — shared by admin setters and view dumps."""
+    """Render a seconds duration for admin setters + view dumps: bare `45s` under a minute, `600s (~10m)` above."""
+    if secs < 60:
+        return f'{secs}s'
     return f'{secs}s (~{secs // 60}m)'
 
 

--- a/allways/cli/swap_commands/miner_commands.py
+++ b/allways/cli/swap_commands/miner_commands.py
@@ -10,6 +10,7 @@ from allways.cli.dendrite_lite import discover_validators, resolve_dendrite_time
 from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
     console,
+    fail,
     from_lamports,
     get_cli_context,
     get_solana_cli_context,
@@ -47,8 +48,7 @@ def miner_status(pubkey: str):
             config = client.get_config()
             ms = client.get_miner_state(target)
     except SolanaClientError as e:
-        console.print(f'[red]Failed to read miner data: {e}[/red]')
-        return
+        fail(f'Failed to read miner data: {e}')
 
     is_active = bool(ms and ms.active)
     has_active_swap = bool(ms and ms.has_active_swap)
@@ -168,8 +168,7 @@ def miner_activate():
         validator_axons = discover_validators(subtensor, netuid)
 
     if not validator_axons:
-        console.print('[red]No validators found on metagraph[/red]\n')
-        return
+        fail('No validators found on metagraph')
 
     # Broadcast, re-signing a fresh timestamp each attempt. On a 429 the request
     # was rejected at the edge proxy and never reached the validator — back off
@@ -220,18 +219,17 @@ def miner_activate():
     if accepted == 0 and no_response == len(validator_axons):
         console.print('[dim]The chain may be slow — the vote could still land after this check.[/dim]')
         console.print('[dim]Retry with a longer timeout: ALW_DENDRITE_TIMEOUT=90 alw miner activate[/dim]')
-        console.print('[dim]Or re-run `alw miner status` in a minute to see if activation completed.[/dim]\n')
+        console.print('[dim]Or re-run `alw miner status` in a minute to see if activation completed.[/dim]')
     elif accepted == 0 and info.category in ('', 'mixed', 'unmatched'):
         # Translator couldn't pin down a single cause — fall back to the prerequisites checklist.
         console.print('[dim]Prerequisites for activation:[/dim]')
         console.print('[dim]  - Hotkey registered on this subnet (btcli subnets register)[/dim]')
         console.print('[dim]  - Trading pair posted (alw miner post)[/dim]')
         console.print('[dim]  - Collateral deposited >= 0.1 TAO (alw collateral deposit)[/dim]')
-        console.print('[dim]Run `alw miner status` to see which are missing.[/dim]\n')
+        console.print('[dim]Run `alw miner status` to see which are missing.[/dim]')
     elif accepted > 0:
-        console.print(
-            '[yellow]Votes submitted but quorum not yet reached. Check status with: alw miner status[/yellow]\n'
-        )
+        console.print('[dim]Votes submitted but quorum not yet reached. Check status with: alw miner status[/dim]')
+    fail('Activation not confirmed on-chain.')
 
 
 @miner_group.command('deactivate')
@@ -257,20 +255,13 @@ def miner_deactivate():
             console.print('[yellow]Miner is not active.[/yellow]\n')
             return
         if ms.has_active_swap:
-            console.print(
-                '[red]Cannot deactivate: you have an active swap.[/red]\n'
-                '[dim]Wait for it to complete or time out, then try again.[/dim]\n'
-            )
-            return
+            console.print('[dim]Wait for it to complete or time out, then try again.[/dim]')
+            fail('Cannot deactivate: you have an active swap.')
         if ms.busy_until > now:
             remaining = ms.busy_until - now
-            console.print(
-                f'[red]Cannot deactivate: you are busy (open pool / held reservation), ~{remaining}s left.[/red]\n'
-            )
-            return
+            fail(f'Cannot deactivate: you are busy (open pool / held reservation), ~{remaining}s left.')
     except SolanaClientError as e:
-        console.print(f'[red]Failed to read miner state: {e}[/red]')
-        return
+        fail(f'Failed to read miner state: {e}')
 
     try:
         with loading('Submitting transaction...'):
@@ -281,7 +272,7 @@ def miner_deactivate():
             cooldown = config.fulfillment_timeout_secs * 2
             console.print(f'[dim]Collateral withdrawal available after {cooldown}s (~{cooldown // 60} min)[/dim]\n')
     except SolanaClientError as e:
-        console.print(f'[red]Failed to deactivate: {e}[/red]')
+        fail(f'Failed to deactivate: {e}')
 
 
 @miner_group.command('mark-fulfilled')
@@ -307,22 +298,16 @@ def miner_mark_fulfilled(from_tx_hash: str, to_tx_hash: str, to_tx_block: int, y
     try:
         acct = client.get_swap(swap_key)
     except SolanaClientError as e:
-        console.print(f'[red]Failed to read swap: {e}[/red]')
-        return
+        fail(f'Failed to read swap: {e}')
     if acct is None:
-        console.print(f'[red]Swap {swap_key.hex()[:16]} not found on-chain.[/red]')
-        return
+        fail(f'Swap {swap_key.hex()[:16]} not found on-chain.')
     swap = swap_from_solana(acct, swap_key)
 
     if str(swap.miner) != str(pubkey):
-        console.print(f'[red]Swap {swap.key_hex[:16]} is assigned to a different miner, not you.[/red]\n')
-        return
+        fail(f'Swap {swap.key_hex[:16]} is assigned to a different miner, not you.')
     if swap.status != 'Active':
-        console.print(
-            f'[yellow]Swap {swap.key_hex[:16]} is not Active — current status: [bold]{swap.status}[/bold].[/yellow]\n'
-            '[dim]mark_fulfilled is only accepted while the swap is Active.[/dim]'
-        )
-        return
+        console.print('[dim]mark_fulfilled is only accepted while the swap is Active.[/dim]')
+        fail(f'Swap {swap.key_hex[:16]} is not Active — current status: {swap.status}.')
 
     console.print(f'\n[bold]Mark Fulfilled — {swap.key_hex[:16]}[/bold]\n')
     console.print(f'  Pair:        {swap.from_chain.upper()} → {swap.to_chain.upper()}')
@@ -339,7 +324,7 @@ def miner_mark_fulfilled(from_tx_hash: str, to_tx_hash: str, to_tx_block: int, y
             sig = client.mark_fulfilled(swap_key=swap_key, to_tx_hash=to_tx_hash, to_tx_block=to_tx_block)
         console.print(f'[green]Swap {swap.key_hex[:16]} marked as fulfilled[/green] (sig: {sig[:16]}...)\n')
     except SolanaClientError as e:
-        console.print(f'[red]Failed to mark fulfilled: {e}[/red]')
+        fail(f'Failed to mark fulfilled: {e}')
 
 
 @miner_group.command('bind-hotkey')
@@ -370,8 +355,7 @@ def miner_bind_hotkey(yes: bool):
     hotkey_bytes = bytes(wallet.hotkey.public_key)
     sig = wallet.hotkey.sign(bytes(pubkey))
     if not bt.Keypair(public_key='0x' + hotkey_bytes.hex()).verify(bytes(pubkey), sig):
-        console.print('[red]Local signature verify failed; not submitting.[/red]')
-        return
+        fail('Local signature verify failed; not submitting.')
 
     if not yes and not click.confirm('Confirm binding?'):
         console.print('[yellow]Cancelled[/yellow]')
@@ -382,4 +366,4 @@ def miner_bind_hotkey(yes: bool):
             client.bind_hotkey(hotkey_bytes, sig)
         console.print(f'[green]Bound {wallet.hotkey.ss58_address} → {pubkey}[/green]\n')
     except SolanaClientError as e:
-        console.print(f'[red]Failed to bind hotkey: {e}[/red]')
+        fail(f'Failed to bind hotkey: {e}')

--- a/allways/cli/swap_commands/miner_commands.py
+++ b/allways/cli/swap_commands/miner_commands.py
@@ -10,6 +10,7 @@ from allways.cli.dendrite_lite import discover_validators, resolve_dendrite_time
 from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
     console,
+    effective_rate,
     fail,
     from_lamports,
     get_cli_context,
@@ -80,7 +81,8 @@ def miner_status(pubkey: str):
         console.print('[bold]Posted Quotes[/bold]\n')
         for q in quotes:
             src_up, dst_up = q.from_chain.upper(), q.to_chain.upper()
-            console.print(f'  {src_up} → {dst_up}: [green]rate {q.rate / RATE_PRECISION:g}[/green]')
+            rd = effective_rate(q.from_chain, q.to_chain, f'{q.rate / RATE_PRECISION:g}')
+            console.print(f'  {src_up} → {dst_up}: [green]{rd} {dst_up}/{src_up}[/green]')
             console.print(f'    receive on {src_up}: [dim]{q.miner_from_addr}[/dim]')
             console.print(f'    send on {dst_up}:    [dim]{q.miner_to_addr}[/dim]')
     else:

--- a/allways/cli/swap_commands/numeraire.py
+++ b/allways/cli/swap_commands/numeraire.py
@@ -20,6 +20,7 @@ import click
 from allways.cli.help import StyledCommand
 from allways.cli.swap_commands.helpers import (
     console,
+    fail,
     get_cli_context,
     get_solana_cli_context,
     loading,
@@ -112,15 +113,12 @@ def quotes_command(spread_bps, dry_run, yes, **spoke_opts):
         if not price or price <= 0:
             continue
         if not addr:
-            console.print(f'[red]--{spoke}-address required with --{spoke}-price[/red]')
-            return
+            fail(f'--{spoke}-address required with --{spoke}-price')
         chain_specs[spoke] = (price, addr)
     if not chain_specs:
-        console.print('[yellow]Nothing to post — give at least one --<chain>-price/--<chain>-address.[/yellow]')
-        return
+        fail('Nothing to post — give at least one --<chain>-price/--<chain>-address.')
     if not sol_address:
-        console.print(f'[red]--{NUMERAIRE_CHAIN}-address is required.[/red]')
-        return
+        fail(f'--{NUMERAIRE_CHAIN}-address is required.')
 
     _, wallet, _, _ = get_cli_context(need_client=False)
     _, client = get_solana_cli_context()
@@ -173,9 +171,10 @@ def quotes_command(spread_bps, dry_run, yes, **spoke_opts):
             posted += 1
         except SolanaClientError as e:
             console.print(f'[red]Failed {sp.from_chain.upper()} → {sp.to_chain.upper()}: {e}[/red]')
-    if posted:
-        console.print(f'[green]Published {posted} quote direction(s)![/green]')
-        write_rate_posted_flag(wallet.hotkey.ss58_address)
+    if not posted:
+        fail('No quotes were published.')
+    console.print(f'[green]Published {posted} quote direction(s)![/green]')
+    write_rate_posted_flag(wallet.hotkey.ss58_address)
 
 
 # Interpolate the registry-derived example into the help (Click doesn't format docstrings).

--- a/allways/cli/swap_commands/numeraire.py
+++ b/allways/cli/swap_commands/numeraire.py
@@ -19,6 +19,7 @@ import click
 
 from allways.cli.help import StyledCommand
 from allways.cli.swap_commands.helpers import (
+    FINITE_FLOAT,
     console,
     fail,
     get_cli_context,
@@ -75,7 +76,7 @@ def quote_options(f):
         f = click.option(f'--{spoke}-address', default=None, help=f'Your {spoke.upper()} address.')(f)
         f = click.option(
             f'--{spoke}-price',
-            type=float,
+            type=FINITE_FLOAT,
             default=None,
             help=f'{spoke.upper()} per 1 {hub} (0/omit to skip {spoke.upper()}).',
         )(f)

--- a/allways/cli/swap_commands/pair.py
+++ b/allways/cli/swap_commands/pair.py
@@ -7,6 +7,7 @@ import click
 from allways.chains import SUPPORTED_CHAINS, canonical_pair
 from allways.cli.help import StyledCommand
 from allways.cli.swap_commands.helpers import (
+    FINITE_FLOAT,
     console,
     fail,
     get_cli_context,
@@ -43,19 +44,19 @@ def prompt_rates(canon_from: str, canon_to: str) -> tuple:
     fwd_label = f'  {src_up} to {dst_up} (user sends {src_up}, miner returns {dst_up})'
     rev_label = f'  {dst_up} to {src_up} (user sends {dst_up}, miner returns {src_up})'
     while True:
-        fwd = click.prompt(fwd_label, type=float)
+        fwd = click.prompt(fwd_label, type=FINITE_FLOAT)
         if fwd < 0:
             console.print('[red]Rate cannot be negative[/red]')
         else:
             break
     if fwd > 0:
-        rev = click.prompt(rev_label, type=float, default=fwd)
+        rev = click.prompt(rev_label, type=FINITE_FLOAT, default=fwd)
         if rev < 0:
             console.print('[red]Rate cannot be negative, using 0 (not offered)[/red]')
             rev = 0.0
     else:
         while True:
-            rev = click.prompt(rev_label, type=float)
+            rev = click.prompt(rev_label, type=FINITE_FLOAT)
             if rev < 0:
                 console.print('[red]Rate cannot be negative[/red]')
             elif rev == 0:
@@ -70,8 +71,8 @@ def prompt_rates(canon_from: str, canon_to: str) -> tuple:
 @click.argument('src_addr', required=False, default=None, type=str)
 @click.argument('dst_chain', required=False, default=None, type=str)
 @click.argument('dst_addr', required=False, default=None, type=str)
-@click.argument('rate', required=False, default=None, type=float)
-@click.argument('counter_rate', required=False, default=None, type=float)
+@click.argument('rate', required=False, default=None, type=FINITE_FLOAT)
+@click.argument('counter_rate', required=False, default=None, type=FINITE_FLOAT)
 @click.option('--dry-run', 'dry_run', is_flag=True, help='Preview quotes + churn fees; post nothing.')
 @click.option('--yes', '-y', is_flag=True, help='Skip confirmation prompt')
 def post_pair(

--- a/allways/cli/swap_commands/pair.py
+++ b/allways/cli/swap_commands/pair.py
@@ -8,6 +8,7 @@ from allways.chains import SUPPORTED_CHAINS, canonical_pair
 from allways.cli.help import StyledCommand
 from allways.cli.swap_commands.helpers import (
     console,
+    fail,
     get_cli_context,
     get_solana_cli_context,
     loading,
@@ -106,9 +107,8 @@ def post_pair(
     else:
         src_chain = src_chain.lower()
         if src_chain not in SUPPORTED_CHAINS:
-            console.print(f'[red]Unsupported chain: {src_chain}[/red]')
             console.print(f'[dim]Supported: {", ".join(SUPPORTED_CHAINS.keys())}[/dim]')
-            return
+            fail(f'Unsupported chain: {src_chain}')
 
     if dst_chain is None:
         remaining = [c for c in SUPPORTED_CHAINS if c != src_chain]
@@ -119,12 +119,10 @@ def post_pair(
     else:
         dst_chain = dst_chain.lower()
         if dst_chain not in SUPPORTED_CHAINS:
-            console.print(f'[red]Unsupported chain: {dst_chain}[/red]')
             console.print(f'[dim]Supported: {", ".join(SUPPORTED_CHAINS.keys())}[/dim]')
-            return
+            fail(f'Unsupported chain: {dst_chain}')
         if dst_chain == src_chain:
-            console.print('[red]Chains must be different[/red]')
-            return
+            fail('Chains must be different')
 
     # --- Addresses ---
     if src_addr is None:
@@ -139,17 +137,14 @@ def post_pair(
     if rate is None:
         rate, counter_rate = prompt_rates(canon_from, canon_to)
     elif rate < 0:
-        console.print('[red]Rate cannot be negative[/red]')
-        return
+        fail('Rate cannot be negative')
     else:
         if counter_rate is None:
             counter_rate = rate
         elif counter_rate < 0:
-            console.print('[red]Rate cannot be negative[/red]')
-            return
+            fail('Rate cannot be negative')
         if rate == 0 and counter_rate == 0:
-            console.print('[red]At least one direction must have a positive rate[/red]')
-            return
+            fail('At least one direction must have a positive rate')
 
     # Normalize to canonical direction.
     # Positional args: RATE = user's source→dest, so swap rates to match canonical order.
@@ -232,9 +227,10 @@ def post_pair(
         except SolanaClientError as e:
             console.print(f'[red]Failed to publish {from_chain.upper()} → {to_chain.upper()}: {e}[/red]')
 
-    if posted:
-        console.print(f'[green]Published {posted} quote direction(s)![/green]')
-        write_rate_posted_flag(wallet.hotkey.ss58_address)
+    if not posted:
+        fail('No quotes were published.')
+    console.print(f'[green]Published {posted} quote direction(s)![/green]')
+    write_rate_posted_flag(wallet.hotkey.ss58_address)
 
 
 def write_rate_posted_flag(hotkey: str) -> None:

--- a/allways/cli/swap_commands/post_tx.py
+++ b/allways/cli/swap_commands/post_tx.py
@@ -1,13 +1,12 @@
 """alw swap post-tx - Submit source transaction hash for a pending swap reservation.
 
-Stub: the reserve→deposit→confirm relay moves on-chain to Solana
-(submit_swap_claim against an on-chain Reservation); the taker CLI intake is not
-wired yet."""
+Deferred: advancing a reservation with a source-tx hash requires verifying the deposit against the source
+chain (a chain-provider check the CLI taker path does not do yet). Exits non-zero; use the browser flow."""
 
 import click
 
 from allways.cli.help import StyledCommand
-from allways.cli.swap_commands.helpers import taker_view_unavailable
+from allways.cli.swap_commands.helpers import not_implemented
 
 
 @click.command('post-tx', cls=StyledCommand, show_disclaimer=True)
@@ -34,4 +33,4 @@ def post_tx_command(tx_hash: str, tx_block: int):
         $ alw swap post-tx abc123def... --block 12345   (escape hatch)
         $ alw swap post-tx  (prompts for tx hash)[/dim]
     """
-    taker_view_unavailable('Swap post-tx')
+    not_implemented('Swap post-tx (CLI fund relay)')

--- a/allways/cli/swap_commands/post_tx.py
+++ b/allways/cli/swap_commands/post_tx.py
@@ -11,26 +11,10 @@ from allways.cli.swap_commands.helpers import not_implemented
 
 @click.command('post-tx', cls=StyledCommand, show_disclaimer=True)
 @click.argument('tx_hash', required=False, default=None, type=str)
-@click.option(
-    '--block',
-    'tx_block',
-    type=int,
-    default=0,
-    help=(
-        'Override the source-tx block number. Usually unnecessary — the CLI '
-        'looks it up automatically across the whole reservation window. Use '
-        'this only when automatic lookup fails (e.g. running against a node '
-        'that has pruned block bodies, or the tx landed on a different node).'
-    ),
-)
-def post_tx_command(tx_hash: str, tx_block: int):
-    """Submit your source transaction hash for a pending swap reservation.
+def post_tx_command(tx_hash: str):
+    """Submit your source transaction hash to advance a reservation (not yet available from the CLI).
 
-    [dim]Reads reservation context from ~/.allways/pending_swap.json (saved by `alw swap now`).[/dim]
-
-    [dim]Examples:
-        $ alw swap post-tx abc123def...
-        $ alw swap post-tx abc123def... --block 12345   (escape hatch)
-        $ alw swap post-tx  (prompts for tx hash)[/dim]
+    [dim]Relaying a deposit verifies your source transaction against the source chain, which the CLI
+    taker path does not do yet — use the browser swap flow to complete a swap end-to-end.[/dim]
     """
     not_implemented('Swap post-tx (CLI fund relay)')

--- a/allways/cli/swap_commands/quote.py
+++ b/allways/cli/swap_commands/quote.py
@@ -1,28 +1,161 @@
 """alw swap quote - Preview rates and estimated receive amounts before swapping.
 
-Stub: the rate preview reads miner quotes from the old ink! commitment
-surface; its Solana MinerQuote-backed taker view is not wired yet."""
+Reads live MinerQuote/MinerState from the Solana program, runs the same miner-selection + amount math the
+origination path uses (`swap_intake`), and shows every viable miner and what you would receive after the 1%
+protocol fee — without committing to a swap."""
+
+import sys
 
 import click
+from rich.table import Table
+from rich.text import Text
 
-from allways.cli.swap_commands.helpers import taker_view_unavailable
+from allways.chains import SUPPORTED_CHAINS, get_chain
+from allways.cli.swap_commands.helpers import (
+    console,
+    fail,
+    from_lamports,
+    get_solana_cli_context,
+    load_miner_book,
+    print_json,
+    safe_read,
+)
+from allways.cli.swap_commands.swap_intake import (
+    MinerCandidate,
+    compute_intake_amounts,
+    rate_display_from_fixed,
+    select_best_miner,
+    swap_viable,
+    to_smallest_units,
+)
+from allways.constants import FEE_DIVISOR
+from allways.utils.rate import apply_fee_deduction, is_executable_rate
+
+
+def _prompt_or_fail(value, prompt_text, opt, cast=str):
+    if value is not None:
+        return value
+    if sys.stdin.isatty():
+        return click.prompt(prompt_text, type=cast)
+    fail(f'{opt} is required (no TTY to prompt).')
 
 
 @click.command('quote')
-@click.option('--from', 'from_chain', default=None, type=str, help='Source chain (e.g. btc, tao)')
-@click.option('--to', 'to_chain', default=None, type=str, help='Destination chain (e.g. btc, tao)')
+@click.option('--from', 'from_chain', default=None, type=str, help='Source chain (e.g. sol, btc, tao)')
+@click.option('--to', 'to_chain', default=None, type=str, help='Destination chain (e.g. sol, btc, tao)')
 @click.option('--amount', default=None, type=float, help='Amount to send in source chain units')
-def quote_command(from_chain: str, to_chain: str, amount: float):
+@click.option('--json', 'as_json', is_flag=True, help='Emit machine-readable JSON instead of a table.')
+def quote_command(from_chain: str, to_chain: str, amount: float, as_json: bool):
     """Preview rates and estimated receive amounts for a swap.
 
     \b
-    Shows all available miners, their rates, and what you would receive
-    after fees — without committing to a swap. Omit any flag to be prompted.
+    Shows every miner that could fund the swap, their rate, and what you would
+    receive after the 1% protocol fee — without committing. The best offer is
+    highlighted. Omit a flag to be prompted (interactive TTY only).
 
     \b
     Examples:
-        alw swap quote
-        alw swap quote --from btc --to tao --amount 0.1
-        alw swap quote --from tao --to btc --amount 50
+        alw swap quote --from sol --to btc --amount 1
+        alw swap quote --from btc --to sol --amount 0.001
     """
-    taker_view_unavailable('Swap quote preview')
+    from_chain = _prompt_or_fail(from_chain, 'Source chain', '--from')
+    to_chain = _prompt_or_fail(to_chain, 'Destination chain', '--to')
+    amount = _prompt_or_fail(amount, 'Amount (source units)', '--amount', cast=float)
+
+    from_chain = from_chain.lower()
+    to_chain = to_chain.lower()
+    if from_chain not in SUPPORTED_CHAINS or to_chain not in SUPPORTED_CHAINS:
+        fail(f'--from/--to must each be one of: {", ".join(SUPPORTED_CHAINS)}')
+    if from_chain == to_chain or 'sol' not in (from_chain, to_chain):
+        fail('A swap must have a SOL leg (sol<->btc or sol<->tao) and two distinct chains.')
+    if amount <= 0:
+        fail('--amount must be positive.')
+
+    _, client = get_solana_cli_context(need_keypair=False)
+    cfg = safe_read(lambda: client.get_config(), what='read config')
+    min_swap = int(getattr(cfg, 'min_swap_amount', 0)) if cfg else 0
+    max_swap = int(getattr(cfg, 'max_swap_amount', 0)) if cfg else 0
+
+    from_amount = to_smallest_units(amount, from_chain)
+    to_dec = get_chain(to_chain).decimals
+
+    book = load_miner_book(client, with_reservation=False)
+    candidates = []
+    for e in book:
+        for q in e.quotes:
+            if q.from_chain == from_chain and q.to_chain == to_chain:
+                candidates.append(
+                    MinerCandidate(miner=q.miner, rate_display=rate_display_from_fixed(q.rate), collateral=e.collateral)
+                )
+
+    # Build the viable set with the same guards the contract enforces, and identify the best offer.
+    viable = []  # (candidate, receive_units)
+    for c in candidates:
+        try:
+            rate = float(c.rate_display)
+        except (TypeError, ValueError):
+            continue
+        if not is_executable_rate(rate, from_chain, to_chain, min_swap, max_swap):
+            continue
+        amts = compute_intake_amounts(from_chain, to_chain, from_amount, c.rate_display)
+        if amts.to_amount <= 0:
+            continue
+        ok, _reason = swap_viable(amts.sol_amount, c.collateral, min_swap, max_swap)
+        if not ok:
+            continue
+        viable.append((c, apply_fee_deduction(amts.to_amount, FEE_DIVISOR)))
+
+    best = select_best_miner(candidates, from_chain, to_chain, from_amount, min_swap, max_swap)
+    best_miner = str(best[0].miner) if best else None
+
+    if as_json:
+        print_json(
+            {
+                'from': from_chain,
+                'to': to_chain,
+                'amount': amount,
+                'fee_percent': 100 / FEE_DIVISOR,
+                'best_miner': best_miner,
+                'offers': [
+                    {
+                        'miner': str(c.miner),
+                        'rate': c.rate_display,
+                        'receive': recv / 10**to_dec,
+                        'collateral_sol': from_lamports(c.collateral),
+                        'best': str(c.miner) == best_miner,
+                    }
+                    for c, recv in sorted(viable, key=lambda x: x[1], reverse=True)
+                ],
+            }
+        )
+        return
+
+    if not viable:
+        why = (
+            'no miner is quoting that direction'
+            if not candidates
+            else 'no miner can fund that swap within bounds/collateral'
+        )
+        fail(f'No quote available: {why} right now.')
+
+    viable.sort(key=lambda x: x[1], reverse=True)
+    table = Table(
+        title=f'Quote: {amount:g} {from_chain.upper()} → {to_chain.upper()}  (after {100 / FEE_DIVISOR:g}% fee)',
+        show_header=True,
+    )
+    table.add_column('Miner', style='cyan')
+    table.add_column('Rate', style='white', justify='right')
+    table.add_column(f'You receive ({to_chain.upper()})', style='green', justify='right')
+    table.add_column('Collateral', justify='right')
+    table.add_column('', style='bold yellow')
+    for c, recv in viable:
+        is_best = str(c.miner) == best_miner
+        table.add_row(
+            Text(str(c.miner)[:12] + '…', style='bold cyan' if is_best else 'cyan'),
+            c.rate_display,
+            f'{recv / 10**to_dec:.8g}',
+            f'{from_lamports(c.collateral):.2f} SOL',
+            '★ best' if is_best else '',
+        )
+    console.print(table)
+    console.print('[dim]Preview only — run `alw swap now` to originate a reservation.[/dim]')

--- a/allways/cli/swap_commands/quote.py
+++ b/allways/cli/swap_commands/quote.py
@@ -12,13 +12,16 @@ from rich.text import Text
 
 from allways.chains import SUPPORTED_CHAINS, get_chain
 from allways.cli.swap_commands.helpers import (
+    FINITE_FLOAT,
     console,
+    effective_rate,
     fail,
     from_lamports,
     get_solana_cli_context,
     load_miner_book,
     print_json,
     safe_read,
+    set_json_output,
 )
 from allways.cli.swap_commands.swap_intake import (
     MinerCandidate,
@@ -43,7 +46,7 @@ def _prompt_or_fail(value, prompt_text, opt, cast=str):
 @click.command('quote')
 @click.option('--from', 'from_chain', default=None, type=str, help='Source chain (e.g. sol, btc, tao)')
 @click.option('--to', 'to_chain', default=None, type=str, help='Destination chain (e.g. sol, btc, tao)')
-@click.option('--amount', default=None, type=float, help='Amount to send in source chain units')
+@click.option('--amount', default=None, type=FINITE_FLOAT, help='Amount to send in source chain units')
 @click.option('--json', 'as_json', is_flag=True, help='Emit machine-readable JSON instead of a table.')
 def quote_command(from_chain: str, to_chain: str, amount: float, as_json: bool):
     """Preview rates and estimated receive amounts for a swap.
@@ -58,6 +61,7 @@ def quote_command(from_chain: str, to_chain: str, amount: float, as_json: bool):
         alw swap quote --from sol --to btc --amount 1
         alw swap quote --from btc --to sol --amount 0.001
     """
+    set_json_output(as_json)
     from_chain = _prompt_or_fail(from_chain, 'Source chain', '--from')
     to_chain = _prompt_or_fail(to_chain, 'Destination chain', '--to')
     amount = _prompt_or_fail(amount, 'Amount (source units)', '--amount', cast=float)
@@ -119,7 +123,8 @@ def quote_command(from_chain: str, to_chain: str, amount: float, as_json: bool):
                 'offers': [
                     {
                         'miner': str(c.miner),
-                        'rate': c.rate_display,
+                        'rate': effective_rate(from_chain, to_chain, c.rate_display),
+                        'rate_unit': f'{to_chain.upper()} per {from_chain.upper()}',
                         'receive': recv / 10**to_dec,
                         'collateral_sol': from_lamports(c.collateral),
                         'best': str(c.miner) == best_miner,
@@ -128,7 +133,8 @@ def quote_command(from_chain: str, to_chain: str, amount: float, as_json: bool):
                 ],
             }
         )
-        return
+        # Same contract as the table path: no fundable offer is a failure, format-independent.
+        raise SystemExit(0 if viable else 1)
 
     if not viable:
         why = (
@@ -144,7 +150,7 @@ def quote_command(from_chain: str, to_chain: str, amount: float, as_json: bool):
         show_header=True,
     )
     table.add_column('Miner', style='cyan')
-    table.add_column('Rate', style='white', justify='right')
+    table.add_column(f'Rate ({to_chain.upper()}/{from_chain.upper()})', style='white', justify='right')
     table.add_column(f'You receive ({to_chain.upper()})', style='green', justify='right')
     table.add_column('Collateral', justify='right')
     table.add_column('', style='bold yellow')
@@ -152,7 +158,7 @@ def quote_command(from_chain: str, to_chain: str, amount: float, as_json: bool):
         is_best = str(c.miner) == best_miner
         table.add_row(
             Text(str(c.miner)[:12] + '…', style='bold cyan' if is_best else 'cyan'),
-            c.rate_display,
+            effective_rate(from_chain, to_chain, c.rate_display),
             f'{recv / 10**to_dec:.8g}',
             f'{from_lamports(c.collateral):.2f} SOL',
             '★ best' if is_best else '',

--- a/allways/cli/swap_commands/resume.py
+++ b/allways/cli/swap_commands/resume.py
@@ -3,38 +3,17 @@
 Deferred: resuming a reservation submits + verifies the source deposit against the source chain (a
 chain-provider check the CLI taker path does not do yet). Exits non-zero; use the browser flow."""
 
-from typing import Optional
-
 import click
 
 from allways.cli.swap_commands.helpers import not_implemented
 
 
 @click.command('resume-reservation')
-@click.option('--from-tx-hash', 'from_tx_hash_opt', default=None, help='Source tx hash (skip fund sending)')
-@click.option(
-    '--send',
-    'auto_send',
-    is_flag=True,
-    help='Broadcast source funds automatically (TAO via wallet, BTC via BTC_PRIVATE_KEY)',
-)
-@click.option('--yes', 'skip_confirm', is_flag=True, help='Skip confirmation prompts')
-def resume_reservation_command(from_tx_hash_opt: Optional[str], auto_send: bool, skip_confirm: bool):
-    """Resume an interrupted pre-initiate reservation.
+def resume_reservation_command():
+    """Resume an interrupted pre-initiate reservation (not yet available from the CLI).
 
-    \b
-    Picks up a reservation that was opened by `alw swap now` but never made
-    it to vote_initiate — submits the source transaction hash and confirms
-    with validators. If the reservation has expired, guides the user to
-    start fresh with `alw swap now`.
-
-    \b
-    Interactive mode:
-        alw swap resume-reservation
-
-    \b
-    Non-interactive mode (for scripting/agents):
-        alw swap resume-reservation --from-tx-hash abc123... --yes
-        alw swap resume-reservation --send --yes
+    Advancing a reservation submits + verifies the source deposit against the source chain, which the
+    CLI taker path does not do yet. Use the browser swap flow to resume; inspect a reservation's state
+    with `alw view reservation --miner <pubkey>`.
     """
     not_implemented('Swap resume-reservation (CLI fund relay)')

--- a/allways/cli/swap_commands/resume.py
+++ b/allways/cli/swap_commands/resume.py
@@ -1,13 +1,13 @@
 """alw swap resume-reservation - Recover an interrupted pre-initiate reservation flow.
 
-Stub: the reserve→deposit→initiate flow moves on-chain to Solana with the
-reservation pool; its Solana-backed re-port is pending (`alw swap now` origination is live)."""
+Deferred: resuming a reservation submits + verifies the source deposit against the source chain (a
+chain-provider check the CLI taker path does not do yet). Exits non-zero; use the browser flow."""
 
 from typing import Optional
 
 import click
 
-from allways.cli.swap_commands.helpers import taker_view_unavailable
+from allways.cli.swap_commands.helpers import not_implemented
 
 
 @click.command('resume-reservation')
@@ -37,4 +37,4 @@ def resume_reservation_command(from_tx_hash_opt: Optional[str], auto_send: bool,
         alw swap resume-reservation --from-tx-hash abc123... --yes
         alw swap resume-reservation --send --yes
     """
-    taker_view_unavailable('Swap resume-reservation')
+    not_implemented('Swap resume-reservation (CLI fund relay)')

--- a/allways/cli/swap_commands/status.py
+++ b/allways/cli/swap_commands/status.py
@@ -1,22 +1,147 @@
-"""alw status - Quick dashboard showing network, wallet, and swap state.
+"""alw status - Quick dashboard: network, Solana RPC/program health, your balance, and miner/taker state.
 
-Stub: the pending-reservation/swap dashboard reads the on-chain
-reservation pool (Solana); its Solana-backed re-port is pending (`alw swap now` origination is live)."""
+Reads the live Solana program. If your keypair is a registered miner it summarizes miner state; otherwise it
+shows the taker view (any live reservation for --miner / the saved swap) and points at the browser swap UI."""
+
+import time
 
 import click
 
 from allways.cli.help import StyledCommand
-from allways.cli.swap_commands.helpers import taker_view_unavailable
+from allways.cli.swap_commands.helpers import (
+    BROWSER_SWAP_URL,
+    ZERO_SWAP_KEY,
+    console,
+    from_lamports,
+    get_effective_config,
+    get_solana_cli_context,
+    print_json,
+    safe_read,
+)
+
+
+def _load_caller():
+    """Load the caller's Solana keypair without creating one. Returns Pubkey or None."""
+    from allways.solana import keys
+
+    try:
+        return keys.load_keypair().pubkey()
+    except Exception:
+        return None
 
 
 @click.command('status', cls=StyledCommand)
-def status_command():
-    """Show a quick dashboard of your current state.
-
-    [dim]Displays network info, wallet balance, active swaps,
-    pending reservations, and miner status (if applicable).[/dim]
+@click.option('--miner', 'miner_pk', default=None, type=str, help='Miner pubkey to check for a taker reservation')
+@click.option('--json', 'as_json', is_flag=True, help='Emit machine-readable JSON instead of a dashboard.')
+def status_command(miner_pk, as_json):
+    """Show a quick dashboard of network, program health, your balance, and swap state.
 
     [dim]Examples:
         $ alw status[/dim]
     """
-    taker_view_unavailable('Swap status dashboard')
+    config = get_effective_config()
+    network = config.get('network', 'finney')
+    _, client = get_solana_cli_context(need_keypair=False)
+
+    cfg = safe_read(lambda: client.get_config(), what='reach Solana RPC')
+    program_initialized = cfg is not None
+    halted = bool(cfg and cfg.halted)
+
+    caller = _load_caller()
+    balance = None
+    miner_state = None
+    if caller is not None:
+        balance = safe_read(lambda: client.rpc.get_account_lamports(caller), what='read balance')
+        miner_state = safe_read(lambda: client.get_miner_state(caller), what='read miner state')
+
+    is_miner = miner_state is not None
+    now = int(time.time())
+
+    # Taker reservation: explicit --miner, else the miner saved by `alw swap now`.
+    resv = None
+    resv_miner = miner_pk or _saved_miner()
+    if not is_miner and resv_miner:
+        from solders.pubkey import Pubkey
+
+        try:
+            resv = safe_read(lambda: client.get_reservation(Pubkey.from_string(resv_miner)), what='read reservation')
+        except (ValueError, TypeError):
+            resv = None
+
+    if as_json:
+        out = {
+            'network': network,
+            'solana_rpc': client.rpc.url,
+            'program_initialized': program_initialized,
+            'halted': halted,
+            'caller': str(caller) if caller else None,
+            'balance_sol': from_lamports(balance) if balance is not None else None,
+            'is_miner': is_miner,
+        }
+        if is_miner:
+            out['miner'] = {
+                'collateral_sol': from_lamports(miner_state.collateral),
+                'active': miner_state.active,
+                'has_active_swap': miner_state.has_active_swap,
+                'successful_swaps': miner_state.successful_swaps,
+                'failed_swaps': miner_state.failed_swaps,
+            }
+        elif resv is not None:
+            out['reservation'] = {
+                'miner': resv_miner,
+                'from_chain': resv.from_chain,
+                'to_chain': resv.to_chain,
+                'reserved_until': int(resv.reserved_until),
+                'deposit_claimed': bytes(resv.claimed_swap_key) != ZERO_SWAP_KEY,
+            }
+        print_json(out)
+        return
+
+    console.print('\n[bold]Allways Status[/bold]\n')
+    console.print(f'  Network:      {network}')
+    console.print(f'  Solana RPC:   {client.rpc.url}')
+    console.print(
+        f'  Program:      {"[green]initialized[/green]" if program_initialized else "[red]not initialized[/red]"}'
+        + ('  [red](halted)[/red]' if halted else '')
+    )
+    if caller is not None:
+        bal = f'{from_lamports(balance):.4f} SOL' if balance is not None else '[dim]unknown[/dim]'
+        console.print(f'  Keypair:      {caller}')
+        console.print(f'  Balance:      {bal}')
+    else:
+        console.print('  Keypair:      [dim]none loaded (set SOLANA_KEYPAIR_PATH)[/dim]')
+
+    if is_miner:
+        console.print('\n[bold]Miner[/bold]\n')
+        console.print(f'  Collateral:      {from_lamports(miner_state.collateral):.4f} SOL')
+        console.print(f'  Active:          {"[green]yes[/green]" if miner_state.active else "[red]no[/red]"}')
+        console.print(f'  Active swap:     {"[yellow]yes[/yellow]" if miner_state.has_active_swap else "no"}')
+        console.print(f'  Swaps (ok/fail): {miner_state.successful_swaps} / {miner_state.failed_swaps}')
+        console.print('\n[dim]Manage with `alw miner status`, `alw collateral view`.[/dim]\n')
+        return
+
+    console.print('\n[bold]Taker[/bold]\n')
+    if resv is not None:
+        remaining = max(0, int(resv.reserved_until) - now)
+        claimed = bytes(resv.claimed_swap_key) != ZERO_SWAP_KEY
+        console.print(f'  Reservation:  {resv.from_chain.upper()} → {resv.to_chain.upper()} on {resv_miner}')
+        console.print(f'  Reserved:     {"expired" if remaining == 0 else f"{remaining}s remaining"}')
+        console.print(f'  Deposit:      {"claimed" if claimed else "not yet sent"}')
+    elif resv_miner:
+        console.print(f'  [dim]No active reservation on {resv_miner}.[/dim]')
+    else:
+        console.print('  [dim]No pending swap. Preview with `alw swap quote`, originate with `alw swap now`.[/dim]')
+    console.print(f'\n[dim]Or swap in the browser: {BROWSER_SWAP_URL}[/dim]\n')
+
+
+def _saved_miner():
+    from allways.cli.swap_commands.helpers import PENDING_SWAP_FILE
+
+    if not PENDING_SWAP_FILE.exists():
+        return None
+    import json
+
+    try:
+        return json.loads(PENDING_SWAP_FILE.read_text()).get('miner')
+    except (json.JSONDecodeError, OSError):
+        return None

--- a/allways/cli/swap_commands/status.py
+++ b/allways/cli/swap_commands/status.py
@@ -12,11 +12,13 @@ from allways.cli.swap_commands.helpers import (
     BROWSER_SWAP_URL,
     ZERO_SWAP_KEY,
     console,
+    fail,
     from_lamports,
     get_effective_config,
     get_solana_cli_context,
     print_json,
     safe_read,
+    set_json_output,
 )
 
 
@@ -39,11 +41,12 @@ def status_command(miner_pk, as_json):
     [dim]Examples:
         $ alw status[/dim]
     """
+    set_json_output(as_json)
     config = get_effective_config()
     network = config.get('network', 'finney')
     _, client = get_solana_cli_context(need_keypair=False)
 
-    cfg = safe_read(lambda: client.get_config(), what='reach Solana RPC')
+    cfg = safe_read(lambda: client.get_config(), what='read the program config')
     program_initialized = cfg is not None
     halted = bool(cfg and cfg.halted)
 
@@ -64,9 +67,10 @@ def status_command(miner_pk, as_json):
         from solders.pubkey import Pubkey
 
         try:
-            resv = safe_read(lambda: client.get_reservation(Pubkey.from_string(resv_miner)), what='read reservation')
+            miner_key = Pubkey.from_string(resv_miner)
         except (ValueError, TypeError):
-            resv = None
+            fail(f'Invalid --miner pubkey: {resv_miner}')
+        resv = safe_read(lambda: client.get_reservation(miner_key), what='read reservation')
 
     if as_json:
         out = {

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -14,7 +14,7 @@ import click
 
 from allways.chains import SUPPORTED_CHAINS, get_chain
 from allways.cli.help import StyledGroup
-from allways.cli.swap_commands.helpers import PENDING_SWAP_FILE, console, fail, get_solana_cli_context
+from allways.cli.swap_commands.helpers import FINITE_FLOAT, PENDING_SWAP_FILE, console, fail, get_solana_cli_context
 from allways.cli.swap_commands.swap_intake import (
     MinerCandidate,
     rate_display_from_fixed,
@@ -54,7 +54,7 @@ def _poll_reservation(client, miner, timeout_secs: int):
 @swap_group.command('now', show_disclaimer=True)
 @click.option('--from', 'from_chain_opt', default=None, help='Source chain (e.g. btc, tao)')
 @click.option('--to', 'to_chain_opt', default=None, help='Destination chain (e.g. btc, tao)')
-@click.option('--amount', 'amount_opt', default=None, type=float, help='Amount to send in source chain units')
+@click.option('--amount', 'amount_opt', default=None, type=FINITE_FLOAT, help='Amount to send in source chain units')
 @click.option('--receive-address', 'receive_address_opt', default=None, help='Receive address on destination chain')
 @click.option('--from-address', 'from_address_opt', default=None, help='Source address on source chain')
 @click.option('--from-tx-hash', 'from_tx_hash_opt', default=None, help='Source tx hash (skip fund sending)')

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -2,10 +2,11 @@
 
 Origination is on-chain on Solana: the taker opens a per-miner reservation pool (`open_or_request`), a
 permissionless stake-weighted draw (`resolve_pool`, run by the validator crank) picks the winning request,
-then the taker sends source funds to the winning miner's address. `swap now` wires the scripted origination
-slice (select miner → compute amounts → open_or_request → poll for the reservation). Fund-sending + post-tx
-(`swap post-tx`) land next."""
+then the taker sends source funds to the winning miner's address. `swap now` wires the flag-driven
+origination slice (select miner → compute amounts → open_or_request → poll for the reservation). Auto
+fund-sending + post-tx (`swap post-tx`) land next."""
 
+import json
 import time
 from typing import List, Optional
 
@@ -13,7 +14,7 @@ import click
 
 from allways.chains import SUPPORTED_CHAINS, get_chain
 from allways.cli.help import StyledGroup
-from allways.cli.swap_commands.helpers import console, get_solana_cli_context
+from allways.cli.swap_commands.helpers import PENDING_SWAP_FILE, console, fail, get_solana_cli_context
 from allways.cli.swap_commands.swap_intake import (
     MinerCandidate,
     rate_display_from_fixed,
@@ -57,7 +58,6 @@ def _poll_reservation(client, miner, timeout_secs: int):
 @click.option('--receive-address', 'receive_address_opt', default=None, help='Receive address on destination chain')
 @click.option('--from-address', 'from_address_opt', default=None, help='Source address on source chain')
 @click.option('--from-tx-hash', 'from_tx_hash_opt', default=None, help='Source tx hash (skip fund sending)')
-@click.option('--auto', 'auto_select', is_flag=True, help='Auto-select best rate miner')
 @click.option('--yes', 'skip_confirm', is_flag=True, help='Skip confirmation prompts')
 @click.option(
     '--btc-fee-rate',
@@ -78,40 +78,30 @@ def swap_now_command(
     receive_address_opt: Optional[str],
     from_address_opt: Optional[str],
     from_tx_hash_opt: Optional[str],
-    auto_select: bool,
     skip_confirm: bool,
     btc_fee_rate_opt: Optional[int],
 ):
     """Originate a swap: reserve a miner on-chain, then send source funds.
 
-    [dim]Scripted form (interactive prompts + auto fund-sending land next):
+    [dim]Flag-driven form (interactive prompts + auto fund-sending land next):
         alw swap now --from sol --to btc --amount 1.0 --receive-address <btc-addr> --yes[/dim]
     """
     from_chain = (from_chain_opt or '').lower()
     to_chain = (to_chain_opt or '').lower()
     if from_chain not in SUPPORTED_CHAINS or to_chain not in SUPPORTED_CHAINS:
-        console.print(f'[red]--from/--to must each be one of: {", ".join(SUPPORTED_CHAINS)}[/red]')
-        return
+        fail(f'--from/--to must each be one of: {", ".join(SUPPORTED_CHAINS)}')
     if from_chain == to_chain or NUMERAIRE_CHAIN not in (from_chain, to_chain):
-        console.print(
-            f'[red]A launch swap must have a {NUMERAIRE_CHAIN.upper()} leg (every pair is hub<->spoke).[/red]'
-        )
-        return
+        fail(f'A launch swap must have a {NUMERAIRE_CHAIN.upper()} leg (every pair is hub<->spoke).')
     if amount_opt is None or amount_opt <= 0:
-        console.print('[red]--amount (source-chain units) is required.[/red]')
-        return
+        fail('--amount (source-chain units) is required.')
     if not receive_address_opt:
-        console.print('[red]--receive-address (destination chain) is required.[/red]')
-        return
+        fail('--receive-address (destination chain) is required.')
 
     _config, client = get_solana_cli_context(need_keypair=True)
     user = client.keypair.pubkey()
     user_from_addr = str(user) if from_chain == NUMERAIRE_CHAIN else (from_address_opt or '')
     if not user_from_addr:
-        console.print(
-            f'[red]--from-address (your source-chain address) is required for a non-{NUMERAIRE_CHAIN.upper()} source.[/red]'
-        )
-        return
+        fail(f'--from-address (your source-chain address) is required for a non-{NUMERAIRE_CHAIN.upper()} source.')
 
     cfg = client.get_config()
     min_swap = int(getattr(cfg, 'min_swap_amount', 0)) if cfg else 0
@@ -121,12 +111,10 @@ def swap_now_command(
     from_amount = to_smallest_units(amount_opt, from_chain)
     candidates = _candidate_miners(client, from_chain, to_chain)
     if not candidates:
-        console.print(f'[yellow]No miners quoting {from_chain}->{to_chain} right now.[/yellow]')
-        return
+        fail(f'No miners quoting {from_chain}->{to_chain} right now.')
     best = select_best_miner(candidates, from_chain, to_chain, from_amount, min_swap, max_swap)
     if best is None:
-        console.print('[yellow]No miner can fund an executable swap for that amount within bounds.[/yellow]')
-        return
+        fail('No miner can fund an executable swap for that amount within bounds.')
     cand, amts = best
     recv = amts.to_amount / 10 ** get_chain(to_chain).decimals
 
@@ -152,12 +140,21 @@ def swap_now_command(
 
     resv = _poll_reservation(client, cand.miner, timeout_secs=pool_window + 60)
     if resv is None:
-        console.print('[yellow]  Pool not resolved yet — check `alw view reservation` shortly.[/yellow]')
-        return
+        fail('  Pool not resolved yet — check `alw view reservation` shortly.')
     if str(resv.user) != str(user):
-        console.print("[yellow]  Another taker won this miner's draw. Re-run to try again.[/yellow]")
-        return
+        fail("  Another taker won this miner's draw. Re-run to try again.")
+
+    _save_pending(cand.miner, from_chain, to_chain)
     console.print(
         f'[green]  Reserved.[/green] Send [cyan]{amount_opt} {from_chain.upper()}[/cyan] to '
         f'[cyan]{resv.miner_from_addr}[/cyan], then run [bold]alw swap post-tx[/bold] with the tx hash.'
     )
+
+
+def _save_pending(miner, from_chain: str, to_chain: str) -> None:
+    """Persist the reserved miner so `alw view reservation` / `alw status` can find it without a flag."""
+    try:
+        PENDING_SWAP_FILE.parent.mkdir(parents=True, exist_ok=True)
+        PENDING_SWAP_FILE.write_text(json.dumps({'miner': str(miner), 'from_chain': from_chain, 'to_chain': to_chain}))
+    except OSError:
+        pass  # best-effort convenience; not required for the swap to proceed

--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -1,25 +1,45 @@
 """alw view - Inspect miners, rates, swaps, validators, config, and reservations.
 
-`view config` and `view validators` read the on-chain Config directly. The taker aggregation
-views (miners/rates/swaps/reservation) still drew from the old ink! contract surface and need a
-Solana-backed re-port (MinerQuote aggregation, on-chain swaps/reservations), so they stay stubbed."""
+All views read the on-chain Solana program: `config`/`validators` read the Config account; `miners`/`rates`
+aggregate MinerQuote + MinerState; `active-swaps`/`swap` read Swap accounts; `reservation` reads a per-miner
+Reservation. Reads need no keypair. Per-miner reliability is keyed by bittensor hotkey (not the Solana miner
+pubkey these views key on), so it is intentionally omitted here rather than shown against the wrong key.
+"""
+
+import json
+import time
 
 import click
+from rich.table import Table
+from rich.text import Text
 from solders.pubkey import Pubkey
 
+from allways.chains import SUPPORTED_CHAINS, get_chain
 from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
+    PENDING_SWAP_FILE,
+    STATUS_SORT_ORDER,
+    STATUS_STYLES,
+    ZERO_SWAP_KEY,
     console,
+    fail,
     from_lamports,
     get_solana_cli_context,
+    load_miner_book,
+    miner_runtime_status,
+    print_json,
+    safe_read,
     secs_str,
-    taker_view_unavailable,
 )
-from allways.solana.client import SolanaClientError
+from allways.cli.swap_commands.swap_intake import rate_display_from_fixed
+from allways.solana.client import swap_from_solana
 
 MINER_SORT_FIELDS = ['uid', 'rate', 'capacity', 'status']
 MINER_STATUS_CHOICES = ['available', 'offline', 'in-swap', 'reserved', 'cooldown']
-RATES_SORT_FIELDS = ['uid', 'rate', 'fwd', 'rev', 'capacity']
+RATES_SORT_FIELDS = ['rate', 'capacity', 'pair', 'uid']
+# On-chain Swap accounts only ever hold these live statuses; completed/timed-out swaps are closed on-chain.
+SWAP_STATUS_CHOICES = ['active', 'fulfilled', 'pending-attestation']
+_SWAP_STATUS_VARIANTS = {'active': 'Active', 'fulfilled': 'Fulfilled', 'pending-attestation': 'PendingAttestation'}
 
 
 @click.group('view', cls=StyledGroup)
@@ -28,15 +48,35 @@ def view_group():
     pass
 
 
+def _short(s: str, full: bool, n: int = 8) -> str:
+    return s if full else (f'{s[:n]}…' if len(s) > n else s)
+
+
+def _quote_dir(q) -> str:
+    return f'{q.from_chain.upper()}→{q.to_chain.upper()}'
+
+
+def _max_rate(entry) -> float:
+    """Highest numeric rate the miner posts (coarse cross-direction proxy for `--sort rate`)."""
+    rates = []
+    for q in entry.quotes:
+        try:
+            rates.append(float(rate_display_from_fixed(q.rate)))
+        except (TypeError, ValueError):
+            continue
+    return max(rates) if rates else 0.0
+
+
 @view_group.command('miners')
-@click.option('--full', is_flag=True, help='Show untruncated addresses and hotkeys')
+@click.option('--full', is_flag=True, help='Show untruncated pubkeys and addresses')
 @click.option(
     '--sort',
     'sort_by',
     type=click.Choice(MINER_SORT_FIELDS, case_sensitive=False),
     default='uid',
     show_default=True,
-    help='Sort field. uid ascends; rate/capacity descend; status groups available→reserved→in-swap→cooldown→offline.',
+    help='Sort field. uid = stable pubkey order; rate/capacity descend; status groups '
+    'available→reserved→in-swap→cooldown→offline.',
 )
 @click.option(
     '--status',
@@ -46,72 +86,328 @@ def view_group():
     help='Only show miners in a given runtime state.',
 )
 @click.option(
-    '--min-capacity', type=float, default=None, help='Only show miners with at least this much collateral (TAO).'
+    '--min-capacity', type=float, default=None, help='Only show miners with at least this much collateral (SOL).'
 )
 @click.option(
     '--search',
     default=None,
     type=str,
-    help='Case-insensitive substring match against UID, addresses, and hotkey.',
+    help='Case-insensitive substring match against pubkey and posted addresses.',
 )
-def view_miners(full, sort_by, status_filter, min_capacity, search):
-    """List active miners with their posted directions and status."""
-    taker_view_unavailable('`view miners`')
+@click.option('--json', 'as_json', is_flag=True, help='Emit machine-readable JSON instead of a table.')
+def view_miners(full, sort_by, status_filter, min_capacity, search, as_json):
+    """List miners with their runtime status, collateral, and posted directions/rates.
+
+    [dim]Miners are Solana pubkeys (no metagraph uid here); '#' is a display index and `--sort uid` means
+    stable pubkey order.[/dim]"""
+    _, client = get_solana_cli_context(need_keypair=False)
+    now = int(time.time())
+    book = load_miner_book(client, with_reservation=True)
+
+    rows = []
+    for e in book:
+        status = miner_runtime_status(e.state, e.reservation, now)
+        addrs = ' '.join(f'{q.miner_from_addr} {q.miner_to_addr}' for q in e.quotes)
+        rows.append((e, status, addrs))
+
+    if status_filter:
+        rows = [r for r in rows if r[1] == status_filter.lower()]
+    if min_capacity is not None:
+        rows = [r for r in rows if from_lamports(r[0].collateral) >= min_capacity]
+    if search:
+        needle = search.lower()
+        rows = [r for r in rows if needle in (r[0].pubkey_str + ' ' + r[2]).lower()]
+
+    if sort_by == 'uid':
+        rows.sort(key=lambda r: r[0].pubkey_str)
+    elif sort_by == 'rate':
+        rows.sort(key=lambda r: _max_rate(r[0]), reverse=True)
+    elif sort_by == 'capacity':
+        rows.sort(key=lambda r: r[0].collateral, reverse=True)
+    elif sort_by == 'status':
+        rows.sort(key=lambda r: STATUS_SORT_ORDER.index(r[1]))
+
+    if as_json:
+        print_json(
+            [
+                {
+                    'miner': e.pubkey_str,
+                    'status': status,
+                    'collateral_sol': from_lamports(e.collateral),
+                    'quotes': [
+                        {
+                            'from': q.from_chain,
+                            'to': q.to_chain,
+                            'rate': rate_display_from_fixed(q.rate),
+                            'miner_from_addr': q.miner_from_addr,
+                            'miner_to_addr': q.miner_to_addr,
+                        }
+                        for q in e.quotes
+                    ],
+                }
+                for e, status, _addrs in rows
+            ]
+        )
+        return
+
+    if not rows:
+        console.print('[yellow]No miners match those filters.[/yellow]')
+        return
+
+    table = Table(title=f'Miners ({len(rows)})', show_header=True, show_lines=True)
+    table.add_column('#', style='dim', justify='right')
+    table.add_column('Miner', style='cyan')
+    table.add_column('Status')
+    table.add_column('Collateral', style='green', justify='right')
+    table.add_column('Directions', style='white')
+    for i, (e, status, _addrs) in enumerate(rows, 1):
+        dirs = Text()
+        for j, q in enumerate(e.quotes):
+            if j:
+                dirs.append('\n')
+            dirs.append(f'{_quote_dir(q)} @ {rate_display_from_fixed(q.rate)}')
+            if full:
+                dirs.append(f'  ({q.miner_from_addr}→{q.miner_to_addr})', style='dim')
+        table.add_row(
+            str(i),
+            _short(e.pubkey_str, full),
+            Text(status, style=STATUS_STYLES.get(status, 'white')),
+            f'{from_lamports(e.collateral):.4f} SOL',
+            dirs,
+        )
+    console.print(table)
+
+
+def _parse_pair(pair: str):
+    """Parse `sol-btc` → ('sol','btc'). Fail (non-zero) on malformed/unknown pair."""
+    parts = pair.lower().split('-')
+    if len(parts) != 2 or parts[0] not in SUPPORTED_CHAINS or parts[1] not in SUPPORTED_CHAINS:
+        fail(f'Invalid --pair {pair!r}. Use <from>-<to> with supported chains, e.g. sol-btc.')
+    return parts[0], parts[1]
 
 
 @view_group.command('rates')
-@click.option('--pair', default=None, type=str, help='Filter by pair (e.g. btc-tao)')
-@click.option('--full', is_flag=True, help='Show untruncated addresses')
+@click.option('--pair', default=None, type=str, help='Filter by direction (e.g. sol-btc)')
+@click.option('--full', is_flag=True, help='Show untruncated pubkeys and addresses')
 @click.option(
     '--sort',
     'sort_by',
     type=click.Choice(RATES_SORT_FIELDS, case_sensitive=False),
     default='rate',
     show_default=True,
-    help='Sort field. rate = best of fwd/rev (desc); fwd/rev = that direction only (desc); uid asc; capacity desc.',
+    help='Sort field. rate descends; capacity descends; pair groups by direction; uid = stable pubkey order.',
 )
 @click.option(
-    '--min-capacity', type=float, default=None, help='Only show miners with at least this much collateral (TAO).'
+    '--min-capacity', type=float, default=None, help='Only show miners with at least this much collateral (SOL).'
 )
 @click.option(
     '--search',
     default=None,
     type=str,
-    help='Case-insensitive substring match against UID and posted addresses.',
+    help='Case-insensitive substring match against pubkey and posted addresses.',
 )
-def view_rates(pair, full, sort_by, min_capacity, search):
-    """Show posted miner rates per direction."""
-    taker_view_unavailable('`view rates`')
+@click.option('--json', 'as_json', is_flag=True, help='Emit machine-readable JSON instead of a table.')
+def view_rates(pair, full, sort_by, min_capacity, search, as_json):
+    """Show posted miner rates, one row per direction."""
+    want = _parse_pair(pair) if pair else None
+    _, client = get_solana_cli_context(need_keypair=False)
+    now = int(time.time())
+    book = load_miner_book(client, with_reservation=True)
+
+    rows = []  # (entry, quote, status)
+    for e in book:
+        status = miner_runtime_status(e.state, e.reservation, now)
+        if min_capacity is not None and from_lamports(e.collateral) < min_capacity:
+            continue
+        for q in e.quotes:
+            if want and (q.from_chain, q.to_chain) != want:
+                continue
+            if search:
+                needle = search.lower()
+                hay = f'{e.pubkey_str} {q.miner_from_addr} {q.miner_to_addr}'.lower()
+                if needle not in hay:
+                    continue
+            rows.append((e, q, status))
+
+    if sort_by == 'rate':
+        rows.sort(key=lambda r: float(rate_display_from_fixed(r[1].rate) or 0), reverse=True)
+    elif sort_by == 'capacity':
+        rows.sort(key=lambda r: r[0].collateral, reverse=True)
+    elif sort_by == 'pair':
+        rows.sort(key=lambda r: (r[1].from_chain, r[1].to_chain))
+    elif sort_by == 'uid':
+        rows.sort(key=lambda r: r[0].pubkey_str)
+
+    if as_json:
+        print_json(
+            [
+                {
+                    'miner': e.pubkey_str,
+                    'from': q.from_chain,
+                    'to': q.to_chain,
+                    'rate': rate_display_from_fixed(q.rate),
+                    'collateral_sol': from_lamports(e.collateral),
+                    'status': status,
+                    'miner_from_addr': q.miner_from_addr,
+                    'miner_to_addr': q.miner_to_addr,
+                }
+                for e, q, status in rows
+            ]
+        )
+        return
+
+    if not rows:
+        console.print('[yellow]No posted rates match those filters.[/yellow]')
+        return
+
+    table = Table(title=f'Posted Rates ({len(rows)})', show_header=True)
+    table.add_column('Direction', style='cyan')
+    table.add_column('Rate', style='green', justify='right')
+    table.add_column('Miner', style='white')
+    table.add_column('Collateral', style='green', justify='right')
+    table.add_column('Status')
+    if full:
+        table.add_column('Addresses', style='dim')
+    for e, q, status in rows:
+        cells = [
+            _quote_dir(q),
+            rate_display_from_fixed(q.rate),
+            _short(e.pubkey_str, full),
+            f'{from_lamports(e.collateral):.4f} SOL',
+            Text(status, style=STATUS_STYLES.get(status, 'white')),
+        ]
+        if full:
+            cells.append(f'{q.miner_from_addr} → {q.miner_to_addr}')
+        table.add_row(*cells)
+    console.print(table)
+
+
+def _swap_json(s):
+    return {
+        'swap_key': s.key_hex,
+        'miner': str(s.miner),
+        'user': str(s.user),
+        'from_chain': s.from_chain,
+        'to_chain': s.to_chain,
+        'from_amount': s.from_amount,
+        'to_amount': s.to_amount,
+        'sol_amount': s.sol_amount,
+        'status': s.status,
+        'from_tx_hash': s.from_tx_hash,
+        'to_tx_hash': s.to_tx_hash,
+        'initiated_at': s.initiated_at,
+        'timeout_at': s.timeout_at,
+        'fulfilled_at': s.fulfilled_at,
+    }
 
 
 @view_group.command('active-swaps')
 @click.option(
     '--status',
+    'status_filter',
     default=None,
-    type=click.Choice(['active', 'fulfilled', 'completed', 'timed_out'], case_sensitive=False),
-    help='Filter by status (active, fulfilled, completed, timed_out)',
+    type=click.Choice(SWAP_STATUS_CHOICES, case_sensitive=False),
+    help='Filter by on-chain status (active, fulfilled, pending-attestation).',
 )
-def view_active_swaps(status: str):
-    """List swaps currently tracked on-chain."""
-    taker_view_unavailable('`view active-swaps`')
+@click.option('--json', 'as_json', is_flag=True, help='Emit machine-readable JSON instead of a table.')
+def view_active_swaps(status_filter, as_json):
+    """List swaps currently open on-chain (completed/timed-out swaps are closed and not listed)."""
+    _, client = get_solana_cli_context(need_keypair=False)
+    variant = _SWAP_STATUS_VARIANTS.get(status_filter.lower()) if status_filter else None
+    raw = safe_read(lambda: client.get_swaps(status=variant), what='read swaps')
+    swaps = [swap_from_solana(s) for _pk, s in raw]
+
+    if as_json:
+        print_json([_swap_json(s) for s in swaps])
+        return
+
+    if not swaps:
+        console.print('[yellow]No swaps currently open on-chain.[/yellow]')
+        return
+
+    table = Table(title=f'Open Swaps ({len(swaps)})', show_header=True)
+    table.add_column('Swap Key', style='cyan')
+    table.add_column('Pair', style='green')
+    table.add_column('From Amt', justify='right')
+    table.add_column('To Amt', justify='right')
+    table.add_column('Status', style='bold')
+    for s in swaps:
+        table.add_row(
+            s.key_hex[:16],
+            f'{s.from_chain.upper()}→{s.to_chain.upper()}',
+            str(s.from_amount),
+            str(s.to_amount),
+            s.status,
+        )
+    console.print(table)
+
+
+def _render_swap_detail(s):
+    to_dec = get_chain(s.to_chain).decimals
+    from_dec = get_chain(s.from_chain).decimals
+    console.print(f'\n[bold]Swap {s.key_hex[:16]}[/bold]\n')
+    console.print(f'  Status:      [bold]{s.status}[/bold]')
+    console.print(f'  Pair:        {s.from_chain.upper()} → {s.to_chain.upper()}')
+    console.print(f'  Miner:       {s.miner}')
+    console.print(f'  User:        {s.user}')
+    console.print(f'  Send:        {s.from_amount / 10**from_dec:g} {s.from_chain.upper()}')
+    console.print(f'  Receive:     {s.to_amount / 10**to_dec:g} {s.to_chain.upper()} (pinned payout)')
+    console.print(f'  User from:   {s.user_from_addr}')
+    console.print(f'  Miner to:    {s.miner_to_addr}')
+    console.print(f'  Source tx:   {s.from_tx_hash or "[dim](none)[/dim]"}')
+    console.print(f'  Dest tx:     {s.to_tx_hash or "[dim](none)[/dim]"}')
+    console.print(f'  Initiated:   {s.initiated_at}')
+    console.print(f'  Timeout at:  {s.timeout_at}')
+    console.print(f'  Fulfilled:   {s.fulfilled_at or "[dim](not yet)[/dim]"}\n')
 
 
 @view_group.command('swap')
-@click.argument('swap_id', type=int)
+@click.argument('swap_key_hex', type=str)
 @click.option('--watch', '-w', is_flag=True, help='Poll and refresh until swap completes or times out')
-def view_swap(swap_id: int, watch: bool):
-    """Inspect a single swap by id."""
-    taker_view_unavailable('`view swap`')
+@click.option('--json', 'as_json', is_flag=True, help='Emit machine-readable JSON instead of detail text.')
+def view_swap(swap_key_hex: str, watch: bool, as_json: bool):
+    """Inspect a single swap by its 32-byte hex swap_key."""
+    try:
+        key = bytes.fromhex(swap_key_hex)
+    except ValueError:
+        fail(f'Invalid swap_key {swap_key_hex!r}: expected hex (the 32-byte swap_key, not an integer id).')
+
+    _, client = get_solana_cli_context(need_keypair=False)
+
+    def _load():
+        acct = safe_read(lambda: client.get_swap(key), what='read swap')
+        return swap_from_solana(acct, key) if acct is not None else None
+
+    s = _load()
+    if s is None:
+        fail(f'No swap found for swap_key {swap_key_hex}.')
+
+    if as_json:
+        print_json(_swap_json(s))
+        return
+
+    if not watch:
+        _render_swap_detail(s)
+        return
+
+    terminal = {'PendingAttestation'}
+    while True:
+        console.clear()
+        _render_swap_detail(s)
+        if s.status in terminal:
+            console.print('[dim]Swap reached a terminal on-chain status.[/dim]')
+            return
+        time.sleep(5)
+        s = _load()
+        if s is None:
+            console.print('[dim]Swap account closed (resolved and cleaned up on-chain).[/dim]')
+            return
 
 
 def _read_config():
-    """Read the on-chain program Config (read-only — no keypair needed). None if unreadable/uninitialized."""
+    """Read the on-chain Config. `fail` (non-zero) on RPC error; None (exit 0) when genuinely uninitialized."""
     _, client = get_solana_cli_context(need_keypair=False)
-    try:
-        cfg = client.get_config()
-    except SolanaClientError as e:
-        console.print(f'[red]Failed to read config: {e}[/red]')
-        return None
+    cfg = safe_read(lambda: client.get_config(), what='read config')
     if cfg is None:
         console.print('[yellow]Program is not initialized (no Config account).[/yellow]')
     return cfg
@@ -161,7 +457,69 @@ def view_validators():
     console.print()
 
 
+def _pending_miner():
+    """Return the miner pubkey string saved by `alw swap now` in pending_swap.json, or None."""
+    if not PENDING_SWAP_FILE.exists():
+        return None
+    try:
+        return json.loads(PENDING_SWAP_FILE.read_text()).get('miner')
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
 @view_group.command('reservation')
-def view_reservation():
-    """Show your current pending reservation, if any."""
-    taker_view_unavailable('`view reservation`')
+@click.option('--miner', 'miner_pk', default=None, type=str, help='Miner pubkey whose reservation to inspect')
+@click.option('--json', 'as_json', is_flag=True, help='Emit machine-readable JSON instead of detail text.')
+def view_reservation(miner_pk, as_json):
+    """Show the reservation held on a miner (reservations are keyed by the miner pubkey)."""
+    target = miner_pk or _pending_miner()
+    if not target:
+        fail('No miner specified and no saved swap found. Pass --miner <pubkey>.')
+    try:
+        miner = Pubkey.from_string(target)
+    except (ValueError, TypeError):
+        fail(f'Invalid miner pubkey: {target}')
+
+    _, client = get_solana_cli_context(need_keypair=False)
+    resv = safe_read(lambda: client.get_reservation(miner), what='read reservation')
+
+    if resv is None:
+        if as_json:
+            print_json({'miner': str(miner), 'reservation': None})
+            return
+        console.print(f'[yellow]No active reservation on miner {target}.[/yellow]')
+        return
+
+    now = int(time.time())
+    remaining = max(0, int(resv.reserved_until) - now)
+    claimed = bytes(resv.claimed_swap_key) != ZERO_SWAP_KEY
+    to_dec = get_chain(resv.to_chain).decimals
+    from_dec = get_chain(resv.from_chain).decimals
+
+    if as_json:
+        print_json(
+            {
+                'miner': str(miner),
+                'user': str(resv.user),
+                'from_chain': resv.from_chain,
+                'to_chain': resv.to_chain,
+                'from_amount': resv.from_amount,
+                'to_amount': resv.to_amount,
+                'sol_amount': resv.sol_amount,
+                'reserved_until': int(resv.reserved_until),
+                'remaining_secs': remaining,
+                'deposit_claimed': claimed,
+                'miner_from_addr': resv.miner_from_addr,
+            }
+        )
+        return
+
+    console.print('\n[bold]Reservation[/bold]\n')
+    console.print(f'  Miner:       {miner}')
+    console.print(f'  User:        {resv.user}')
+    console.print(f'  Pair:        {resv.from_chain.upper()} → {resv.to_chain.upper()}')
+    console.print(f'  Send:        {resv.from_amount / 10**from_dec:g} {resv.from_chain.upper()}')
+    console.print(f'  Receive:     {resv.to_amount / 10**to_dec:g} {resv.to_chain.upper()}')
+    console.print(f'  Send to:     {resv.miner_from_addr}')
+    console.print(f'  Reserved:    {"expired" if remaining == 0 else secs_str(remaining) + " remaining"}')
+    console.print(f'  Deposit:     {"claimed" if claimed else "[dim]not yet sent[/dim]"}\n')

--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -17,11 +17,13 @@ from solders.pubkey import Pubkey
 from allways.chains import SUPPORTED_CHAINS, get_chain
 from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
+    FINITE_FLOAT,
     PENDING_SWAP_FILE,
     STATUS_SORT_ORDER,
     STATUS_STYLES,
     ZERO_SWAP_KEY,
     console,
+    effective_rate,
     fail,
     from_lamports,
     get_solana_cli_context,
@@ -30,6 +32,7 @@ from allways.cli.swap_commands.helpers import (
     print_json,
     safe_read,
     secs_str,
+    set_json_output,
 )
 from allways.cli.swap_commands.swap_intake import rate_display_from_fixed
 from allways.solana.client import swap_from_solana
@@ -54,6 +57,11 @@ def _short(s: str, full: bool, n: int = 8) -> str:
 
 def _quote_dir(q) -> str:
     return f'{q.from_chain.upper()}→{q.to_chain.upper()}'
+
+
+def _rate(q) -> str:
+    """Effective directional rate ('to per 1 from') for display — see helpers.effective_rate."""
+    return effective_rate(q.from_chain, q.to_chain, rate_display_from_fixed(q.rate))
 
 
 def _max_rate(entry) -> float:
@@ -86,7 +94,7 @@ def _max_rate(entry) -> float:
     help='Only show miners in a given runtime state.',
 )
 @click.option(
-    '--min-capacity', type=float, default=None, help='Only show miners with at least this much collateral (SOL).'
+    '--min-capacity', type=FINITE_FLOAT, default=None, help='Only show miners with at least this much collateral (SOL).'
 )
 @click.option(
     '--search',
@@ -100,6 +108,7 @@ def view_miners(full, sort_by, status_filter, min_capacity, search, as_json):
 
     [dim]Miners are Solana pubkeys (no metagraph uid here); '#' is a display index and `--sort uid` means
     stable pubkey order.[/dim]"""
+    set_json_output(as_json)
     _, client = get_solana_cli_context(need_keypair=False)
     now = int(time.time())
     book = load_miner_book(client, with_reservation=True)
@@ -138,7 +147,7 @@ def view_miners(full, sort_by, status_filter, min_capacity, search, as_json):
                         {
                             'from': q.from_chain,
                             'to': q.to_chain,
-                            'rate': rate_display_from_fixed(q.rate),
+                            'rate': _rate(q),
                             'miner_from_addr': q.miner_from_addr,
                             'miner_to_addr': q.miner_to_addr,
                         }
@@ -165,7 +174,7 @@ def view_miners(full, sort_by, status_filter, min_capacity, search, as_json):
         for j, q in enumerate(e.quotes):
             if j:
                 dirs.append('\n')
-            dirs.append(f'{_quote_dir(q)} @ {rate_display_from_fixed(q.rate)}')
+            dirs.append(f'{_quote_dir(q)} @ {_rate(q)}')
             if full:
                 dirs.append(f'  ({q.miner_from_addr}→{q.miner_to_addr})', style='dim')
         table.add_row(
@@ -198,7 +207,7 @@ def _parse_pair(pair: str):
     help='Sort field. rate descends; capacity descends; pair groups by direction; uid = stable pubkey order.',
 )
 @click.option(
-    '--min-capacity', type=float, default=None, help='Only show miners with at least this much collateral (SOL).'
+    '--min-capacity', type=FINITE_FLOAT, default=None, help='Only show miners with at least this much collateral (SOL).'
 )
 @click.option(
     '--search',
@@ -209,6 +218,7 @@ def _parse_pair(pair: str):
 @click.option('--json', 'as_json', is_flag=True, help='Emit machine-readable JSON instead of a table.')
 def view_rates(pair, full, sort_by, min_capacity, search, as_json):
     """Show posted miner rates, one row per direction."""
+    set_json_output(as_json)
     want = _parse_pair(pair) if pair else None
     _, client = get_solana_cli_context(need_keypair=False)
     now = int(time.time())
@@ -230,7 +240,7 @@ def view_rates(pair, full, sort_by, min_capacity, search, as_json):
             rows.append((e, q, status))
 
     if sort_by == 'rate':
-        rows.sort(key=lambda r: float(rate_display_from_fixed(r[1].rate) or 0), reverse=True)
+        rows.sort(key=lambda r: float(_rate(r[1]) or 0), reverse=True)
     elif sort_by == 'capacity':
         rows.sort(key=lambda r: r[0].collateral, reverse=True)
     elif sort_by == 'pair':
@@ -245,7 +255,7 @@ def view_rates(pair, full, sort_by, min_capacity, search, as_json):
                     'miner': e.pubkey_str,
                     'from': q.from_chain,
                     'to': q.to_chain,
-                    'rate': rate_display_from_fixed(q.rate),
+                    'rate': _rate(q),
                     'collateral_sol': from_lamports(e.collateral),
                     'status': status,
                     'miner_from_addr': q.miner_from_addr,
@@ -262,7 +272,7 @@ def view_rates(pair, full, sort_by, min_capacity, search, as_json):
 
     table = Table(title=f'Posted Rates ({len(rows)})', show_header=True)
     table.add_column('Direction', style='cyan')
-    table.add_column('Rate', style='green', justify='right')
+    table.add_column('Rate (to/from)', style='green', justify='right')
     table.add_column('Miner', style='white')
     table.add_column('Collateral', style='green', justify='right')
     table.add_column('Status')
@@ -271,7 +281,7 @@ def view_rates(pair, full, sort_by, min_capacity, search, as_json):
     for e, q, status in rows:
         cells = [
             _quote_dir(q),
-            rate_display_from_fixed(q.rate),
+            _rate(q),
             _short(e.pubkey_str, full),
             f'{from_lamports(e.collateral):.4f} SOL',
             Text(status, style=STATUS_STYLES.get(status, 'white')),
@@ -312,6 +322,7 @@ def _swap_json(s):
 @click.option('--json', 'as_json', is_flag=True, help='Emit machine-readable JSON instead of a table.')
 def view_active_swaps(status_filter, as_json):
     """List swaps currently open on-chain (completed/timed-out swaps are closed and not listed)."""
+    set_json_output(as_json)
     _, client = get_solana_cli_context(need_keypair=False)
     variant = _SWAP_STATUS_VARIANTS.get(status_filter.lower()) if status_filter else None
     raw = safe_read(lambda: client.get_swaps(status=variant), what='read swaps')
@@ -367,6 +378,7 @@ def _render_swap_detail(s):
 @click.option('--json', 'as_json', is_flag=True, help='Emit machine-readable JSON instead of detail text.')
 def view_swap(swap_key_hex: str, watch: bool, as_json: bool):
     """Inspect a single swap by its 32-byte hex swap_key."""
+    set_json_output(as_json)
     try:
         key = bytes.fromhex(swap_key_hex)
     except ValueError:
@@ -404,24 +416,42 @@ def view_swap(swap_key_hex: str, watch: bool, as_json: bool):
             return
 
 
-def _read_config():
-    """Read the on-chain Config. `fail` (non-zero) on RPC error; None (exit 0) when genuinely uninitialized."""
-    _, client = get_solana_cli_context(need_keypair=False)
-    cfg = safe_read(lambda: client.get_config(), what='read config')
-    if cfg is None:
-        console.print('[yellow]Program is not initialized (no Config account).[/yellow]')
-    return cfg
-
-
 def _sol_or(amount: int, zero_label: str) -> str:
     return f'{from_lamports(amount):.4f} SOL' + (f' ({zero_label})' if amount == 0 else '')
 
 
 @view_group.command('config')
-def view_config():
+@click.option('--json', 'as_json', is_flag=True, help='Emit machine-readable JSON instead of text.')
+def view_config(as_json):
     """Show the current on-chain program Config (bounds, fees, windows, threshold). Read-only."""
-    cfg = _read_config()
+    set_json_output(as_json)
+    _, client = get_solana_cli_context(need_keypair=False)
+    cfg = safe_read(lambda: client.get_config(), what='read config')
     if cfg is None:
+        print_json({'initialized': False}) if as_json else console.print(
+            '[yellow]Program is not initialized (no Config account).[/yellow]'
+        )
+        return
+    if as_json:
+        print_json(
+            {
+                'admin': str(cfg.admin),
+                'version': cfg.version,
+                'halted': bool(cfg.halted),
+                'consensus_threshold_percent': cfg.consensus_threshold_percent,
+                'reservation_fee_sol': from_lamports(cfg.reservation_fee_lamports),
+                'min_collateral_sol': from_lamports(cfg.min_collateral),
+                'max_collateral_sol': from_lamports(cfg.max_collateral),
+                'min_swap_amount_sol': from_lamports(cfg.min_swap_amount),
+                'max_swap_amount_sol': from_lamports(cfg.max_swap_amount),
+                'fulfillment_timeout_secs': cfg.fulfillment_timeout_secs,
+                'reservation_ttl_secs': cfg.reservation_ttl_secs,
+                'pool_window_secs': cfg.pool_window_secs,
+                'weights_update_min_interval_secs': cfg.weights_update_min_interval_secs,
+                'max_total_extension_secs': cfg.max_total_extension_secs,
+                'validator_count': len(cfg.validators),
+            }
+        )
         return
     console.print('\n[bold]Program Config[/bold]\n')
     console.print(f'  Admin:                {cfg.admin}')
@@ -442,18 +472,28 @@ def view_config():
 
 
 @view_group.command('validators')
-def view_validators():
+@click.option('--json', 'as_json', is_flag=True, help='Emit machine-readable JSON instead of text.')
+def view_validators(as_json):
     """List the registered validators with their lottery weights and the consensus threshold."""
-    cfg = _read_config()
+    set_json_output(as_json)
+    _, client = get_solana_cli_context(need_keypair=False)
+    cfg = safe_read(lambda: client.get_config(), what='read config')
     if cfg is None:
+        print_json({'initialized': False, 'validators': []}) if as_json else console.print(
+            '[yellow]Program is not initialized (no Config account).[/yellow]'
+        )
+        return
+    validators = [{'pubkey': str(Pubkey.from_bytes(bytes(v.key))), 'weight': v.weight} for v in cfg.validators]
+    if as_json:
+        print_json({'consensus_threshold_percent': cfg.consensus_threshold_percent, 'validators': validators})
         return
     console.print('\n[bold]Validators[/bold]\n')
     console.print(f'  Consensus threshold: {cfg.consensus_threshold_percent}%\n')
-    if not cfg.validators:
+    if not validators:
         console.print('  [yellow]No validators registered.[/yellow]\n')
         return
-    for v in cfg.validators:
-        console.print(f'  {Pubkey.from_bytes(bytes(v.key))}  weight={v.weight}')
+    for v in validators:
+        console.print(f'  {v["pubkey"]}  weight={v["weight"]}')
     console.print()
 
 
@@ -472,6 +512,7 @@ def _pending_miner():
 @click.option('--json', 'as_json', is_flag=True, help='Emit machine-readable JSON instead of detail text.')
 def view_reservation(miner_pk, as_json):
     """Show the reservation held on a miner (reservations are keyed by the miner pubkey)."""
+    set_json_output(as_json)
     target = miner_pk or _pending_miner()
     if not target:
         fail('No miner specified and no saved swap found. Pass --miner <pubkey>.')

--- a/neurons/base/neuron.py
+++ b/neurons/base/neuron.py
@@ -12,6 +12,7 @@ from allways.constants import STALE_BLOCK_POLL_THRESHOLD
 from allways.utils.config import add_args, check_config, config
 from allways.utils.misc import ttl_get_block
 
+
 def validator_dev_mode() -> bool:
     """Dev / testnet mode: the validator observes but takes no binding actions — it does NOT
     submit Solana consensus votes (the swap loop logs "WOULD …") and does NOT set Bittensor

--- a/tests/test_axon_handlers.py
+++ b/tests/test_axon_handlers.py
@@ -8,7 +8,6 @@ test_axon_solana_handlers.py.
 
 import asyncio
 import threading
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from allways.synapses import SwapReserveSynapse

--- a/tests/test_cli_miner_solana.py
+++ b/tests/test_cli_miner_solana.py
@@ -67,7 +67,7 @@ def test_deposit_respects_max_collateral():
     c = _client(config=_config(max_collateral=1_000_000), collateral=900_000)
     with patch('allways.cli.swap_commands.collateral.get_solana_cli_context', return_value=({}, c)):
         res = CliRunner().invoke(collateral_group, ['deposit', '--amount', '5', '--yes'])
-    assert res.exit_code == 0
+    assert res.exit_code != 0  # a rejected deposit must exit non-zero (script-safe)
     c.post_collateral.assert_not_called()
     assert 'exceed the max collateral' in res.output
 
@@ -76,7 +76,7 @@ def test_withdraw_blocked_while_active():
     c = _client(state=_state(active=True))
     with patch('allways.cli.swap_commands.collateral.get_solana_cli_context', return_value=({}, c)):
         res = CliRunner().invoke(collateral_group, ['withdraw', '--amount', '1', '--yes'])
-    assert res.exit_code == 0
+    assert res.exit_code != 0  # a blocked withdrawal must exit non-zero (script-safe)
     c.withdraw_collateral.assert_not_called()
     assert 'while miner is active' in res.output
 
@@ -88,7 +88,7 @@ def test_withdraw_blocked_within_cooldown():
         c = _client(state=_state(active=False, deactivation_at=1_000_000), config=_config(fulfillment_timeout_secs=600))
         with patch('allways.cli.swap_commands.collateral.get_solana_cli_context', return_value=({}, c)):
             res = CliRunner().invoke(collateral_group, ['withdraw', '--amount', '1', '--yes'])
-    assert res.exit_code == 0
+    assert res.exit_code != 0  # a blocked withdrawal must exit non-zero (script-safe)
     c.withdraw_collateral.assert_not_called()
     assert 'cooldown active' in res.output
 


### PR DESCRIPTION
Deep vet of every `alw` command against a live local stack, as taker / miner / admin, then hardened against an adversarial QA pass.

## Taker read path — was all stubs ("not available", exit 0), now live on Solana
- `swap quote` — every viable miner + what you receive after the 1% fee, best ★
- `view miners` / `view rates` — MinerQuote + MinerState + collateral, runtime status, all `--status/--sort/--min-capacity/--search` filters honored
- `view active-swaps` / `view swap <hex>` / `view reservation` — on-chain Swap/Reservation reads
- `status` — network + RPC/program health + balance + miner-or-taker dashboard
- `--json` on every read view (incl. `view config`/`view validators`)

## Script-safety
- shared `fail()` → every error exits non-zero (was uniformly exit 0); `--json` errors emit `{"error": ...}`
- `safe_read()` turns RPC/decode faults into clean non-zero, never a stacktrace
- `FiniteFloat` param type rejects `nan/inf/1e999` at parse time across all amount inputs
- deferred fund relays (post-tx/claim/resume) exit 69 with honest guidance to the browser flow
- `admin --yes` (+ `ALW_ASSUME_YES`) so setters run headless

## Accuracy / rot
- effective directional rate in quote/view/miner-status (`476.19 SOL/BTC`, not the backwards hub rate)
- `view swap` int id → 32-byte hex key; `--min-capacity` TAO→SOL; dead `--auto` gone; legacy `contract-address` dropped from config; `secs_str` shows bare `<60s`

Verified live against the local solana stack; 622 tests pass, ruff clean. Passed an internal adversarial CLI-breaking pass (nan/inf, json-exit, effective-rate, stub-help, garbage-input) with all findings fixed.

Base `contract-v2` (not yet merged to test, like the W4 allways PRs).