### PR TITLE
Add dev-signal NDJSON emitter and gated fault flags

### DIFF
--- a/allways/dev_signal.py
+++ b/allways/dev_signal.py
@@ -1,0 +1,37 @@
+"""Dev-only structured signal (T3 assertion surface for the e2e harness).
+
+``emit`` is a no-op unless ``ALLWAYS_DEV_SIGNAL`` is set to a writable path; then each call
+appends one NDJSON line ``{"ts": ..., "event": ..., ...fields}``. It mirrors existing log
+lines — it never replaces them — and never raises.
+
+``fault`` gates harness-injected failure paths (e.g. withholding a dest send to force the
+slash path). ``ALLWAYS_DEV_FAULTS`` names a file whose content is a comma/newline-separated
+flag list, so the harness can toggle faults on a running neuron. Both env vars are unset in
+production, making this module inert.
+"""
+
+import json
+import os
+import time
+
+
+def emit(event: str, **fields) -> None:
+    path = os.environ.get('ALLWAYS_DEV_SIGNAL')
+    if not path:
+        return
+    try:
+        with open(path, 'a') as f:
+            f.write(json.dumps({'ts': time.time(), 'event': event, **fields}, default=str) + '\n')
+    except Exception:
+        pass
+
+
+def fault(name: str) -> bool:
+    path = os.environ.get('ALLWAYS_DEV_FAULTS')
+    if not path:
+        return False
+    try:
+        flags = open(path).read().replace('\n', ',')
+    except OSError:
+        return False
+    return name in {f.strip() for f in flags.split(',') if f.strip()}

--- a/allways/miner/fulfillment.py
+++ b/allways/miner/fulfillment.py
@@ -16,6 +16,7 @@ from typing import Dict, Optional, Set, Tuple
 
 import bittensor as bt
 
+from allways import dev_signal
 from allways.chain_providers.base import ChainProvider, ProviderUnreachableError
 from allways.constants import FEE_DIVISOR, MINER_TIMEOUT_CUSHION_SECS, SENT_CACHE_DISCARD_MARGIN_SECS
 from allways.solana.client import SolanaClientError, SolanaSwap
@@ -171,15 +172,18 @@ class SwapFulfiller:
                     f'(now {now} >= {swap.timeout_at} - {MINER_TIMEOUT_CUSHION_SECS})'
                 )
                 self.cushion_warned.add(swap.key_hex)
+            dev_signal.emit('refuse', swap_key=swap.key_hex, reason='inside_cushion')
             return None
 
         if not swap.miner_from_addr:
             bt.logging.error(f'Swap {swap.key_hex[:16]}: missing miner_from_addr on swap')
+            dev_signal.emit('refuse', swap_key=swap.key_hex, reason='missing_miner_from_addr')
             return None
 
         user_receives = apply_fee_deduction(swap.to_amount, self.fee_divisor)
         if user_receives == 0:
             bt.logging.error(f'Swap {swap.key_hex[:16]}: pinned to_amount yields 0 after the fee haircut')
+            dev_signal.emit('refuse', swap_key=swap.key_hex, reason='zero_after_fee')
             return None
 
         return user_receives, swap.miner_from_addr
@@ -213,6 +217,7 @@ class SwapFulfiller:
                 return False
 
             bt.logging.info(f'Swap {swap.key_hex[:16]}: source funds verified ({tx_info.amount} from {tx_info.sender})')
+            dev_signal.emit('source_verified', swap_key=swap.key_hex, sender=tx_info.sender, amount=tx_info.amount)
             return True
 
         except ProviderUnreachableError as e:
@@ -227,6 +232,12 @@ class SwapFulfiller:
         provider = self.providers.get(swap.to_chain)
         if not provider:
             bt.logging.error(f'Swap {swap.key_hex[:16]}: no provider for dest chain: {swap.to_chain}')
+            return None
+
+        # Harness-injected slash path: pretend the send failed so the swap times out and slashes.
+        if dev_signal.fault('withhold_dest'):
+            bt.logging.warning(f'Swap {swap.key_hex[:16]}: withholding dest funds (dev fault withhold_dest)')
+            dev_signal.emit('refuse', swap_key=swap.key_hex, reason='withhold_dest')
             return None
 
         # Miner's own dest-chain sending address — cached from this miner's posted quote at startup, passed
@@ -245,6 +256,7 @@ class SwapFulfiller:
                 f'Swap {swap.key_hex[:16]}: sent {user_receives_amount} to {swap.user_to_addr} '
                 f'on {swap.to_chain} (tx: {tx_hash}, block: {block_num})'
             )
+            dev_signal.emit('dest_sent', swap_key=swap.key_hex, tx=tx_hash, amount=user_receives_amount)
         else:
             reason = getattr(provider, 'last_send_error', None) or 'no provider error captured'
             bt.logging.error(
@@ -315,6 +327,7 @@ class SwapFulfiller:
             self.save_sent_cache()
             self.mark_fulfilled_attempts.pop(key, None)
             bt.logging.success(f'Swap {key[:16]}: marked as fulfilled')
+            dev_signal.emit('marked_fulfilled', swap_key=key, tx=sent.to_tx_hash)
             return True
         except SolanaClientError as e:
             attempts = self.mark_fulfilled_attempts.get(key, 0) + 1

--- a/allways/validator/event_index.py
+++ b/allways/validator/event_index.py
@@ -22,6 +22,7 @@ from typing import Callable, Dict, List, Optional, Set
 
 import bittensor as bt
 
+from allways import dev_signal
 from allways.classes import ActivityTransition, MinerActivity
 from allways.constants import RATE_PRECISION
 from allways.solana.events import EventRecord
@@ -91,6 +92,7 @@ class SolanaEventIndex:
             outcome = _OUTCOME_BY_EVENT.get(name)
             if outcome is not None:
                 self.state_store.record_swap_outcome(bytes(rec.fields['swap_key']).hex(), outcome, block_time)
+                dev_signal.emit('swap_outcome', swap_key=bytes(rec.fields['swap_key']).hex(), outcome=outcome)
             # SwapCompleted is the only swap event carrying realized legs — persist
             # them as a clearing-rate sample for the C-rev quality reference, in
             # addition to closing the fulfillment above.
@@ -108,7 +110,12 @@ class SolanaEventIndex:
             # A PendingAttestation claim reaped stale: the Swap PDA is gone, so record the terminal
             # 'expired' outcome for the seam. No activity edge — the miner never entered FULFILLING;
             # its synthetic RESERVE_EXPIRE already returns it to AVAILABLE.
-            self.state_store.record_swap_outcome(bytes(rec.fields['swap_key']).hex(), _OUTCOME_BY_EVENT[name], block_time)
+            self.state_store.record_swap_outcome(
+                bytes(rec.fields['swap_key']).hex(), _OUTCOME_BY_EVENT[name], block_time
+            )
+            dev_signal.emit(
+                'swap_outcome', swap_key=bytes(rec.fields['swap_key']).hex(), outcome=_OUTCOME_BY_EVENT[name]
+            )
             return True
         if name in ('CollateralPosted', 'CollateralWithdrawn'):
             total = int(rec.fields['total'])

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 import bittensor as bt
 
+from allways import dev_signal
 from allways.utils.logging import log_crown_winners
 from allways.validator.binding import build_attribution
 from allways.validator.scoring import (
@@ -63,6 +64,7 @@ async def forward(self: Validator) -> None:
     # one); halt-aware clearing happens once per round in `_flush_halt_window`.
     crown_snapshot = snapshot_current_crown_holders(self)
     log_crown_winners(self.metagraph, self.block, crown_snapshot)
+    dev_signal.emit('crown_snapshot', holders={f'{k[0]}-{k[1]}': v for k, v in crown_snapshot.items()})
     if self.database_storage.is_enabled():
         try:
             self.database_storage.upsert_current_crown_snapshot(crown_snapshot)

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Set, Tuple
 import bittensor as bt
 import numpy as np
 
+from allways import dev_signal
 from allways.chains import canonical_pair, get_chain
 from allways.classes import ActivityTransition, MinerActivity, next_activity
 from allways.constants import (
@@ -98,6 +99,7 @@ def score_and_reward_miners(self: Validator) -> None:
         else:
             rewards, miner_uids = calculate_miner_rewards(self, now)
         self.update_scores(rewards, miner_uids)
+        dev_signal.emit('scoring_rewards', halted=halted, rewards={i: float(r) for i, r in enumerate(rewards) if r})
         prune_crown_events(self, now)
         # Advance both cursors only after a round completes, so a mid-round
         # failure retries the same window next forward. last_scored_block gates

--- a/allways/validator/solana_swap_loop.py
+++ b/allways/validator/solana_swap_loop.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, NamedTuple, Optional, Set, Tuple
 import bittensor as bt
 from solders.pubkey import Pubkey
 
+from allways import dev_signal
 from allways.chain_providers.base import ProviderUnreachableError
 from allways.chains import compute_extension_target_secs
 from allways.constants import EXTENSION_PADDING_SECONDS
@@ -270,6 +271,7 @@ class SolanaSwapLoop:
             f'{self._label(swap)}: REJECT — to_amount {swap.to_amount} inconsistent with pinned rate '
             f'{swap.rate} (expected {expected_to}); refusing to attest [swap_key {key}]'
         )
+        dev_signal.emit('d1_reject', swap_key=key, expected=expected_to, got=int(swap.to_amount))
 
     def _claim_is_stale(self, reservation: Any, swap: Any, now: int) -> bool:
         """A PendingAttestation claim is orphaned when its reservation can no longer carry it to attestation:
@@ -349,22 +351,22 @@ class SolanaSwapLoop:
             if decision == SwapDecision.ATTEST:
                 if self.client.has_voted(pdas.REQ_INITIATE, swap.miner, voter):
                     return False
-                self.client.vote_initiate(swap_key, swap.miner)
+                sig = self.client.vote_initiate(swap_key, swap.miner)
             elif decision == SwapDecision.CONFIRM:
                 if self.client.has_voted(pdas.REQ_CONFIRM, swap_key, voter):
                     return False
-                self.client.confirm_swap(swap_key, swap.miner, swap.from_chain, swap.to_chain)
+                sig = self.client.confirm_swap(swap_key, swap.miner, swap.from_chain, swap.to_chain)
             elif decision == SwapDecision.TIMEOUT:
                 if self.client.has_voted(pdas.REQ_TIMEOUT, swap_key, voter):
                     return False
-                self.client.timeout_swap(swap_key, swap.miner, swap.user)
+                sig = self.client.timeout_swap(swap_key, swap.miner, swap.user)
             elif decision == SwapDecision.CANCEL:
                 # Permissionless reap (no vote round) — first validator wins, peers no-op benignly.
-                self.client.close_stale_claim(swap.miner, swap_key)
+                sig = self.client.close_stale_claim(swap.miner, swap_key)
             elif decision == SwapDecision.EXTEND_RESERVATION:
-                self.client.extend_reservation(swap.miner, action.target_at)
+                sig = self.client.extend_reservation(swap.miner, action.target_at)
             elif decision == SwapDecision.EXTEND_TIMEOUT:
-                self.client.extend_timeout(swap_key, swap.miner, action.target_at)
+                sig = self.client.extend_timeout(swap_key, swap.miner, action.target_at)
             else:
                 return False  # REJECT / non-actionable: cast nothing
         except Exception as e:
@@ -377,6 +379,7 @@ class SolanaSwapLoop:
             bt.logging.error(f'{label}: {decision.value} failed: {e}')
             return False
         bt.logging.success(f'{label}: {decision.value} submitted')
+        dev_signal.emit('vote_cast', swap_key=_swap_key_hex(swap.swap_key), decision=decision.value, sig=sig)
         return True
 
     def resolve_pools_once(self, now: int) -> List[str]:
@@ -431,6 +434,7 @@ class SolanaSwapLoop:
                 bt.logging.error(f'pool {miner}: resolve_pool failed: {e}')
                 continue
             bt.logging.success(f'pool {miner}: resolved ({len(pool.requests)} req)')
+            dev_signal.emit('pool_resolved', miner=str(miner), requests=len(reqs))
             resolved.append(str(miner))
         return resolved
 
@@ -452,6 +456,13 @@ class SolanaSwapLoop:
             # round, including a plain WAIT (previously silent, which hid a stalled swap until it timed out).
             reason = f' — {action.reason}' if action.reason else ''
             bt.logging.info(f'swap {key} [{_status_name(swap)}]: {action.decision.value}{reason}')
+            dev_signal.emit(
+                'decision',
+                swap_key=key,
+                status=_status_name(swap),
+                decision=action.decision.value,
+                reason=action.reason,
+            )
             if action.decision in ACTIONABLE:
                 if self.read_only:
                     bt.logging.info(f'swap {key} [{_status_name(swap)}]: WOULD {action.decision.value} (read-only)')

--- a/tests/test_dev_signal.py
+++ b/tests/test_dev_signal.py
@@ -1,0 +1,81 @@
+"""dev_signal — the T3 NDJSON emitter and file-backed fault flags. Both must be inert
+(no file writes, no faults) when their env vars are unset, and must never raise."""
+
+import json
+from unittest.mock import MagicMock
+
+from allways import dev_signal
+from allways.miner.fulfillment import SwapFulfiller
+
+from .test_fulfillment import make_swap
+
+
+class TestEmit:
+    def test_noop_without_env(self, tmp_path, monkeypatch):
+        monkeypatch.delenv('ALLWAYS_DEV_SIGNAL', raising=False)
+        dev_signal.emit('vote_cast', swap_key='ab', sig='s1')
+        assert list(tmp_path.iterdir()) == []
+
+    def test_appends_ndjson_lines(self, tmp_path, monkeypatch):
+        out = tmp_path / 'signal.ndjson'
+        monkeypatch.setenv('ALLWAYS_DEV_SIGNAL', str(out))
+        dev_signal.emit('vote_cast', swap_key='ab', sig='s1')
+        dev_signal.emit('d1_reject', swap_key='cd', expected=100, got=99)
+        lines = [json.loads(line) for line in out.read_text().splitlines()]
+        assert [line['event'] for line in lines] == ['vote_cast', 'd1_reject']
+        assert lines[0]['swap_key'] == 'ab' and 'ts' in lines[0]
+        assert lines[1]['expected'] == 100
+
+    def test_non_json_fields_stringified(self, tmp_path, monkeypatch):
+        out = tmp_path / 'signal.ndjson'
+        monkeypatch.setenv('ALLWAYS_DEV_SIGNAL', str(out))
+        dev_signal.emit('decision', key=b'\x2a')
+        assert json.loads(out.read_text())['event'] == 'decision'
+
+    def test_unwritable_path_never_raises(self, tmp_path, monkeypatch):
+        monkeypatch.setenv('ALLWAYS_DEV_SIGNAL', str(tmp_path / 'no' / 'such' / 'dir' / 'f'))
+        dev_signal.emit('vote_cast')  # must not raise
+
+
+class TestFault:
+    def test_false_without_env(self, monkeypatch):
+        monkeypatch.delenv('ALLWAYS_DEV_FAULTS', raising=False)
+        assert not dev_signal.fault('withhold_dest')
+
+    def test_false_when_file_missing_or_empty(self, tmp_path, monkeypatch):
+        flags = tmp_path / 'faults'
+        monkeypatch.setenv('ALLWAYS_DEV_FAULTS', str(flags))
+        assert not dev_signal.fault('withhold_dest')
+        flags.write_text('')
+        assert not dev_signal.fault('withhold_dest')
+
+    def test_toggles_at_runtime_via_file(self, tmp_path, monkeypatch):
+        flags = tmp_path / 'faults'
+        monkeypatch.setenv('ALLWAYS_DEV_FAULTS', str(flags))
+        flags.write_text('withhold_dest\nother_flag')
+        assert dev_signal.fault('withhold_dest')
+        assert dev_signal.fault('other_flag')
+        assert not dev_signal.fault('unrelated')
+        flags.write_text('')
+        assert not dev_signal.fault('withhold_dest')
+
+
+class TestWithholdDestFault:
+    def test_withhold_blocks_send_and_emits_refuse(self, tmp_path, monkeypatch):
+        flags, out = tmp_path / 'faults', tmp_path / 'signal.ndjson'
+        flags.write_text('withhold_dest')
+        monkeypatch.setenv('ALLWAYS_DEV_FAULTS', str(flags))
+        monkeypatch.setenv('ALLWAYS_DEV_SIGNAL', str(out))
+        provider = MagicMock()
+        f = SwapFulfiller(solana_client=MagicMock(), chain_providers={'tao': provider})
+        assert f.send_dest_funds(make_swap(), 341_550_000) is None
+        provider.send_amount.assert_not_called()
+        refuse = json.loads(out.read_text())
+        assert refuse['event'] == 'refuse' and refuse['reason'] == 'withhold_dest'
+
+    def test_send_proceeds_without_fault(self, monkeypatch):
+        monkeypatch.delenv('ALLWAYS_DEV_FAULTS', raising=False)
+        provider = MagicMock()
+        provider.send_amount.return_value = ('txhash', 7)
+        f = SwapFulfiller(solana_client=MagicMock(), chain_providers={'tao': provider})
+        assert f.send_dest_funds(make_swap(), 341_550_000) == ('txhash', 7)


### PR DESCRIPTION
## Summary
Adds the T3 structured dev-signal surface from the contract-v2 QA plan: a gated NDJSON emitter mirroring the lifecycle decisions that today exist only as free-text logs, plus a file-backed fault flag the e2e harness uses to force the slash path. Inert in production (both env vars unset).

## Changes
- allways/dev_signal.py: emit() appends one NDJSON line per event when ALLWAYS_DEV_SIGNAL=<path>; fault() reads runtime-toggleable flags from the file named by ALLWAYS_DEV_FAULTS; both no-op otherwise and never raise
- Validator call sites (one line each, beside the existing log): vote_cast with the tx sig (previously discarded), per-swap decision+reason, d1_reject, pool_resolved, swap_outcome (event_index), crown_snapshot, scoring_rewards
- Miner call sites: source_verified, dest_sent, marked_fulfilled, refuse with reason
- send_dest_funds honors the withhold_dest fault: logs, emits refuse, returns None so the swap times out and slashes
- tests/test_dev_signal.py covers emitter gating/NDJSON shape, fault-file toggling, and the withhold path

Miner poll-interval override was also scoped here but --miner.poll_interval already exists on contract-v2, so nothing to add.