### PR TITLE
refactor(solana): resolve the program id in one place, env before config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,71 +4,64 @@ WALLET_NAME=default
 HOTKEY_NAME=default
 WALLET_PATH=~/.bittensor/wallets
 
-# Subtensor endpoint. Validators should point at a local lite node for cheap
-# commitment polling. Examples:
-#   SUBTENSOR_NETWORK=local             # ws://127.0.0.1:9944 (lite node or dev env)
-#   SUBTENSOR_NETWORK=finney            # public mainnet entrypoint
-#   SUBTENSOR_NETWORK=ws://host:9944    # custom remote node
+# local (ws://127.0.0.1:9944) | finney | ws://host:9944
+# Validators should point at a local lite node for cheap commitment polling.
 SUBTENSOR_NETWORK=finney
 
 PORT=8091
 LOG_LEVEL=info
 
-# Restrict the axon to host loopback so only a local reverse proxy can reach it (unset = raw internet publish).
+# Bind the axon loopback-only behind a reverse proxy. Unset publishes to the raw internet.
 # AXON_PUBLISH=127.0.0.1:9000
 
 # ─── Contract ──────────────────────────────────────────────
-# Override the default Allways Swap Manager contract address. Leave unset to
-# use the bundled mainnet default. Set this when running against testnet,
-# the dev environment, or a forked deployment.
-CONTRACT_ADDRESS=
+# allways_swap_manager program address. Unset uses the committed devnet default.
+# Must match the deployed program: a mismatch derives different PDAs, so accounts
+# read as absent rather than erroring. Wins over `alw config set program-id`.
+# ALLWAYS_PROGRAM_ID=
 
 # ─── Chain: Solana ─────────────────────────────────────────
-# RPC endpoint for the Allways Swap Manager program (SOL collateral, reservations,
-# swap lifecycle) — read by the miner, validator, and `alw`. Leave unset for the
-# local default (http://127.0.0.1:8899); set to your mainnet/dev-env RPC otherwise.
+# Read by the miner, validator, and `alw`. Unset uses http://127.0.0.1:8899.
 SOLANA_RPC_URL=
 
-# ─── Chain: Bitcoin (env_prefix=BTC) ───────────────────────
-# lightweight = Blockstream/Esplora API (no local node required). Local-node mode is deprecated.
-BTC_MODE=lightweight
+# Solana signer for miner/admin commands (collateral, quotes, config are keyed by this
+# pubkey — not the bt wallet). Unset falls back to `alw config set solana-keypair`,
+# then the solana-CLI default ~/.solana/id.json.
+# SOLANA_KEYPAIR_PATH=
+
+# ─── Chain: Bitcoin ────────────────────────────────────────
 # mainnet | testnet | testnet4
 BTC_NETWORK=mainnet
-# Esplora endpoints, tried in order.
-# Optional — unset uses public blockstream.info then mempool.space.
-# Each entry is URL or URL|API_KEY; keyed entries send the key via the header
-# named below. Default Authorization carries a "Bearer " prefix; any other
-# header name sends the raw key (e.g. Maestro uses "api-key").
+
+# Esplora endpoints, tried in order. Unset uses public blockstream.info then mempool.space.
+# Each entry is URL or URL|API_KEY. A keyed entry sends the key via the header named below;
+# the default Authorization header adds a "Bearer " prefix, any other name sends the raw key.
 # BTC_ESPLORA_API_KEY_HEADER=api-key
 # BTC_ESPLORA_URLS=https://xbt-mainnet.gomaestro-api.org/v0/esplora|your_maestro_key,https://mempool.space/api
 
 # ─── Bitcoin signing (users + miners) ──────────────────────
-# WIF private key. Required for miners in lightweight mode. Optional for
-# users running `alw swap`: when set, the CLI signs and broadcasts BTC
-# sends locally; when unset, the CLI falls back to a bring-your-own-signature
-# flow and you broadcast via your own wallet.
+# WIF private key. Required for miners. Optional for `alw swap`: when set the CLI signs and
+# broadcasts BTC sends locally; when unset you sign and broadcast via your own wallet.
 BTC_PRIVATE_KEY=
 
 # ─── Miner-only ───────────────────────────────────────────
-MINER_BTC_ADDRESS=
-
-# Bittensor coldkey password for headless miners. The miner unlocks the
-# coldkey once at startup so per-swap TAO transfers don't re-prompt; when the
-# process runs detached from a TTY (pm2/systemd) the prompt would otherwise
-# fail and every fulfillment would error with "password invalid". Leave unset
-# to be prompted interactively at launch.
+# Coldkey password for headless miners. Unlocked once at startup so per-swap TAO transfers
+# don't re-prompt — detached from a TTY the prompt fails and every fulfillment errors with
+# "password invalid". Unset prompts interactively at launch.
 MINER_BITTENSOR_COLDKEY_PASSWORD=
 
-# ─── Validator: dev / testnet mode ─────────────────────────
-# VALIDATOR_DEV_MODE=1 makes the validator observe-only: it verifies swaps and computes
-# scores but submits NO Solana consensus votes (logs "WOULD …") and does NOT set Bittensor
-# weights. Use it to stage a new validator before it can affect consensus or emissions;
-# unset / 0 for a live validator.
+# ─── Validator ─────────────────────────────────────────────
+# 1 = observe-only: verifies swaps and computes scores, but submits no Solana votes
+# (logs "WOULD …") and sets no Bittensor weights. Stage a new validator before it can
+# affect consensus or emissions. Unset / 0 for a live validator.
 # VALIDATOR_DEV_MODE=0
+
+# Raise on testnet where slower RPC stretches a forward step. Default 5.
+# VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE=5
 
 # ─── Validator: Weights & Biases ───────────────────────────
 # The validator opens a wandb run at startup that captures its console output.
-# Set WANDB_API_KEY to log online; unset runs offline (./wandb/) or pass
+# Set WANDB_API_KEY to log online; unset runs offline (./wandb/), or pass
 # --neuron.wandb_off to disable entirely.
 WANDB_API_KEY=
 WANDB_ENTITY=entrius-gittensor

--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -584,22 +584,12 @@ def get_solana_cli_context(need_keypair: bool = True):
     ~/.solana/id.json), NOT the bt wallet — collateral, quotes, and config are keyed by that pubkey on the
     program. The bt wallet is only needed where a command links the two identities (`alw miner bind-hotkey`).
     """
-    from solders.pubkey import Pubkey
-
-    from allways.solana import pdas
     from allways.solana.client import AllwaysSolanaClient
+    from allways.solana.program import resolve_program_id
 
     config = get_effective_config()
     rpc_url = resolve_solana_rpc(config)
-    program_id = pdas.PROGRAM_ID
-    configured = config.get('program-id') or config.get('contract')
-    if configured:
-        try:
-            program_id = Pubkey.from_string(configured)
-        except (ValueError, TypeError):
-            console.print(
-                f'[yellow]Ignoring invalid program-id config {configured!r}; using default {program_id}[/yellow]'
-            )
+    program_id = resolve_program_id(config)
     keypair = load_cli_keypair(config) if need_keypair else None
     return config, AllwaysSolanaClient(rpc_url, program_id=program_id, keypair=keypair)
 

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -6,8 +6,10 @@ from allways.classes import MinerActivity
 NETUID_FINNEY = 7
 
 # ─── Contract ──────────────────────────────────────────────
-# Mainnet default; override via CONTRACT_ADDRESS env var.
-CONTRACT_ADDRESS = '5DjJmTpcHZvF3aZZEafKBdo3ksmdUSZ8bBBUSFhW3Ce3xf1J'
+# allways_swap_manager program address. Committed default is the devnet deployment;
+# override with ALLWAYS_PROGRAM_ID. Must match the deployed program — a mismatch derives
+# different PDAs, so every account merely reads as absent instead of erroring.
+PROGRAM_ID = 'AKgfVK8zJVHuZwttdjU2CPykaHyTAvw5r9FUFUpM74JU'
 
 # ─── Polling ──────────────────────────────────────────────
 # Bittensor base-neuron heartbeat, not the scoring/forward cadence.

--- a/allways/solana/__init__.py
+++ b/allways/solana/__init__.py
@@ -4,6 +4,6 @@ Hand-rolled + sync: `solders` (keys/tx primitives) + `borsh-construct` (account/
 thin JSON-RPC layer. The validator's sole on-chain client (the old ink!/Substrate client is gone).
 """
 
-from allways.solana.pdas import PROGRAM_ID
+from allways.solana.program import resolve_program_id
 
-__all__ = ['PROGRAM_ID']
+__all__ = ['resolve_program_id']

--- a/allways/solana/client.py
+++ b/allways/solana/client.py
@@ -19,6 +19,7 @@ from solders.pubkey import Pubkey
 from solders.transaction import Transaction
 
 from allways.solana import layouts, pdas
+from allways.solana.program import resolve_program_id
 from allways.solana.rpc import SolanaRpc
 
 SYSTEM_PROGRAM = Pubkey.from_string('11111111111111111111111111111111')
@@ -112,10 +113,14 @@ class SolanaClientError(Exception):
 
 class AllwaysSolanaClient:
     def __init__(
-        self, rpc_url: str, program_id: Pubkey = pdas.PROGRAM_ID, keypair: Optional[Keypair] = None, timeout: int = 30
+        self,
+        rpc_url: str,
+        program_id: Optional[Pubkey] = None,
+        keypair: Optional[Keypair] = None,
+        timeout: int = 30,
     ):
         self.rpc = SolanaRpc(rpc_url, timeout=timeout)
-        self.program_id = program_id
+        self.program_id = program_id or resolve_program_id()
         self.keypair = keypair
 
     # ---------- decode ----------

--- a/allways/solana/pdas.py
+++ b/allways/solana/pdas.py
@@ -7,14 +7,11 @@ Seeds mirror smart-contracts/solana/.../constants.rs. Composite seeds:
   hkbind        : [b"hkbind", hotkey]   (hotkey = 32-byte sr25519 pubkey)
 """
 
-import os
+from typing import Optional
 
 from solders.pubkey import Pubkey
 
-# Program address. Defaults to the committed DEV program id (reproducible local builds); testnet/mainnet set
-# ALLWAYS_PROGRAM_ID so the deployed address is never baked into code. Must match the deployed program.
-DEV_PROGRAM_ID = 'AKgfVK8zJVHuZwttdjU2CPykaHyTAvw5r9FUFUpM74JU'
-PROGRAM_ID = Pubkey.from_string(os.environ.get('ALLWAYS_PROGRAM_ID', DEV_PROGRAM_ID))
+from allways.solana.program import resolve_program_id
 
 # Vote-round request types (constants.rs). REQ_RESERVE is gone (lottery-based).
 REQ_ACTIVATE = 0
@@ -34,55 +31,55 @@ def _pk_bytes(p) -> bytes:
     return bytes(Pubkey.from_string(str(p)))
 
 
-def _derive(seeds, program_id: Pubkey = PROGRAM_ID) -> Pubkey:
-    return Pubkey.find_program_address(seeds, program_id)[0]
+def _derive(seeds, program_id: Optional[Pubkey] = None) -> Pubkey:
+    return Pubkey.find_program_address(seeds, program_id or resolve_program_id())[0]
 
 
-def config_pda(program_id: Pubkey = PROGRAM_ID) -> Pubkey:
+def config_pda(program_id: Optional[Pubkey] = None) -> Pubkey:
     return _derive([b'config'], program_id)
 
 
-def treasury_pda(program_id: Pubkey = PROGRAM_ID) -> Pubkey:
+def treasury_pda(program_id: Optional[Pubkey] = None) -> Pubkey:
     return _derive([b'treasury'], program_id)
 
 
-def miner_state_pda(miner, program_id: Pubkey = PROGRAM_ID) -> Pubkey:
+def miner_state_pda(miner, program_id: Optional[Pubkey] = None) -> Pubkey:
     return _derive([b'miner', _pk_bytes(miner)], program_id)
 
 
-def collateral_vault_pda(miner, program_id: Pubkey = PROGRAM_ID) -> Pubkey:
+def collateral_vault_pda(miner, program_id: Optional[Pubkey] = None) -> Pubkey:
     return _derive([b'collateral', _pk_bytes(miner)], program_id)
 
 
-def binding_pda(miner, program_id: Pubkey = PROGRAM_ID) -> Pubkey:
+def binding_pda(miner, program_id: Optional[Pubkey] = None) -> Pubkey:
     return _derive([b'bind', _pk_bytes(miner)], program_id)
 
 
-def hotkey_binding_pda(hotkey: bytes, program_id: Pubkey = PROGRAM_ID) -> Pubkey:
+def hotkey_binding_pda(hotkey: bytes, program_id: Optional[Pubkey] = None) -> Pubkey:
     return _derive([b'hkbind', bytes(hotkey)], program_id)
 
 
-def reservation_pda(miner, program_id: Pubkey = PROGRAM_ID) -> Pubkey:
+def reservation_pda(miner, program_id: Optional[Pubkey] = None) -> Pubkey:
     return _derive([b'resv', _pk_bytes(miner)], program_id)
 
 
-def pool_pda(miner, program_id: Pubkey = PROGRAM_ID) -> Pubkey:
+def pool_pda(miner, program_id: Optional[Pubkey] = None) -> Pubkey:
     return _derive([b'pool', _pk_bytes(miner)], program_id)
 
 
-def swap_pda(swap_key: bytes, program_id: Pubkey = PROGRAM_ID) -> Pubkey:
+def swap_pda(swap_key: bytes, program_id: Optional[Pubkey] = None) -> Pubkey:
     return _derive([b'swap', bytes(swap_key)], program_id)
 
 
-def quote_pda(miner, from_chain: str, to_chain: str, program_id: Pubkey = PROGRAM_ID) -> Pubkey:
+def quote_pda(miner, from_chain: str, to_chain: str, program_id: Optional[Pubkey] = None) -> Pubkey:
     return _derive([b'quote', _pk_bytes(miner), from_chain.encode(), to_chain.encode()], program_id)
 
 
-def stats_pda(miner, from_chain: str, to_chain: str, program_id: Pubkey = PROGRAM_ID) -> Pubkey:
+def stats_pda(miner, from_chain: str, to_chain: str, program_id: Optional[Pubkey] = None) -> Pubkey:
     return _derive([b'stats', _pk_bytes(miner), from_chain.encode(), to_chain.encode()], program_id)
 
 
-def vote_round_pda(req_type: int, target=None, program_id: Pubkey = PROGRAM_ID) -> Pubkey:
+def vote_round_pda(req_type: int, target=None, program_id: Optional[Pubkey] = None) -> Pubkey:
     """Per-target vote round, or the global weights round when target is None (REQ_SET_WEIGHTS)."""
     seeds = [b'vote', bytes([req_type])]
     if target is not None:

--- a/allways/solana/program.py
+++ b/allways/solana/program.py
@@ -1,0 +1,53 @@
+"""Single resolution point for the allways_swap_manager program address.
+
+Precedence: ALLWAYS_PROGRAM_ID env > CLI config (`program-id`, legacy `contract`) > constants.PROGRAM_ID.
+
+Resolved lazily on every call, never at import. Import-time resolution silently froze the address
+before `load_dotenv()` ran in the neurons, so a `.env` override was ignored there.
+"""
+
+import os
+from typing import Optional
+
+from solders.pubkey import Pubkey
+
+from allways.constants import PROGRAM_ID as DEFAULT_PROGRAM_ID
+
+ENV_VAR = 'ALLWAYS_PROGRAM_ID'
+# `contract` is the legacy ink!-era key name, still honored for existing ~/.allways/config.json.
+CONFIG_KEYS = ('program-id', 'contract')
+
+
+def _warn(message: str) -> None:
+    try:
+        import bittensor as bt
+
+        bt.logging.warning(message)
+    except Exception:
+        print(f'WARNING: {message}')
+
+
+def resolve_program_id(config: Optional[dict] = None) -> Pubkey:
+    """Program address from env, else CLI config, else the committed default.
+
+    A malformed env value raises: it is explicit operator intent, and silently falling back to the
+    devnet default would point a mainnet node at the wrong program. A malformed config value only
+    warns and falls through, preserving the CLI's existing behavior.
+    """
+    raw = os.environ.get(ENV_VAR)
+    if raw:
+        try:
+            return Pubkey.from_string(raw)
+        except (ValueError, TypeError) as exc:
+            raise ValueError(f'{ENV_VAR}={raw!r} is not a valid Solana address') from exc
+
+    for key in CONFIG_KEYS:
+        configured = (config or {}).get(key)
+        if configured:
+            try:
+                return Pubkey.from_string(configured)
+            except (ValueError, TypeError):
+                _warn(f'Ignoring invalid {key} config {configured!r}; using default {DEFAULT_PROGRAM_ID}')
+            break
+
+    return Pubkey.from_string(DEFAULT_PROGRAM_ID)

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -12,19 +12,21 @@ import time
 from pathlib import Path
 from typing import Dict
 
-import bittensor as bt
-from bittensor import Keypair as BtKeypair
 from dotenv import load_dotenv
 
-from allways.chain_providers import create_chain_providers
-from allways.constants import FORWARD_STALL_THRESHOLD_SECONDS
-from allways.miner.fulfillment import SwapFulfiller
-from allways.miner.swap_poller import SwapPoller
-from allways.solana import keys
-from allways.solana.client import AllwaysSolanaClient
-from neurons.base.miner import BaseMinerNeuron
-
+# Must precede the allways imports: they resolve env-backed settings, and a later load would be a no-op.
 load_dotenv()
+
+import bittensor as bt  # noqa: E402
+from bittensor import Keypair as BtKeypair  # noqa: E402
+
+from allways.chain_providers import create_chain_providers  # noqa: E402
+from allways.constants import FORWARD_STALL_THRESHOLD_SECONDS  # noqa: E402
+from allways.miner.fulfillment import SwapFulfiller  # noqa: E402
+from allways.miner.swap_poller import SwapPoller  # noqa: E402
+from allways.solana import keys  # noqa: E402
+from allways.solana.client import AllwaysSolanaClient  # noqa: E402
+from neurons.base.miner import BaseMinerNeuron  # noqa: E402
 
 
 class Miner(BaseMinerNeuron):

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -14,22 +14,26 @@ import threading
 import time
 from functools import partial
 
-import bittensor as bt
-import wandb
 from dotenv import load_dotenv
 
-from allways import __version__
-from allways.chain_providers import create_chain_providers
-from allways.constants import (
+# Must precede the allways imports: they resolve env-backed settings, and a later load would be a no-op.
+load_dotenv()
+
+import bittensor as bt  # noqa: E402
+import wandb  # noqa: E402
+
+from allways import __version__  # noqa: E402
+from allways.chain_providers import create_chain_providers  # noqa: E402
+from allways.constants import (  # noqa: E402
     FEE_DIVISOR,
     FORWARD_STALL_THRESHOLD_SECONDS,
     SCORING_WINDOW_BLOCKS,
     SCORING_WINDOW_SECS,
 )
-from allways.solana import keys
-from allways.solana.client import AllwaysSolanaClient
-from allways.solana.events import SolanaEventIngest
-from allways.validator.axon_handlers import (
+from allways.solana import keys  # noqa: E402
+from allways.solana.client import AllwaysSolanaClient  # noqa: E402
+from allways.solana.events import SolanaEventIngest  # noqa: E402
+from allways.validator.axon_handlers import (  # noqa: E402
     blacklist_miner_activate,
     blacklist_swap_confirm,
     blacklist_swap_reserve,
@@ -40,17 +44,15 @@ from allways.validator.axon_handlers import (
     priority_swap_confirm,
     priority_swap_reserve,
 )
-from allways.validator.bounds_cache import SolanaConfigCache
-from allways.validator.event_index import SolanaEventIndex
-from allways.validator.forward import forward
-from allways.validator.seam_http import maybe_start_seam
-from allways.validator.solana_swap_loop import SolanaSwapLoop
-from allways.validator.state_store import ValidatorStateStore
-from allways.validator.storage import DatabaseStorage
-from neurons.base.neuron import validator_dev_mode
-from neurons.base.validator import BaseValidatorNeuron
-
-load_dotenv()
+from allways.validator.bounds_cache import SolanaConfigCache  # noqa: E402
+from allways.validator.event_index import SolanaEventIndex  # noqa: E402
+from allways.validator.forward import forward  # noqa: E402
+from allways.validator.seam_http import maybe_start_seam  # noqa: E402
+from allways.validator.solana_swap_loop import SolanaSwapLoop  # noqa: E402
+from allways.validator.state_store import ValidatorStateStore  # noqa: E402
+from allways.validator.storage import DatabaseStorage  # noqa: E402
+from neurons.base.neuron import validator_dev_mode  # noqa: E402
+from neurons.base.validator import BaseValidatorNeuron  # noqa: E402
 
 WANDB_ENTITY = os.getenv('WANDB_ENTITY', 'entrius-gittensor')
 WANDB_PROJECT = os.getenv('WANDB_PROJECT', 'allways-validators')

--- a/tests/test_cli_program_id.py
+++ b/tests/test_cli_program_id.py
@@ -1,26 +1,76 @@
-"""B5 — the CLI honors a configured Solana program-id / RPC instead of ignoring it.
+"""The program address resolves from one place, with env > CLI config > committed default.
 
 `get_solana_cli_context` used to hardcode `pdas.PROGRAM_ID` and read the RPC from the env only, so
-`alw config set program-id <addr>` (and the legacy `contract` key) silently had no effect. These lock the
-config → client wiring.
+`alw config set program-id <addr>` (and the legacy `contract` key) silently had no effect. Later it
+let config override the env, inverting the precedence its sibling resolvers use. These lock the
+config → client wiring and the precedence order.
 """
 
 import os
 from unittest.mock import patch
 
+import pytest
 from solders.keypair import Keypair
+from solders.pubkey import Pubkey
 
 from allways.cli.swap_commands import helpers
-from allways.solana import pdas
+from allways.constants import PROGRAM_ID as DEFAULT_PROGRAM_ID
+from allways.solana.program import ENV_VAR, resolve_program_id
 
 
-def _ctx(config):
+def _ctx(config, env=None):
     """Call get_solana_cli_context with a fixed config and no real keypair/RPC."""
     with (
+        patch.dict(os.environ, env or {}, clear=True),
         patch.object(helpers, 'get_effective_config', return_value=config),
         patch('allways.solana.keys.load_or_create', return_value=Keypair()),
     ):
         return helpers.get_solana_cli_context()
+
+
+# ---------- resolver precedence ----------
+
+
+def test_env_overrides_config():
+    custom, ignored = str(Keypair().pubkey()), str(Keypair().pubkey())
+    with patch.dict(os.environ, {ENV_VAR: custom}, clear=True):
+        assert str(resolve_program_id({'program-id': ignored})) == custom
+
+
+def test_config_used_when_env_unset():
+    custom = str(Keypair().pubkey())
+    with patch.dict(os.environ, {}, clear=True):
+        assert str(resolve_program_id({'program-id': custom})) == custom
+
+
+def test_defaults_when_env_and_config_unset():
+    with patch.dict(os.environ, {}, clear=True):
+        assert resolve_program_id({}) == Pubkey.from_string(DEFAULT_PROGRAM_ID)
+        assert resolve_program_id(None) == Pubkey.from_string(DEFAULT_PROGRAM_ID)
+
+
+def test_invalid_env_raises():
+    """Silently falling back would point a mainnet node at the devnet program."""
+    with patch.dict(os.environ, {ENV_VAR: 'not-a-valid-pubkey'}, clear=True):
+        with pytest.raises(ValueError, match=ENV_VAR):
+            resolve_program_id({})
+
+
+def test_invalid_config_falls_back_to_default():
+    with patch.dict(os.environ, {}, clear=True):
+        assert resolve_program_id({'program-id': 'not-a-valid-pubkey'}) == Pubkey.from_string(DEFAULT_PROGRAM_ID)
+
+
+def test_resolution_is_lazy_not_import_time():
+    """pdas/client must not freeze the address at import — that is what broke .env in the neurons."""
+    custom = str(Keypair().pubkey())
+    with patch.dict(os.environ, {ENV_VAR: custom}, clear=True):
+        from allways.solana import pdas
+
+        assert pdas.config_pda() == Pubkey.find_program_address([b'config'], Pubkey.from_string(custom))[0]
+
+
+# ---------- CLI wiring ----------
 
 
 def test_program_id_config_is_honored():
@@ -41,23 +91,27 @@ def test_program_id_key_wins_over_contract_alias():
     assert str(client.program_id) == primary
 
 
-def test_defaults_to_pdas_program_id_when_absent():
+def test_cli_env_overrides_config():
+    custom = str(Keypair().pubkey())
+    _, client = _ctx({'program-id': str(Keypair().pubkey())}, env={ENV_VAR: custom})
+    assert str(client.program_id) == custom
+
+
+def test_defaults_to_committed_program_id_when_absent():
     _, client = _ctx({})
-    assert client.program_id == pdas.PROGRAM_ID
+    assert client.program_id == Pubkey.from_string(DEFAULT_PROGRAM_ID)
 
 
 def test_invalid_program_id_falls_back_to_default():
     _, client = _ctx({'program-id': 'not-a-valid-pubkey'})
-    assert client.program_id == pdas.PROGRAM_ID
+    assert client.program_id == Pubkey.from_string(DEFAULT_PROGRAM_ID)
 
 
 def test_solana_rpc_config_used_when_env_unset():
-    with patch.dict(os.environ, {}, clear=True):
-        _, client = _ctx({'solana-rpc': 'http://example.test:1234'})
+    _, client = _ctx({'solana-rpc': 'http://example.test:1234'})
     assert client.rpc.url == 'http://example.test:1234'
 
 
 def test_env_rpc_overrides_config():
-    with patch.dict(os.environ, {'SOLANA_RPC_URL': 'http://env.test:9999'}, clear=True):
-        _, client = _ctx({'solana-rpc': 'http://config.test:1111'})
+    _, client = _ctx({'solana-rpc': 'http://config.test:1111'}, env={'SOLANA_RPC_URL': 'http://env.test:9999'})
     assert client.rpc.url == 'http://env.test:9999'

--- a/tests/test_solana_b4_builders.py
+++ b/tests/test_solana_b4_builders.py
@@ -14,8 +14,9 @@ from solders.keypair import Keypair
 
 from allways.solana import layouts, pdas
 from allways.solana.client import SYSTEM_PROGRAM, AllwaysSolanaClient, swap_from_solana, swap_key_from_tx_hash
+from allways.solana.program import resolve_program_id
 
-PID = pdas.PROGRAM_ID
+PID = resolve_program_id()
 
 
 def _global_disc(name: str) -> bytes:

--- a/tests/test_solana_d6_builders.py
+++ b/tests/test_solana_d6_builders.py
@@ -11,8 +11,9 @@ from solders.keypair import Keypair
 
 from allways.solana import layouts, pdas
 from allways.solana.client import AllwaysSolanaClient
+from allways.solana.program import resolve_program_id
 
-PID = pdas.PROGRAM_ID
+PID = resolve_program_id()
 
 
 def _global_disc(name: str) -> bytes:

--- a/tests/test_solana_phase9_builders.py
+++ b/tests/test_solana_phase9_builders.py
@@ -13,8 +13,9 @@ from solders.keypair import Keypair
 
 from allways.solana import layouts, pdas
 from allways.solana.client import SLOT_HASHES, SYSTEM_PROGRAM, AllwaysSolanaClient
+from allways.solana.program import resolve_program_id
 
-PID = pdas.PROGRAM_ID
+PID = resolve_program_id()
 
 
 def _global_disc(name: str) -> bytes:

--- a/tests/test_solana_vote_builders.py
+++ b/tests/test_solana_vote_builders.py
@@ -13,8 +13,9 @@ from solders.keypair import Keypair
 
 from allways.solana import layouts, pdas
 from allways.solana.client import SYSTEM_PROGRAM, AllwaysSolanaClient, swap_key_from_tx_hash
+from allways.solana.program import resolve_program_id
 
-PID = pdas.PROGRAM_ID
+PID = resolve_program_id()
 SK = bytes(range(32))  # a stand-in 32-byte swap_key
 
 


### PR DESCRIPTION
## Why

The program address was resolved three different ways:

- `pdas.py` read `ALLWAYS_PROGRAM_ID` **at module-import time** into `PROGRAM_ID`, falling back to a second constant `DEV_PROGRAM_ID`.
- `AllwaysSolanaClient.__init__` bound that module global as a **default argument** — also frozen at import.
- The CLI's `get_solana_cli_context` layered a config lookup on top that **overrode** the env.

That produced two real defects.

### 1. `.env` was silently ignored by the validator and miner

Both neurons import `allways.solana.client` *before* calling `load_dotenv()`, so the address was frozen to the committed default before the file was ever read. Only a genuinely exported shell variable (compose `environment:`) reached them. `allways/cli/main.py` happened to get the order right.

Demonstrated on the pre-fix tree with a `.env` containing `ALLWAYS_PROGRAM_ID=1111...1111`:

```
VALIDATOR ORDER  -> pdas.PROGRAM_ID = AKgfVK8zJVHuZwttdjU2CPykaHyTAvw5r9FUFUpM74JU   # .env ignored
CLI ORDER        -> pdas.PROGRAM_ID = 11111111111111111111111111111111               # .env honored
```

The failure mode is what makes this worth fixing rather than documenting: a wrong program id derives *different PDAs*, so every account simply reads as absent. It looks like a fresh deployment. Nothing raises.

### 2. CLI precedence was inverted

`get_solana_cli_context` did `config > env`, while its two siblings in the same file — `resolve_solana_rpc` and `resolve_solana_keypair_path` — both do `env > config`. One file, two precedence rules.

## What changed

All of it collapses into one function, `allways/solana/program.py::resolve_program_id(config=None)`:

> env `ALLWAYS_PROGRAM_ID` → CLI config (`program-id`, legacy `contract`) → `constants.PROGRAM_ID`

- **Resolution is lazy.** Nothing reads `os.environ` at import; `AllwaysSolanaClient` takes `program_id: Optional[Pubkey] = None`. Import order no longer matters, so the bug is fixed at the root rather than papered over by moving a call.
- **One constant.** `DEV_PROGRAM_ID` + `PROGRAM_ID` fold into `constants.PROGRAM_ID`. The split only existed because the env read shared a line with the constant definition.
- **`load_dotenv()` hoisted** above the allways imports in both neurons. Correct on its own merits and stops this recurring for any *other* env var, but the fix no longer depends on it.
- **Dead `CONTRACT_ADDRESS` constant removed** — an ink!-era leftover whose comment claimed "override via CONTRACT_ADDRESS env var" while no code ever read it.

### One deliberate asymmetry

A malformed `ALLWAYS_PROGRAM_ID` now **raises**; a malformed config value still warns and falls back. Env is explicit operator intent, and silently defaulting would point a mainnet node at the devnet program. Config keeps its previous behavior so existing CLI UX is unchanged. Happy to make both raise if reviewers prefer.

## `.env.example`

Documented two knobs that existed but appeared nowhere: `ALLWAYS_PROGRAM_ID` and `SOLANA_KEYPAIR_PATH`. Removed three that are read by no Python, compose file, or script anywhere in the repo:

| Removed | Why |
|---|---|
| `CONTRACT_ADDRESS` | ink!-era leftover; zero references |
| `MINER_BTC_ADDRESS` | zero references; the miner's addresses live on-chain in the `MinerQuote` PDA, set as a CLI argument to `alw miner post` → `set_quote(..., miner_from_addr, miner_to_addr, ...)` |
| `BTC_MODE` | local-node mode was removed; `bitcoin.py` now reads it only to warn on stale values |

Vars with no Python references but real consumers (`NETUID`, `PORT`, `AXON_PUBLISH`, `WANDB_API_KEY`, …) were kept — they're used by `scripts/*-entrypoint.sh`, the compose files, or the wandb SDK.

## Verification

- `673 passed, 6 deselected` — full suite, on this base.
- `ruff check` clean; `ruff format --check` clean.
- Byte-compiled the touched files and **actually imported** `neurons.validator` and `neurons.miner` (the `# noqa: E402` markers are load-bearing now).
- Re-ran the original repro against the fixed tree with the deliberately hostile old import order — `.env` is now honored:
  ```
  resolve_program_id()      = 11111111111111111111111111111111
  client default program_id = 11111111111111111111111111111111
  config_pda() derives from = env
  ```
- `alw --help` smoke; confirmed the CLI reads the repo `.env` and that env beats a conflicting config value.

New tests in `tests/test_cli_program_id.py` lock the precedence order, the raise-on-bad-env behavior, and that resolution is lazy rather than import-time.