### PR TITLE
fix(cli): swap now must not send funds against a stale reservation

### DIFF
--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -208,6 +208,24 @@ def clear_pending_swap() -> None:
         pass
 
 
+EMPTY_SWAP_KEY = bytes(32)
+
+
+def live_unclaimed(resv) -> bool:
+    """Shared 'usable reservation' predicate for BOTH origination (`swap now`) and confirm (`post-tx`),
+    so the two paths can never disagree about what counts as a resolved reservation.
+
+    A reservation must exist, still be within its TTL (``reserved_until > now``), and carry no claim yet
+    (empty ``claimed_swap_key``). Crucially, ``reserved_until != 0`` alone is NOT sufficient: a reservation
+    left over from an abandoned reserve keeps its non-zero-but-past ``reserved_until`` indefinitely (nothing
+    reaps it on-chain), and treating that stale value as 'the draw resolved' is what let `swap now` tell a
+    taker to send funds before the pool draw ran — an unrecoverable loss."""
+    if resv is None:
+        return False
+    now = int(time.time())
+    return int(resv.reserved_until) > now and bytes(resv.claimed_swap_key) == EMPTY_SWAP_KEY
+
+
 def print_json(data) -> None:
     """Emit a value as pretty JSON (str fallback for non-serializable types like Pubkey)."""
     click.echo(json.dumps(data, indent=2, default=str))

--- a/allways/cli/swap_commands/post_tx.py
+++ b/allways/cli/swap_commands/post_tx.py
@@ -13,8 +13,6 @@ taker who won the draw, because ``Reservation.from_addr`` is pinned at reserve t
 relay the confirm, but only the winner's deposit verifies.
 """
 
-import time
-
 import click
 
 from allways.cli.dendrite_lite import (
@@ -29,23 +27,12 @@ from allways.cli.swap_commands.helpers import (
     get_cli_context,
     get_solana_cli_context,
     hotkey_bytes_to_ss58,
+    live_unclaimed,
     load_pending_swap,
     loading,
 )
 from allways.cli.validator_rejections import render_and_aggregate
 from allways.synapses import SwapConfirmSynapse
-
-EMPTY_SWAP_KEY = bytes(32)
-
-
-def _live_unclaimed(resv) -> bool:
-    """The reservation exists, is still within its TTL, and has no claim yet."""
-    now = int(time.time())
-    return (
-        resv is not None
-        and int(resv.reserved_until) > now
-        and bytes(resv.claimed_swap_key) == EMPTY_SWAP_KEY
-    )
 
 
 def _find_reservations(client, user, miner_hint, require_user):
@@ -71,7 +58,7 @@ def _find_reservations(client, user, miner_hint, require_user):
             console.print(f'[red]Invalid miner pubkey: {miner_hint}[/red]')
             return []
         resv = client.get_reservation(mpk)
-        if _live_unclaimed(resv) and (not require_user or str(resv.user) == str(user)):
+        if live_unclaimed(resv) and (not require_user or str(resv.user) == str(user)):
             return [(mpk, _hotkey(mpk), resv)]
         return []
 
@@ -79,7 +66,7 @@ def _find_reservations(client, user, miner_hint, require_user):
     for _pda, binding in client.get_all('Binding'):
         mpk = binding.miner
         resv = client.get_reservation(mpk)
-        if _live_unclaimed(resv) and str(resv.user) == str(user):
+        if live_unclaimed(resv) and str(resv.user) == str(user):
             found.append((mpk, hotkey_bytes_to_ss58(binding.hotkey), resv))
     return found
 

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -14,7 +14,14 @@ import click
 
 from allways.chains import SUPPORTED_CHAINS, get_chain
 from allways.cli.help import StyledGroup
-from allways.cli.swap_commands.helpers import FINITE_FLOAT, PENDING_SWAP_FILE, console, fail, get_solana_cli_context
+from allways.cli.swap_commands.helpers import (
+    FINITE_FLOAT,
+    PENDING_SWAP_FILE,
+    console,
+    fail,
+    get_solana_cli_context,
+    live_unclaimed,
+)
 from allways.cli.swap_commands.swap_intake import (
     MinerCandidate,
     rate_display_from_fixed,
@@ -40,12 +47,32 @@ def _candidate_miners(client, from_chain: str, to_chain: str) -> List[MinerCandi
     return out
 
 
+# Slack (seconds) added on top of a source chain's confirmation wait before we'll tell a taker to send:
+# covers broadcast + the post-tx relay round trip.
+_RELAY_MARGIN_SECS = 30
+
+
+def _send_margin_secs(chain_id: str) -> int:
+    """Minimum reservation life required before instructing a send on ``chain_id``: the source chain's
+    confirmation wait (``min_confirmations × seconds_per_block``) plus relay slack. Sending into a
+    reservation that expires before the deposit can be claimed strands the funds (no escrow, no Swap,
+    no refund)."""
+    ch = get_chain(chain_id)
+    return int(ch.min_confirmations) * int(ch.seconds_per_block) + _RELAY_MARGIN_SECS
+
+
 def _poll_reservation(client, miner, timeout_secs: int):
-    """Poll the per-miner Reservation until the draw populates it (reserved_until != 0) or we time out."""
+    """Poll until THIS request's draw writes a live, unclaimed Reservation — or we time out.
+
+    Uses the shared ``live_unclaimed`` predicate (same one `post-tx` uses), NOT ``reserved_until != 0``.
+    A reservation left over from an abandoned reserve keeps a non-zero-but-past ``reserved_until``
+    indefinitely; the old check matched it instantly and made `swap now` tell the taker to send funds
+    before ``resolve_pool`` ran. Requiring liveness means we keep waiting through both the pre-draw
+    (``reserved_until == 0``) and the stale-leftover (expired) states until the draw writes a fresh one."""
     deadline = time.time() + timeout_secs
     while time.time() < deadline:
         resv = client.get_reservation(miner)
-        if resv is not None and int(getattr(resv, 'reserved_until', 0)) != 0:
+        if live_unclaimed(resv):
             return resv
         time.sleep(3)
     return None
@@ -140,9 +167,19 @@ def swap_now_command(
 
     resv = _poll_reservation(client, cand.miner, timeout_secs=pool_window + 60)
     if resv is None:
-        fail('  Pool not resolved yet — check `alw view reservation` shortly.')
+        fail('  Draw did not resolve into a live reservation in time — no reservation won. '
+             'Do NOT send funds; check `alw view reservation` and re-run.')
     if str(resv.user) != str(user):
-        fail("  Another taker won this miner's draw. Re-run to try again.")
+        fail("  Another taker won this miner's draw. Do NOT send funds; re-run to try again.")
+    # Never instruct a send the reservation can't outlive: the deposit must land and reach the source
+    # chain's confirmation depth before reserved_until, or the claim is rejected and the funds are
+    # stranded (funds go straight to the miner — no escrow, no Swap, no timeout, no refund).
+    remaining = int(resv.reserved_until) - int(time.time())
+    margin = _send_margin_secs(from_chain)
+    if remaining < margin:
+        fail(f'  Reservation has only {remaining}s left — too short to send {from_chain.upper()} safely '
+             f'(needs ~{margin}s for {from_chain.upper()} confirmations + relay). Do NOT send funds; '
+             'raise reservation_ttl (or re-run for a fresh reservation).')
 
     _save_pending(cand.miner, from_chain, to_chain)
     console.print(

--- a/tests/test_swap_now_reservation.py
+++ b/tests/test_swap_now_reservation.py
@@ -1,0 +1,60 @@
+"""Regression: `alw swap now` must not treat a stale/expired reservation as a resolved draw.
+
+Guards the fund-loss bug where `_poll_reservation` returned on `reserved_until != 0` and matched a
+leftover reservation from an abandoned reserve (non-zero but expired), making `swap now` instruct a
+taker to send funds before the pool draw ran. Origination now uses the same `live_unclaimed`
+predicate as `post-tx`, and a send is gated on the reservation outliving the source chain's
+confirmation wait.
+"""
+
+import time
+import types
+from unittest.mock import MagicMock, patch
+
+from allways.cli.swap_commands.helpers import live_unclaimed
+from allways.cli.swap_commands.swap import _poll_reservation, _send_margin_secs
+
+EMPTY = bytes(32)
+
+
+def _resv(reserved_until, claimed=EMPTY, user='68ToGUYj'):
+    """Stand-in for a decoded Reservation (only the predicate-relevant fields)."""
+    return types.SimpleNamespace(
+        reserved_until=reserved_until, claimed_swap_key=claimed, user=user, miner_from_addr='miner-addr'
+    )
+
+
+def test_live_unclaimed_rejects_the_stale_leftover_state():
+    now = int(time.time())
+    # The exact state that triggered the bug: non-zero but expired, empty claim, caller's own user.
+    assert live_unclaimed(_resv(now - 100)) is False
+    assert live_unclaimed(_resv(0)) is False  # pre-draw: no reservation written yet
+    assert live_unclaimed(None) is False
+    assert live_unclaimed(_resv(now + 300)) is True  # fresh, live, unclaimed
+    assert live_unclaimed(_resv(now + 300, claimed=bytes([1] + [0] * 31))) is False  # already claimed
+
+
+def test_poll_skips_stale_leftover_and_waits_for_the_fresh_draw():
+    now = int(time.time())
+    stale = _resv(now - 5)  # residue of an abandoned reserve — non-zero but in the past
+    fresh = _resv(now + 300)  # what resolve_pool writes for this request
+    client = MagicMock()
+    client.get_reservation.side_effect = [stale, stale, fresh]
+    with patch('allways.cli.swap_commands.swap.time.sleep'):
+        got = _poll_reservation(client, 'miner', timeout_secs=100)
+    assert got is fresh  # never the stale leftover
+    assert client.get_reservation.call_count == 3
+
+
+def test_poll_times_out_rather_than_returning_a_stale_reservation():
+    now = int(time.time())
+    client = MagicMock()
+    client.get_reservation.return_value = _resv(now - 5)  # always stale/expired
+    with patch('allways.cli.swap_commands.swap.time.sleep'):
+        got = _poll_reservation(client, 'miner', timeout_secs=0.05)
+    assert got is None  # would rather time out than green-light a send against a stale reservation
+
+
+def test_send_margin_scales_with_source_confirmation_wait():
+    assert _send_margin_secs('btc') > _send_margin_secs('tao') > _send_margin_secs('sol')
+    assert _send_margin_secs('btc') == 2 * 600 + 30  # 2 confs × 600s/block + relay slack


### PR DESCRIPTION
## Problem
`alw swap now` can tell a taker to **send source funds before the pool draw resolves** — an unrecoverable loss.

`_poll_reservation` returned on `reserved_until != 0`, which matches a reservation **left over from an abandoned reserve** (a ctrl-C'd `swap now`, an abandoned reserve, etc.). Expiry on-chain is a passive timestamp comparison — nothing reaps the record, so `reserved_until` stays non-zero-but-in-the-past indefinitely. `swap now` then only checked `resv.user == caller`, so a taker **retrying their own interrupted swap** sailed through and got `Reserved. Send X…` while the pool was still gathering bids.

Following that instruction is unrecoverable: source funds go **straight to the miner (no escrow)**, and the deposit is mined *before* `resolve_pool` stamps `Reservation.created_at`, so every validator rejects it on freshness (`replay_grace_secs = 0`). No claim, no `Swap`, no timeout, no slash. Deterministic — even a sole winner loses.

`post-tx` already used the correct predicate (`_live_unclaimed`); origination and confirm disagreed.

## Fix
- **Shared `live_unclaimed(resv)` in helpers** (`reserved_until > now` AND empty `claimed_swap_key`), used by **both** `_poll_reservation` (origination) and `post-tx` (confirm) so they can't drift. Origination now waits through the stale/expired leftover instead of mistaking it for a resolved draw. (`!= 0` is deliberately not dropped — the field is genuinely `0` pre-draw, and the poller keeps waiting through that too.)
- **Send-window guard** `_send_margin_secs(chain)` = `min_confirmations × seconds_per_block + relay slack`; refuse to instruct a send the reservation can't outlive (else the deposit lands but can't be claimed before expiry → stranded).
- **Distinct exits**: draw-not-resolved vs another-taker-won vs reservation-too-short — all instruct *not* to send.
- **Regression test** for the exact trigger state (non-zero-but-expired reservation, empty claim, caller's own user).

## Test
`tests/test_swap_now_reservation.py` (4 tests) + full swap/cli suite green (174 passed, 0 regressions).

## Notes
- Found on devnet 2026-07-08 during a sol↔tao pressure test; the harness's own check aborted before any funds were lost.
- The send-window guard means **btc→sol via CLI needs a reservation TTL longer than BTC's ~20-min 2-conf wait** (or the deferred-confirm/extension path live on the validator). With the current 480s TTL it will (correctly) refuse a BTC send rather than strand funds — surfacing a real prerequisite for BTC testing.

cc @landyndev (swap CLI lane)