### PR TITLE
feat(validator): log confirmation progress and extension targets on deferral

### DIFF
--- a/allways/validator/solana_swap_loop.py
+++ b/allways/validator/solana_swap_loop.py
@@ -17,7 +17,7 @@ import bittensor as bt
 from solders.pubkey import Pubkey
 
 from allways.chain_providers.base import ProviderUnreachableError
-from allways.chains import compute_extension_target_secs
+from allways.chains import compute_extension_target_secs, get_chain
 from allways.constants import EXTENSION_PADDING_SECONDS
 from allways.solana import pdas
 from allways.solana.client import swap_from_solana, swap_key_from_tx_hash
@@ -77,6 +77,12 @@ def _status_name(swap: Any) -> str:
     """Borsh enum decodes to an instance whose type name is the variant (Active/Fulfilled/...)."""
     s = swap.status
     return s if isinstance(s, str) else type(s).__name__
+
+
+def _confs(chain_id: str, info: Any) -> str:
+    """Confirmation progress of a leg, e.g. '1/2 confs'. Unmined or absent legs read 0."""
+    have = int(getattr(info, 'confirmations', 0) or 0)
+    return f'{have}/{get_chain(chain_id).min_confirmations} confs'
 
 
 def _swap_key_hex(key: Any) -> str:
@@ -244,7 +250,10 @@ class SolanaSwapLoop:
             # fall through to the same overdue rule (at the ceiling + overdue still slashes).
             action = self._extend_timeout_action(swap, d_info, now)
             if action.decision == SwapDecision.EXTEND_TIMEOUT:
-                return action._replace(reason='dest confirmed-pending near timeout → extend')
+                return action._replace(
+                    reason=f'dest {_confs(swap.to_chain, d_info)} near timeout → extend timeout_at to '
+                    f'{action.target_at} (+{action.target_at - now}s)'
+                )
         # Dest freshness: payout must be mined after the swap was initiated on-chain (replay defense).
         elif (
             s_status == 'ok'
@@ -252,8 +261,11 @@ class SolanaSwapLoop:
             and self._is_fresh(d_info, int(swap.initiated_at), swap.to_chain, self._label(swap))
         ):
             return SwapAction(SwapDecision.CONFIRM, reason='src=ok dst=ok dst-fresh — both legs verified')
-        # Unverifiable/stale dest + overdue ⇒ TIMEOUT; else wait for the leg.
-        why = f'src={s_status} dst={d_status}'
+        # Unverifiable/stale dest + overdue ⇒ TIMEOUT; else wait for the leg. Without the confirmation
+        # count and remaining runway, a healthy deferral and an imminent slash render identically.
+        why = (
+            f'src={s_status} dst={d_status} [{_confs(swap.to_chain, d_info)}] timeout_in={int(swap.timeout_at) - now}s'
+        )
         return (
             SwapAction(SwapDecision.TIMEOUT, reason=f'{why} + overdue — dest unverifiable, slashing')
             if overdue
@@ -306,9 +318,14 @@ class SolanaSwapLoop:
             return SwapAction(SwapDecision.SKIP, reason='source provider unreachable')
         if s_status == 'pending':
             # Valid-but-unconfirmed deposit near reservation expiry → extend so the honest miner isn't slashed.
-            return self._extend_reservation_action(swap, info, now)._replace(
-                reason='source confirmed-pending near reservation expiry'
-            )
+            action = self._extend_reservation_action(swap, info, now)
+            left = int(reservation.reserved_until) - now if reservation is not None else 0
+            detail = f'source {_confs(swap.from_chain, info)} reserved_until_in={left}s'
+            if action.decision == SwapDecision.EXTEND_RESERVATION:
+                return action._replace(
+                    reason=f'{detail} → extend reserved_until to {action.target_at} (+{action.target_at - now}s)'
+                )
+            return action._replace(reason=f'{detail} — awaiting confirmations')
         if s_status != 'ok':
             return SwapAction(SwapDecision.WAIT, reason=f'source deposit {s_status} — awaiting user funds')
         if reservation is None:


### PR DESCRIPTION
## Problem

A swap that is deferring healthily and a swap one pass away from an unjust slash produce **identical** log lines. Driving a `sol->btc` swap on devnet, the dest leg sat here for minutes:

```
swap ba2eb784… [Fulfilled]: wait — src=ok dst=pending — awaiting a verifiable+fresh dest leg
```

Nothing tells you how far along the confirmations are, how much runway is left before `timeout_at`, or that an extension ever fired. `timeout_swap` accepts `Fulfilled`, so a delivered-but-unconfirmed swap *can* be slashed — and this line looks the same right up to that moment.

## Change

`_decide_fulfilled` and `_decide_pending_attestation` already fetch the leg info that carries `.confirmations`; they hand it to the extension helpers and then throw it away. This prints it, alongside the remaining runway, and records where an extension moved the deadline.

Before:
```
swap ba2eb784… [Fulfilled]: wait — src=ok dst=pending — awaiting a verifiable+fresh dest leg
```

After:
```
swap ba2eb784… [Fulfilled]: wait — src=ok dst=pending [0/2 confs] timeout_in=978s — awaiting a verifiable+fresh dest leg
swap ba2eb784… [Fulfilled]: extend_timeout — dest 0/2 confs near timeout → extend timeout_at to 1783570914 (+1406s)
```

The source-leg (`EXTEND_RESERVATION`) path gets the symmetric treatment, reporting `source 0/2 confs reserved_until_in=Ns`.

**No extra RPC.** The confirmation count rides along on data already fetched this pass.

## Drive-by fix

The source path called `._replace(reason='source confirmed-pending near reservation expiry')` on the result of `_extend_reservation_action` **unconditionally** — so a plain `WAIT` (not near expiry, nothing extended) still logged "near reservation expiry". The reason now follows the decision.

## Testing

- `pytest -k "swap_loop or solana_swap or extend or decide"` — 55 passed
- `ruff check` / `ruff format --check` clean
- Verified against a live devnet `sol->btc` swap whose `EXTEND_TIMEOUT` fired at the 120s padding boundary, sliding `timeout_at` by +1406s