### PR TITLE
feat: restore deferred-confirmation swap intake — validator reaper + CLI post-tx relay

### DIFF
--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -10,6 +10,7 @@ from typing import Callable, List, Optional, Tuple
 import bittensor as bt
 import click
 import requests
+from bittensor.utils import ss58_encode
 from rich.console import Console
 from rich.text import Text
 
@@ -147,6 +148,36 @@ def not_implemented(what: str, code: int = NOT_IMPLEMENTED_EXIT) -> None:
         f'`alw swap now` originates a reservation on-chain.[/dim]'
     )
     raise SystemExit(code)
+
+
+# --- Pending swap context (taker reserve → post-tx handoff) ---------------
+# `alw swap now` stashes the just-reserved miner pubkey via `_save_pending` (see swap.py). That gives
+# `alw swap post-tx` a fast, unambiguous handle on the winning miner; post-tx re-validates it against
+# the chain and falls back to scanning all bindings if it's missing (e.g. run from another machine).
+# The confirm relay is keyed by the miner's Bittensor hotkey (reservations are keyed by miner), so
+# post-tx resolves the pubkey → hotkey via the on-chain binding. Non-authoritative cache — safe to delete.
+def hotkey_bytes_to_ss58(hotkey: bytes) -> str:
+    """32-byte sr25519 public key → ss58 (Bittensor format 42). Empty on bad input."""
+    try:
+        return ss58_encode(bytes(hotkey), ss58_format=42)
+    except Exception:
+        return ''
+
+
+def load_pending_swap() -> Optional[dict]:
+    """Read the stashed swap context, or None if absent/unreadable."""
+    try:
+        return json.loads(PENDING_SWAP_FILE.read_text())
+    except Exception:
+        return None
+
+
+def clear_pending_swap() -> None:
+    """Remove the stashed context once the confirm relay is accepted."""
+    try:
+        PENDING_SWAP_FILE.unlink()
+    except Exception:
+        pass
 
 
 def print_json(data) -> None:

--- a/allways/cli/swap_commands/post_tx.py
+++ b/allways/cli/swap_commands/post_tx.py
@@ -1,20 +1,218 @@
-"""alw swap post-tx - Submit source transaction hash for a pending swap reservation.
+"""alw swap post-tx - Confirm a swap by relaying your source-chain deposit to the validators.
 
-Deferred: advancing a reservation with a source-tx hash requires verifying the deposit against the source
-chain (a chain-provider check the CLI taker path does not do yet). Exits non-zero; use the browser flow."""
+After `alw swap now` reserves a miner and you've sent the source funds to that miner's address, this
+command relays the source-tx hash to every serving validator via a ``SwapConfirmSynapse``. Each
+validator independently verifies the deposit against the pinned on-chain ``Reservation`` — recipient =
+the reserved miner address, amount = the reserved amount, and crucially **sender = the reservation's
+pinned taker address** — then submits ``submit_swap_claim`` on-chain (→ ``PendingAttestation``).
+
+Auth model: the confirm carries no taker identity. The relay is signed by a throwaway *ephemeral*
+Bittensor hotkey (``dendrite_lite.get_ephemeral_wallet``) purely as transport — validators do NOT
+blacklist on it. The real proof is the on-chain source deposit itself: it can only have come from the
+taker who won the draw, because ``Reservation.from_addr`` is pinned at reserve time. So anyone may
+relay the confirm, but only the winner's deposit verifies.
+"""
+
+import time
 
 import click
 
+from allways.cli.dendrite_lite import (
+    broadcast_synapse,
+    discover_validators,
+    get_ephemeral_wallet,
+)
 from allways.cli.help import StyledCommand
-from allways.cli.swap_commands.helpers import not_implemented
+from allways.cli.swap_commands.helpers import (
+    clear_pending_swap,
+    console,
+    get_cli_context,
+    get_solana_cli_context,
+    hotkey_bytes_to_ss58,
+    load_pending_swap,
+    loading,
+)
+from allways.cli.validator_rejections import render_and_aggregate
+from allways.synapses import SwapConfirmSynapse
+
+EMPTY_SWAP_KEY = bytes(32)
+
+
+def _live_unclaimed(resv) -> bool:
+    """The reservation exists, is still within its TTL, and has no claim yet."""
+    now = int(time.time())
+    return (
+        resv is not None
+        and int(resv.reserved_until) > now
+        and bytes(resv.claimed_swap_key) == EMPTY_SWAP_KEY
+    )
+
+
+def _find_reservations(client, user, miner_hint, require_user):
+    """Locate the live, unclaimed reservation(s) to confirm.
+
+    Targeted (miner_hint set — an explicit --miner or the stash from `alw swap now`): return that
+    one miner's reservation. Scan (no hint): walk every on-chain Binding (each carries its miner
+    pubkey + hotkey) and collect reservations belonging to this user. ``require_user`` gates the
+    user-match: True for auto-discovery ("find MY reservation"), False for an explicit --miner relay
+    (confirm is permissionless — the on-chain deposit is the auth, not the caller). Returns a list of
+    (miner_pubkey, hotkey_ss58, reservation) so the caller can disambiguate ties.
+    """
+    from solders.pubkey import Pubkey
+
+    def _hotkey(miner_pk):
+        b = client.get_binding(miner_pk)
+        return hotkey_bytes_to_ss58(b.hotkey) if b else ''
+
+    if miner_hint:
+        try:
+            mpk = Pubkey.from_string(miner_hint)
+        except Exception:
+            console.print(f'[red]Invalid miner pubkey: {miner_hint}[/red]')
+            return []
+        resv = client.get_reservation(mpk)
+        if _live_unclaimed(resv) and (not require_user or str(resv.user) == str(user)):
+            return [(mpk, _hotkey(mpk), resv)]
+        return []
+
+    found = []
+    for _pda, binding in client.get_all('Binding'):
+        mpk = binding.miner
+        resv = client.get_reservation(mpk)
+        if _live_unclaimed(resv) and str(resv.user) == str(user):
+            found.append((mpk, hotkey_bytes_to_ss58(binding.hotkey), resv))
+    return found
 
 
 @click.command('post-tx', cls=StyledCommand, show_disclaimer=True)
 @click.argument('tx_hash', required=False, default=None, type=str)
-def post_tx_command(tx_hash: str):
-    """Submit your source transaction hash to advance a reservation (not yet available from the CLI).
+@click.option(
+    '--block',
+    'tx_block',
+    type=int,
+    default=0,
+    help=(
+        'Override the source-tx slot number. Usually unnecessary — the CLI looks it up '
+        'automatically. Use this only when automatic lookup fails (e.g. the node has pruned the tx).'
+    ),
+)
+@click.option(
+    '--miner',
+    'miner_hint',
+    default=None,
+    help='Miner Solana pubkey to confirm against (disambiguates if you hold multiple reservations).',
+)
+def post_tx_command(tx_hash: str, tx_block: int, miner_hint: str):
+    """Confirm your swap by relaying the source-tx hash to the validators.
 
-    [dim]Relaying a deposit verifies your source transaction against the source chain, which the CLI
-    taker path does not do yet — use the browser swap flow to complete a swap end-to-end.[/dim]
+    [dim]Run this after `alw swap now` reserves a miner and you've sent your source funds to the
+    miner's address. The validators verify the on-chain deposit against your pinned reservation and
+    submit the claim; the miner then fulfils the destination leg.[/dim]
+
+    [dim]Reservation context is read from ~/.allways/pending_swap.json (saved by `alw swap now`); if
+    it's missing the CLI finds your live reservation on-chain.[/dim]
+
+    [dim]Examples:
+        $ alw swap post-tx 54foaURhGH...
+        $ alw swap post-tx 54foaURhGH... --miner ER9Jt5...        (pick a specific reservation)
+        $ alw swap post-tx 54foaURhGH... --block 371234567        (escape hatch)[/dim]
     """
-    not_implemented('Swap post-tx (CLI fund relay)')
+    if not tx_hash:
+        tx_hash = click.prompt('Source transaction hash').strip()
+    else:
+        tx_hash = tx_hash.strip()
+    if not tx_hash:
+        console.print('[red]A source transaction hash is required.[/red]')
+        return
+
+    _config, client = get_solana_cli_context(need_keypair=True)
+    user = client.keypair.pubkey()
+
+    # Explicit --miner is a permissionless relay (confirm any live reservation for that miner);
+    # otherwise auto-discover this keypair's own reservation, preferring the stash from `alw swap now`.
+    pending = load_pending_swap() or {}
+    if miner_hint:
+        matches = _find_reservations(client, user, miner_hint, require_user=False)
+    else:
+        matches = _find_reservations(client, user, pending.get('miner'), require_user=True)
+        if not matches and pending.get('miner'):
+            # Stashed miner no longer valid (expired/claimed/superseded) — scan for any live one.
+            matches = _find_reservations(client, user, None, require_user=True)
+
+    if not matches:
+        console.print(
+            '[yellow]No live, unclaimed reservation found for your address.[/yellow]\n'
+            '[dim]Reserve one with `alw swap now` first, and confirm before it expires. '
+            'Check status with `alw view reservation`.[/dim]'
+        )
+        return
+    if len(matches) > 1:
+        console.print('[yellow]You hold multiple live reservations — pick one with --miner <pubkey>:[/yellow]')
+        for mpk, _hotkey, resv in matches:
+            console.print(
+                f'  [cyan]{mpk}[/cyan]  {resv.from_chain}->{resv.to_chain}  '
+                f'send to [dim]{resv.miner_from_addr}[/dim]'
+            )
+        return
+
+    miner_pk, miner_hotkey, resv = matches[0]
+    if not miner_hotkey:
+        console.print(
+            f'[red]Miner {miner_pk} has no verifiable hotkey binding — validators cannot resolve the '
+            'reservation. The miner must `alw miner bind-hotkey` before this swap can be confirmed.[/red]'
+        )
+        return
+
+    # Resolve the source-tx slot as a verification hint (validators can scan without it, but a slot
+    # makes it O(1)). Best-effort: fall back to 0 (server-side lookup) or the --block override.
+    if tx_block == 0:
+        try:
+            info = client.rpc.get_transaction(tx_hash)
+            if info and info.get('slot'):
+                tx_block = int(info['slot'])
+        except Exception:
+            pass
+
+    on_behalf = '' if str(resv.user) == str(user) else f'  [dim](relaying on behalf of {str(resv.user)[:8]}…)[/dim]'
+    console.print(
+        f'\n[bold]Confirming deposit[/bold] for {resv.from_chain.upper()}->{resv.to_chain.upper()} swap{on_behalf}\n'
+        f'  Miner:   [dim]{miner_hotkey[:16]}… ({str(miner_pk)[:8]}…)[/dim]\n'
+        f'  Deposit: [cyan]{tx_hash}[/cyan]{f" [dim](slot {tx_block})[/dim]" if tx_block else ""}\n'
+    )
+
+    synapse = SwapConfirmSynapse(
+        reservation_id=miner_hotkey,
+        from_tx_hash=tx_hash,
+        from_tx_proof='',  # Solana: the tx hash is the proof — validators look it up on-chain.
+        from_address=resv.from_addr,
+        from_tx_block=tx_block,
+        to_address=resv.user_to_addr,
+        from_chain=resv.from_chain,
+        to_chain=resv.to_chain,
+    )
+
+    config, _wallet, subtensor, _ = get_cli_context(need_wallet=False)
+    netuid = int(config['netuid'])
+    validator_axons = discover_validators(subtensor, netuid)
+    if not validator_axons:
+        console.print('[red]No serving validators found on the metagraph.[/red]')
+        return
+
+    wallet = get_ephemeral_wallet()  # transport-only throwaway hotkey; auth is the on-chain deposit
+    with loading(f'Relaying deposit to {len(validator_axons)} validator(s)...'):
+        responses = broadcast_synapse(wallet, validator_axons, synapse, timeout=60.0)
+
+    info = render_and_aggregate(console, responses, label='V', context={'miner_hotkey': miner_hotkey})
+    if info.accepted:
+        clear_pending_swap()
+        console.print(
+            f'\n[green]Deposit confirmed by {info.accepted} validator(s).[/green] '
+            'The miner will fulfil the destination leg once the claim is attested.\n'
+            '[dim]Track it with `alw view swap`.[/dim]'
+        )
+    else:
+        console.print(
+            '\n[yellow]No validator accepted the confirm yet.[/yellow]\n'
+            '[dim]Re-run `alw swap post-tx` with the same hash in a moment. If it keeps failing, '
+            'check the reservation is still active with `alw view reservation`.[/dim]'
+        )

--- a/allways/solana/client.py
+++ b/allways/solana/client.py
@@ -477,6 +477,21 @@ class AllwaysSolanaClient:
         args = layouts.IX_SWAP_KEY_ARGS.build({'swap_key': swap_key})
         return self._send([self._ix('timeout_swap', args, metas)])
 
+    def close_stale_claim(self, miner, swap_key: bytes) -> str:
+        """Permissionless: reap an orphaned PendingAttestation claim whose reservation has expired (or was
+        superseded). Closes the Swap PDA (rent -> caller) and frees the reservation's claim slot. No slash —
+        the claim never obligated the miner. Caller = this client's keypair."""
+        caller = self.keypair.pubkey()
+        m = _as_pubkey(miner)
+        metas = [
+            AccountMeta(caller, True, True),
+            AccountMeta(m, False, False),
+            AccountMeta(pdas.reservation_pda(m, self.program_id), False, True),
+            AccountMeta(pdas.swap_pda(swap_key, self.program_id), False, True),
+        ]
+        args = layouts.IX_SWAP_KEY_ARGS.build({'swap_key': swap_key})
+        return self._send([self._ix('close_stale_claim', args, metas)])
+
     def vote_activate(self, miner) -> str:
         """Vote to activate a miner; on quorum its MinerState flips active=true."""
         validator = self.keypair.pubkey()

--- a/allways/solana/layouts.py
+++ b/allways/solana/layouts.py
@@ -325,6 +325,7 @@ IX_DISCRIMINATORS = {
     'vote_initiate': bytes([210, 23, 157, 114, 35, 129, 164, 4]),
     'confirm_swap': bytes([183, 168, 179, 117, 86, 243, 166, 195]),
     'timeout_swap': bytes([18, 157, 212, 120, 145, 200, 239, 63]),
+    'close_stale_claim': bytes([185, 69, 27, 37, 187, 78, 157, 188]),  # reap an orphaned PendingAttestation claim
     'vote_activate': bytes([24, 233, 47, 230, 116, 115, 109, 41]),
     'mark_fulfilled': bytes([40, 188, 159, 127, 20, 151, 228, 191]),
     'extend_timeout': bytes([246, 84, 96, 134, 76, 55, 57, 33]),

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -163,7 +163,9 @@ class ConfirmResult:
 
 def confirm_deposit(validator, miner_hotkey: str, from_tx_hash: str, from_tx_block: int = 0) -> ConfirmResult:
     """Relay a user's source deposit into a claim: verify the tx against the pinned reservation, then
-    submit_swap_claim. Rejects (caller resends) if the tx isn't visible/confirmed yet — no queue."""
+    submit_swap_claim (creating the Swap in PendingAttestation). Accepts a content-valid deposit even before
+    it fully confirms — the crank defers voting until confirmations accrue. Fast-fails (no claim, so the short
+    TTL frees the miner) only when the tx is absent or its content doesn't match the reservation."""
     from allways.validator.solana_swap_loop import is_tx_fresh
 
     # Reject empty/whitespace-only hashes and strip surrounding whitespace before use (#167).
@@ -198,12 +200,17 @@ def confirm_deposit(validator, miner_hotkey: str, from_tx_hash: str, from_tx_blo
         )
     except ProviderUnreachableError:
         return ConfirmResult(False, 'Source-chain provider unreachable; resend shortly')
-    if tx_info is None or not tx_info.confirmed:
-        return ConfirmResult(False, 'Source tx not yet visible/confirmed — resend once it has enough confirmations')
+    if tx_info is None:
+        # None = absent or content-mismatch; fast-fail (no claim) so the short TTL frees the miner.
+        return ConfirmResult(False, 'Source tx not visible or does not match the reservation')
 
-    grace = getattr(provider.get_chain(), 'replay_grace_secs', 0)
-    if not is_tx_fresh(tx_info, int(reservation.created_at), grace):
-        return ConfirmResult(False, 'Source tx fails freshness — stale/replayed deposit')
+    # Deferred intake: accept a content-valid deposit pre-confirmation — the crank defers voting until it
+    # confirms (source 'pending'->extend, 'ok'+fresh->attest). A 0-conf mempool tx has no block_time, so its
+    # freshness is deferred too; only a mined tx is freshness-checked here (fast-fail a stale mined deposit).
+    if tx_info.block_time is not None:
+        grace = getattr(provider.get_chain(), 'replay_grace_secs', 0)
+        if not is_tx_fresh(tx_info, int(reservation.created_at), grace):
+            return ConfirmResult(False, 'Source tx fails freshness — stale/replayed deposit')
 
     swap_key = swap_key_from_tx_hash(from_tx_hash)
     sig = client.submit_swap_claim(miner_pk, swap_key, from_tx_hash, tx_info.block_number or 0)

--- a/allways/validator/solana_swap_loop.py
+++ b/allways/validator/solana_swap_loop.py
@@ -28,6 +28,7 @@ class SwapDecision(Enum):
     ATTEST = 'attest'  # PendingAttestation: source deposit verified -> would vote_initiate
     CONFIRM = 'confirm'  # Fulfilled: both legs verified -> would confirm_swap
     TIMEOUT = 'timeout'  # Active past its deadline -> would timeout_swap
+    CANCEL = 'cancel'  # PendingAttestation whose reservation expired -> close_stale_claim (reap, no slash)
     EXTEND_RESERVATION = 'extend_reservation'  # source valid-but-unconfirmed near expiry -> slide reserved_until
     EXTEND_TIMEOUT = 'extend_timeout'  # dest valid-but-unconfirmed near timeout -> slide timeout_at
     WAIT = 'wait'  # in-flight, nothing to do yet
@@ -50,6 +51,7 @@ ACTIONABLE = frozenset(
         SwapDecision.ATTEST,
         SwapDecision.CONFIRM,
         SwapDecision.TIMEOUT,
+        SwapDecision.CANCEL,
         SwapDecision.EXTEND_RESERVATION,
         SwapDecision.EXTEND_TIMEOUT,
     }
@@ -64,6 +66,11 @@ _BENIGN_EXTEND_MARKERS = ('ExtensionNotLater', 'ExtensionExceedsCeiling')
 # resolved it (NoRequests: opened_at zeroed), or the on-chain clock hasn't crossed closes_at yet
 # (PoolNotClosed, clock skew) — both expected, retried next pass. Real failures still surface.
 _BENIGN_RESOLVE_MARKERS = ('NoRequests', 'PoolNotClosed')
+
+# close_stale_claim is permissionless, so every validator cranks every stale claim and the first-wins race
+# leaves losers with a benign failure: a peer already reaped it (the Swap PDA is gone), or the reservation is
+# not yet expired on the on-chain clock (ClaimNotExpired, clock skew) — both expected, retried/settled next pass.
+_BENIGN_CLOSE_MARKERS = ('ClaimNotExpired', 'NotPending', 'AccountNotInitialized', 'could not find account')
 
 
 def _status_name(swap: Any) -> str:
@@ -84,6 +91,11 @@ def _is_benign_extension(e: Exception) -> bool:
 def _is_benign_resolve(e: Exception) -> bool:
     """A lost resolve_pool race — a peer already resolved it, or the clock hasn't crossed closes_at."""
     return any(m in str(e) for m in _BENIGN_RESOLVE_MARKERS)
+
+
+def _is_benign_close(e: Exception) -> bool:
+    """A lost close_stale_claim race — a peer already reaped it, or the reservation isn't expired yet."""
+    return any(m in str(e) for m in _BENIGN_CLOSE_MARKERS)
 
 
 def is_tx_fresh(info: Any, floor_unix: int, grace: int = 0) -> bool:
@@ -259,7 +271,24 @@ class SolanaSwapLoop:
             f'{swap.rate} (expected {expected_to}); refusing to attest [swap_key {key}]'
         )
 
+    def _claim_is_stale(self, reservation: Any, swap: Any, now: int) -> bool:
+        """A PendingAttestation claim is orphaned when its reservation can no longer carry it to attestation:
+        expired (reserved_until < now) or its claim slot no longer points at this swap (re-resolved/consumed).
+        Mirrors the contract's close_stale_claim guard so we never send a tx it would reject. False when the
+        reservation is unreadable this round (retry next pass)."""
+        if reservation is None:
+            return False
+        if int(reservation.reserved_until) < now:
+            return True
+        return bytes(reservation.claimed_swap_key) != swap_key_from_tx_hash(swap.from_tx_hash)
+
     def _decide_pending_attestation(self, swap: Any, now: int) -> SwapAction:
+        reservation = self._get_reservation(swap.miner)
+        # An orphaned claim can never attest (vote_initiate needs a live reservation) — reap it (close_stale_claim)
+        # to free the miner + reclaim rent. Covers a dropped/RBF'd source and one past its extension ceiling; a
+        # source landing after the ceiling is the taker's tail risk (nothing moved on our side to refund).
+        if self._claim_is_stale(reservation, swap, now):
+            return SwapAction(SwapDecision.CANCEL, reason='reservation expired/superseded — reaping stale claim')
         # D1: refuse to attest if to_amount is inconsistent with the pinned (unforgeable) miner rate.
         expected_to, _ = expected_swap_amounts(swap, self.fee_divisor)
         if expected_to == 0 or abs(int(swap.to_amount) - expected_to) > 1:
@@ -282,7 +311,6 @@ class SolanaSwapLoop:
             )
         if s_status != 'ok':
             return SwapAction(SwapDecision.WAIT, reason=f'source deposit {s_status} — awaiting user funds')
-        reservation = self._get_reservation(swap.miner)
         if reservation is None:
             bt.logging.warning(f'{self._label(swap)}: no reservation read — cannot check freshness, waiting')
             return SwapAction(SwapDecision.WAIT, reason='no reservation read')
@@ -330,6 +358,9 @@ class SolanaSwapLoop:
                 if self.client.has_voted(pdas.REQ_TIMEOUT, swap_key, voter):
                     return False
                 self.client.timeout_swap(swap_key, swap.miner, swap.user)
+            elif decision == SwapDecision.CANCEL:
+                # Permissionless reap (no vote round) — first validator wins, peers no-op benignly.
+                self.client.close_stale_claim(swap.miner, swap_key)
             elif decision == SwapDecision.EXTEND_RESERVATION:
                 self.client.extend_reservation(swap.miner, action.target_at)
             elif decision == SwapDecision.EXTEND_TIMEOUT:
@@ -338,6 +369,9 @@ class SolanaSwapLoop:
                 return False  # REJECT / non-actionable: cast nothing
         except Exception as e:
             if decision in (SwapDecision.EXTEND_RESERVATION, SwapDecision.EXTEND_TIMEOUT) and _is_benign_extension(e):
+                bt.logging.debug(f'{label}: {decision.value} no-op ({e})')
+                return False
+            if decision == SwapDecision.CANCEL and _is_benign_close(e):
                 bt.logging.debug(f'{label}: {decision.value} no-op ({e})')
                 return False
             bt.logging.error(f'{label}: {decision.value} failed: {e}')

--- a/tests/test_axon_solana_handlers.py
+++ b/tests/test_axon_solana_handlers.py
@@ -176,10 +176,29 @@ def test_confirm_already_claimed_rejects():
 
 
 def test_confirm_tx_not_visible_rejects():
+    # Absent tx (verify → None): fast-fail with no claim, so the short TTL frees the miner.
     client = FakeSolanaClient(reservation=_reservation())
     s = run(axon_handlers.handle_swap_confirm(make_validator(client, FakeProvider(None)), confirm_synapse()))
-    assert s.accepted is False and 'not yet visible' in s.rejection_reason
+    assert s.accepted is False and 'not visible' in s.rejection_reason
     assert client.calls == []
+
+
+def test_confirm_unconfirmed_mempool_deposit_relays_claim():
+    # Deferred intake: a content-valid but unconfirmed (0-conf mempool) deposit still creates the claim;
+    # the crank defers voting until confirmations accrue.
+    mempool = TransactionInfo(
+        tx_hash='srctx',
+        confirmed=False,
+        sender='userBTC',
+        recipient='minerBTC',
+        amount=500,
+        block_number=None,
+        block_time=None,  # unmined → no block_time; freshness deferred to the crank's 'ok' gate
+    )
+    client = FakeSolanaClient(reservation=_reservation())
+    s = run(axon_handlers.handle_swap_confirm(make_validator(client, FakeProvider(mempool)), confirm_synapse()))
+    assert s.accepted is True
+    assert client.calls == [('submit_swap_claim', MINER_PK, swap_key_from_tx_hash('srctx'), 'srctx', 0)]
 
 
 def test_confirm_stale_deposit_rejects():

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -302,3 +302,122 @@ def test_malformed_swap_key_raises_value_error(tmp_path):
         except ValueError:
             pass
     store.close()
+
+
+# ── confirm_deposit: deferred-confirmation intake. Accepts a content-valid deposit even before it fully
+# confirms (the crank defers voting until confirmations accrue); fast-fails without a claim on absent/mismatch
+# (None) or a stale MINED deposit, so the short reservation TTL frees the miner.
+from allways.chain_providers.base import ProviderUnreachableError, TransactionInfo  # noqa: E402
+from allways.validator.reserve_engine import confirm_deposit  # noqa: E402
+
+CONFIRM_CREATED_AT = 1000
+
+
+class _ConfirmClient(FakeClient):
+    def __init__(self, reservation, **kw):
+        super().__init__(**kw)
+        self._reservation = reservation
+        self.claims = []
+
+    def get_reservation(self, miner):
+        return self._reservation
+
+    def submit_swap_claim(self, miner, swap_key, from_tx_hash, from_tx_block):
+        self.claims.append((swap_key, from_tx_hash, from_tx_block))
+        return 'claimsig'
+
+
+class _FakeProvider:
+    def __init__(self, tx_info, *, unreachable=False, grace=0):
+        self._tx = tx_info
+        self._unreachable = unreachable
+        self._grace = grace
+
+    def verify_transaction(self, **kw):
+        if self._unreachable:
+            raise ProviderUnreachableError('down')
+        return self._tx
+
+    def get_chain(self):
+        return SimpleNamespace(replay_grace_secs=self._grace)
+
+
+def _confirm_reservation(**over):
+    d = dict(
+        reserved_until=FUTURE,
+        claimed_swap_key=b'\x00' * 32,
+        from_chain='btc',
+        miner_from_addr='minerBTC',
+        from_amount=100_000,
+        from_addr='userBTC',
+        created_at=CONFIRM_CREATED_AT,
+    )
+    d.update(over)
+    return SimpleNamespace(**d)
+
+
+def _tx(*, confirmed, block_time, confirmations=0):
+    return TransactionInfo(
+        tx_hash='abc',
+        confirmed=confirmed,
+        sender='userBTC',
+        recipient='minerBTC',
+        amount=100_000,
+        block_number=(None if block_time is None else 500),
+        confirmations=confirmations,
+        block_time=block_time,
+    )
+
+
+def _confirm(reservation, tx_info, *, unreachable=False):
+    client = _ConfirmClient(reservation)
+    provider = _FakeProvider(tx_info, unreachable=unreachable)
+    validator = SimpleNamespace(
+        solana_client=client, axon_chain_providers={'btc': provider}, axon_lock=threading.RLock()
+    )
+    return confirm_deposit(validator, HOTKEY, 'srctxhash'), client
+
+
+def test_confirm_accepts_unconfirmed_mempool_deposit():
+    # KEY new behavior: a content-valid 0-conf mempool tx (no block_time) still creates the claim.
+    r, client = _confirm(_confirm_reservation(), _tx(confirmed=False, block_time=None))
+    assert r.ok and client.claims
+
+
+def test_confirm_accepts_mined_low_conf_fresh_deposit():
+    # Mined but below min_confirmations, block_time present + fresh → accepted; crank defers the rest.
+    r, client = _confirm(_confirm_reservation(), _tx(confirmed=False, block_time=CONFIRM_CREATED_AT + 5, confirmations=1))
+    assert r.ok and client.claims
+
+
+def test_confirm_accepts_deeply_confirmed_fast_chain_deposit():
+    # Regression: a deeply-confirmed source still creates the claim (unchanged path for SOL/TAO fast chains).
+    r, client = _confirm(_confirm_reservation(), _tx(confirmed=True, block_time=CONFIRM_CREATED_AT + 5, confirmations=6))
+    assert r.ok and client.claims
+
+
+def test_confirm_rejects_absent_or_mismatch_without_claim():
+    # verify_transaction None (absent OR content mismatch) → fast-fail, no claim, TTL frees the miner.
+    r, client = _confirm(_confirm_reservation(), None)
+    assert not r.ok and not client.claims
+
+
+def test_confirm_rejects_stale_mined_deposit_without_claim():
+    # A MINED tx older than the reservation floor is a replay → freshness fast-fail (block_time checkable).
+    r, client = _confirm(_confirm_reservation(), _tx(confirmed=True, block_time=CONFIRM_CREATED_AT - 1, confirmations=6))
+    assert not r.ok and not client.claims
+
+
+def test_confirm_rejects_when_reservation_expired():
+    r, client = _confirm(_confirm_reservation(reserved_until=1), _tx(confirmed=False, block_time=None))
+    assert not r.ok and not client.claims
+
+
+def test_confirm_rejects_when_reservation_already_claimed():
+    r, client = _confirm(_confirm_reservation(claimed_swap_key=b'\x07' * 32), _tx(confirmed=True, block_time=FUTURE))
+    assert not r.ok and not client.claims
+
+
+def test_confirm_provider_unreachable_resends_without_claim():
+    r, client = _confirm(_confirm_reservation(), None, unreachable=True)
+    assert not r.ok and not client.claims and 'unreachable' in r.reason.lower()

--- a/tests/test_solana_swap_loop.py
+++ b/tests/test_solana_swap_loop.py
@@ -8,11 +8,13 @@ Mocks the solana client (get_swaps / get_reservation) + chain providers; no chai
 from types import SimpleNamespace
 
 from allways.chain_providers.base import ProviderUnreachableError
+from allways.solana.client import swap_key_from_tx_hash
 from allways.validator.solana_swap_loop import SolanaSwapLoop, SwapAction, SwapDecision, _is_benign_resolve
 
 INITIATED_AT = 1000  # dest-freshness floor
 RESV_CREATED_AT = 1200  # source-freshness floor
 FRESH = 5000  # block_time comfortably after both floors
+DEFAULT_CLAIM_KEY = swap_key_from_tx_hash('srctx')  # keccak of make_swap's default from_tx_hash — the live claim
 
 
 def make_swap(
@@ -74,8 +76,15 @@ class RecordingProvider:
         )
 
 
-def make_reservation(created_at=RESV_CREATED_AT, reserved_until=0, max_extend_at=10_000):
-    return SimpleNamespace(created_at=created_at, reserved_until=reserved_until, max_extend_at=max_extend_at)
+def make_reservation(created_at=RESV_CREATED_AT, reserved_until=1_000_000, max_extend_at=10_000, claimed_swap_key=None):
+    # Defaults model a LIVE reservation pinning make_swap's default claim (reserved_until well past any test
+    # `now`, claim slot pointing at the swap) so PendingAttestation decisions aren't reaped as stale.
+    return SimpleNamespace(
+        created_at=created_at,
+        reserved_until=reserved_until,
+        max_extend_at=max_extend_at,
+        claimed_swap_key=DEFAULT_CLAIM_KEY if claimed_swap_key is None else claimed_swap_key,
+    )
 
 
 def loop_with(result=True, created_at=RESV_CREATED_AT, reservation=None):
@@ -342,12 +351,40 @@ def test_extension_target_clamped_to_ceiling():
     assert action.target_at > 1600
 
 
-class ExtendRecordingClient:
-    """Captures extend calls; raisers simulate the contract ceiling / lost-race rejections."""
+# ── Deferred-confirmation reaper: a PendingAttestation claim whose reservation can no longer carry it to
+# attestation (expired past its ceiling, or its slot re-resolved) is reaped via close_stale_claim, freeing
+# the miner. The stale check precedes the leg fetch, since no source status can rescue a dead reservation.
+def test_pending_attestation_expired_reservation_reaps():
+    resv = make_reservation(reserved_until=1000)  # ran past its ceiling (< now 1500), source never confirmed
+    loop, _ = loop_with(result=None, reservation=resv)  # source absent (dropped/RBF'd)
+    assert loop.decide(make_swap(status='PendingAttestation'), now=1500).decision == SwapDecision.CANCEL
 
-    def __init__(self, reservation_exc=None, timeout_exc=None):
+
+def test_pending_attestation_expired_reservation_reaps_even_if_source_pending():
+    resv = make_reservation(reserved_until=1000)
+    loop, _ = loop_with(result=False, reservation=resv)  # still in mempool, but the reservation is already dead
+    assert loop.decide(make_swap(status='PendingAttestation'), now=1500).decision == SwapDecision.CANCEL
+
+
+def test_pending_attestation_superseded_claim_reaps():
+    resv = make_reservation(reserved_until=1_000_000, claimed_swap_key=b'\x09' * 32)  # slot points elsewhere
+    loop, _ = loop_with(result=True, reservation=resv)
+    assert loop.decide(make_swap(status='PendingAttestation'), now=1500).decision == SwapDecision.CANCEL
+
+
+def test_pending_attestation_live_matching_reservation_not_reaped():
+    # Regression: a live reservation whose claim slot matches must attest on a confirmed source, never reap.
+    loop, _ = loop_with(result=True)  # default reservation is live + matching
+    assert loop.decide(make_swap(status='PendingAttestation'), now=1500).decision == SwapDecision.ATTEST
+
+
+class ExtendRecordingClient:
+    """Captures extend/close calls; raisers simulate the contract ceiling / lost-race rejections."""
+
+    def __init__(self, reservation_exc=None, timeout_exc=None, close_exc=None):
         self.reservation_exc = reservation_exc
         self.timeout_exc = timeout_exc
+        self.close_exc = close_exc
         self.calls = []
         self.keypair = SimpleNamespace(pubkey=lambda: 'VALIDATOR')
 
@@ -360,6 +397,11 @@ class ExtendRecordingClient:
         self.calls.append(('extend_timeout', swap_key, miner, target_at))
         if self.timeout_exc:
             raise self.timeout_exc
+
+    def close_stale_claim(self, miner, swap_key):
+        self.calls.append(('close_stale_claim', miner, swap_key))
+        if self.close_exc:
+            raise self.close_exc
 
 
 def test_cast_extend_reservation_calls_client():
@@ -379,6 +421,27 @@ def test_cast_extend_tolerates_exceeds_ceiling_as_noop():
     client = ExtendRecordingClient(timeout_exc=RuntimeError('ExtensionExceedsCeiling'))
     loop = SolanaSwapLoop(client, {}, fee_divisor=100)
     assert loop._cast_vote(make_swap(), SwapAction(SwapDecision.EXTEND_TIMEOUT, 2160)) is False  # no raise
+
+
+def test_cast_cancel_calls_close_stale_claim():
+    client = ExtendRecordingClient()
+    loop = SolanaSwapLoop(client, {}, fee_divisor=100)
+    assert loop._cast_vote(make_swap(), SwapAction(SwapDecision.CANCEL)) is True
+    assert client.calls[0][0] == 'close_stale_claim' and client.calls[0][1] == 'minerPK'
+
+
+def test_cast_cancel_tolerates_claim_not_expired_as_noop():
+    # Another validator's clock hasn't crossed expiry yet — contract rejects with ClaimNotExpired; benign.
+    client = ExtendRecordingClient(close_exc=RuntimeError('ClaimNotExpired'))
+    loop = SolanaSwapLoop(client, {}, fee_divisor=100)
+    assert loop._cast_vote(make_swap(), SwapAction(SwapDecision.CANCEL)) is False  # no raise
+
+
+def test_cast_cancel_tolerates_already_reaped_as_noop():
+    # A peer already reaped it — the Swap PDA is gone; benign lost race.
+    client = ExtendRecordingClient(close_exc=RuntimeError('AccountNotInitialized: swap'))
+    loop = SolanaSwapLoop(client, {}, fee_divisor=100)
+    assert loop._cast_vote(make_swap(), SwapAction(SwapDecision.CANCEL)) is False  # no raise
 
 
 def test_run_once_discovers_and_decides_mix():

--- a/tests/test_solana_vote_builders.py
+++ b/tests/test_solana_vote_builders.py
@@ -52,6 +52,7 @@ def test_ix_discriminators_match_anchor_global_formula():
         'vote_initiate',
         'confirm_swap',
         'timeout_swap',
+        'close_stale_claim',
         'vote_activate',
         'mark_fulfilled',
         'extend_timeout',
@@ -119,6 +120,21 @@ def test_confirm_swap_ix(client):
         (pdas.stats_pda(miner, 'BTC', 'tao', PID), False, True),
         (pdas.vote_round_pda(pdas.REQ_CONFIRM, SK, PID), False, True),
         (SYSTEM_PROGRAM, False, False),
+    ]
+
+
+def test_close_stale_claim_ix(client):
+    miner = Keypair().pubkey()
+    client.close_stale_claim(miner, SK)
+    ix = _ix(client)
+    assert ix.data[:8] == layouts.IX_DISCRIMINATORS['close_stale_claim']
+    assert ix.data[8:] == SK
+    # Accounts match CloseStaleClaim<'info>: caller(signer,writable), miner, reservation(mut), swap(mut).
+    assert _metas(ix) == [
+        (client.keypair.pubkey(), True, True),
+        (miner, False, False),
+        (pdas.reservation_pda(miner, PID), False, True),
+        (pdas.swap_pda(SK, PID), False, True),
     ]
 
 


### PR DESCRIPTION
## What & why

Restores the ink!-era **deferred confirmation** for source deposits, dropped in the Solana port (#496). Previously `confirm_deposit` rejected a source tx unless it was *already* fully confirmed — fine for SOL (~13s) but it forced a BTC taker to wait ~20 min for 2 confs before `post-tx` even succeeded, timing out honest BTC takers who were just waiting on blocks.

**Model — the contract is the queue** (no validator-side queue; the old ink! `pending_confirms` SQLite table stays gone): a Swap PDA in `PendingAttestation` stores `from_tx_hash`, and the crank re-checks it each round (`pending`→extend, `ok`+fresh→attest). Voting is deferred, not the claim.

## Changes

### Validator — deferred intake + stale-claim reaper (`4cac166`)
- **`reserve_engine.confirm_deposit`**: accept a content-valid deposit even before it fully confirms. Fast-fail with **no claim** only when `verify_transaction` returns `None` (absent/content-mismatch), so the short TTL frees the miner. Freshness is enforced only when `block_time` is present (mined); a 0-conf mempool tx defers freshness to the crank's `ok` gate (BTC Esplora returns full vin/vout for mempool txs).
- **`solana_swap_loop`**: new `CANCEL` decision + `_claim_is_stale` mirroring the contract's `close_stale_claim` guard — reaps an orphaned `PendingAttestation` claim (reservation expired past its ceiling, or slot re-resolved), freeing the miner + reclaiming rent. Closes the deadline gap: `decide()` previously had no timeout branch for `PendingAttestation`. Benign first-wins race handling.
- **`solana/{client,layouts}.py`**: wire the **pre-existing** `close_stale_claim` instruction (discriminator + builder). Its event was already mapped in #514; only the trigger was missing. No contract/IDL change.

### CLI — re-port `alw swap post-tx` (`4bdd575`)
- `alw swap post-tx <tx-hash>` relays the source-tx hash to serving validators via `SwapConfirmSynapse`; each validator verifies the on-chain deposit against the pinned Reservation and submits the claim. Permissionless — signed by an ephemeral throwaway hotkey as transport only (the on-chain deposit is the auth), so a pure-Solana taker needs no registered neuron. Resolves the winning miner from the pending-swap stash (fast path) or by scanning bindings; `--miner` relays on anyone's behalf. Verified live on devnet/testnet.

## Not a bug (documented)
`Reservation.claimed_swap_key` reading all-zeros post-attestation is by design — `vote_initiate` zeroes it + `reserved_until` at quorum. The double-claim guard is set at `submit_swap_claim` and cleared at attestation.

## Config (companion, separate PR)
- **reservation_ttl 2500→480** (8-min anti-grief gate; the conf runway is carried by extensions): deploy default in **entrius/alw-utils#84**; the live cluster needs a one-time `alw admin set-reservation-ttl 480` (Config PDA persists across redeploys).
- **max_total_extension stays 7200** — 8400 would exceed the hard on-chain lid (`MAX_TOTAL_EXTENSION_SECS_MAX`) and require a redeploy; at ttl=480 the ~128-min source ceiling already drives block-variance BTC 2-conf failures to ~1-in-26k.

## Testing
- **640 passed.** +18 new: `confirm_deposit` accepts unconfirmed-mempool / mined-low-conf / deeply-confirmed (fast-chain regression), rejects absent-or-mismatch / stale-mined / expired / already-claimed / unreachable — all without a claim; crank reaper decisions (incl. source-pending-but-expired) + live-matching regression; `close_stale_claim` cast + benign races; builder discriminator verified vs Anchor `sha256("global:…")` + account metas.
- CLI `post-tx` path verified live on devnet/testnet (ok → on-chain Swap created → FULFILLED).
- **Not run here:** validator-side devnet + BTC testnet4/signet integration — an 8-min BTC-source swap surviving via extension to 2 confs, and a dropped-tx reap.

@landyndev — swap CLI + validator swap lane.