### PR TITLE
fix(contract): arm the pool draw after the window closes, never from a guessed slot

### DIFF
--- a/allways/validator/solana_swap_loop.py
+++ b/allways/validator/solana_swap_loop.py
@@ -64,9 +64,10 @@ _BENIGN_EXTEND_MARKERS = ('ExtensionNotLater', 'ExtensionExceedsCeiling')
 
 # resolve_pool is permissionless, so every validator cranks every closed pool and the contract's
 # first-wins idempotency handles the race. A loser's tx fails with one of these — a peer already
-# resolved it (NoRequests: opened_at zeroed), or the on-chain clock hasn't crossed closes_at yet
-# (PoolNotClosed, clock skew) — both expected, retried next pass. Real failures still surface.
-_BENIGN_RESOLVE_MARKERS = ('NoRequests', 'PoolNotClosed')
+# resolved it (NoRequests: opened_at zeroed), the on-chain clock hasn't crossed closes_at yet
+# (PoolNotClosed, clock skew), or the armed draw slot isn't on-chain yet (SeedSlotNotYetProduced —
+# resolve is two-phase: arm, then draw). All expected, retried next pass. Real failures still surface.
+_BENIGN_RESOLVE_MARKERS = ('NoRequests', 'PoolNotClosed', 'SeedSlotNotYetProduced')
 
 # close_stale_claim is permissionless, so every validator cranks every stale claim and the first-wins race
 # leaves losers with a benign failure: a peer already reaped it (the Swap PDA is gone), or the reservation is

--- a/smart-contracts/solana/programs/allways_swap_manager/Cargo.toml
+++ b/smart-contracts/solana/programs/allways_swap_manager/Cargo.toml
@@ -26,6 +26,10 @@ solana-keccak-hasher = "3.1.0"
 
 [dev-dependencies]
 litesvm = "0.10.0"
+# SlotHashes: seeded into LiteSVM so resolve_pool's draw runs against the canonical sysvar layout
+# rather than a test-only fallback seed.
+solana-sysvar = "3.1.1"
+solana-slot-hashes = "3.1.0"
 solana-message = "3.0.1"
 solana-transaction = "3.0.2"
 solana-signer = "3.0.0"

--- a/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
@@ -76,9 +76,9 @@ pub const REQ_TIMEOUT: u8 = 7;
 /// Global (non-per-target) round for the validator-weight vector.
 pub const REQ_SET_WEIGHTS: u8 = 8;
 
-/// Solana slot time (ms) — a chain property, used with `POOL_WINDOW_SECS` (economic-levers section
-/// below) to pin the draw's future seed slot from the window duration.
-pub const SLOT_MS: u64 = 400;
+/// Slots the draw's seed slot is pinned ahead of the arming crank. Small: the pool has already
+/// closed, so this only has to be far enough ahead that the slot is unproduced when pinned.
+pub const SEED_SLOT_DELAY_SLOTS: u64 = 4;
 
 /// Bounded max lengths for stored strings.
 pub const MAX_ADDR_LEN: usize = 80;
@@ -168,8 +168,7 @@ pub const RESERVATION_FEE_LAMPORTS: u64 = 20_000_000;
 
 /// Initial reservation-lottery pooling window (seconds). Seeds `Config.pool_window_secs` — how long
 /// a pool gathers contending requests before the stake-weighted draw. Must stay well below the
-/// reservation TTL; paired with `SLOT_MS` to pin the draw's seed slot. Runtime-adjustable via
-/// `set_pool_window` (dev seeds 5s for fast swaps).
+/// reservation TTL. Runtime-adjustable via `set_pool_window` (dev seeds 5s for fast swaps).
 pub const POOL_WINDOW_SECS: i64 = 30;
 
 /// Initial minimum seconds between successful validator-weight updates (Phase 10) — an anti-thrash

--- a/smart-contracts/solana/programs/allways_swap_manager/src/error.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/error.rs
@@ -107,6 +107,8 @@ pub enum ErrorCode {
     AlreadyRequested,
     #[msg("Pool has no requests to resolve")]
     NoRequests,
+    #[msg("Draw seed slot has not been produced yet; retry once the chain advances")]
+    SeedSlotNotYetProduced,
 
     // --- Phase 10: consensus validator weights ---
     #[msg("Weights vector length must match the validator set")]

--- a/smart-contracts/solana/programs/allways_swap_manager/src/events.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/events.rs
@@ -187,6 +187,14 @@ pub struct ReservationRequested {
     pub requests: u8,
 }
 
+/// The closed pool's draw seed slot has been pinned to a not-yet-produced slot. Re-emitted if that
+/// slot rolls out of SlotHashes before any crank resolves (a stall long enough to lose ~512 slots).
+#[event]
+pub struct PoolDrawArmed {
+    pub miner: Pubkey,
+    pub seed_slot: u64,
+}
+
 #[event]
 pub struct PoolResolved {
     pub miner: Pubkey,

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/open_or_request.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/open_or_request.rs
@@ -3,7 +3,7 @@ use anchor_lang::system_program::{transfer, Transfer};
 
 use crate::constants::{
     CONFIG_SEED, MAX_ADDR_LEN, MAX_CHAIN_LEN, MAX_VALIDATORS, MINER_SEED, POOL_SEED, QUOTE_SEED,
-    RESV_SEED, SLOT_MS, TREASURY_SEED,
+    RESV_SEED, TREASURY_SEED,
 };
 use crate::error::ErrorCode;
 use crate::events::{PoolOpened, ReservationRequested};
@@ -185,9 +185,6 @@ pub fn handler(
             q.rate,
         );
         let window = ctx.accounts.config.pool_window_secs;
-        let seed_slot = clock
-            .slot
-            .saturating_add((window as u64).saturating_mul(1000) / SLOT_MS);
         let closes_at = now.saturating_add(window);
 
         // Busy from the moment the pool opens: covers the window + the eventual reservation TTL.
@@ -203,7 +200,9 @@ pub fn handler(
         pool.rate = rate;
         pool.opened_at = now;
         pool.closes_at = closes_at;
-        pool.seed_slot = seed_slot;
+        // Unpinned: `resolve_pool` arms the seed slot after the window shuts, so the draw's entropy
+        // cannot be read (or predicted) while bids are still being placed.
+        pool.seed_slot = 0;
         pool.requests.clear();
         pool.requests.push(req);
         pool.bump = pool_bump;
@@ -214,7 +213,7 @@ pub fn handler(
             from_chain,
             to_chain,
             closes_at,
-            seed_slot,
+            seed_slot: 0, // armed later by resolve_pool; kept in the event for schema stability
         });
     } else {
         // JOIN or UPDATE — must be within the window and match the pinned pair.

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/resolve_pool.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/resolve_pool.rs
@@ -1,22 +1,31 @@
 use anchor_lang::prelude::*;
 
-use crate::constants::{CONFIG_SEED, MINER_SEED, POOL_SEED, RESV_SEED};
+use crate::constants::{CONFIG_SEED, MINER_SEED, POOL_SEED, RESV_SEED, SEED_SLOT_DELAY_SLOTS};
 
 /// SlotHashes sysvar address (not re-exported by anchor's solana_program facade in this version).
 const SLOT_HASHES_ID: Pubkey = Pubkey::from_str_const("SysvarS1otHashes111111111111111111111111111");
 use crate::error::ErrorCode;
-use crate::events::PoolResolved;
+use crate::events::{PoolDrawArmed, PoolResolved};
 use crate::lottery::{draw_seed, pick_weighted};
 use crate::state::{Config, MinerState, Pool, Reservation};
 
-/// Permissionless. After a pool's window closes, run the stake-weighted draw over its requests and
-/// create the `Reservation` for the winner, then reset the pool for reuse.
+/// Permissionless, two-phase. After a pool's window closes the first call *arms* the draw by pinning
+/// `seed_slot` to a slot the chain has not produced yet; a later call resolves against that slot's
+/// hash, runs the stake-weighted draw, creates the winner's `Reservation`, and resets the pool.
 ///
-/// Randomness: `seed = keccak(pool_key || SlotHashes[seed_slot])` — a future slot pinned at open,
-/// unknown then, fixed once produced. If that slot rolled off the SlotHashes window (or the sysvar is
-/// empty, e.g. LiteSVM) a deterministic fallback keeps the pool resolvable; residual grind is bounded
-/// since a reservation only grants a hold — moving funds still needs `vote_initiate` consensus + a
-/// real on-chain tx.
+/// Randomness: `seed = keccak(pool_key || SlotHashes[first slot >= seed_slot])`.
+///
+/// Arming *after* the window shuts is the point: pinning at open would make the entropy readable
+/// while bids were still being placed (a bidder could then join only when it would win), and any
+/// fixed slot-time assumption used to place that slot is wrong the moment real slot time drifts.
+///
+/// The lookup takes the lowest produced slot at-or-after `seed_slot`, so a skipped seed slot is
+/// tolerated without falling back to a predictable seed. If `seed_slot` rolls out of SlotHashes
+/// (~512 slots) before any crank resolves, the draw is re-armed rather than resolved from a stale
+/// or caller-chosen hash.
+///
+/// Residual: the leader of the seed slot can bias its own block's hash. Bounded — a reservation only
+/// grants a hold; moving funds still needs `vote_initiate` consensus + a real on-chain tx.
 #[derive(Accounts)]
 pub struct ResolvePool<'info> {
     #[account(mut)]
@@ -55,6 +64,55 @@ pub struct ResolvePool<'info> {
     pub system_program: Program<'info, System>,
 }
 
+/// Outcome of resolving `seed_slot` against the SlotHashes ring buffer.
+enum SeedLookup {
+    /// Hash of the lowest produced slot at-or-after `seed_slot`.
+    Found([u8; 32]),
+    /// The chain has not reached `seed_slot` yet — retry.
+    NotYetProduced,
+    /// `seed_slot` aged out of the 512-entry window — re-arm, never guess.
+    RolledOff,
+}
+
+/// SlotHashes layout: 8-byte little-endian count, then 40-byte `(slot, hash)` entries sorted by slot
+/// DESCENDING. Scanning down, the last entry still `>= seed_slot` is the lowest such slot.
+fn find_seed_hash(data: &[u8], seed_slot: u64) -> SeedLookup {
+    if data.len() < 8 {
+        return SeedLookup::NotYetProduced; // sysvar unpopulated
+    }
+    let declared = u64::from_le_bytes(data[0..8].try_into().unwrap()) as usize;
+    let capacity = (data.len() - 8) / 40;
+    let n = declared.min(capacity);
+    if n == 0 {
+        return SeedLookup::NotYetProduced;
+    }
+
+    let entry = |i: usize| -> (u64, [u8; 32]) {
+        let off = 8 + i * 40;
+        let slot = u64::from_le_bytes(data[off..off + 8].try_into().unwrap());
+        let mut h = [0u8; 32];
+        h.copy_from_slice(&data[off + 8..off + 40]);
+        (slot, h)
+    };
+
+    if entry(0).0 < seed_slot {
+        return SeedLookup::NotYetProduced;
+    }
+    if entry(n - 1).0 > seed_slot {
+        return SeedLookup::RolledOff;
+    }
+
+    let mut found = [0u8; 32];
+    for i in 0..n {
+        let (slot, h) = entry(i);
+        if slot < seed_slot {
+            break;
+        }
+        found = h; // descending: keep overwriting, so the last kept is the lowest slot >= seed_slot
+    }
+    SeedLookup::Found(found)
+}
+
 pub fn handler(ctx: Context<ResolvePool>) -> Result<()> {
     let now = Clock::get()?.unix_timestamp;
 
@@ -66,40 +124,37 @@ pub fn handler(ctx: Context<ResolvePool>) -> Result<()> {
     // move — the backstop if a future busy-clearing path ever breaks this invariant.
 
     let pool_key = ctx.accounts.pool.key();
-    let seed_slot = ctx.accounts.pool.seed_slot;
+    let miner_key = ctx.accounts.miner.key();
+    let cur_slot = Clock::get()?.slot;
 
-    // Resolve the seed slot's hash from SlotHashes (descending by slot, 40 bytes/entry after an
-    // 8-byte count). The time window (now > closes_at) guarantees the pinned slot is produced on a
-    // real chain, so the exact match is the normal path; absence (rolled off, or empty under LiteSVM)
-    // takes the deterministic fallback below.
-    let slot_hash: Option<[u8; 32]> = {
+    // Phase 1 — arm. The window has shut, so no further bids can react to the entropy we pin here,
+    // and the slot itself does not exist yet, so nobody (including this caller) knows its hash.
+    if ctx.accounts.pool.seed_slot == 0 {
+        let seed_slot = cur_slot.saturating_add(SEED_SLOT_DELAY_SLOTS);
+        ctx.accounts.pool.seed_slot = seed_slot;
+        emit!(PoolDrawArmed { miner: miner_key, seed_slot });
+        return Ok(());
+    }
+
+    // Phase 2 — resolve against the armed slot.
+    let seed_slot = ctx.accounts.pool.seed_slot;
+    let lookup = {
         let data = ctx.accounts.slot_hashes.try_borrow_data()?;
-        let mut found = None;
-        if data.len() >= 8 {
-            let n = u64::from_le_bytes(data[0..8].try_into().unwrap()) as usize;
-            for i in 0..n {
-                let off = 8 + i * 40;
-                if off + 40 > data.len() {
-                    break;
-                }
-                let slot = u64::from_le_bytes(data[off..off + 8].try_into().unwrap());
-                if slot == seed_slot {
-                    let mut h = [0u8; 32];
-                    h.copy_from_slice(&data[off + 8..off + 40]);
-                    found = Some(h);
-                    break;
-                }
-                if slot < seed_slot {
-                    break; // descending order — target not present (not yet produced / rolled off)
-                }
-            }
+        find_seed_hash(&data, seed_slot)
+    };
+    let slot_hash = match lookup {
+        SeedLookup::Found(h) => h,
+        SeedLookup::NotYetProduced => return Err(ErrorCode::SeedSlotNotYetProduced.into()),
+        SeedLookup::RolledOff => {
+            // Only reachable after a ~512-slot stall. Re-arm rather than draw from a hash the caller
+            // could have waited for.
+            let seed_slot = cur_slot.saturating_add(SEED_SLOT_DELAY_SLOTS);
+            ctx.accounts.pool.seed_slot = seed_slot;
+            emit!(PoolDrawArmed { miner: miner_key, seed_slot });
+            return Ok(());
         }
-        found
     };
-    let seed = match slot_hash {
-        Some(h) => draw_seed(&pool_key, &h),
-        None => draw_seed(&pool_key, &seed_slot.to_le_bytes()),
-    };
+    let seed = draw_seed(&pool_key, &slot_hash);
 
     // Weight per request = its router's config weight (0 if the router isn't a whitelisted validator —
     // e.g. a plain user). pick_weighted falls back to uniform if every weight is 0.
@@ -159,10 +214,11 @@ pub fn handler(ctx: Context<ResolvePool>) -> Result<()> {
     // Lock the miner busy for the reservation's life (read by deactivate/withdraw, non-bypassable).
     ctx.accounts.miner_state.busy_until = now.saturating_add(ttl);
 
-    // Reset the pool for the next contest (rent stays parked).
-    let miner_key = ctx.accounts.miner.key();
+    // Reset the pool for the next contest (rent stays parked). seed_slot back to 0 so the next
+    // pool re-arms instead of inheriting this draw's slot.
     let pool = &mut ctx.accounts.pool;
     pool.opened_at = 0;
+    pool.seed_slot = 0;
     pool.requests.clear();
 
     emit!(PoolResolved {
@@ -172,4 +228,89 @@ pub fn handler(ctx: Context<ResolvePool>) -> Result<()> {
         requests: req_count,
     });
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a SlotHashes buffer: 8-byte count + 40-byte (slot, hash) entries, slots DESCENDING.
+    /// Each slot's hash is [slot as u8; 32] so we can assert which entry was picked.
+    fn sysvar(slots: &[u64]) -> Vec<u8> {
+        let mut v = (slots.len() as u64).to_le_bytes().to_vec();
+        for &s in slots {
+            v.extend_from_slice(&s.to_le_bytes());
+            v.extend_from_slice(&[s as u8; 32]);
+        }
+        v
+    }
+
+    fn found(data: &[u8], seed: u64) -> u8 {
+        match find_seed_hash(data, seed) {
+            SeedLookup::Found(h) => h[0],
+            _ => panic!("expected Found"),
+        }
+    }
+
+    #[test]
+    fn exact_seed_slot_is_used() {
+        let d = sysvar(&[105, 104, 103, 102, 101]);
+        assert_eq!(found(&d, 103), 103);
+    }
+
+    #[test]
+    fn skipped_seed_slot_takes_lowest_produced_above() {
+        // 103 was skipped; the draw must use 104, never a fallback.
+        let d = sysvar(&[105, 104, 102, 101]);
+        assert_eq!(found(&d, 103), 104);
+    }
+
+    #[test]
+    fn oldest_entry_equal_to_seed_slot_is_found() {
+        let d = sysvar(&[105, 104, 103]);
+        assert_eq!(found(&d, 103), 103);
+    }
+
+    #[test]
+    fn newest_entry_equal_to_seed_slot_is_found() {
+        let d = sysvar(&[105, 104, 103]);
+        assert_eq!(found(&d, 105), 105);
+    }
+
+    #[test]
+    fn not_yet_produced_when_chain_is_behind_seed_slot() {
+        let d = sysvar(&[105, 104, 103]);
+        assert!(matches!(find_seed_hash(&d, 106), SeedLookup::NotYetProduced));
+    }
+
+    #[test]
+    fn rolled_off_when_seed_slot_predates_the_window() {
+        let d = sysvar(&[105, 104, 103]);
+        assert!(matches!(find_seed_hash(&d, 102), SeedLookup::RolledOff));
+    }
+
+    #[test]
+    fn empty_or_short_sysvar_never_falls_back() {
+        assert!(matches!(find_seed_hash(&[], 10), SeedLookup::NotYetProduced));
+        assert!(matches!(find_seed_hash(&sysvar(&[]), 10), SeedLookup::NotYetProduced));
+        assert!(matches!(find_seed_hash(&[0u8; 4], 10), SeedLookup::NotYetProduced));
+    }
+
+    #[test]
+    fn declared_count_beyond_buffer_is_clamped() {
+        // A lying count must not read out of bounds.
+        let mut d = sysvar(&[105, 104]);
+        d[0..8].copy_from_slice(&999u64.to_le_bytes());
+        assert_eq!(found(&d, 104), 104);
+    }
+
+    #[test]
+    fn pick_is_stable_as_newer_slots_arrive() {
+        // Once the seed slot exists, later slots must not change the chosen hash — otherwise a
+        // cranker could grind by choosing when to call.
+        let seed = 103;
+        let a = found(&sysvar(&[104, 103, 102]), seed);
+        let b = found(&sysvar(&[110, 109, 108, 107, 106, 105, 104, 103, 102]), seed);
+        assert_eq!(a, b, "chosen hash must not depend on when resolve is called");
+    }
 }

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_extensions.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_extensions.rs
@@ -10,12 +10,14 @@ use {
         AccountDeserialize, InstructionData, ToAccountMetas,
     },
     allways_swap_manager::constants::{MAX_TOTAL_EXTENSION_SECS, POOL_WINDOW_SECS},
-    allways_swap_manager::state::{MinerState, Reservation, Swap},
+    allways_swap_manager::state::{MinerState, Pool, Reservation, Swap},
     litesvm::LiteSVM,
+    solana_hash::Hash,
     solana_keccak_hasher::hashv,
     solana_keypair::Keypair,
     solana_message::{Message, VersionedMessage},
     solana_signer::Signer,
+    solana_slot_hashes::SlotHashes,
     solana_transaction::versioned::VersionedTransaction,
 };
 
@@ -68,6 +70,20 @@ fn swap_pda(key: &[u8; 32]) -> Pubkey {
 }
 fn swap_key(from_tx_hash: &str) -> [u8; 32] {
     hashv(&[from_tx_hash.as_bytes()]).to_bytes()
+}
+
+/// resolve_pool is two-phase: arm the draw on a future slot, produce it, then draw. See
+/// tests/test_reservation.rs for the entropy invariants this protects.
+fn arm_and_resolve(svm: &mut LiteSVM, val: &Keypair, miner: &Pubkey) {
+    send(svm, resolve_ix(&val.pubkey(), miner), &val.pubkey(), val).expect("arm draw");
+    let a = svm.get_account(&pool_pda(miner)).unwrap();
+    let seed_slot = Pool::try_deserialize(&mut a.data.as_slice()).unwrap().seed_slot;
+    let entries: Vec<(u64, Hash)> = [seed_slot - 1, seed_slot, seed_slot + 1]
+        .iter()
+        .map(|&s| (s, Hash::new_from_array([s as u8; 32])))
+        .collect();
+    svm.set_sysvar::<SlotHashes>(&SlotHashes::new(&entries));
+    send(svm, resolve_ix(&val.pubkey(), miner), &val.pubkey(), val).expect("resolve");
 }
 
 fn set_clock(svm: &mut LiteSVM, ts: i64) {
@@ -335,7 +351,7 @@ fn setup() -> (LiteSVM, Vec<Keypair>, Keypair) {
     let user = Keypair::new().pubkey();
     send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), &user), &vals[0].pubkey(), &vals[0]).expect("open");
     set_clock(&mut svm, setup_ts + POOL_WINDOW_SECS + 1);
-    send(&mut svm, resolve_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0]).expect("resolve");
+    arm_and_resolve(&mut svm, &vals[0], &miner.pubkey());
     set_clock(&mut svm, BASE_TS);
     (svm, vals, miner)
 }

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_reservation.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_reservation.rs
@@ -1,10 +1,13 @@
 // Phase 9 — reservation lottery: open_or_request / resolve_pool, flat fee, guards (LiteSVM).
 //   cargo test -p allways_swap_manager --test test_reservation
 //
-// The weighted draw itself is unit-tested as a pure fn in src/lottery.rs (LiteSVM doesn't populate
-// SlotHashes with future slots, so resolve here uses the deterministic fallback seed). These tests
-// cover the on-chain machinery: open pins the miner quote, the per-request fee accrues to treasury,
-// validator dedup, pair-mismatch, window timing, guards, single/multi-requester resolve.
+// resolve_pool is two-phase: the first call after the window shuts arms the draw on a future slot,
+// a later call resolves against that slot's hash. Tests seed the real SlotHashes sysvar between the
+// two (see `arm_and_resolve`) — there is no fallback seed to lean on. The weighted draw itself is
+// unit-tested as a pure fn in src/lottery.rs, and the sysvar scan in src/instructions/resolve_pool.rs.
+//
+// These cover the on-chain machinery: open pins the miner quote, the per-request fee accrues to
+// treasury, validator dedup, pair-mismatch, window timing, guards, single/multi-requester resolve.
 use {
     anchor_lang::{
         prelude::Pubkey, solana_program::clock::Clock, solana_program::instruction::Instruction,
@@ -13,9 +16,11 @@ use {
     allways_swap_manager::constants::{POOL_WINDOW_SECS, RESERVATION_FEE_LAMPORTS},
     allways_swap_manager::state::{MinerState, Pool, Reservation, Treasury},
     litesvm::LiteSVM,
+    solana_hash::Hash,
     solana_keypair::Keypair,
     solana_message::{Message, VersionedMessage},
     solana_signer::Signer,
+    solana_slot_hashes::SlotHashes,
     solana_transaction::versioned::VersionedTransaction,
 };
 
@@ -62,6 +67,36 @@ fn set_clock(svm: &mut LiteSVM, ts: i64) {
     let mut clock = svm.get_sysvar::<Clock>();
     clock.unix_timestamp = ts;
     svm.set_sysvar::<Clock>(&clock);
+}
+
+/// LiteSVM never advances Clock::slot on its own; the draw needs it to move.
+fn set_slot(svm: &mut LiteSVM, slot: u64) {
+    let mut clock = svm.get_sysvar::<Clock>();
+    clock.slot = slot;
+    svm.set_sysvar::<Clock>(&clock);
+}
+
+/// Populate SlotHashes with `slots` (any order — SlotHashes::new sorts descending, as on-chain).
+/// Each slot's hash is `[slot as u8; 32]` so a test can tell which entry the draw consumed.
+fn set_slot_hashes(svm: &mut LiteSVM, slots: &[u64]) {
+    let entries: Vec<(u64, Hash)> = slots.iter().map(|&s| (s, Hash::new_from_array([s as u8; 32]))).collect();
+    svm.set_sysvar::<SlotHashes>(&SlotHashes::new(&entries));
+}
+
+/// Crank #1 arms the draw on a future slot; make that slot (and a couple after it) exist.
+/// Returns the armed seed slot.
+fn arm_draw(svm: &mut LiteSVM, val: &Keypair, miner: &Pubkey) -> u64 {
+    send(svm, resolve_ix(&val.pubkey(), miner), &val.pubkey(), val).expect("arm draw");
+    let seed_slot = pool(svm, miner).seed_slot;
+    assert_ne!(seed_slot, 0, "first resolve after close must arm a seed slot");
+    seed_slot
+}
+
+/// Arm, produce the seed slot, then resolve. The normal two-crank path.
+fn arm_and_resolve(svm: &mut LiteSVM, val: &Keypair, miner: &Pubkey) -> Result<(), String> {
+    let seed_slot = arm_draw(svm, val, miner);
+    set_slot_hashes(svm, &[seed_slot - 1, seed_slot, seed_slot + 1]);
+    send(svm, resolve_ix(&val.pubkey(), miner), &val.pubkey(), val)
 }
 
 fn send(svm: &mut LiteSVM, ix: Instruction, payer: &Pubkey, signer: &Keypair) -> Result<(), String> {
@@ -339,7 +374,7 @@ fn test_single_requester_resolve_creates_reservation() {
 
     // warp past close, resolve (sole entrant wins regardless of seed)
     set_clock(&mut svm, BASE_TS + POOL_WINDOW_SECS + 1);
-    send(&mut svm, resolve_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0]).expect("resolve");
+    arm_and_resolve(&mut svm, &vals[0], &miner.pubkey()).expect("resolve");
 
     let r = reservation(&svm, &miner.pubkey());
     assert_eq!(r.reserved_until, BASE_TS + POOL_WINDOW_SECS + 1 + TTL, "reserved with TTL from resolve time");
@@ -364,7 +399,7 @@ fn test_multi_requester_resolve_picks_one() {
     send(&mut svm, open_ix(&vals[1].pubkey(), &miner.pubkey(), "BTC", "SOL", &u1, "from1", "to1", 2_000_000_000, 1, 0), &vals[1].pubkey(), &vals[1]).expect("join");
 
     set_clock(&mut svm, BASE_TS + POOL_WINDOW_SECS + 1);
-    send(&mut svm, resolve_ix(&vals[2].pubkey(), &miner.pubkey()), &vals[2].pubkey(), &vals[2]).expect("resolve");
+    arm_and_resolve(&mut svm, &vals[2], &miner.pubkey()).expect("resolve");
 
     let r = reservation(&svm, &miner.pubkey());
     assert!(r.reserved_until > 0, "a winner was reserved");
@@ -419,7 +454,7 @@ fn test_open_blocked_while_reserved() {
     let user = Keypair::new().pubkey();
     send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL", &user, "u1", "uSOL", 2_000_000_000, 1, 0), &vals[0].pubkey(), &vals[0]).expect("open");
     set_clock(&mut svm, BASE_TS + POOL_WINDOW_SECS + 1);
-    send(&mut svm, resolve_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0]).expect("resolve");
+    arm_and_resolve(&mut svm, &vals[0], &miner.pubkey()).expect("resolve");
     assert!(reservation(&svm, &miner.pubkey()).reserved_until > 0);
 
     // a new open is blocked while the reservation is active
@@ -445,7 +480,7 @@ fn test_reservation_blocks_deactivate_until_expiry() {
     let user = Keypair::new().pubkey();
     send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL", &user, "u", "uSOL", 2_000_000_000, 1, 0), &vals[0].pubkey(), &vals[0]).expect("open");
     set_clock(&mut svm, BASE_TS + POOL_WINDOW_SECS + 1);
-    send(&mut svm, resolve_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0]).expect("resolve");
+    arm_and_resolve(&mut svm, &vals[0], &miner.pubkey()).expect("resolve");
     assert!(is_active(&svm, &miner.pubkey()));
 
     let blocked = send(&mut svm, deactivate_ix(&miner.pubkey()), &miner.pubkey(), &miner);
@@ -533,7 +568,7 @@ fn test_cannot_force_deactivate_while_reserved() {
     let user = Keypair::new().pubkey();
     send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL", &user, "u", "uSOL", 2_000_000_000, 1, 0), &vals[0].pubkey(), &vals[0]).expect("open");
     set_clock(&mut svm, BASE_TS + POOL_WINDOW_SECS + 1);
-    send(&mut svm, resolve_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0]).expect("resolve");
+    arm_and_resolve(&mut svm, &vals[0], &miner.pubkey()).expect("resolve");
     let blocked = send(&mut svm, vote_deactivate_ix(&vals[1].pubkey(), &miner.pubkey()), &vals[1].pubkey(), &vals[1]);
     assert!(blocked.is_err(), "cannot force-deactivate a reserved miner");
 }
@@ -555,7 +590,7 @@ fn test_update_reflected_in_reservation() {
     send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL", &u2, "fromB", "toB", 2_000_000_000, 9, 0), &vals[0].pubkey(), &vals[0]).expect("update");
 
     set_clock(&mut svm, BASE_TS + POOL_WINDOW_SECS + 1);
-    send(&mut svm, resolve_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0]).expect("resolve");
+    arm_and_resolve(&mut svm, &vals[0], &miner.pubkey()).expect("resolve");
 
     let r = reservation(&svm, &miner.pubkey());
     assert_eq!(r.sol_amount, 2_000_000_000, "reservation reflects the updated bid amount");
@@ -583,4 +618,109 @@ fn test_update_after_window_close_fails() {
     set_clock(&mut svm, BASE_TS + POOL_WINDOW_SECS + 1);
     let late = send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL", &user, "u1", "uSOL", 2, 2, 0), &vals[0].pubkey(), &vals[0]);
     assert!(late.is_err(), "cannot update after the window closed");
+}
+
+// --- draw entropy: arm-after-close, skip tolerance, no predictable fallback ---
+
+/// Open a pool with one request and warp past the window close.
+fn open_and_close(svm: &mut LiteSVM, vals: &[Keypair], miner: &Keypair) {
+    let user = Keypair::new().pubkey();
+    send(
+        svm,
+        open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL", &user, "userBTC", "userSOL", 2_000_000_000, 100_000, 0),
+        &vals[0].pubkey(),
+        &vals[0],
+    )
+    .expect("open");
+    set_clock(svm, BASE_TS + POOL_WINDOW_SECS + 1);
+}
+
+#[test]
+fn test_open_does_not_pin_seed_slot() {
+    // The entropy must not be knowable while bids are still being placed: pinning at open let a
+    // late joiner read the slot hash and enter only when it would win.
+    let (mut svm, _admin, vals, miner) = setup(0, 0);
+    let user = Keypair::new().pubkey();
+    send(
+        &mut svm,
+        open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL", &user, "userBTC", "userSOL", 2_000_000_000, 100_000, 0),
+        &vals[0].pubkey(),
+        &vals[0],
+    )
+    .expect("open");
+    assert_eq!(pool(&svm, &miner.pubkey()).seed_slot, 0, "seed slot must stay unpinned during the bidding window");
+}
+
+#[test]
+fn test_arming_creates_no_reservation() {
+    let (mut svm, _admin, vals, miner) = setup(0, 0);
+    open_and_close(&mut svm, &vals, &miner);
+    let seed_slot = arm_draw(&mut svm, &vals[0], &miner.pubkey());
+    assert!(seed_slot > 0);
+    assert_eq!(reservation(&svm, &miner.pubkey()).reserved_until, 0, "arming must not draw a winner");
+    assert_ne!(pool(&svm, &miner.pubkey()).opened_at, 0, "pool stays open until the draw resolves");
+}
+
+#[test]
+fn test_resolve_before_seed_slot_is_produced_errors() {
+    let (mut svm, _admin, vals, miner) = setup(0, 0);
+    open_and_close(&mut svm, &vals, &miner);
+    let seed_slot = arm_draw(&mut svm, &vals[0], &miner.pubkey());
+
+    // Chain has not reached the armed slot yet.
+    set_slot_hashes(&mut svm, &[seed_slot - 2, seed_slot - 1]);
+    let e = send(&mut svm, resolve_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0])
+        .expect_err("must not resolve before the seed slot exists");
+    assert!(e.contains("SeedSlotNotYetProduced"), "unexpected error: {e}");
+    assert_eq!(reservation(&svm, &miner.pubkey()).reserved_until, 0, "no reservation from an unproduced seed");
+    assert_eq!(pool(&svm, &miner.pubkey()).seed_slot, seed_slot, "armed slot must not drift on a failed retry");
+}
+
+#[test]
+fn test_skipped_seed_slot_resolves_from_next_produced_slot() {
+    // A skipped seed slot used to fall through to a seed derivable at pool-open. Now it takes the
+    // lowest produced slot above it and draws normally.
+    let (mut svm, _admin, vals, miner) = setup(0, 0);
+    open_and_close(&mut svm, &vals, &miner);
+    let seed_slot = arm_draw(&mut svm, &vals[0], &miner.pubkey());
+
+    // Buffer straddles the seed slot, but the seed slot itself was never produced (leader skipped it).
+    set_slot_hashes(&mut svm, &[seed_slot - 1, seed_slot + 1, seed_slot + 2]);
+    send(&mut svm, resolve_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0])
+        .expect("skipped seed slot must still resolve");
+    assert_ne!(reservation(&svm, &miner.pubkey()).reserved_until, 0, "winner drawn");
+    assert_eq!(pool(&svm, &miner.pubkey()).seed_slot, 0, "pool reset re-arms next contest");
+}
+
+#[test]
+fn test_rolled_off_seed_slot_rearms_instead_of_drawing() {
+    // After a long stall the armed slot ages out of SlotHashes. Drawing from whatever is left would
+    // let the caller pick the hash by choosing when to crank, so we re-arm.
+    let (mut svm, _admin, vals, miner) = setup(0, 0);
+    open_and_close(&mut svm, &vals, &miner);
+    let first = arm_draw(&mut svm, &vals[0], &miner.pubkey());
+
+    // >512 slots later: every retained slot is newer than the armed one.
+    set_slot(&mut svm, first + 601);
+    set_slot_hashes(&mut svm, &[first + 600, first + 601]);
+    send(&mut svm, resolve_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0]).expect("re-arm");
+
+    let second = pool(&svm, &miner.pubkey()).seed_slot;
+    assert_ne!(second, first, "must re-arm on a fresh slot");
+    assert_ne!(second, 0);
+    assert_eq!(reservation(&svm, &miner.pubkey()).reserved_until, 0, "no draw from a rolled-off window");
+    assert_ne!(pool(&svm, &miner.pubkey()).opened_at, 0, "bids survive the re-arm");
+}
+
+#[test]
+fn test_armed_slot_is_ahead_of_every_produced_slot() {
+    // The security property: at arm time the seed slot does not exist, so nobody — not the arming
+    // cranker, not a bidder — can know the hash the draw will consume.
+    let (mut svm, _admin, vals, miner) = setup(0, 0);
+    set_slot(&mut svm, 1_000);
+    set_slot_hashes(&mut svm, &[998, 999, 1_000]);
+    open_and_close(&mut svm, &vals, &miner);
+
+    let seed_slot = arm_draw(&mut svm, &vals[0], &miner.pubkey());
+    assert!(seed_slot > 1_000, "armed slot {seed_slot} must exceed the newest produced slot (1000)");
 }

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_swap.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_swap.rs
@@ -6,12 +6,14 @@ use {
         AccountDeserialize, InstructionData, ToAccountMetas,
     },
     allways_swap_manager::constants::{POOL_WINDOW_SECS, RESERVATION_FEE_LAMPORTS},
-    allways_swap_manager::state::{MinerDirectionStats, MinerState, Reservation, Swap, SwapStatus, Treasury},
+    allways_swap_manager::state::{MinerDirectionStats, MinerState, Pool, Reservation, Swap, SwapStatus, Treasury},
     litesvm::LiteSVM,
+    solana_hash::Hash,
     solana_keccak_hasher::hashv,
     solana_keypair::Keypair,
     solana_message::{Message, VersionedMessage},
     solana_signer::Signer,
+    solana_slot_hashes::SlotHashes,
     solana_transaction::versioned::VersionedTransaction,
 };
 
@@ -82,6 +84,20 @@ fn set_clock(svm: &mut LiteSVM, ts: i64) {
     clock.unix_timestamp = ts;
     svm.set_sysvar::<Clock>(&clock);
 }
+/// resolve_pool is two-phase: arm the draw on a future slot, produce it, then draw. See
+/// tests/test_reservation.rs for the entropy invariants this protects.
+fn arm_and_resolve(svm: &mut LiteSVM, val: &Keypair, miner: &Pubkey) {
+    send(svm, resolve_ix(&val.pubkey(), miner), &val.pubkey(), val).expect("arm draw");
+    let a = svm.get_account(&pool_pda(miner)).unwrap();
+    let seed_slot = Pool::try_deserialize(&mut a.data.as_slice()).unwrap().seed_slot;
+    let entries: Vec<(u64, Hash)> = [seed_slot - 1, seed_slot, seed_slot + 1]
+        .iter()
+        .map(|&s| (s, Hash::new_from_array([s as u8; 32])))
+        .collect();
+    svm.set_sysvar::<SlotHashes>(&SlotHashes::new(&entries));
+    send(svm, resolve_ix(&val.pubkey(), miner), &val.pubkey(), val).expect("resolve");
+}
+
 fn send(svm: &mut LiteSVM, ix: Instruction, payer: &Pubkey, signer: &Keypair) -> Result<(), String> {
     svm.expire_blockhash();
     let bh = svm.latest_blockhash();
@@ -425,7 +441,7 @@ fn setup_full(collateral: u64) -> (LiteSVM, Keypair, Vec<Keypair>, Keypair, u64)
     set_clock(&mut svm, setup_ts);
     send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER), &vals[0].pubkey(), &vals[0]).expect("open");
     set_clock(&mut svm, setup_ts + POOL_WINDOW_SECS + 1);
-    send(&mut svm, resolve_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0]).expect("resolve");
+    arm_and_resolve(&mut svm, &vals[0], &miner.pubkey());
     set_clock(&mut svm, BASE_TS);
 
     (svm, admin, vals, miner, rent_reserve)
@@ -445,7 +461,7 @@ fn do_reserve(svm: &mut LiteSVM, opener: &Keypair, miner: &Pubkey) {
     let user = Keypair::new().pubkey();
     send(svm, open_ix(&opener.pubkey(), miner, &user), &opener.pubkey(), opener).expect("open");
     set_clock(svm, now + POOL_WINDOW_SECS + 1);
-    send(svm, resolve_ix(&opener.pubkey(), miner), &opener.pubkey(), opener).expect("resolve");
+    arm_and_resolve(svm, opener, miner);
 }
 
 fn invariant_holds(svm: &LiteSVM, miner: &Pubkey, rent_reserve: u64) -> bool {

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_treasury.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_treasury.rs
@@ -7,12 +7,14 @@ use {
         AccountDeserialize, InstructionData, ToAccountMetas,
     },
     allways_swap_manager::constants::{POOL_WINDOW_SECS, RESERVATION_FEE_LAMPORTS},
-    allways_swap_manager::state::Treasury,
+    allways_swap_manager::state::{Pool, Treasury},
     litesvm::LiteSVM,
+    solana_hash::Hash,
     solana_keccak_hasher::hashv,
     solana_keypair::Keypair,
     solana_message::{Message, VersionedMessage},
     solana_signer::Signer,
+    solana_slot_hashes::SlotHashes,
     solana_transaction::versioned::VersionedTransaction,
 };
 
@@ -146,10 +148,16 @@ fn setup_with_fee() -> (LiteSVM, Keypair, u64) {
         allways_swap_manager::accounts::OpenOrRequest { router: vals[0].pubkey(), config: cfg(), miner: miner.pubkey(), miner_state: miner_pda(&miner.pubkey()), quote: quote_pda(&miner.pubkey(), "BTC", "SOL"), pool: pool_pda(&miner.pubkey()), treasury: treasury_pda(), reservation: resv_pda(&miner.pubkey()), system_program: SYS }.to_account_metas(None),
     ), &vals[0].pubkey(), &vals[0]).expect("open");
     set_clock(&mut svm, BASE_TS + POOL_WINDOW_SECS + 1);
-    send(&mut svm, Instruction::new_with_bytes(pid(),
+    // resolve_pool is two-phase: arm the draw on a future slot, produce it, then draw.
+    let ix = Instruction::new_with_bytes(pid(),
         &allways_swap_manager::instruction::ResolvePool {}.data(),
         allways_swap_manager::accounts::ResolvePool { caller: vals[0].pubkey(), config: cfg(), miner: miner.pubkey(), miner_state: miner_pda(&miner.pubkey()), pool: pool_pda(&miner.pubkey()), reservation: resv_pda(&miner.pubkey()), slot_hashes: SLOT_HASHES_ID, system_program: SYS }.to_account_metas(None),
-    ), &vals[0].pubkey(), &vals[0]).expect("resolve");
+    );
+    send(&mut svm, ix.clone(), &vals[0].pubkey(), &vals[0]).expect("arm draw");
+    let seed_slot = Pool::try_deserialize(&mut svm.get_account(&pool_pda(&miner.pubkey())).unwrap().data.as_slice()).unwrap().seed_slot;
+    let entries: Vec<(u64, Hash)> = [seed_slot - 1, seed_slot, seed_slot + 1].iter().map(|&s| (s, Hash::new_from_array([s as u8; 32]))).collect();
+    svm.set_sysvar::<SlotHashes>(&SlotHashes::new(&entries));
+    send(&mut svm, ix, &vals[0].pubkey(), &vals[0]).expect("resolve");
 
     let key = skey("tx1");
     // claim the source tx on-chain (PendingAttestation), then attest it to quorum


### PR DESCRIPTION
## Why

The reservation lottery seeded its draw from a slot pinned at pool-open as
`open_slot + pool_window_secs * 1000 / SLOT_MS`, with `SLOT_MS` **hardcoded to 400ms**. That places the
seed slot at exactly the moment the window shuts — zero margin — and real slot time is never exactly
400ms. Both directions were exploitable, **neither requiring collusion or capital**:

- **Slots faster than 400ms** (devnet measures 381ms; live `pool_window_secs=60`): the seed slot was
  produced **2.85s before bidding closed**. `seed_slot` was public (emitted in `PoolOpened`) and
  `pool_key` is a derivable PDA, so a late bidder could compute the seed, run `pick_weighted` itself,
  and enter *only when it would win*. A free option on a fair lottery.
- **Slots slower than 400ms** (routine on mainnet): the seed slot didn't exist at close, the descending
  scan broke, and resolve silently fell back to `keccak(pool_key || seed_slot.to_le_bytes())` — both
  inputs public at pool-open. The winner was predictable before anyone bid, and grindable by choosing
  the open slot.

A skipped seed slot hit the same fallback. The fallback was **silent** (no event), so a degraded draw
was indistinguishable from a real one after the fact.

The impact is bounded — a reservation grants only a *hold*; moving funds still needs `vote_initiate`
consensus + a real on-chain tx — so this is priority-access MEV and miner-squat griefing, not theft. It
never bit us in practice only because every pool in testing had a single bidder (a one-entrant lottery
returns index 0 for any seed).

## What changed

`resolve_pool` is now **two-phase**:

1. **Arm** — the first crank after `closes_at` pins `seed_slot = clock.slot + SEED_SLOT_DELAY_SLOTS`
   (4), a slot that doesn't exist yet. Bidding is already shut, so nobody can react to the entropy; the
   slot is unproduced, so nobody — including the arming caller — knows its hash.
2. **Resolve** — a later crank draws against that slot's hash.

- `SLOT_MS` is **deleted**. No slot-time assumption survives, so a future cadence change (Alpenglow)
  can't silently reintroduce the bug.
- The lookup takes the **lowest produced slot at-or-after** `seed_slot`, tolerating a skipped leader
  slot without guessing.
- If `seed_slot` ages out of `SlotHashes` (~512 slots, i.e. a long validator stall) the draw
  **re-arms** rather than drawing from a hash the caller could have waited for. Bids survive the re-arm.
- Validator: `SeedSlotNotYetProduced` joins the benign resolve markers — it's the expected result of
  cranking between arm and draw.

Cost: one extra crank round-trip (~12s/swap). Users lose no runway — `reserved_until` is still stamped
at draw time.

## Residual (documented, not closed)

The leader of the seed slot can bias its own block's hash. This requires an attacker to be **both** a
whitelisted subnet validator (lottery weight comes from `config.validators`; a plain user's router has
weight 0 and can never win) **and** colluding with a Solana block producer. Closing it entirely needs a
VRF; a separate design doc weighs ORAO/Switchboard against the cost and liveness trade-offs. This PR
converts an unbounded, free, no-collusion exploit into the fair weight share `p`.

## Tests

- **103 Rust tests green** across all suites (`cargo build-sbf` first — the tests `include_bytes!` the
  `.so`, so a stale binary will pass the old behavior; that's how these slipped through originally).
- New unit tests for the `SlotHashes` scan (exact / skipped / not-yet-produced / rolled-off / clamped
  count / stable-as-newer-slots-arrive).
- New on-chain tests: open doesn't pin the seed slot, arming creates no reservation, resolve-before-
  produced errors, skipped seed slot resolves from the next slot, rolled-off re-arms, armed slot is
  ahead of every produced slot.
- Tests now seed the real `SlotHashes` sysvar via `solana-slot-hashes` instead of leaning on a
  fallback — which also pins the contract's hand-rolled parse against Solana's own serializer.
- 673 Python tests green; ruff clean.