### PR TITLE
Persist per-round score snapshots and a live mid-round tip

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -71,11 +71,11 @@ DIRECTION_POOLS: dict[tuple[str, str], float] = {
 # Idle-crown penalty: 0 = none, 1 = pure volume share, 0.5 = half-credit floor.
 VOLUME_WEIGHT_ALPHA: float = 0.5
 # Volume floor: a direction whose in-window SOL-side notional clears less than this
-# (lamports — 1 SOL) is treated as having no volume for the round: the quality-volume
-# slice folds into crown and volume_factor stays neutral, the same fallback as a fully
+# (lamports — 1 SOL) is treated as having no volume for the round: the execution
+# slice folds into crown and fill_ratio stays neutral, the same fallback as a fully
 # idle direction. Keeps a couple of dust swaps from steering the weights.
 MIN_DIRECTION_VOLUME = 1_000_000_000
-# Reward-shape weights (B3.5): reward = eligible × [w_a·crown + w_b·quality_volume].
+# Reward-shape weights (B3.5): reward = eligible × [w_a·crown + w_b·execution].
 # w_a weights the crown-time component (best-rate presence × capacity), w_b the
 # realized-volume share × rate-quality (executed throughput at fair rates). Phase C
 # turns w_b on at a conservative 0.2 so crown stays the primary driver while real
@@ -83,7 +83,7 @@ MIN_DIRECTION_VOLUME = 1_000_000_000
 # envelope is unchanged. Too-thin on-chain clearing-rate history ⇒ rate_quality neutral
 # (1.0), so w_b still pays realized volume by raw share — it never zeroes everyone.
 REWARD_WEIGHT_CROWN: float = 0.8
-REWARD_WEIGHT_QUALITY_VOLUME: float = 0.2
+REWARD_WEIGHT_EXECUTION: float = 0.2
 # Flat eligibility gate (B3.3): read off the on-chain MinerState counters,
 # replacing the success_rate³ × credibility ramp. A miner is crown-eligible iff
 # it has at least MIN_SUCCESSFUL_SWAPS successes and at most MAX_FAILED_SWAPS
@@ -93,7 +93,7 @@ MAX_FAILED_SWAPS: int = 2
 
 # ─── Rate-quality curve (Phase C) ────────────────────────
 # One-sided clamp mapping realized-VWAP-vs-market advantage → a quality
-# multiplier on the quality-volume reward. At/above market (within a tolerance
+# multiplier on the execution reward. At/above market (within a tolerance
 # deadband) scores 1.0 — the crown already rewards best-rate presence, so
 # above-market is not paid again here. Worse-than-market ramps linearly to
 # RATE_QUALITY_MIN at RATE_QUALITY_FLOOR_ADV. Tunable without code changes.

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -15,6 +15,7 @@ from allways.validator.scoring import (
     due_for_scoring,
     score_and_reward_miners,
     snapshot_current_crown_holders,
+    snapshot_current_miner_scores,
 )
 
 if TYPE_CHECKING:
@@ -70,6 +71,13 @@ async def forward(self: Validator) -> None:
             self.database_storage.upsert_current_crown_snapshot(crown_snapshot)
         except Exception as e:
             bt.logging.warning(f'current_crown_holders snapshot failed: {e}')
+        # Live mid-round score tip — the factors each holder would be paid on
+        # if the in-progress round flushed now. Same storage gate/cadence as
+        # the crown snapshot; computed only when someone is reading (DB on).
+        try:
+            self.database_storage.replace_current_miner_scores(snapshot_current_miner_scores(self))
+        except Exception as e:
+            bt.logging.warning(f'current_miner_scores snapshot failed: {e}')
 
 
 def clear_provider_caches(self: Validator) -> None:

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -1,15 +1,15 @@
 """Crown-time scoring pipeline.
 
-Reward per miner is ``eligible × [w_a·crown + w_b·quality_volume]`` (B3.5),
+Reward per miner is ``eligible × [w_a·crown + w_b·execution]`` (B3.5),
 where ``eligible`` is a flat 0/1 gate read off the on-chain ``MinerState``
 counters (B3.3) — it replaces the old ``sr³ × credibility ramp``. The crown
-component is ``pool × crown_share × capacity × volume_factor``; the
-quality-volume component is the pool's realized-volume share, summed over the
+component is ``pool × crown_share × capacity × fill_ratio``; the
+execution component is the pool's realized-volume share, summed over the
 scored window from the ingested ``clearing_rates`` ledger (the ``SwapCompleted``
 history — volume is what cleared this round, not a lifetime account total) and
 gated by the ``rate_quality`` curve. A direction clearing less than
 ``MIN_DIRECTION_VOLUME`` on its SOL side in the window is treated as zero-volume
-(w_a folds to 1.0, ``volume_factor`` neutral) so dust can't steer the weights.
+(w_a folds to 1.0, ``fill_ratio`` neutral) so dust can't steer the weights.
 The curve compares a miner's realized rate against an on-chain reference (C-rev):
 a trimmed, volume-weighted, per-miner-capped average of completed-swap clearing
 rates per direction (``build_direction_references``), computed deterministically
@@ -50,7 +50,7 @@ from allways.constants import (
     RECYCLE_UID,
     REWARD_MINER_STATES,
     REWARD_WEIGHT_CROWN,
-    REWARD_WEIGHT_QUALITY_VOLUME,
+    REWARD_WEIGHT_EXECUTION,
     SCORING_WINDOW_BLOCKS,
     SCORING_WINDOW_SECS,
     SWAP_OUTCOME_RETENTION_SECS,
@@ -257,7 +257,7 @@ class ScoreRow:
     eligible: bool
     crown_share: float
     capacity: float
-    volume_factor: float
+    fill_ratio: float
     vol_share: float
     rate_quality: float
     reward: float
@@ -284,12 +284,12 @@ def build_direction_score_rows(
     caller's unweighted-baseline trace.
 
     W_B falls back to crown for a direction with no realized volume: the
-    quality-volume slice has nothing to distribute, so handing it to crown
+    execution slice has nothing to distribute, so handing it to crown
     keeps a quiet direction at full pool rather than recycling 20% (Phase C).
     """
     total_crown_dir = sum(crown_time.values())
     if total_volume_dir > 0:
-        w_a, w_b = REWARD_WEIGHT_CROWN, REWARD_WEIGHT_QUALITY_VOLUME
+        w_a, w_b = REWARD_WEIGHT_CROWN, REWARD_WEIGHT_EXECUTION
     else:
         w_a, w_b = 1.0, 0.0
     rows: List[ScoreRow] = []
@@ -307,17 +307,17 @@ def build_direction_score_rows(
         crown_share_dir = secs / total_crown_dir
         vol_dir = volumes_dir.get(hotkey, 0)
         vol_share_dir = (vol_dir / total_volume_dir) if total_volume_dir > 0 else 0.0
-        vol_factor = volume_factor(vol_dir, total_volume_dir, crown_share_dir)
-        # Reward = eligible × [w_a·crown + w_b·quality_volume] (Phase C). crown
-        # is the B3.3 reward (pool·share·cap·vol_factor); quality_volume is the
+        fill = fill_ratio(vol_dir, total_volume_dir, crown_share_dir)
+        # Reward = eligible × [w_a·crown + w_b·execution] (Phase C). crown
+        # is the B3.3 reward (pool·share·cap·fill_ratio); execution is the
         # pool's volume share × rate-quality (vs the on-chain reference). w_a/w_b
         # are the direction's effective weights (0.8/0.2, or 1.0/0.0 if idle).
-        crown_component = pool * crown_share_dir * cap * vol_factor
+        crown_component = pool * crown_share_dir * cap * fill
         # Quality compares the miner's OWN windowed realized rate against the
         # direction reference — same windowed clearing-rate basis (C-rev).
         realized_rate = reference.miner_rates.get(hotkey, 0.0) if reference is not None else 0.0
         quality = rate_quality(from_chain, to_chain, realized_rate, reference_rate)
-        quality_volume_component = pool * vol_share_dir * quality
+        execution_component = pool * vol_share_dir * quality
         rows.append(
             ScoreRow(
                 hotkey=hotkey,
@@ -326,10 +326,10 @@ def build_direction_score_rows(
                 eligible=eligible,
                 crown_share=crown_share_dir,
                 capacity=cap,
-                volume_factor=vol_factor,
+                fill_ratio=fill,
                 vol_share=vol_share_dir,
                 rate_quality=quality,
-                reward=(1.0 if eligible else 0.0) * (w_a * crown_component + w_b * quality_volume_component),
+                reward=(1.0 if eligible else 0.0) * (w_a * crown_component + w_b * execution_component),
             )
         )
     return rows, w_a
@@ -498,7 +498,7 @@ def rate_quality(
 
 def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndarray, Set[int]]:
     """Replay the crown-time event stream, derive per-miner rewards
-    (eligible × [w_a·crown + w_b·quality_volume]), recycle the rest.
+    (eligible × [w_a·crown + w_b·execution]), recycle the rest.
     ``current_time`` is the unix-seconds window_end (the crown axis).
 
     Volume weighting is *per direction*: a miner earning crown on btc→tao is
@@ -625,11 +625,11 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
             unweighted_rewards[uid] += eligible * w_a * pool * row.crown_share * row.capacity
             rewards[uid] += row.reward
             score_rows.append(row)
-            if row.volume_factor < 1.0:
+            if row.fill_ratio < 1.0:
                 bt.logging.debug(
                     f'V1 scoring [{from_chain}→{to_chain}] {row.hotkey[:8]}: '
                     f'crown_share={row.crown_share:.3f} vol_share={row.vol_share:.3f} '
-                    f'vol_factor={row.volume_factor:.3f}'
+                    f'fill_ratio={row.fill_ratio:.3f}'
                 )
 
     record_volume_traces(
@@ -698,7 +698,7 @@ def miner_score_tuples(score_rows: List[ScoreRow], ts: int) -> List[Tuple]:
             r.eligible,
             r.crown_share,
             r.capacity,
-            r.volume_factor,
+            r.fill_ratio,
             r.vol_share,
             r.rate_quality,
             r.reward,
@@ -774,7 +774,7 @@ def capacity_factor(collateral_rao: int, max_swap_amount_rao: int) -> float:
     return min(1.0, collateral_rao / max_swap_amount_rao)
 
 
-def volume_factor(
+def fill_ratio(
     vol_rao: int,
     total_volume_rao: int,
     crown_share: float,

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -223,6 +223,118 @@ def direction_sol_volume(from_chain: str, leg_sums: Dict[str, Tuple[int, int]]) 
     return sum(legs[side] for legs in leg_sums.values())
 
 
+def windowed_direction_volumes(
+    clearing_volumes: Dict[Tuple[str, str], Dict[str, Tuple[int, int]]],
+    from_chain: str,
+    to_chain: str,
+    rewardable_hotkeys: Set[str],
+) -> Tuple[Dict[str, int], int]:
+    """One direction's scored volume: metagraph-filter the windowed leg sums,
+    apply the SOL-side floor (below ``MIN_DIRECTION_VOLUME`` ⇒ scored as
+    zero-volume, so dust can't steer the round), and return
+    ``({hotkey: from_leg}, total)`` — within a direction, vol_share stays in
+    from-asset units."""
+    leg_sums = {
+        hk: legs for hk, legs in clearing_volumes.get((from_chain, to_chain), {}).items() if hk in rewardable_hotkeys
+    }
+    if direction_sol_volume(from_chain, leg_sums) < MIN_DIRECTION_VOLUME:
+        leg_sums = {}
+    volumes_dir = {hk: legs[0] for hk, legs in leg_sums.items()}
+    return volumes_dir, sum(volumes_dir.values())
+
+
+@dataclass
+class ScoreRow:
+    """One (hotkey, direction) scoring snapshot: the factors the reward math
+    actually used, in the shape the ``miner_scores`` / ``current_miner_scores``
+    tables persist. ``reward`` is the direction's final emission share (post
+    eligibility gate); the other fields are its inputs, so the dashboard can
+    write the multiplication out."""
+
+    hotkey: str
+    from_chain: str
+    to_chain: str
+    eligible: bool
+    crown_share: float
+    capacity: float
+    volume_factor: float
+    vol_share: float
+    rate_quality: float
+    reward: float
+
+
+def build_direction_score_rows(
+    from_chain: str,
+    to_chain: str,
+    pool: float,
+    crown_time: Dict[str, float],
+    cap_weighted_time: Dict[str, float],
+    volumes_dir: Dict[str, int],
+    total_volume_dir: int,
+    eligibility: Dict[str, bool],
+    reference: Optional[DirectionReference],
+) -> Tuple[List[ScoreRow], float]:
+    """Per-holder factors + reward for one direction — the single place the
+    reward multiplication lives, shared by the round scorer
+    (``calculate_miner_rewards``) and the live tip
+    (``snapshot_current_miner_scores``) so the two can never disagree.
+
+    Returns ``(rows, w_a)`` — one row per crown holder (only crown holders
+    earn either slice), plus the direction's effective crown weight for the
+    caller's unweighted-baseline trace.
+
+    W_B falls back to crown for a direction with no realized volume: the
+    quality-volume slice has nothing to distribute, so handing it to crown
+    keeps a quiet direction at full pool rather than recycling 20% (Phase C).
+    """
+    total_crown_dir = sum(crown_time.values())
+    if total_volume_dir > 0:
+        w_a, w_b = REWARD_WEIGHT_CROWN, REWARD_WEIGHT_QUALITY_VOLUME
+    else:
+        w_a, w_b = 1.0, 0.0
+    rows: List[ScoreRow] = []
+    if total_crown_dir <= 0:
+        return rows, w_a
+    reference_rate = reference.reference if reference is not None else None
+    for hotkey, secs in crown_time.items():
+        # Capacity is integrated over time during the replay, so the effective
+        # multiplier is the time-weighted average over the miner's crown
+        # intervals. Reading current collateral here would let a post-window
+        # top-up retroactively boost credit already earned (#409).
+        cap_secs = cap_weighted_time.get(hotkey, 0.0)
+        cap = (cap_secs / secs) if secs > 0 else 0.0
+        eligible = eligibility.get(hotkey, False)
+        crown_share_dir = secs / total_crown_dir
+        vol_dir = volumes_dir.get(hotkey, 0)
+        vol_share_dir = (vol_dir / total_volume_dir) if total_volume_dir > 0 else 0.0
+        vol_factor = volume_factor(vol_dir, total_volume_dir, crown_share_dir)
+        # Reward = eligible × [w_a·crown + w_b·quality_volume] (Phase C). crown
+        # is the B3.3 reward (pool·share·cap·vol_factor); quality_volume is the
+        # pool's volume share × rate-quality (vs the on-chain reference). w_a/w_b
+        # are the direction's effective weights (0.8/0.2, or 1.0/0.0 if idle).
+        crown_component = pool * crown_share_dir * cap * vol_factor
+        # Quality compares the miner's OWN windowed realized rate against the
+        # direction reference — same windowed clearing-rate basis (C-rev).
+        realized_rate = reference.miner_rates.get(hotkey, 0.0) if reference is not None else 0.0
+        quality = rate_quality(from_chain, to_chain, realized_rate, reference_rate)
+        quality_volume_component = pool * vol_share_dir * quality
+        rows.append(
+            ScoreRow(
+                hotkey=hotkey,
+                from_chain=from_chain,
+                to_chain=to_chain,
+                eligible=eligible,
+                crown_share=crown_share_dir,
+                capacity=cap,
+                volume_factor=vol_factor,
+                vol_share=vol_share_dir,
+                rate_quality=quality,
+                reward=(1.0 if eligible else 0.0) * (w_a * crown_component + w_b * quality_volume_component),
+            )
+        )
+    return rows, w_a
+
+
 def _canonical_rate_and_weight(from_chain: str, to_chain: str, from_amount: int, to_amount: int) -> Tuple[float, int]:
     """Canonical 'dest per source' rate (TAO per BTC for the btc/tao pair) plus
     the swap's volume weight = the **canonical-source** native leg. Weighting a
@@ -427,6 +539,9 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
 
     direction_traces: Dict[Tuple[str, str], DirectionTrace] = {}
     weighting_traces: Dict[str, WeightingTrace] = {}
+    # Per-(hotkey, direction) factor snapshots — the rows miner_scores persists.
+    # Only on-metagraph holders land here (a dereg'd miner is paid nothing).
+    score_rows: List[ScoreRow] = []
     # Captured only when dashboard storage is enabled — the tee inside
     # replay_crown_time_window is a no-op when intervals_out is None, so
     # disabled validators pay zero cost here.
@@ -468,34 +583,15 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
             max_swap_lamports=max_swap_amount,
         )
         total_crown_dir = sum(crown_time.values())
-        leg_sums = {
-            hk: legs
-            for hk, legs in clearing_volumes.get((from_chain, to_chain), {}).items()
-            if hk in rewardable_hotkeys
-        }
-        # Volume floor: a direction clearing less than MIN_DIRECTION_VOLUME on
-        # its SOL side this window is too thin to signal anything — treat it as
-        # zero-volume so the fallback below folds w_a to 1.0 and volume_factor
-        # stays neutral, and a couple of dust swaps can't steer the round.
-        if direction_sol_volume(from_chain, leg_sums) < MIN_DIRECTION_VOLUME:
-            leg_sums = {}
-        # Within a direction, vol_share stays in from-asset units.
-        volumes_dir = {hk: legs[0] for hk, legs in leg_sums.items()}
-        total_volume_dir = sum(volumes_dir.values())
+        volumes_dir, total_volume_dir = windowed_direction_volumes(
+            clearing_volumes, from_chain, to_chain, rewardable_hotkeys
+        )
         for hk, v in volumes_dir.items():
             miner_volume_total[hk] = miner_volume_total.get(hk, 0) + int(v)
         network_volume_total += int(total_volume_dir)
         for hk, secs in crown_time.items():
             miner_crown_total[hk] = miner_crown_total.get(hk, 0.0) + secs
         network_crown_total += total_crown_dir
-
-        # W_B falls back to crown for a direction with no realized volume: the
-        # quality-volume slice has nothing to distribute, so handing it to crown
-        # keeps a quiet direction at full pool rather than recycling 20% (Phase C).
-        if total_volume_dir > 0:
-            w_a, w_b = REWARD_WEIGHT_CROWN, REWARD_WEIGHT_QUALITY_VOLUME
-        else:
-            w_a, w_b = 1.0, 0.0
 
         bt.logging.debug(
             f'V1 scoring [{from_chain}→{to_chain}]: '
@@ -505,48 +601,35 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
         if total_crown_dir == 0:
             continue  # empty bucket — pool recycles via the remainder below
 
-        for hotkey, secs in crown_time.items():
-            uid = hotkey_to_uid.get(hotkey)
+        rows, w_a = build_direction_score_rows(
+            from_chain,
+            to_chain,
+            pool,
+            crown_time=crown_time,
+            cap_weighted_time=trace.cap_weighted_time,
+            volumes_dir=volumes_dir,
+            total_volume_dir=total_volume_dir,
+            eligibility=eligibility,
+            reference=references.get((from_chain, to_chain)),
+        )
+        for row in rows:
+            uid = hotkey_to_uid.get(row.hotkey)
             if uid is None:
                 continue  # dereg'd mid-window; credit forfeited
-            # Capacity is integrated over time during the replay, so the
-            # effective multiplier is the time-weighted average over the
-            # miner's crown intervals. Reading current collateral here
-            # would let a post-window top-up retroactively boost credit
-            # already earned (#409).
-            cap_secs = trace.cap_weighted_time.get(hotkey, 0.0)
-            cap = (cap_secs / secs) if secs > 0 else 0.0
-            eligible = 1.0 if eligibility.get(hotkey, False) else 0.0
-            wt = weighting_traces.setdefault(hotkey, WeightingTrace())
-            wt.record_capacity(factor=cap)
-            wt.record_eligibility(eligible=bool(eligible))
-            crown_share_dir = secs / total_crown_dir
-            vol_dir = volumes_dir.get(hotkey, 0)
-            vol_share_dir = (vol_dir / total_volume_dir) if total_volume_dir > 0 else 0.0
-            vol_factor = volume_factor(vol_dir, total_volume_dir, crown_share_dir)
-            # Reward = eligible × [w_a·crown + w_b·quality_volume] (Phase C). crown
-            # is the B3.3 reward (pool·share·cap·vol_factor); quality_volume is the
-            # pool's volume share × rate-quality (vs the live market). w_a/w_b are
-            # the direction's effective weights (0.8/0.2, or 1.0/0.0 if idle).
-            crown_component = pool * crown_share_dir * cap * vol_factor
-            # Quality compares the miner's OWN windowed realized rate against the
-            # direction reference — same windowed clearing-rate basis (C-rev).
-            ref = references.get((from_chain, to_chain))
-            reference_rate = ref.reference if ref is not None else None
-            realized_rate = ref.miner_rates.get(hotkey, 0.0) if ref is not None else 0.0
-            quality_volume_component = (
-                pool * vol_share_dir * rate_quality(from_chain, to_chain, realized_rate, reference_rate)
-            )
-            base = eligible * (w_a * crown_component + w_b * quality_volume_component)
+            eligible = 1.0 if row.eligible else 0.0
+            wt = weighting_traces.setdefault(row.hotkey, WeightingTrace())
+            wt.record_capacity(factor=row.capacity)
+            wt.record_eligibility(eligible=row.eligible)
             # Trace baseline is the pre-volume crown reward (dashboard attributes
             # the volume penalty off the gap to the final weighted reward).
-            unweighted_rewards[uid] += eligible * w_a * pool * crown_share_dir * cap
-            rewards[uid] += base
-            if vol_factor < 1.0:
+            unweighted_rewards[uid] += eligible * w_a * pool * row.crown_share * row.capacity
+            rewards[uid] += row.reward
+            score_rows.append(row)
+            if row.volume_factor < 1.0:
                 bt.logging.debug(
-                    f'V1 scoring [{from_chain}→{to_chain}] {hotkey[:8]}: '
-                    f'crown_share={crown_share_dir:.3f} vol_share={vol_share_dir:.3f} '
-                    f'vol_factor={vol_factor:.3f}'
+                    f'V1 scoring [{from_chain}→{to_chain}] {row.hotkey[:8]}: '
+                    f'crown_share={row.crown_share:.3f} vol_share={row.vol_share:.3f} '
+                    f'vol_factor={row.volume_factor:.3f}'
                 )
 
     record_volume_traces(
@@ -583,24 +666,103 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
         # Persist the crown intervals directly (no per-tick expansion).
         # `flush_scoring_window` deletes [window_start, window_end) per
         # direction before upserting, so the wipe matches the data exactly.
+        # rate_history is NOT written here: the indexer owns it (real-time,
+        # per QuoteSet event) — the validator only persists what it paid.
         crown_rows_by_dir = {d: intervals_to_crown_rows(ivs, d[0], d[1]) for d, ivs in intervals_by_dir.items()}
-        rate_rows: List[Tuple[str, str, str, float, int]] = []
-        for from_chain, to_chain in DIRECTION_POOLS:
-            for e in self.state_store.get_rate_events_in_range(from_chain, to_chain, window_start, window_end):
-                # e['block'] is the event's unix blockTime (see state_store).
-                rate_rows.append((e['hotkey'], from_chain, to_chain, float(e['rate']), e['block']))
         # Crown intervals tile [window_start, window_end); the last one ends at
         # window_end, so the freshness cursor is "as of window_end" (unix secs).
+        # window_end also keys the round in miner_scores — one snapshot row per
+        # (round, hotkey, direction), written in the same transaction as the
+        # crown ledger so the two can never disagree about a round.
         cursor_ts = max(0, window_end)
         self.database_storage.flush_scoring_window(
-            rate_rows=rate_rows,
             crown_rows_by_direction=crown_rows_by_dir,
             crown_window_bounds_by_direction={d: (window_start, window_end) for d in DIRECTION_POOLS},
-            rate_snapshot_max_ts=cursor_ts,
+            miner_score_rows=miner_score_tuples(score_rows, cursor_ts),
             crown_holders_max_ts=cursor_ts,
         )
 
     return rewards, set(range(n_uids))
+
+
+def miner_score_tuples(score_rows: List[ScoreRow], ts: int) -> List[Tuple]:
+    """Shape ``ScoreRow``s for the storage layer (which takes ready-made row
+    tuples): ``ts`` leads as ``round_ts`` (round flush) or snapshot ``ts``
+    (live tip) — the two tables share the rest of the shape."""
+    return [
+        (
+            ts,
+            r.hotkey,
+            r.from_chain,
+            r.to_chain,
+            r.eligible,
+            r.crown_share,
+            r.capacity,
+            r.volume_factor,
+            r.vol_share,
+            r.rate_quality,
+            r.reward,
+        )
+        for r in score_rows
+    ]
+
+
+def snapshot_current_miner_scores(self: Validator, at_time: Optional[int] = None) -> List[Tuple]:
+    """Mid-round live tip: the factors each crown holder would be paid on if
+    the in-progress round [last_scored_time, now] flushed right now — the same
+    replay + ``build_direction_score_rows`` math ``calculate_miner_rewards``
+    runs, minus weights/traces/recycle. Returns ``current_miner_scores``-shaped
+    tuples for the per-forward-step wipe+insert (``miner_scores``' live
+    counterpart, same pattern as ``current_crown_holders``).
+
+    Cost: one MinerState read for eligibility plus SQLite replays over the
+    partial window — bounded by the round width. Only called when dashboard
+    storage is enabled."""
+    ts = int(time.time()) if at_time is None else at_time
+    window_start, window_end = scoring_window_bounds(ts, self.last_scored_time)
+    rewardable_hotkeys: Set[str] = set(self.metagraph.hotkeys)
+    eligibility = build_eligibility(self.solana_client, self.metagraph)
+    clearing_volumes = self.state_store.get_clearing_volumes(window_start, window_end)
+    references = build_direction_references(self.state_store, window_end)
+    try:
+        min_swap_amount = int(self.solana_config_cache.min_swap_amount())
+        max_swap_amount = int(self.solana_config_cache.max_swap_amount())
+    except Exception as e:
+        bt.logging.warning(f'swap-bounds read failed in live score snapshot: {e}')
+        min_swap_amount = max_swap_amount = 0
+    rows: List[ScoreRow] = []
+    for (from_chain, to_chain), pool in DIRECTION_POOLS.items():
+        trace = DirectionTrace(pool=pool)
+        crown_time = replay_crown_time_window(
+            store=self.state_store,
+            event_index=self.event_index,
+            from_chain=from_chain,
+            to_chain=to_chain,
+            window_start=window_start,
+            window_end=window_end,
+            rewardable_hotkeys=rewardable_hotkeys,
+            trace=trace,
+            min_swap_lamports=min_swap_amount,
+            max_swap_lamports=max_swap_amount,
+        )
+        if not crown_time:
+            continue
+        volumes_dir, total_volume_dir = windowed_direction_volumes(
+            clearing_volumes, from_chain, to_chain, rewardable_hotkeys
+        )
+        dir_rows, _ = build_direction_score_rows(
+            from_chain,
+            to_chain,
+            pool,
+            crown_time=crown_time,
+            cap_weighted_time=trace.cap_weighted_time,
+            volumes_dir=volumes_dir,
+            total_volume_dir=total_volume_dir,
+            eligibility=eligibility,
+            reference=references.get((from_chain, to_chain)),
+        )
+        rows.extend(dir_rows)
+    return miner_score_tuples(rows, ts)
 
 
 def capacity_factor(collateral_rao: int, max_swap_amount_rao: int) -> float:

--- a/allways/validator/scoring_trace.py
+++ b/allways/validator/scoring_trace.py
@@ -40,7 +40,7 @@ class WeightingTrace:
     crown_share: float = 0.0
     volume_share: float = 0.0
     participation: float = 1.0
-    volume_factor: float = 1.0
+    fill_ratio: float = 1.0
     eligible: bool = False
 
     def record_capacity(self, factor: float) -> None:
@@ -51,7 +51,7 @@ class WeightingTrace:
         self.crown_share = crown_share
         self.volume_share = (vol_rao / total_volume_rao) if total_volume_rao > 0 else 0.0
         self.participation = min(1.0, self.volume_share / crown_share) if crown_share > 0 else 1.0
-        self.volume_factor = factor
+        self.fill_ratio = factor
 
     def record_eligibility(self, eligible: bool) -> None:
         self.eligible = eligible
@@ -101,7 +101,7 @@ def log_scoring_trace(
             extras = (
                 f' cap={wt.capacity_factor:.2f}'
                 f' vol={wt.volume_rao / TAO_TO_RAO:g}t vol_share={wt.volume_share:.2f}'
-                f' crown_share={wt.crown_share:.2f} vol_f={wt.volume_factor:.2f}'
+                f' crown_share={wt.crown_share:.2f} fill={wt.fill_ratio:.2f}'
             )
         lines.append(
             f'  uid={uid} hotkey={hk[:8]}.. crown_s={crown_secs:.0f} eligible={eligible}{extras} reward={crown_reward:.3f}'

--- a/allways/validator/storage/__init__.py
+++ b/allways/validator/storage/__init__.py
@@ -1,12 +1,13 @@
 """Validator-side Postgres storage for dashboard data.
 
-Writes the same `crown_holders` / `rate_history` / `sync_cursor` rows that
-alw-utils/sync-validator-state writes today — but from inside the validator
-during the scoring run, so there is no Python re-implementation of the
-scoring walker to drift from the validator's truth.
+Writes the `crown_holders` / `miner_scores` ledgers, their live tips
+(`current_crown_holders` / `current_miner_scores`), and the `sync_cursor`
+watermark from inside the validator during the scoring run — so there is no
+Python re-implementation of the scoring walker to drift from the validator's
+truth. `rate_history` belongs to the indexer (real-time, per QuoteSet event).
 
 Called from the validator's scoring run (`calculate_miner_rewards`) and the
-per-forward live-crown snapshot; gated by `STORE_DB_RESULTS`.
+per-forward live snapshots; gated by `STORE_DB_RESULTS`.
 """
 
 from .database import create_database_connection

--- a/allways/validator/storage/queries.py
+++ b/allways/validator/storage/queries.py
@@ -4,16 +4,6 @@
 # produces: rate quotes and crown intervals timestamped in unix seconds
 # (blockTime axis), not block numbers.
 
-# rate_history: per-miner on-chain rate quotes, append-only by (hotkey,
-# direction, ts). Last-write-wins on the rate column if the same timestamp is
-# re-emitted.
-BULK_UPSERT_RATE_HISTORY = """
-INSERT INTO rate_history (hotkey, from_chain, to_chain, rate, ts)
-VALUES (%s, %s, %s, %s, %s)
-ON CONFLICT (hotkey, from_chain, to_chain, ts)
-DO UPDATE SET rate = EXCLUDED.rate
-"""
-
 # crown_holders window wipe: crown derivation operates on a moving time
 # window, so an old window's intervals are deleted before the recomputed ones
 # are upserted. Bounded by the caller (the scoring window, in unix seconds).
@@ -58,4 +48,34 @@ DO UPDATE SET credit = EXCLUDED.credit,
               rate   = EXCLUDED.rate,
               ts     = EXCLUDED.ts,
               updated_at = NOW()
+"""
+
+# miner_scores: per-round factor snapshots — what the validator actually paid,
+# one row per (round, hotkey, direction), flushed in the same transaction as
+# the crown ledger. Idempotent on retry of the same round.
+BULK_UPSERT_MINER_SCORES = """
+INSERT INTO miner_scores (round_ts, hotkey, from_chain, to_chain, eligible,
+                          crown_share, capacity, fill_ratio, vol_share, rate_quality, reward)
+VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+ON CONFLICT (round_ts, hotkey, from_chain, to_chain)
+DO UPDATE SET eligible     = EXCLUDED.eligible,
+              crown_share  = EXCLUDED.crown_share,
+              capacity     = EXCLUDED.capacity,
+              fill_ratio   = EXCLUDED.fill_ratio,
+              vol_share    = EXCLUDED.vol_share,
+              rate_quality = EXCLUDED.rate_quality,
+              reward       = EXCLUDED.reward
+"""
+
+# current_miner_scores: the live mid-round tip of miner_scores, wiped and
+# rewritten every forward step. The table only ever holds the in-progress round,
+# so the wipe is unconditional (no per-direction bookkeeping needed).
+DELETE_CURRENT_MINER_SCORES = """
+DELETE FROM current_miner_scores
+"""
+
+BULK_INSERT_CURRENT_MINER_SCORES = """
+INSERT INTO current_miner_scores (ts, hotkey, from_chain, to_chain, eligible,
+                                  crown_share, capacity, fill_ratio, vol_share, rate_quality, reward, updated_at)
+VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())
 """

--- a/allways/validator/storage/repository.py
+++ b/allways/validator/storage/repository.py
@@ -10,11 +10,13 @@ from contextlib import contextmanager
 from typing import Dict, List, Tuple
 
 from .queries import (
+    BULK_INSERT_CURRENT_MINER_SCORES,
     BULK_UPSERT_CROWN_HOLDERS,
     BULK_UPSERT_CURRENT_CROWN_HOLDERS,
-    BULK_UPSERT_RATE_HISTORY,
+    BULK_UPSERT_MINER_SCORES,
     DELETE_CROWN_IN_RANGE,
     DELETE_CURRENT_CROWN_BY_DIRECTION,
+    DELETE_CURRENT_MINER_SCORES,
     SET_SYNC_CURSOR,
 )
 
@@ -48,26 +50,6 @@ class BaseRepository:
 
 class Repository(BaseRepository):
     """Bulk write methods for the validator's dashboard-write path."""
-
-    def store_rate_history_bulk(
-        self,
-        rows: List[Tuple[str, str, str, float, int]],
-        commit: bool = True,
-    ) -> int:
-        """Upsert rate quotes. Rows: (hotkey, from_chain, to_chain, rate, ts)."""
-        if not rows:
-            return 0
-        try:
-            with self.get_cursor() as cursor:
-                cursor.executemany(BULK_UPSERT_RATE_HISTORY, rows)
-                if commit:
-                    self.db.commit()
-                return len(rows)
-        except Exception as e:
-            if commit:
-                self.db.rollback()
-            self.logger.error(f'Error in bulk rate_history storage: {e}')
-            return 0
 
     def delete_crown_in_range(
         self,
@@ -111,6 +93,52 @@ class Repository(BaseRepository):
         data the cursor describes so partial writes don't desync the
         dashboard's freshness signal."""
         return self.execute_command(SET_SYNC_CURSOR, (name, value), commit=commit)
+
+    def store_miner_scores_bulk(
+        self,
+        rows: List[Tuple],
+        commit: bool = True,
+    ) -> int:
+        """Upsert per-round score snapshots. Rows: (round_ts, hotkey, from_chain,
+        to_chain, eligible, crown_share, capacity, fill_ratio, vol_share,
+        rate_quality, reward)."""
+        if not rows:
+            return 0
+        try:
+            with self.get_cursor() as cursor:
+                cursor.executemany(BULK_UPSERT_MINER_SCORES, rows)
+                if commit:
+                    self.db.commit()
+                return len(rows)
+        except Exception as e:
+            if commit:
+                self.db.rollback()
+            self.logger.error(f'Error in bulk miner_scores storage: {e}')
+            return 0
+
+    def replace_current_miner_scores(
+        self,
+        rows: List[Tuple],
+        commit: bool = True,
+    ) -> int:
+        """Wipe + rewrite the live score tip. Rows: (ts, hotkey, from_chain,
+        to_chain, eligible, crown_share, capacity, fill_ratio, vol_share,
+        rate_quality, reward). The table only holds the in-progress round, so
+        the delete is unconditional; one transaction so readers never see a
+        partial tip. An empty row list clears it (halt, or no crown holder)."""
+        try:
+            with self.get_cursor() as cursor:
+                cursor.execute(DELETE_CURRENT_MINER_SCORES)
+                if rows:
+                    cursor.executemany(BULK_INSERT_CURRENT_MINER_SCORES, rows)
+                if commit:
+                    self.db.commit()
+            return len(rows)
+        except Exception as e:
+            if commit:
+                self.db.rollback()
+            self.logger.error(f'Error in current_miner_scores replace: {e}')
+            return 0
 
     def replace_current_crown(
         self,

--- a/allways/validator/storage/storage.py
+++ b/allways/validator/storage/storage.py
@@ -120,21 +120,24 @@ class DatabaseStorage:
 
     def flush_scoring_window(
         self,
-        rate_rows: List[Tuple[str, str, str, float, int]],
         crown_rows_by_direction: Dict[Tuple[str, str], List[Tuple[int, int, str, str, str, float, float]]],
         crown_window_bounds_by_direction: Dict[Tuple[str, str], Tuple[int, int]],
-        rate_snapshot_max_ts: int,
+        miner_score_rows: List[Tuple],
         crown_holders_max_ts: int,
     ) -> StorageResult:
         """All-or-nothing flush for one scoring window.
 
-        - `rate_rows`: new rate quotes seen this round.
         - `crown_rows_by_direction`: recomputed crown rows, keyed by (from, to).
         - `crown_window_bounds_by_direction`: [lo, hi) unix-second range to wipe
           before re-upserting, keyed by (from, to). Must match the rows above.
-        - The two `_max_ts` values advance the corresponding sync_cursor
-          watermarks so the dashboard can render an "as-of <unix ts>" freshness
-          signal.
+        - `miner_score_rows`: per-(hotkey, direction) factor snapshots for the
+          round — written in the same transaction as the crown ledger so the
+          two can never disagree about a round.
+        - `crown_holders_max_ts` advances the sync_cursor watermark so the
+          dashboard can render an "as-of <unix ts>" freshness signal.
+
+        rate_history is not written here — the indexer owns it (real-time,
+        per QuoteSet event), including its freshness cursor.
 
         Failure on any write rolls back the whole window — the cursor is
         never left ahead of (or behind) the rows it describes.
@@ -149,8 +152,6 @@ class DatabaseStorage:
             self.db_connection.autocommit = False
 
             with self.db_connection.pipeline():
-                result.stored_counts['rate_history'] = self.repo.store_rate_history_bulk(rate_rows, commit=False)
-
                 crown_inserted = 0
                 for direction, rows in crown_rows_by_direction.items():
                     from_chain, to_chain = direction
@@ -159,7 +160,8 @@ class DatabaseStorage:
                     crown_inserted += self.repo.store_crown_holders_bulk(rows, commit=False)
                 result.stored_counts['crown_holders'] = crown_inserted
 
-                self.repo.set_sync_cursor('rate_snapshot_max_ts', rate_snapshot_max_ts, commit=False)
+                result.stored_counts['miner_scores'] = self.repo.store_miner_scores_bulk(miner_score_rows, commit=False)
+
                 self.repo.set_sync_cursor('crown_holders_max_ts', crown_holders_max_ts, commit=False)
 
             self.db_connection.commit()
@@ -183,14 +185,14 @@ class DatabaseStorage:
         During a halt, no miner earns crown and the pool recycles
         (see ``build_halted_rewards``). Mirror that on the dashboard by
         deleting any pre-existing crown_holders rows in the halted
-        window and advancing the cursor — leaves no stale "current
-        holder" implication on the historical grid. Rate events that
-        fired during halt are *not* written: the daemon never wrote
-        them either, and rate_history during a recycle has no scoring
-        meaning.
+        window, clearing the live score tip (nothing is being paid),
+        and advancing the cursor — leaves no stale "current holder"
+        implication on the historical grid. No miner_scores rows are
+        written for a halted round: the ledger records what was paid,
+        and nothing was.
 
         ``[window_start, window_end)`` is the unix-second range to clear per
-        direction. ``max_ts`` advances both sync_cursor watermarks.
+        direction. ``max_ts`` advances the crown sync_cursor watermark.
         """
         if not self._ensure_connection():
             return StorageResult(success=False, errors=['Validator DB storage not enabled'])
@@ -203,7 +205,7 @@ class DatabaseStorage:
             with self.db_connection.pipeline():
                 for from_chain, to_chain in directions:
                     self.repo.delete_crown_in_range(from_chain, to_chain, window_start, window_end, commit=False)
-                self.repo.set_sync_cursor('rate_snapshot_max_ts', max_ts, commit=False)
+                self.repo.replace_current_miner_scores([], commit=False)
                 self.repo.set_sync_cursor('crown_holders_max_ts', max_ts, commit=False)
 
             self.db_connection.commit()
@@ -244,6 +246,29 @@ class DatabaseStorage:
         except Exception as ex:
             result.success = False
             result.errors.append(self._handle_write_failure(ex, 'Failed to upsert current_crown_holders'))
+
+        return result
+
+    def replace_current_miner_scores(self, rows: List[Tuple]) -> StorageResult:
+        """Wipe + rewrite current_miner_scores — the live mid-round tip of
+        miner_scores. Called per forward step alongside the current-crown
+        snapshot; ``miner_scores`` gets the same factors at round end. Rows
+        are ``miner_score_tuples`` shaped, ts first. An empty list clears
+        the tip (no qualifying holder right now)."""
+        if not self._ensure_connection():
+            return StorageResult(success=False, errors=['Validator DB storage not enabled'])
+
+        result = StorageResult(success=True)
+        try:
+            assert self.db_connection is not None and self.repo is not None
+            self.db_connection.autocommit = False
+            count = self.repo.replace_current_miner_scores(rows, commit=False)
+            self.db_connection.commit()
+            self.db_connection.autocommit = True
+            result.stored_counts['current_miner_scores'] = count
+        except Exception as ex:
+            result.success = False
+            result.errors.append(self._handle_write_failure(ex, 'Failed to replace current_miner_scores'))
 
         return result
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -90,7 +90,7 @@ class Validator(BaseValidatorNeuron):
             db_path=state_db_path,
             current_block_fn=lambda: self.block,
         )
-        # Mirrors crown_holders / rate_history into Postgres for the miner
+        # Mirrors crown_holders / miner_scores into Postgres for the miner
         # dashboard. Disabled by default; opt in per host with
         # STORE_DB_RESULTS=true and DB_* env vars. When disabled the scoring
         # path's storage tee is a no-op — zero overhead for validators that

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -31,6 +31,7 @@ from allways.validator.scoring import (
     score_and_reward_miners,
     scoring_window_bounds,
     snapshot_current_crown_holders,
+    snapshot_current_miner_scores,
 )
 from allways.validator.state_store import ValidatorStateStore
 
@@ -2720,3 +2721,84 @@ class TestCrownPredicateParity:
         assert min_leg > 0  # rate is executable, so the gate is live
         assert can_fund('hk_poor', rate) is False
         assert can_fund('hk_rich', rate) is True
+
+
+class TestScoreSnapshots:
+    """miner_scores round rows + the current_miner_scores live tip (D8): the
+    persisted factors must be exactly what the reward math paid — same shared
+    ``build_direction_score_rows``, so a snapshot can never disagree with the
+    weights that went on chain."""
+
+    def _solo_with_storage(self, tmp_path: Path) -> SimpleNamespace:
+        v = TestRewardShapeWeights()._solo_crown_with_volume(tmp_path)
+        v.database_storage.is_enabled.return_value = True
+        return v
+
+    def test_round_flush_rows_match_reward_math(self, tmp_path: Path):
+        v = self._solo_with_storage(tmp_path)
+        rewards, _ = calculate_miner_rewards(v, v.block)
+        kwargs = v.database_storage.flush_scoring_window.call_args.kwargs
+        rows = kwargs['miner_score_rows']
+        assert len(rows) == 1
+        (round_ts, hotkey, from_c, to_c, eligible, crown_share, capacity, fill_ratio, vol_share, quality, reward) = (
+            rows[0]
+        )
+        assert round_ts == v.block  # round keyed by window_end
+        assert (hotkey, from_c, to_c) == ('hk_a', 'btc', 'sol')
+        assert eligible is True
+        np.testing.assert_allclose((crown_share, capacity, fill_ratio, vol_share, quality), (1.0,) * 5)
+        # The persisted factors reproduce the persisted reward, and the
+        # persisted reward is what the weights actually paid.
+        expected = 0.8 * POOL_BTC_SOL * crown_share * capacity * fill_ratio + 0.2 * POOL_BTC_SOL * vol_share * quality
+        np.testing.assert_allclose(reward, expected, atol=1e-9)
+        np.testing.assert_allclose(reward, rewards[0], atol=1e-6)
+
+    def test_ineligible_holder_persists_factors_with_zero_reward(self, tmp_path: Path):
+        """The gate zeroes the reward but the factors are still recorded — the
+        dashboard can show WHY the eligible=false round paid nothing."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
+        v = make_validator(tmp_path, hotkeys, all_eligible=False)
+        v.database_storage.is_enabled.return_value = True
+        conn = v.state_store.require_connection()
+        conn.execute(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            ('hk_a', 'btc', 'sol', 0.00020, 0),
+        )
+        conn.commit()
+        rewards, _ = calculate_miner_rewards(v, v.block)
+        rows = v.database_storage.flush_scoring_window.call_args.kwargs['miner_score_rows']
+        assert len(rows) == 1
+        row = rows[0]
+        assert row[4] is False  # eligible
+        np.testing.assert_allclose(row[5], 1.0)  # crown_share still recorded
+        assert row[10] == 0.0  # reward
+        assert rewards[0] == 0.0
+        v.state_store.close()
+
+    def test_live_tip_equals_round_rows_for_same_window(self, tmp_path: Path):
+        """The tip is the same math over the same window — identical rows,
+        with ts standing in for round_ts."""
+        v = self._solo_with_storage(tmp_path)
+        tip = snapshot_current_miner_scores(v, at_time=v.block)
+        calculate_miner_rewards(v, v.block)
+        round_rows = v.database_storage.flush_scoring_window.call_args.kwargs['miner_score_rows']
+        assert tip == round_rows
+        v.state_store.close()
+
+    def test_tip_empty_when_no_crown(self, tmp_path: Path):
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
+        v = make_validator(tmp_path, hotkeys)
+        assert snapshot_current_miner_scores(v, at_time=v.block) == []
+        v.state_store.close()
+
+    def test_halt_flush_carries_no_score_rows(self, tmp_path: Path):
+        """A halted round pays nobody: the halt flush goes through
+        flush_halt_window (which clears the live tip) and miner_scores gets no
+        rows for the round."""
+        v = self._solo_with_storage(tmp_path)
+        v.solana_config_cache.halted.return_value = True
+        v.update_scores = lambda rewards, miner_uids: None
+        score_and_reward_miners(v)
+        assert v.database_storage.flush_halt_window.called
+        assert not v.database_storage.flush_scoring_window.called
+        v.state_store.close()

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -1671,64 +1671,64 @@ class TestCapacityFactorHelper:
         assert capacity_factor(100_000_000, -1) == 1.0
 
 
-class TestVolumeFactorHelper:
-    """Direct unit tests for the volume_factor pure function.
+class TestFillRatioHelper:
+    """Direct unit tests for the fill_ratio pure function.
 
-    Signature: volume_factor(vol_rao, total_volume_rao, crown_share, alpha).
+    Signature: fill_ratio(vol_rao, total_volume_rao, crown_share, alpha).
     """
 
     def test_idle_crown_loses_alpha(self):
         """vol=0 of total=1 → vol_share=0, participation=0 → factor = (1-α)."""
-        from allways.validator.scoring import volume_factor
+        from allways.validator.scoring import fill_ratio
 
-        assert volume_factor(0, 1_000, crown_share=1.0, alpha=0.5) == 0.5
+        assert fill_ratio(0, 1_000, crown_share=1.0, alpha=0.5) == 0.5
 
     def test_matching_volume_keeps_full_reward(self):
-        from allways.validator.scoring import volume_factor
+        from allways.validator.scoring import fill_ratio
 
         # 500/1000 = 0.5 vol_share, crown_share 0.5 → participation 1.0.
-        assert volume_factor(500, 1_000, crown_share=0.5, alpha=0.5) == 1.0
+        assert fill_ratio(500, 1_000, crown_share=0.5, alpha=0.5) == 1.0
 
     def test_over_serving_capped_at_one(self):
         """Anti-wash-trade: high volume / low crown stays at 1.0."""
-        from allways.validator.scoring import volume_factor
+        from allways.validator.scoring import fill_ratio
 
-        assert volume_factor(900, 1_000, crown_share=0.1, alpha=0.5) == 1.0
+        assert fill_ratio(900, 1_000, crown_share=0.1, alpha=0.5) == 1.0
 
     def test_partial_mismatch_interpolates(self):
         """vol_share/crown_share = 0.5 → factor = 0.5 + 0.5*0.5 = 0.75."""
-        from allways.validator.scoring import volume_factor
+        from allways.validator.scoring import fill_ratio
 
-        assert volume_factor(250, 1_000, crown_share=0.5, alpha=0.5) == 0.75
+        assert fill_ratio(250, 1_000, crown_share=0.5, alpha=0.5) == 0.75
 
     def test_zero_crown_share_is_moot(self):
-        from allways.validator.scoring import volume_factor
+        from allways.validator.scoring import fill_ratio
 
-        assert volume_factor(500, 1_000, crown_share=0.0, alpha=0.5) == 1.0
+        assert fill_ratio(500, 1_000, crown_share=0.0, alpha=0.5) == 1.0
 
     def test_idle_network_short_circuits_to_one(self):
         """total_volume == 0 → factor = 1.0 (no penalty for a quiet window)."""
-        from allways.validator.scoring import volume_factor
+        from allways.validator.scoring import fill_ratio
 
-        assert volume_factor(0, 0, crown_share=1.0, alpha=0.5) == 1.0
+        assert fill_ratio(0, 0, crown_share=1.0, alpha=0.5) == 1.0
 
     def test_alpha_zero_disables_volume_weighting(self):
-        from allways.validator.scoring import volume_factor
+        from allways.validator.scoring import fill_ratio
 
         for vol in (0, 250, 500, 750, 1_000):
-            assert volume_factor(vol, 1_000, crown_share=1.0, alpha=0.0) == 1.0
+            assert fill_ratio(vol, 1_000, crown_share=1.0, alpha=0.0) == 1.0
 
     def test_alpha_one_is_pure_volume_share(self):
-        from allways.validator.scoring import volume_factor
+        from allways.validator.scoring import fill_ratio
 
-        assert volume_factor(0, 1_000, crown_share=1.0, alpha=1.0) == 0.0
-        assert volume_factor(250, 1_000, crown_share=0.5, alpha=1.0) == 0.5
+        assert fill_ratio(0, 1_000, crown_share=1.0, alpha=1.0) == 0.0
+        assert fill_ratio(250, 1_000, crown_share=0.5, alpha=1.0) == 0.5
 
     def test_alpha_03_softer_penalty(self):
-        from allways.validator.scoring import volume_factor
+        from allways.validator.scoring import fill_ratio
 
-        assert volume_factor(0, 1_000, crown_share=1.0, alpha=0.3) == 0.7
-        np.testing.assert_allclose(volume_factor(500, 1_000, crown_share=1.0, alpha=0.3), 0.85, atol=1e-6)
+        assert fill_ratio(0, 1_000, crown_share=1.0, alpha=0.3) == 0.7
+        np.testing.assert_allclose(fill_ratio(500, 1_000, crown_share=1.0, alpha=0.3), 0.85, atol=1e-6)
 
 
 class TestCapacityWeighting:
@@ -1914,7 +1914,7 @@ class TestWeightingTraceRecorders:
         assert wt.volume_share == 0.25
         assert wt.crown_share == 0.5
         assert wt.participation == 0.5
-        assert wt.volume_factor == 0.75
+        assert wt.fill_ratio == 0.75
 
     def test_record_volume_idle_network_zeros_share(self):
         """total_volume == 0 → volume_share = 0, participation defaults to 1.0
@@ -1925,7 +1925,7 @@ class TestWeightingTraceRecorders:
         wt.record_volume(vol_rao=0, total_volume_rao=0, crown_share=1.0, factor=1.0)
         assert wt.volume_share == 0.0
         assert wt.participation == 0.0  # vol_share / crown_share = 0/1 = 0
-        assert wt.volume_factor == 1.0  # set by caller (idle-network short-circuit)
+        assert wt.fill_ratio == 1.0  # set by caller (idle-network short-circuit)
 
     def test_record_volume_caps_participation_at_one(self):
         """Over-serving: vol_share/crown_share > 1 → participation capped."""
@@ -1970,7 +1970,7 @@ class TestVolumeWeighting:
     ) -> None:
         """Seed one completed swap's realized legs on the ``clearing_rates``
         ledger — the windowed volume read the reward weighting consumes.
-        ``from_amount`` is the from-leg the ``volume_factor`` compares within a
+        ``from_amount`` is the from-leg the ``fill_ratio`` compares within a
         direction. A non-completed swap never lands a ``SwapCompleted`` event,
         so it writes nothing — timed-out swaps contribute no volume."""
         if not completed:
@@ -2002,7 +2002,7 @@ class TestVolumeWeighting:
         # B doesn't post a rate → never holds crown.
         self.insert_volume(v, 'hk_b', from_amount=1_000_000_000)
         rewards, _ = calculate_miner_rewards(v, v.block)
-        # A's vol_share = 0, crown_share = 1.0 → participation = 0 → vol_factor = 0.5.
+        # A's vol_share = 0, crown_share = 1.0 → participation = 0 → fill_ratio = 0.5.
         # Volume>0 in this direction → w_a=0.8/w_b=0.2; A's qv_share is 0, so
         # A = 0.8·(pool·0.5). B has crown_share = 0 → no crown reward to multiply.
         np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 0.8 * 0.5, atol=1e-6)
@@ -2050,7 +2050,7 @@ class TestVolumeWeighting:
         self.insert_volume(v, 'hk_a', from_amount=100_000_000, from_chain='sol', to_chain='btc')
         self.insert_volume(v, 'hk_b', from_amount=900_000_000, from_chain='sol', to_chain='btc')
         rewards, _ = calculate_miner_rewards(v, v.block)
-        # A: crown_share = 1.0, vol_share = 0.1, participation = 0.1 → vol_factor = 0.55.
+        # A: crown_share = 1.0, vol_share = 0.1, participation = 0.1 → fill_ratio = 0.55.
         # w_a=0.8/w_b=0.2: 0.8·(pool·0.55) + 0.2·(pool·0.1) = pool·0.46.
         np.testing.assert_allclose(rewards[0], POOL_SOL_BTC * 0.46, atol=1e-6)
         # B: crown_share = 0 → factor moot, no reward to multiply.
@@ -2082,7 +2082,7 @@ class TestVolumeWeighting:
         self.insert_volume(v, 'hk_b', from_amount=800_000_000, from_chain='sol', to_chain='btc')
         rewards, _ = calculate_miner_rewards(v, v.block)
         # Crown: A=240/300=0.8, B=60/300=0.2. Volume: A=0.2, B=0.8.
-        # A participation = 0.2/0.8 = 0.25 → vol_factor 0.625; B → vol_factor 1.0.
+        # A participation = 0.2/0.8 = 0.25 → fill_ratio 0.625; B → fill_ratio 1.0.
         # w_a=0.8/w_b=0.2 (volume>0): A = 0.8·(0.8·0.625) + 0.2·0.2 = 0.44·pool.
         #                              B = 0.8·(0.2·1.0)  + 0.2·0.8 = 0.32·pool.
         np.testing.assert_allclose(rewards[0], POOL_SOL_BTC * 0.44, atol=1e-6)
@@ -2148,7 +2148,7 @@ class TestVolumeWeighting:
 
     def test_below_floor_direction_falls_back_to_crown_only(self, tmp_path: Path):
         """A direction clearing less than MIN_DIRECTION_VOLUME on its SOL side is
-        scored as zero-volume: w_a folds to 1.0 and volume_factor stays neutral,
+        scored as zero-volume: w_a folds to 1.0 and fill_ratio stays neutral,
         so a dust swap neither pays the w_b slice nor penalizes the crown holder."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a', 'hk_b'])
         v = make_validator(tmp_path, hotkeys)
@@ -2169,7 +2169,7 @@ class TestVolumeWeighting:
         self.insert_volume(v, 'hk_b', from_amount=1_000_000_000, to_amount=1_000_000_000)
         rewards, _ = calculate_miner_rewards(v, v.block)
         # Same shape as test_idle_crown_holder_loses_alpha: A holds all crown,
-        # serves none of the (at-floor) volume → w_a·pool·vol_factor(0.5).
+        # serves none of the (at-floor) volume → w_a·pool·fill_ratio(0.5).
         np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 0.8 * 0.5, atol=1e-6)
         v.state_store.close()
 
@@ -2217,7 +2217,7 @@ class TestVolumeWeighting:
 
 
 class TestRewardShapeWeights:
-    """Reward = eligible × [w_a·crown + w_b·quality_volume]. Phase C set the live
+    """Reward = eligible × [w_a·crown + w_b·execution]. Phase C set the live
     weights to w_a=0.8/w_b=0.2; a larger w_b shifts weight toward realized
     volume. A solo crown holder with full volume share earns the whole pool for
     any w_a+w_b=1 (both components equal the pool there)."""
@@ -2253,15 +2253,15 @@ class TestRewardShapeWeights:
         component, so a volume-serving crown holder earns strictly more than it
         does under the w_b=0 baseline."""
         # Pin w_a=1.0 across both runs and vary only w_b (0 → 0.5) so the delta
-        # isolates the added quality-volume term (weights need not sum to 1 here —
+        # isolates the added execution term (weights need not sum to 1 here —
         # this is a formula sanity check, not a distribution).
         monkeypatch.setattr(scoring_mod, 'REWARD_WEIGHT_CROWN', 1.0)
-        monkeypatch.setattr(scoring_mod, 'REWARD_WEIGHT_QUALITY_VOLUME', 0.0)
+        monkeypatch.setattr(scoring_mod, 'REWARD_WEIGHT_EXECUTION', 0.0)
         v_base = self._solo_crown_with_volume(tmp_path / 'base')
         baseline, _ = calculate_miner_rewards(v_base, v_base.block)
         v_base.state_store.close()
 
-        monkeypatch.setattr(scoring_mod, 'REWARD_WEIGHT_QUALITY_VOLUME', 0.5)
+        monkeypatch.setattr(scoring_mod, 'REWARD_WEIGHT_EXECUTION', 0.5)
         v_vol = self._solo_crown_with_volume(tmp_path / 'vol')
         weighted, _ = calculate_miner_rewards(v_vol, v_vol.block)
         v_vol.state_store.close()
@@ -2272,7 +2272,7 @@ class TestRewardShapeWeights:
 
 
 class TestCrevReference:
-    """C-rev — the on-chain trimmed reference gates the quality-volume slice,
+    """C-rev — the on-chain trimmed reference gates the execution slice,
     replacing the external feed. The solo holder executes tao→btc at a realized
     500 TAO/BTC; seeding the network's clearing-rate history around 500 sets the
     reference (the 500 outlier is trimmed when other rates dominate), and the
@@ -2377,7 +2377,7 @@ class TestCapacityVolumeInteraction:
         # B serves the market's (floor-clearing) volume so A's vol_share = 0.
         v.state_store.insert_clearing_rate(9_900, 'hk_b', 'btc', 'sol', 1_000_000_000, 1_000_000_000)
         rewards, _ = calculate_miner_rewards(v, v.block)
-        # A: w_a 0.8 × pool × crown 1.0 × eligible 1 × capacity 0.5 × volume_factor 0.5.
+        # A: w_a 0.8 × pool × crown 1.0 × eligible 1 × capacity 0.5 × fill_ratio 0.5.
         # A serves no volume (B does), so A's w_b slice is 0 → only the crown term.
         np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 0.8 * 1.0 * 0.5 * 0.5, atol=1e-6)
         v.state_store.close()

--- a/tests/test_validator_storage.py
+++ b/tests/test_validator_storage.py
@@ -57,6 +57,10 @@ class FakeRepo:
         self.conn._maybe_fail()
         return len(rows_by_direction)
 
+    def replace_current_miner_scores(self, rows, commit=False):
+        self.conn._maybe_fail()
+        return len(rows)
+
     def delete_crown_in_range(self, from_chain, to_chain, lo, hi, commit=False):
         self.conn._maybe_fail()
 
@@ -165,3 +169,16 @@ def test_gated_caller_path_reaches_the_redial(monkeypatch):
     _flush_halt_window(SimpleNamespace(database_storage=storage), current_time=1_000_000)
     assert storage.db_connection is fresh
     assert fresh.commits == 2  # flush_halt_window + upsert_current_crown_snapshot both landed
+
+
+def test_halt_flush_clears_live_score_tip(monkeypatch):
+    """flush_halt_window wipes current_miner_scores in the same transaction as
+    the crown clear — the dashboard never shows a live tip while the pool is
+    recycling."""
+    conn = FakeConnection()
+    storage = make_storage(monkeypatch, [conn])
+    calls = []
+    storage.repo.replace_current_miner_scores = lambda rows, commit=False: calls.append(rows) or len(rows)
+    result = storage.flush_halt_window(directions=[('sol', 'btc')], window_start=0, window_end=100, max_ts=100)
+    assert result.success
+    assert calls == [[]]


### PR DESCRIPTION
## Summary
The validator persists the factors it actually paid: miner_scores rows flush in the same transaction as the crown ledger each round, and current_miner_scores is wiped and rewritten every forward step from the same shared build_direction_score_rows math — neither table can disagree with the weights. Validator rate_history writes are removed; the indexer owns that table (real-time, per QuoteSet).

## Changes
- Shared build_direction_score_rows: the reward multiplication lives once, used by the round scorer and the live tip
- flush_scoring_window gains miner_score_rows; halt flush clears the tip and writes no score rows
- snapshot_current_miner_scores per forward step (storage-gated, failure-isolated)
- store_rate_history_bulk / BULK_UPSERT_RATE_HISTORY / rate_snapshot cursor deleted
- Tests: snapshot rows reproduce the reward math; ineligible rounds persist factors with reward 0; tip equals round rows for the same window; halt clears the tip

Stacked on #528. Verified live: rows land in miner_scores/current_miner_scores, tip updates ~12s, halt path covered by tests; run-suites fast matrix 3/3 PASS.