### PR TITLE
feat(cli): solana-keypair config key — select the Solana signer via alw config

### DIFF
--- a/allways/cli/main.py
+++ b/allways/cli/main.py
@@ -59,6 +59,7 @@ from allways.cli.swap_commands.helpers import (  # noqa: E402
     apply_btc_network_env,
     apply_global_flags,
     console,
+    fail,
     get_effective_config,
 )
 
@@ -113,12 +114,32 @@ def show_config():
             table.add_row(key, str(value))
 
         console.print(table)
+
+        # Show which key will actually sign (env > solana-keypair config > ~/.solana/id.json),
+        # so a wrong signer is visible here instead of as a cryptic on-chain failure.
+        signer = _resolved_signer_line(config)
+        if signer:
+            console.print(f'\n[dim]Solana signer:[/dim] {signer}')
         console.print(f'\n[dim]Config file: {CONFIG_FILE}[/dim]\n')
 
     except json.JSONDecodeError:
         console.print('[red]Error: Invalid JSON in config file[/red]')
     except Exception as e:
         console.print(f'[red]Error reading config: {e}[/red]')
+
+
+def _resolved_signer_line(config: dict) -> str | None:
+    """Resolved Solana signer as 'pubkey (path)', or a not-found note; None only on import trouble."""
+    try:
+        from allways.cli.swap_commands.helpers import resolve_solana_keypair_path
+        from allways.solana import keys
+
+        path = resolve_solana_keypair_path(config)
+        if not os.path.isfile(path):
+            return f'[yellow]no keypair at {path}[/yellow]'
+        return f'{keys.load_keypair(path).pubkey()} [dim]({path})[/dim]'
+    except Exception:
+        return None
 
 
 KNOWN_NETWORKS = {
@@ -135,6 +156,7 @@ VALID_CONFIG_KEYS = (
     'program-id',
     'solana-rpc',
     'solana-network',
+    'solana-keypair',
     'btc-network',
     'env',
 )
@@ -157,6 +179,7 @@ def config_set(key: str, value: str):
         netuid              Subnet UID
         solana-network      Solana network name (devnet/mainnet/localnet) → RPC resolved in code
         solana-rpc          Custom Solana RPC URL (escape hatch; SOLANA_RPC_URL env wins)
+        solana-keypair      Path to the Solana keypair that signs miner/admin ops (SOLANA_KEYPAIR_PATH env wins)
         btc-network         Bitcoin network name (mainnet/testnet4/testnet/signet)
         program-id          Solana program ID (miner/admin commands)[/dim]
 
@@ -170,6 +193,7 @@ def config_set(key: str, value: str):
         $ alw config set env testnet          # bittensor test + solana devnet + btc testnet4 + netuid 19
         $ alw config set wallet alice
         $ alw config set solana-network devnet
+        $ alw config set solana-keypair ~/.config/solana/dev.json
         $ alw config set network finney[/dim]
     """
     ALLWAYS_DIR.mkdir(parents=True, exist_ok=True)
@@ -202,6 +226,20 @@ def config_set(key: str, value: str):
         console.print(f'[red]Unknown btc-network {value!r}; expected {list(BTC_NETWORKS)}.[/red]')
         return
 
+    # Validate the keypair at set time and echo its pubkey, so a typo'd path or wrong file
+    # fails here — not later as an unfunded/non-authority signer on a live command.
+    keypair_pubkey = None
+    if key == 'solana-keypair':
+        from allways.solana import keys
+
+        value = os.path.expanduser(value)
+        if not os.path.isfile(value):
+            fail(f'solana-keypair {value} not found.')
+        try:
+            keypair_pubkey = keys.load_keypair(value).pubkey()
+        except Exception as e:
+            fail(f'solana-keypair {value} is not a loadable Solana keypair file: {e}')
+
     # Normalize network: reverse-map known endpoints to names
     if key == 'network':
         for name, endpoint in KNOWN_NETWORKS.items():
@@ -217,6 +255,8 @@ def config_set(key: str, value: str):
     display = value
     if key == 'network' and value in KNOWN_NETWORKS:
         display = f'{value} ({KNOWN_NETWORKS[value]})'
+    if keypair_pubkey is not None:
+        display = f'{value} → signs as {keypair_pubkey}'
 
     if old_value is not None:
         console.print(f'[green]Updated {key}:[/green] {old_value} -> {display}')

--- a/allways/cli/swap_commands/collateral.py
+++ b/allways/cli/swap_commands/collateral.py
@@ -44,7 +44,7 @@ def collateral_group():
 def collateral_deposit(amount: float | None, yes: bool):
     """Deposit SOL collateral to the swap program.
 
-    [dim]Amount is in SOL, posted from your Solana keypair (SOLANA_KEYPAIR_PATH / ~/.solana/id.json).[/dim]
+    [dim]Amount is in SOL, posted from your Solana keypair (SOLANA_KEYPAIR_PATH / solana-keypair config / ~/.solana/id.json).[/dim]
 
     [dim]Examples:
         $ alw collateral deposit --amount 5.0

--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -27,6 +27,8 @@ PENDING_SWAP_FILE = ALLWAYS_DIR / 'pending_swap.json'
 # Each chain takes a simple network NAME (alw config set solana-network devnet); the code
 # maps it to an endpoint so operators never hand-copy RPC URLs. Raw-URL escape hatches still
 # win for paid/custom RPCs (SOLANA_RPC_URL env / solana-rpc config; BTC_ESPLORA_URLS env).
+# The Solana SIGNER resolves the same way: SOLANA_KEYPAIR_PATH env wins, else the
+# solana-keypair config path, else the solana-CLI default ~/.solana/id.json.
 SOLANA_NETWORKS = {
     'devnet': 'https://api.devnet.solana.com',
     'mainnet': 'https://api.mainnet-beta.solana.com',
@@ -56,6 +58,32 @@ def resolve_solana_rpc(config: dict) -> str:
             f'[yellow]Unknown solana-network {name!r} (expected {list(SOLANA_NETWORKS)}); using localnet.[/yellow]'
         )
     return 'http://127.0.0.1:8899'
+
+
+def resolve_solana_keypair_path(config: dict) -> str:
+    """Solana keypair precedence: SOLANA_KEYPAIR_PATH env (raw path escape hatch) wins;
+    else the solana-keypair config path; else the solana-CLI default ~/.solana/id.json."""
+    raw = os.environ.get('SOLANA_KEYPAIR_PATH') or config.get('solana-keypair')
+    if raw:
+        return os.path.expanduser(raw)
+    return str(Path.home() / '.solana' / 'id.json')
+
+
+def load_cli_keypair(config: dict):
+    """Load the CLI signing keypair from the resolved path (see resolve_solana_keypair_path).
+
+    An explicitly pointed-at path (env/config) must exist — minting a fresh key there would
+    silently sign with an unfunded, non-authority identity. Only the bare ~/.solana/id.json
+    default keeps the auto-generate convenience."""
+    from allways.solana import keys
+
+    path = resolve_solana_keypair_path(config)
+    explicit = os.environ.get('SOLANA_KEYPAIR_PATH') or config.get('solana-keypair')
+    if explicit and not os.path.exists(path):
+        fail(
+            f'Configured solana-keypair {path} not found (from SOLANA_KEYPAIR_PATH env or `alw config set solana-keypair`).'
+        )
+    return keys.load_or_create(path)
 
 
 def apply_btc_network_env(config: dict) -> None:
@@ -534,13 +562,13 @@ def secs_str(secs: int) -> str:
 def get_solana_cli_context(need_keypair: bool = True):
     """Solana CLI setup for the B4-repointed miner/admin commands → (config, solana_client).
 
-    The miner/admin identity is the Solana keypair (SOLANA_KEYPAIR_PATH / ~/.solana/id.json), NOT the bt
-    wallet — collateral, quotes, and config are keyed by that pubkey on the program. The bt wallet is only
-    needed where a command links the two identities (`alw miner bind-hotkey`).
+    The miner/admin identity is the Solana keypair (SOLANA_KEYPAIR_PATH env / solana-keypair config /
+    ~/.solana/id.json), NOT the bt wallet — collateral, quotes, and config are keyed by that pubkey on the
+    program. The bt wallet is only needed where a command links the two identities (`alw miner bind-hotkey`).
     """
     from solders.pubkey import Pubkey
 
-    from allways.solana import keys, pdas
+    from allways.solana import pdas
     from allways.solana.client import AllwaysSolanaClient
 
     config = get_effective_config()
@@ -554,7 +582,7 @@ def get_solana_cli_context(need_keypair: bool = True):
             console.print(
                 f'[yellow]Ignoring invalid program-id config {configured!r}; using default {program_id}[/yellow]'
             )
-    keypair = keys.load_or_create() if need_keypair else None
+    keypair = load_cli_keypair(config) if need_keypair else None
     return config, AllwaysSolanaClient(rpc_url, program_id=program_id, keypair=keypair)
 
 

--- a/allways/cli/swap_commands/status.py
+++ b/allways/cli/swap_commands/status.py
@@ -17,17 +17,18 @@ from allways.cli.swap_commands.helpers import (
     get_effective_config,
     get_solana_cli_context,
     print_json,
+    resolve_solana_keypair_path,
     safe_read,
     set_json_output,
 )
 
 
-def _load_caller():
-    """Load the caller's Solana keypair without creating one. Returns Pubkey or None."""
+def _load_caller(config):
+    """Load the caller's Solana keypair (env/config-resolved) without creating one. Returns Pubkey or None."""
     from allways.solana import keys
 
     try:
-        return keys.load_keypair().pubkey()
+        return keys.load_keypair(resolve_solana_keypair_path(config)).pubkey()
     except Exception:
         return None
 
@@ -50,7 +51,7 @@ def status_command(miner_pk, as_json):
     program_initialized = cfg is not None
     halted = bool(cfg and cfg.halted)
 
-    caller = _load_caller()
+    caller = _load_caller(config)
     balance = None
     miner_state = None
     if caller is not None:
@@ -113,7 +114,9 @@ def status_command(miner_pk, as_json):
         console.print(f'  Keypair:      {caller}')
         console.print(f'  Balance:      {bal}')
     else:
-        console.print('  Keypair:      [dim]none loaded (set SOLANA_KEYPAIR_PATH)[/dim]')
+        console.print(
+            '  Keypair:      [dim]none loaded (`alw config set solana-keypair <path>` or SOLANA_KEYPAIR_PATH)[/dim]'
+        )
 
     if is_miner:
         console.print('\n[bold]Miner[/bold]\n')

--- a/tests/test_network_config.py
+++ b/tests/test_network_config.py
@@ -2,14 +2,22 @@
 
 Raw-URL escape hatches (SOLANA_RPC_URL env / solana-rpc config, BTC_NETWORK env) win for
 paid/custom endpoints; otherwise the name maps to a public default. `env` is a one-liner bundle
-that sets all three chains' networks + netuid at once.
+that sets all three chains' networks + netuid at once. The Solana signer resolves the same way:
+SOLANA_KEYPAIR_PATH env > solana-keypair config > ~/.solana/id.json.
 """
+
+import json
+from pathlib import Path
+
+import pytest
 
 from allways.cli.swap_commands.helpers import (
     BTC_NETWORKS,
     ENV_BUNDLES,
     SOLANA_NETWORKS,
     apply_btc_network_env,
+    load_cli_keypair,
+    resolve_solana_keypair_path,
     resolve_solana_rpc,
 )
 
@@ -63,3 +71,64 @@ def test_btc_shim_respects_real_env(monkeypatch):
     import os
 
     assert os.environ['BTC_NETWORK'] == 'mainnet'  # explicit env wins
+
+
+def test_keypair_env_wins_over_config(monkeypatch):
+    monkeypatch.setenv('SOLANA_KEYPAIR_PATH', '/env/id.json')
+    assert resolve_solana_keypair_path({'solana-keypair': '/cfg/id.json'}) == '/env/id.json'
+
+
+def test_keypair_config_used_when_env_unset(monkeypatch):
+    monkeypatch.delenv('SOLANA_KEYPAIR_PATH', raising=False)
+    assert resolve_solana_keypair_path({'solana-keypair': '/cfg/id.json'}) == '/cfg/id.json'
+
+
+def test_keypair_defaults_to_solana_cli_path(monkeypatch):
+    monkeypatch.delenv('SOLANA_KEYPAIR_PATH', raising=False)
+    assert resolve_solana_keypair_path({}) == str(Path.home() / '.solana' / 'id.json')
+
+
+def test_keypair_config_tilde_expands(monkeypatch):
+    monkeypatch.delenv('SOLANA_KEYPAIR_PATH', raising=False)
+    assert resolve_solana_keypair_path({'solana-keypair': '~/keys/id.json'}) == str(Path.home() / 'keys' / 'id.json')
+
+
+def test_keypair_env_tilde_expands(monkeypatch):
+    monkeypatch.setenv('SOLANA_KEYPAIR_PATH', '~/env-keys/id.json')
+    assert resolve_solana_keypair_path({}) == str(Path.home() / 'env-keys' / 'id.json')
+
+
+def test_configured_missing_keypair_fails_not_generates(monkeypatch, tmp_path):
+    monkeypatch.delenv('SOLANA_KEYPAIR_PATH', raising=False)
+    missing = tmp_path / 'nope.json'
+    with pytest.raises(SystemExit):
+        load_cli_keypair({'solana-keypair': str(missing)})
+    assert not missing.exists()  # must NOT silently mint a fresh key at an explicit path
+
+
+def test_env_missing_keypair_fails_not_generates(monkeypatch, tmp_path):
+    missing = tmp_path / 'nope.json'
+    monkeypatch.setenv('SOLANA_KEYPAIR_PATH', str(missing))
+    with pytest.raises(SystemExit):
+        load_cli_keypair({})
+    assert not missing.exists()
+
+
+def test_configured_keypair_loads(monkeypatch, tmp_path):
+    from solders.keypair import Keypair
+
+    kp = Keypair()
+    p = tmp_path / 'id.json'
+    p.write_text(json.dumps(list(bytes(kp))))
+    monkeypatch.delenv('SOLANA_KEYPAIR_PATH', raising=False)
+    assert load_cli_keypair({'solana-keypair': str(p)}).pubkey() == kp.pubkey()
+
+
+def test_bare_default_still_auto_generates(monkeypatch, tmp_path):
+    # No env, no config → the solana-CLI default path keeps its dev convenience of minting a key.
+    monkeypatch.delenv('SOLANA_KEYPAIR_PATH', raising=False)
+    monkeypatch.setenv('HOME', str(tmp_path))
+    kp = load_cli_keypair({})
+    default = tmp_path / '.solana' / 'id.json'
+    assert default.exists()
+    assert json.loads(default.read_text()) == list(bytes(kp))


### PR DESCRIPTION
@landyndev — CLI change, your lane.

## Problem

The Bittensor wallet is selectable via config (`alw config set wallet/hotkey`), but the Solana signer was **env-only**: `get_solana_cli_context` called `keys.load_or_create()` with no path, so it only ever looked at `SOLANA_KEYPAIR_PATH` / `~/.solana/id.json`. There was no way to persist which Solana key signs miner/admin ops, and running e.g. `alw admin set-reservation-ttl` without the env var picked up an auto-generated, unfunded `~/.solana/id.json` key — surfacing as \"Attempt to debit an account but found no record of a prior credit\" or a program-authority rejection. The RPC already had a config key (`solana-rpc`); the keypair was just left out.

## Changes

- **`resolve_solana_keypair_path(config)`** (helpers.py), mirroring `resolve_solana_rpc`: `SOLANA_KEYPAIR_PATH` env (escape hatch, wins) → `solana-keypair` config → `~/.solana/id.json` default, with `~` expansion.
- **`load_cli_keypair(config)`**, wired into `get_solana_cli_context`: if the path was explicitly pointed at (env or config) but the file doesn't exist, it **fails loudly via `fail()`** instead of silently minting a fresh (unfunded, non-authority) key. Only the bare `~/.solana/id.json` default keeps the auto-generate convenience.
- **`alw config set solana-keypair <path>`** validates at set time — expands `~`, requires the file to exist and load as a solana-CLI keypair — and echoes the resolved pubkey so you confirm the right key: `Set solana-keypair: /path/dev-asm.json → signs as 68ToG…`. Missing/invalid file exits non-zero via `fail()` (script-safe, post-#516).
- **Signer visibility**: `alw config` now prints the resolved signer pubkey + path under the table; `alw status` resolves its caller keypair through the same precedence and its \"none loaded\" hint mentions the config key.

## Untouched by design

`keys.py::_default_path` / `load_or_create()` semantics are unchanged — miner/validator startup (`neurons/miner.py`, `neurons/validator.py`) still auto-generates on the bare default path.

## Tests

New coverage in `tests/test_network_config.py` mirroring the `resolve_solana_rpc` tests: env-wins-over-config, config-when-env-unset, default path, `~` expansion (config and env), configured-but-missing path fails **without** creating the file (config and env variants), configured key loads the right pubkey, and bare default still auto-generates. Full suite: **649 passed**.

## Verified

With an isolated `$HOME`: `alw config set solana-keypair <path>` echoes the pubkey and `get_solana_cli_context`'s loader signs as that key with no env prefix; a bogus path errors with exit 1; `SOLANA_KEYPAIR_PATH` still overrides config; env pointing at a missing file fails loudly and does not create it.