### PR TITLE
fix(cli): send margin must not scale with source confirmation depth

### DIFF
--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -47,18 +47,11 @@ def _candidate_miners(client, from_chain: str, to_chain: str) -> List[MinerCandi
     return out
 
 
-# Slack (seconds) added on top of a source chain's confirmation wait before we'll tell a taker to send:
-# covers broadcast + the post-tx relay round trip.
-_RELAY_MARGIN_SECS = 30
-
-
-def _send_margin_secs(chain_id: str) -> int:
-    """Minimum reservation life required before instructing a send on ``chain_id``: the source chain's
-    confirmation wait (``min_confirmations × seconds_per_block``) plus relay slack. Sending into a
-    reservation that expires before the deposit can be claimed strands the funds (no escrow, no Swap,
-    no refund)."""
-    ch = get_chain(chain_id)
-    return int(ch.min_confirmations) * int(ch.seconds_per_block) + _RELAY_MARGIN_SECS
+# Minimum reservation life required before we'll instruct a send. The reservation must outlive
+# broadcast -> mempool visibility -> post-tx relay -> submit_swap_claim landing, which is all the
+# on-chain claim gate checks (`reserved_until >= now`, empty claim slot). Chain-independent by
+# construction: 60s post-tx dendrite timeout + ~60s Solana claim landing + 60s slack.
+_SEND_MARGIN_SECS = 180
 
 
 def _poll_reservation(client, miner, timeout_secs: int):
@@ -171,15 +164,14 @@ def swap_now_command(
              'Do NOT send funds; check `alw view reservation` and re-run.')
     if str(resv.user) != str(user):
         fail("  Another taker won this miner's draw. Do NOT send funds; re-run to try again.")
-    # Never instruct a send the reservation can't outlive: the deposit must land and reach the source
-    # chain's confirmation depth before reserved_until, or the claim is rejected and the funds are
-    # stranded (funds go straight to the miner — no escrow, no Swap, no timeout, no refund).
+    # Never instruct a send the reservation can't outlive: a deposit that lands after reserved_until
+    # yields no claim, and the funds are stranded (straight to the miner — no escrow, no Swap, no
+    # timeout, no refund). Confirmations accrue *after* the claim, so they don't belong in this margin.
     remaining = int(resv.reserved_until) - int(time.time())
-    margin = _send_margin_secs(from_chain)
-    if remaining < margin:
-        fail(f'  Reservation has only {remaining}s left — too short to send {from_chain.upper()} safely '
-             f'(needs ~{margin}s for {from_chain.upper()} confirmations + relay). Do NOT send funds; '
-             'raise reservation_ttl (or re-run for a fresh reservation).')
+    if remaining < _SEND_MARGIN_SECS:
+        fail(f'  Reservation has only {remaining}s left — too short to land the claim for your '
+             f'{from_chain.upper()} deposit (needs ~{_SEND_MARGIN_SECS}s to relay it on-chain). '
+             'Do NOT send funds; re-run for a fresh reservation.')
 
     _save_pending(cand.miner, from_chain, to_chain)
     console.print(

--- a/tests/test_swap_now_reservation.py
+++ b/tests/test_swap_now_reservation.py
@@ -3,8 +3,8 @@
 Guards the fund-loss bug where `_poll_reservation` returned on `reserved_until != 0` and matched a
 leftover reservation from an abandoned reserve (non-zero but expired), making `swap now` instruct a
 taker to send funds before the pool draw ran. Origination now uses the same `live_unclaimed`
-predicate as `post-tx`, and a send is gated on the reservation outliving the source chain's
-confirmation wait.
+predicate as `post-tx`, and a send is gated on the reservation outliving the *claim relay* — not the
+source chain's confirmation depth, which accrues after the claim via the crank's EXTEND_RESERVATION.
 """
 
 import time
@@ -12,7 +12,7 @@ import types
 from unittest.mock import MagicMock, patch
 
 from allways.cli.swap_commands.helpers import live_unclaimed
-from allways.cli.swap_commands.swap import _poll_reservation, _send_margin_secs
+from allways.cli.swap_commands.swap import _SEND_MARGIN_SECS, _poll_reservation
 
 EMPTY = bytes(32)
 
@@ -55,6 +55,60 @@ def test_poll_times_out_rather_than_returning_a_stale_reservation():
     assert got is None  # would rather time out than green-light a send against a stale reservation
 
 
-def test_send_margin_scales_with_source_confirmation_wait():
-    assert _send_margin_secs('btc') > _send_margin_secs('tao') > _send_margin_secs('sol')
-    assert _send_margin_secs('btc') == 2 * 600 + 30  # 2 confs × 600s/block + relay slack
+def test_send_margin_does_not_scale_with_confirmation_depth():
+    """The margin covers relaying the claim on-chain, not waiting for confirmations. It must therefore
+    fit inside a freshly-won reservation (ttl 480s, minus the ~60-80s pool draw) for EVERY chain —
+    including BTC, whose 2 x 600s confirmation wait alone exceeds the whole TTL."""
+    from allways.chains import get_chain
+
+    btc = get_chain('btc')
+    assert btc.min_confirmations * btc.seconds_per_block > _SEND_MARGIN_SECS
+    assert _SEND_MARGIN_SECS < 480 - 80  # clears a fresh reservation post-draw, on any source chain
+
+
+def _run_swap_now(reserved_until, from_chain='btc'):
+    """Drive `swap now` end-to-end with a stubbed chain/client, returning the CliRunner result."""
+    from click.testing import CliRunner
+
+    from allways.cli.swap_commands.swap import swap_now_command
+
+    user = '68ToGUYjjYpqi7Atx7QyhbybR2RCfo2tkmgcoNR3DxYF'
+    resv = _resv(reserved_until, user=user)
+    client = MagicMock()
+    client.keypair.pubkey.return_value = user
+    client.get_config.return_value = types.SimpleNamespace(
+        min_swap_amount=1, max_swap_amount=10**18, pool_window_secs=60
+    )
+    client.open_or_request.return_value = 'sig' * 8
+    amts = types.SimpleNamespace(sol_amount=10**9, from_amount=5000, to_amount=10**9)
+    cand = types.SimpleNamespace(miner='miner-pk', rate_display='0.0021', collateral=10**10)
+
+    argv = ['--from', from_chain, '--to', 'sol', '--amount', '0.00005']
+    argv += ['--from-address', 'tb1qsource', '--receive-address', user, '--yes']
+
+    with (
+        patch('allways.cli.swap_commands.swap.get_solana_cli_context', return_value=(None, client)),
+        patch('allways.cli.swap_commands.swap._candidate_miners', return_value=[cand]),
+        patch('allways.cli.swap_commands.swap.select_best_miner', return_value=(cand, amts)),
+        patch('allways.cli.swap_commands.swap._poll_reservation', return_value=resv),
+        patch('allways.cli.swap_commands.swap._save_pending'),
+    ):
+        return CliRunner().invoke(swap_now_command, argv)
+
+
+def test_btc_source_reservation_with_400s_left_is_accepted_for_send():
+    """Deliverable #5: the exact state that used to refuse deterministically — a freshly won BTC-source
+    reservation, ~400s of life left. BTC needs 1200s of confirmations; the claim needs only the relay."""
+    result = _run_swap_now(int(time.time()) + 400)
+    assert result.exit_code == 0, result.output
+    assert 'Reserved.' in result.output
+    assert 'miner-addr' in result.output  # the send instruction the taker was never getting
+    assert 'too short' not in result.output
+
+
+def test_reservation_with_seconds_left_still_refuses_the_send():
+    """Deliverable #3: the guard still bites when the claim genuinely can't land, and still says DON'T send."""
+    result = _run_swap_now(int(time.time()) + 5)
+    assert result.exit_code != 0
+    assert 'too short' in result.output
+    assert 'Do NOT send funds' in result.output


### PR DESCRIPTION
Fixes the issue where `alw swap now --from btc` deterministically refuses to instruct a send.

cc @landyndev (swap CLI lane)

## The collision

`_send_margin_secs` sized the required reservation lifetime to the source chain's **full confirmation depth**: `min_confirmations × seconds_per_block + relay_slack`. For BTC that's `2 × 600 + 30 = 1230s`. Live `reservation_ttl_secs` is **480s**, and the pool draw eats ~60–80s of it. `1230 > 480` regardless of when you look, so **btc→sol could not be originated through the CLI at all** — and the taker had already burned the 0.02 SOL reservation fee by the time the guard fired.

SOL (62s) and TAO (102s) cleared the margin, which is why this only surfaced once BTC source legs were exercised.

## Why confirmation depth no longer belongs in this margin

The margin was written against a pipeline that no longer exists. Deferred-confirmation intake (#517) changed what the reservation has to outlive.

**`confirm_deposit`** (`allways/validator/reserve_engine.py:164-217`) rejects **only** when `tx_info is None` — absent or content-mismatch — with the comment *"fast-fail (no claim) so the short TTL frees the miner."* Otherwise it accepts a content-valid deposit pre-confirmation. There is no `min_confirmations` comparison anywhere in that path. Even freshness is deferred: it's gated on `if tx_info.block_time is not None:`, and a 0-conf mempool tx has no `block_time`. It then calls `submit_swap_claim` immediately, creating the Swap in `PendingAttestation`.

**On-chain, the contract agrees.** `submit_swap_claim`'s only reservation preconditions (`instructions/submit_swap_claim.rs:64-70`) are:

```rust
require!(resv.reserved_until != 0 && resv.reserved_until >= now, ErrorCode::NoReservation);
require!(resv.claimed_swap_key == [0u8; 32], ErrorCode::ClaimAlreadyExists);
```

No depth. No `min_confirmations`. The CLI comment asserted a contract rule the contract never had — which is how a 1230s constant looked justified for as long as it did.

**Depth is carried afterward, by the crank.** A source leg seen as `'pending'` near expiry produces an `EXTEND_RESERVATION`, sliding `reserved_until` under the `max_extend_at` ceiling (`max_total_extension_secs = 8400s` live). The extension budget funds the confirmation wait — not the base TTL.

So the reservation only needs to outlive **broadcast → mempool visibility → dendrite relay → `submit_swap_claim` landing**. That is chain-independent and measured in tens of seconds.

## The change

`_send_margin_secs(chain_id)` becomes a module constant, because the margin genuinely does not depend on the chain:

```python
_SEND_MARGIN_SECS = 180
```

Derived, not magic: **60s** post-tx dendrite broadcast timeout (`post_tx.py:190`, overridable via `ALW_DENDRITE_TIMEOUT`) + **~60s** Solana claim-tx landing (a blockhash is valid ~150 slots) + **60s** slack. Comfortably inside a freshly-won 480s reservation on every chain, including BTC. Both the guard's comment and the constant's now describe the deferred-confirmation pipeline the code actually relies on (deliverable #6).

## Non-regression: PR #522's fund-loss fix still holds

Source funds go straight to the miner with **no escrow** — a deposit that never produces a claim is gone (no `Swap`, no timeout, no slash, no refund). All four load-bearing properties are preserved, and I checked each explicitly:

1. **Single liveness predicate.** Origination and `post-tx` both call `live_unclaimed(resv)` from `helpers.py` (`reserved_until > now` AND empty `claimed_swap_key`). Untouched, not forked.
2. **`_poll_reservation` still waits through both bad states** — the pre-draw (`reserved_until == 0`) and the stale non-zero-but-expired leftover — rather than matching either. Untouched.
3. **A too-short reservation still refuses the send**, and every refusal path still says *"Do NOT send funds."* Only the threshold changed, never the guard.
4. **The three exit messages stay distinct**: draw-not-resolved / another-taker-won / reservation-too-short.

## Tests

`tests/test_swap_now_reservation.py` — `655 → 666 passed`, whole suite green.

- **Removed** `test_send_margin_scales_with_source_confirmation_wait`. It asserted `_send_margin_secs('btc') == 2 * 600 + 30` — it *encoded the bug*, so it's deleted rather than repaired. Calling that out rather than dropping it quietly.
- **New** `test_btc_source_reservation_with_400s_left_is_accepted_for_send` — drives `swap_now_command` end-to-end through CliRunner against a BTC-source reservation with ~400s left, asserting it prints the send instruction (deliverable #5).
- **New** `test_reservation_with_seconds_left_still_refuses_the_send` — 5s of life left still refuses, and still says "Do NOT send funds" (deliverable #3).
- **New** `test_send_margin_does_not_scale_with_confirmation_depth` — pins the invariant: BTC's confirmation wait exceeds the margin, and the margin fits a post-draw reservation (deliverable #2).
- **Kept** the stale-leftover and pre-draw coverage unchanged (deliverable #4).

Both new behavioral tests were verified to **fail against the old 1230s constant** and pass against the new one, so they exercise the guard rather than passing vacuously.

## Live devnet verification

Program `AKgfVK8zJVHuZwttdjU2CPykaHyTAvw5r9FUFUpM74JU`, the exact repro from the issue:

```
$ alw view config
  Reservation TTL:      480s (~8m)
  Max total extension:  8400s (~140m)

$ python -c "from allways.chains import get_chain; c=get_chain('btc'); print(c.min_confirmations, c.seconds_per_block)"
2 600          # → old margin 1230s, unreachable against a 480s TTL

$ alw swap now --from btc --to sol --amount 0.00005 \
    --from-address tb1q76qwnr9zu3pa76se7emv0wmtk2zzu2ffl8c38m \
    --receive-address 68ToGUYjjYpqi7Atx7QyhbybR2RCfo2tkmgcoNR3DxYF --yes

  Swap 5e-05 BTC -> ~0.5 SOL  (miner ER9Jt5SB…, rate 0.0001 per SOL)
  Reservation requested (tx 4DwnMQyhJT7vzX9b…). Waiting for the draw to resolve…
  Reserved. Send 5e-05 BTC to tb1qhh6ud46m60zslnjk0w4nq95ffvltq2uudfpsf7, then run alw swap post-tx with the tx hash.
```

It wins the draw and **prints the send instruction** instead of refusing. `alw view reservation` confirms the won reservation, `467s remaining` — clears the 180s margin with room, and shows why the old 1230s bar was unreachable:

```
  Pair:        BTC → SOL
  Send to:     tb1qhh6ud46m60zslnjk0w4nq95ffvltq2uudfpsf7
  Reserved:    467s (~7m) remaining
  Deposit:     not yet sent
```

I stopped at origination and did not send BTC — origination is what the fix changes, and every deliverable is provable without moving funds. The reservation was left to expire.

## Scope

CLI only. No contract change, no IDL change, no validator change — `confirm_deposit` was already correct. A CLI release picks this up; nothing to redeploy.
