### PR TITLE
feat(contract): raise max total extension ceiling to 7200s → 8400s (140 min)

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -186,5 +186,5 @@ MINER_TIMEOUT_CUSHION_SECS = MINER_TIMEOUT_CUSHION_BLOCKS * SECS_PER_BLOCK
 # discard then re-send a still-claimable swap (#461 double-send). The contract slides the deadline
 # cumulatively up to the extension ceiling, so cover that full budget plus one base window. Keep
 # CONTRACT_MAX_TOTAL_EXTENSION_SECS in sync with smart-contracts/solana/.../constants.rs.
-CONTRACT_MAX_TOTAL_EXTENSION_SECS = 7200  # 120 min — mirror of the contract's MAX_TOTAL_EXTENSION_SECS
+CONTRACT_MAX_TOTAL_EXTENSION_SECS = 8400  # 140 min — mirror of the contract's MAX_TOTAL_EXTENSION_SECS
 SENT_CACHE_DISCARD_MARGIN_SECS = CONTRACT_MAX_TOTAL_EXTENSION_SECS + DEFAULT_FULFILLMENT_TIMEOUT_BLOCKS * SECS_PER_BLOCK

--- a/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
@@ -187,17 +187,17 @@ pub const DEFAULT_RESERVATION_TTL_SECS: i64 = 600; // 10 min
 
 /// Total seconds a reservation/swap deadline may be slid forward across all extensions, frozen into
 /// each at creation as `deadline + this`. Seeds `Config.max_total_extension_secs`; runtime-tunable
-/// within [MIN, MAX]. 120 min gives edge-case BTC headroom: a run of back-to-back slow blocks can
+/// within [MIN, MAX]. 140 min gives edge-case BTC headroom: a run of back-to-back slow blocks can
 /// leave an honest, adequately-fee'd payout waiting >90 min for two confirmations, and the ceiling
 /// is the only bound on extensions (no per-swap count cap), so it must cover the slow tail.
-pub const MAX_TOTAL_EXTENSION_SECS: i64 = 7_200; // 120 min
+pub const MAX_TOTAL_EXTENSION_SECS: i64 = 8_400; // 140 min
 pub const MAX_TOTAL_EXTENSION_SECS_MIN: i64 = 1_800; // 30 min — two 15-min BTC blocks
-pub const MAX_TOTAL_EXTENSION_SECS_MAX: i64 = 7_200; // 120 min — hard lid
+pub const MAX_TOTAL_EXTENSION_SECS_MAX: i64 = 8_400; // 140 min — hard lid
 
 const _: () = assert!(
     MAX_TOTAL_EXTENSION_SECS >= MAX_TOTAL_EXTENSION_SECS_MIN
         && MAX_TOTAL_EXTENSION_SECS <= MAX_TOTAL_EXTENSION_SECS_MAX,
-    "MAX_TOTAL_EXTENSION_SECS must be within [30 min, 120 min]"
+    "MAX_TOTAL_EXTENSION_SECS must be within [30 min, 140 min]"
 );
 
 #[cfg(test)]

--- a/smart-contracts/solana/programs/allways_swap_manager/src/validate.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/validate.rs
@@ -54,7 +54,7 @@ pub fn collateral_bounds(min: u64, max: u64) -> Result<()> {
     Ok(())
 }
 
-/// Total deadline-extension budget, clamped to [30 min, 120 min]: the floor keeps it above one BTC
+/// Total deadline-extension budget, clamped to [30 min, 140 min]: the floor keeps it above one BTC
 /// block; the ceiling caps how long a miner can be held, since it's the only such bound.
 pub fn max_total_extension(secs: i64) -> Result<()> {
     require!(

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_extensions.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_extensions.rs
@@ -448,14 +448,20 @@ fn test_extend_timeout_validator_only() {
 }
 
 #[test]
-fn test_extension_ceiling_is_120_minutes() {
+fn test_extension_ceiling_is_140_minutes() {
     // Pin the tuned ceiling. In v2 extensions are bounded solely by MAX_TOTAL_EXTENSION_SECS — there is
     // NO per-swap extension count cap — so this constant is the only lever protecting an honest, slow-BTC
     // payout from a premature slash. The ceiling-rejection tests above read max_extend_at dynamically, so
     // a silent change to the constant would still pass them; this one fails if the value moves.
     assert_eq!(
         allways_swap_manager::constants::MAX_TOTAL_EXTENSION_SECS,
-        7_200,
-        "extension ceiling must be 120 min (two slow-BTC-block headroom); see constants.rs"
+        8_400,
+        "extension ceiling must be 140 min (two slow-BTC-block headroom); see constants.rs"
+    );
+    // The runtime lid must admit the default, else `set_max_total_extension(8400)` reverts on-chain.
+    assert_eq!(
+        allways_swap_manager::constants::MAX_TOTAL_EXTENSION_SECS_MAX,
+        8_400,
+        "runtime hard lid must permit the 140-min ceiling; see constants.rs"
     );
 }


### PR DESCRIPTION
cc @landyndev — contract lane.

## What

Raises the swap/reservation **total extension ceiling** from 7200s (120 min) to **8400s (140 min)**, giving BTC-source/dest swaps more confirmation slack. Already deployed in place on **devnet** (same program id, `AKgfVK8zJVHuZwttdjU2CPykaHyTAvw5r9FUFUpM74JU`).

## The non-obvious bit

The constant that actually rejected `set_max_total_extension(8400)` was **`MAX_TOTAL_EXTENSION_SECS_MAX`** (the runtime hard lid checked in `validate::max_total_extension`), *not* `MAX_TOTAL_EXTENSION_SECS` (the `initialize` default). They were both 7200, and a `const _: () = assert!(default <= MAX)` ties them together — so bumping only the default is a **compile error**, and bumping only the lid would leave fresh deploys at 120 min. Both move to 8400.

No other clamp exists: `extend_reservation` / `extend_timeout` both compare against the per-object `max_extend_at`, which is frozen at creation from `config.max_total_extension_secs`. No per-swap extension count cap.

## Changes

| File | Change |
|---|---|
| `constants.rs` | `MAX_TOTAL_EXTENSION_SECS` 7200 → 8400 (initialize default) |
| `constants.rs` | `MAX_TOTAL_EXTENSION_SECS_MAX` 7200 → 8400 (runtime lid) |
| `constants.rs` / `validate.rs` | doc comments + const-assert message: 120 min → 140 min |
| `tests/test_extensions.rs` | pin test renamed; now pins **both** the default and the lid |
| `allways/constants.py` | `CONTRACT_MAX_TOTAL_EXTENSION_SECS` mirror → 8400 |

`SENT_CACHE_DISCARD_MARGIN_SECS` is derived (`ceiling + one 600s base window`) and follows automatically: 7800 → 9000. Still exactly "full extension budget plus one base window", so the #461 double-send guard keeps its meaning.

## IDL

**No layout drift.** The constant isn't an Anchor `#[constant]`, so the regenerated IDL is byte-identical (verified by rebuilding at both revisions and diffing). Nothing to sync — and note `allways/allways/metadata/allways_swap_manager.json` is the legacy **ink!/substrate** metadata, not the Anchor IDL, so it is untouched.

## Verification

- `cargo test -p allways_swap_manager` — all green (LiteSVM runs the rebuilt `.so`; the frozen-ceiling assertions now land at `deadline + 8400`).
- 38 Python tests across fulfillment / CLI-admin / solana-client pass.
- Devnet upgrade (in place, program id unchanged), sig `64MmnnRCpYQct4ywg4oXSrGkAXLfCVQc3KTB8UZCavvAu8ses2GXufUzUThPaMf4hZb7Ln2Zc3K4PgbBAnJCJhMb`
- `alw admin set-max-extension 8400` → **succeeds** (rejected pre-upgrade); `alw view config` → `Max total extension: 8400s (~140m)`
- `set-max-extension 8401` → **rejected** at `validate.rs:60`, proving the lid is exactly 8400.

## Notes / follow-ups

- The ceiling is **frozen at creation**. Reservations/swaps opened before the bump keep 7200; only new ones get 8400. Verified against the live pre-upgrade reservation (`budget = 7200`).
- Reservation `max_extend_at = created_at + ttl + budget` (e.g. `created_at + 480 + 8400`), *not* `created_at + budget`.
- The out-of-range rejection surfaces as `ErrorCode::InvalidAmount` — "Amount must be greater than zero" — which is misleading for a range violation. Pre-existing; worth a dedicated error code.

Companion PRs: `alw-utils` (bringup/init-cluster wiring), `allways-docs-ui` (CLI bounds).