### PR TITLE
Rename volume_factor to fill_ratio and quality_volume to execution

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -74,11 +74,11 @@ DIRECTION_POOLS: dict[tuple[str, str], float] = {
 # Idle-crown penalty: 0 = none, 1 = pure volume share, 0.5 = half-credit floor.
 VOLUME_WEIGHT_ALPHA: float = 0.5
 # Volume floor: a direction whose in-window SOL-side notional clears less than this
-# (lamports — 1 SOL) is treated as having no volume for the round: the quality-volume
-# slice folds into crown and volume_factor stays neutral, the same fallback as a fully
+# (lamports — 1 SOL) is treated as having no volume for the round: the execution
+# slice folds into crown and fill_ratio stays neutral, the same fallback as a fully
 # idle direction. Keeps a couple of dust swaps from steering the weights.
 MIN_DIRECTION_VOLUME = 1_000_000_000
-# Reward-shape weights (B3.5): reward = eligible × [w_a·crown + w_b·quality_volume].
+# Reward-shape weights (B3.5): reward = eligible × [w_a·crown + w_b·execution].
 # w_a weights the crown-time component (best-rate presence × capacity), w_b the
 # realized-volume share × rate-quality (executed throughput at fair rates). Phase C
 # turns w_b on at a conservative 0.2 so crown stays the primary driver while real
@@ -86,7 +86,7 @@ MIN_DIRECTION_VOLUME = 1_000_000_000
 # envelope is unchanged. Too-thin on-chain clearing-rate history ⇒ rate_quality neutral
 # (1.0), so w_b still pays realized volume by raw share — it never zeroes everyone.
 REWARD_WEIGHT_CROWN: float = 0.8
-REWARD_WEIGHT_QUALITY_VOLUME: float = 0.2
+REWARD_WEIGHT_EXECUTION: float = 0.2
 # Flat eligibility gate (B3.3): read off the on-chain MinerState counters,
 # replacing the success_rate³ × credibility ramp. A miner is crown-eligible iff
 # it has at least MIN_SUCCESSFUL_SWAPS successes and at most MAX_FAILED_SWAPS
@@ -96,7 +96,7 @@ MAX_FAILED_SWAPS: int = 2
 
 # ─── Rate-quality curve (Phase C) ────────────────────────
 # One-sided clamp mapping realized-VWAP-vs-market advantage → a quality
-# multiplier on the quality-volume reward. At/above market (within a tolerance
+# multiplier on the execution reward. At/above market (within a tolerance
 # deadband) scores 1.0 — the crown already rewards best-rate presence, so
 # above-market is not paid again here. Worse-than-market ramps linearly to
 # RATE_QUALITY_MIN at RATE_QUALITY_FLOOR_ADV. Tunable without code changes.

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -1,15 +1,15 @@
 """Crown-time scoring pipeline.
 
-Reward per miner is ``eligible × [w_a·crown + w_b·quality_volume]`` (B3.5),
+Reward per miner is ``eligible × [w_a·crown + w_b·execution]`` (B3.5),
 where ``eligible`` is a flat 0/1 gate read off the on-chain ``MinerState``
 counters (B3.3) — it replaces the old ``sr³ × credibility ramp``. The crown
-component is ``pool × crown_share × capacity × volume_factor``; the
-quality-volume component is the pool's realized-volume share, summed over the
+component is ``pool × crown_share × capacity × fill_ratio``; the
+execution component is the pool's realized-volume share, summed over the
 scored window from the ingested ``clearing_rates`` ledger (the ``SwapCompleted``
 history — volume is what cleared this round, not a lifetime account total) and
 gated by the ``rate_quality`` curve. A direction clearing less than
 ``MIN_DIRECTION_VOLUME`` on its SOL side in the window is treated as zero-volume
-(w_a folds to 1.0, ``volume_factor`` neutral) so dust can't steer the weights.
+(w_a folds to 1.0, ``fill_ratio`` neutral) so dust can't steer the weights.
 The curve compares a miner's realized rate against an on-chain reference (C-rev):
 a trimmed, volume-weighted, per-miner-capped average of completed-swap clearing
 rates per direction (``build_direction_references``), computed deterministically
@@ -50,7 +50,7 @@ from allways.constants import (
     RECYCLE_UID,
     REWARD_MINER_STATES,
     REWARD_WEIGHT_CROWN,
-    REWARD_WEIGHT_QUALITY_VOLUME,
+    REWARD_WEIGHT_EXECUTION,
     SCORING_WINDOW_BLOCKS,
     SCORING_WINDOW_SECS,
     SWAP_OUTCOME_RETENTION_SECS,
@@ -257,7 +257,7 @@ class ScoreRow:
     eligible: bool
     crown_share: float
     capacity: float
-    volume_factor: float
+    fill_ratio: float
     vol_share: float
     rate_quality: float
     reward: float
@@ -284,12 +284,12 @@ def build_direction_score_rows(
     caller's unweighted-baseline trace.
 
     W_B falls back to crown for a direction with no realized volume: the
-    quality-volume slice has nothing to distribute, so handing it to crown
+    execution slice has nothing to distribute, so handing it to crown
     keeps a quiet direction at full pool rather than recycling 20% (Phase C).
     """
     total_crown_dir = sum(crown_time.values())
     if total_volume_dir > 0:
-        w_a, w_b = REWARD_WEIGHT_CROWN, REWARD_WEIGHT_QUALITY_VOLUME
+        w_a, w_b = REWARD_WEIGHT_CROWN, REWARD_WEIGHT_EXECUTION
     else:
         w_a, w_b = 1.0, 0.0
     rows: List[ScoreRow] = []
@@ -307,17 +307,17 @@ def build_direction_score_rows(
         crown_share_dir = secs / total_crown_dir
         vol_dir = volumes_dir.get(hotkey, 0)
         vol_share_dir = (vol_dir / total_volume_dir) if total_volume_dir > 0 else 0.0
-        vol_factor = volume_factor(vol_dir, total_volume_dir, crown_share_dir)
-        # Reward = eligible × [w_a·crown + w_b·quality_volume] (Phase C). crown
-        # is the B3.3 reward (pool·share·cap·vol_factor); quality_volume is the
+        fill = fill_ratio(vol_dir, total_volume_dir, crown_share_dir)
+        # Reward = eligible × [w_a·crown + w_b·execution] (Phase C). crown
+        # is the B3.3 reward (pool·share·cap·fill_ratio); execution is the
         # pool's volume share × rate-quality (vs the on-chain reference). w_a/w_b
         # are the direction's effective weights (0.8/0.2, or 1.0/0.0 if idle).
-        crown_component = pool * crown_share_dir * cap * vol_factor
+        crown_component = pool * crown_share_dir * cap * fill
         # Quality compares the miner's OWN windowed realized rate against the
         # direction reference — same windowed clearing-rate basis (C-rev).
         realized_rate = reference.miner_rates.get(hotkey, 0.0) if reference is not None else 0.0
         quality = rate_quality(from_chain, to_chain, realized_rate, reference_rate)
-        quality_volume_component = pool * vol_share_dir * quality
+        execution_component = pool * vol_share_dir * quality
         rows.append(
             ScoreRow(
                 hotkey=hotkey,
@@ -326,10 +326,10 @@ def build_direction_score_rows(
                 eligible=eligible,
                 crown_share=crown_share_dir,
                 capacity=cap,
-                volume_factor=vol_factor,
+                fill_ratio=fill,
                 vol_share=vol_share_dir,
                 rate_quality=quality,
-                reward=(1.0 if eligible else 0.0) * (w_a * crown_component + w_b * quality_volume_component),
+                reward=(1.0 if eligible else 0.0) * (w_a * crown_component + w_b * execution_component),
             )
         )
     return rows, w_a
@@ -498,7 +498,7 @@ def rate_quality(
 
 def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndarray, Set[int]]:
     """Replay the crown-time event stream, derive per-miner rewards
-    (eligible × [w_a·crown + w_b·quality_volume]), recycle the rest.
+    (eligible × [w_a·crown + w_b·execution]), recycle the rest.
     ``current_time`` is the unix-seconds window_end (the crown axis).
 
     Volume weighting is *per direction*: a miner earning crown on btc→tao is
@@ -625,11 +625,11 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
             unweighted_rewards[uid] += eligible * w_a * pool * row.crown_share * row.capacity
             rewards[uid] += row.reward
             score_rows.append(row)
-            if row.volume_factor < 1.0:
+            if row.fill_ratio < 1.0:
                 bt.logging.debug(
                     f'V1 scoring [{from_chain}→{to_chain}] {row.hotkey[:8]}: '
                     f'crown_share={row.crown_share:.3f} vol_share={row.vol_share:.3f} '
-                    f'vol_factor={row.volume_factor:.3f}'
+                    f'fill_ratio={row.fill_ratio:.3f}'
                 )
 
     record_volume_traces(
@@ -698,7 +698,7 @@ def miner_score_tuples(score_rows: List[ScoreRow], ts: int) -> List[Tuple]:
             r.eligible,
             r.crown_share,
             r.capacity,
-            r.volume_factor,
+            r.fill_ratio,
             r.vol_share,
             r.rate_quality,
             r.reward,
@@ -774,7 +774,7 @@ def capacity_factor(collateral_rao: int, max_swap_amount_rao: int) -> float:
     return min(1.0, collateral_rao / max_swap_amount_rao)
 
 
-def volume_factor(
+def fill_ratio(
     vol_rao: int,
     total_volume_rao: int,
     crown_share: float,

--- a/allways/validator/scoring_trace.py
+++ b/allways/validator/scoring_trace.py
@@ -40,7 +40,7 @@ class WeightingTrace:
     crown_share: float = 0.0
     volume_share: float = 0.0
     participation: float = 1.0
-    volume_factor: float = 1.0
+    fill_ratio: float = 1.0
     eligible: bool = False
 
     def record_capacity(self, factor: float) -> None:
@@ -51,7 +51,7 @@ class WeightingTrace:
         self.crown_share = crown_share
         self.volume_share = (vol_rao / total_volume_rao) if total_volume_rao > 0 else 0.0
         self.participation = min(1.0, self.volume_share / crown_share) if crown_share > 0 else 1.0
-        self.volume_factor = factor
+        self.fill_ratio = factor
 
     def record_eligibility(self, eligible: bool) -> None:
         self.eligible = eligible
@@ -101,7 +101,7 @@ def log_scoring_trace(
             extras = (
                 f' cap={wt.capacity_factor:.2f}'
                 f' vol={wt.volume_rao / TAO_TO_RAO:g}t vol_share={wt.volume_share:.2f}'
-                f' crown_share={wt.crown_share:.2f} vol_f={wt.volume_factor:.2f}'
+                f' crown_share={wt.crown_share:.2f} fill={wt.fill_ratio:.2f}'
             )
         lines.append(
             f'  uid={uid} hotkey={hk[:8]}.. crown_s={crown_secs:.0f} eligible={eligible}{extras} reward={crown_reward:.3f}'

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -1671,64 +1671,64 @@ class TestCapacityFactorHelper:
         assert capacity_factor(100_000_000, -1) == 1.0
 
 
-class TestVolumeFactorHelper:
-    """Direct unit tests for the volume_factor pure function.
+class TestFillRatioHelper:
+    """Direct unit tests for the fill_ratio pure function.
 
-    Signature: volume_factor(vol_rao, total_volume_rao, crown_share, alpha).
+    Signature: fill_ratio(vol_rao, total_volume_rao, crown_share, alpha).
     """
 
     def test_idle_crown_loses_alpha(self):
         """vol=0 of total=1 → vol_share=0, participation=0 → factor = (1-α)."""
-        from allways.validator.scoring import volume_factor
+        from allways.validator.scoring import fill_ratio
 
-        assert volume_factor(0, 1_000, crown_share=1.0, alpha=0.5) == 0.5
+        assert fill_ratio(0, 1_000, crown_share=1.0, alpha=0.5) == 0.5
 
     def test_matching_volume_keeps_full_reward(self):
-        from allways.validator.scoring import volume_factor
+        from allways.validator.scoring import fill_ratio
 
         # 500/1000 = 0.5 vol_share, crown_share 0.5 → participation 1.0.
-        assert volume_factor(500, 1_000, crown_share=0.5, alpha=0.5) == 1.0
+        assert fill_ratio(500, 1_000, crown_share=0.5, alpha=0.5) == 1.0
 
     def test_over_serving_capped_at_one(self):
         """Anti-wash-trade: high volume / low crown stays at 1.0."""
-        from allways.validator.scoring import volume_factor
+        from allways.validator.scoring import fill_ratio
 
-        assert volume_factor(900, 1_000, crown_share=0.1, alpha=0.5) == 1.0
+        assert fill_ratio(900, 1_000, crown_share=0.1, alpha=0.5) == 1.0
 
     def test_partial_mismatch_interpolates(self):
         """vol_share/crown_share = 0.5 → factor = 0.5 + 0.5*0.5 = 0.75."""
-        from allways.validator.scoring import volume_factor
+        from allways.validator.scoring import fill_ratio
 
-        assert volume_factor(250, 1_000, crown_share=0.5, alpha=0.5) == 0.75
+        assert fill_ratio(250, 1_000, crown_share=0.5, alpha=0.5) == 0.75
 
     def test_zero_crown_share_is_moot(self):
-        from allways.validator.scoring import volume_factor
+        from allways.validator.scoring import fill_ratio
 
-        assert volume_factor(500, 1_000, crown_share=0.0, alpha=0.5) == 1.0
+        assert fill_ratio(500, 1_000, crown_share=0.0, alpha=0.5) == 1.0
 
     def test_idle_network_short_circuits_to_one(self):
         """total_volume == 0 → factor = 1.0 (no penalty for a quiet window)."""
-        from allways.validator.scoring import volume_factor
+        from allways.validator.scoring import fill_ratio
 
-        assert volume_factor(0, 0, crown_share=1.0, alpha=0.5) == 1.0
+        assert fill_ratio(0, 0, crown_share=1.0, alpha=0.5) == 1.0
 
     def test_alpha_zero_disables_volume_weighting(self):
-        from allways.validator.scoring import volume_factor
+        from allways.validator.scoring import fill_ratio
 
         for vol in (0, 250, 500, 750, 1_000):
-            assert volume_factor(vol, 1_000, crown_share=1.0, alpha=0.0) == 1.0
+            assert fill_ratio(vol, 1_000, crown_share=1.0, alpha=0.0) == 1.0
 
     def test_alpha_one_is_pure_volume_share(self):
-        from allways.validator.scoring import volume_factor
+        from allways.validator.scoring import fill_ratio
 
-        assert volume_factor(0, 1_000, crown_share=1.0, alpha=1.0) == 0.0
-        assert volume_factor(250, 1_000, crown_share=0.5, alpha=1.0) == 0.5
+        assert fill_ratio(0, 1_000, crown_share=1.0, alpha=1.0) == 0.0
+        assert fill_ratio(250, 1_000, crown_share=0.5, alpha=1.0) == 0.5
 
     def test_alpha_03_softer_penalty(self):
-        from allways.validator.scoring import volume_factor
+        from allways.validator.scoring import fill_ratio
 
-        assert volume_factor(0, 1_000, crown_share=1.0, alpha=0.3) == 0.7
-        np.testing.assert_allclose(volume_factor(500, 1_000, crown_share=1.0, alpha=0.3), 0.85, atol=1e-6)
+        assert fill_ratio(0, 1_000, crown_share=1.0, alpha=0.3) == 0.7
+        np.testing.assert_allclose(fill_ratio(500, 1_000, crown_share=1.0, alpha=0.3), 0.85, atol=1e-6)
 
 
 class TestCapacityWeighting:
@@ -1914,7 +1914,7 @@ class TestWeightingTraceRecorders:
         assert wt.volume_share == 0.25
         assert wt.crown_share == 0.5
         assert wt.participation == 0.5
-        assert wt.volume_factor == 0.75
+        assert wt.fill_ratio == 0.75
 
     def test_record_volume_idle_network_zeros_share(self):
         """total_volume == 0 → volume_share = 0, participation defaults to 1.0
@@ -1925,7 +1925,7 @@ class TestWeightingTraceRecorders:
         wt.record_volume(vol_rao=0, total_volume_rao=0, crown_share=1.0, factor=1.0)
         assert wt.volume_share == 0.0
         assert wt.participation == 0.0  # vol_share / crown_share = 0/1 = 0
-        assert wt.volume_factor == 1.0  # set by caller (idle-network short-circuit)
+        assert wt.fill_ratio == 1.0  # set by caller (idle-network short-circuit)
 
     def test_record_volume_caps_participation_at_one(self):
         """Over-serving: vol_share/crown_share > 1 → participation capped."""
@@ -1970,7 +1970,7 @@ class TestVolumeWeighting:
     ) -> None:
         """Seed one completed swap's realized legs on the ``clearing_rates``
         ledger — the windowed volume read the reward weighting consumes.
-        ``from_amount`` is the from-leg the ``volume_factor`` compares within a
+        ``from_amount`` is the from-leg the ``fill_ratio`` compares within a
         direction. A non-completed swap never lands a ``SwapCompleted`` event,
         so it writes nothing — timed-out swaps contribute no volume."""
         if not completed:
@@ -2002,7 +2002,7 @@ class TestVolumeWeighting:
         # B doesn't post a rate → never holds crown.
         self.insert_volume(v, 'hk_b', from_amount=1_000_000_000)
         rewards, _ = calculate_miner_rewards(v, v.block)
-        # A's vol_share = 0, crown_share = 1.0 → participation = 0 → vol_factor = 0.5.
+        # A's vol_share = 0, crown_share = 1.0 → participation = 0 → fill_ratio = 0.5.
         # Volume>0 in this direction → w_a=0.8/w_b=0.2; A's qv_share is 0, so
         # A = 0.8·(pool·0.5). B has crown_share = 0 → no crown reward to multiply.
         np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 0.8 * 0.5, atol=1e-6)
@@ -2050,7 +2050,7 @@ class TestVolumeWeighting:
         self.insert_volume(v, 'hk_a', from_amount=100_000_000, from_chain='sol', to_chain='btc')
         self.insert_volume(v, 'hk_b', from_amount=900_000_000, from_chain='sol', to_chain='btc')
         rewards, _ = calculate_miner_rewards(v, v.block)
-        # A: crown_share = 1.0, vol_share = 0.1, participation = 0.1 → vol_factor = 0.55.
+        # A: crown_share = 1.0, vol_share = 0.1, participation = 0.1 → fill_ratio = 0.55.
         # w_a=0.8/w_b=0.2: 0.8·(pool·0.55) + 0.2·(pool·0.1) = pool·0.46.
         np.testing.assert_allclose(rewards[0], POOL_SOL_BTC * 0.46, atol=1e-6)
         # B: crown_share = 0 → factor moot, no reward to multiply.
@@ -2082,7 +2082,7 @@ class TestVolumeWeighting:
         self.insert_volume(v, 'hk_b', from_amount=800_000_000, from_chain='sol', to_chain='btc')
         rewards, _ = calculate_miner_rewards(v, v.block)
         # Crown: A=240/300=0.8, B=60/300=0.2. Volume: A=0.2, B=0.8.
-        # A participation = 0.2/0.8 = 0.25 → vol_factor 0.625; B → vol_factor 1.0.
+        # A participation = 0.2/0.8 = 0.25 → fill_ratio 0.625; B → fill_ratio 1.0.
         # w_a=0.8/w_b=0.2 (volume>0): A = 0.8·(0.8·0.625) + 0.2·0.2 = 0.44·pool.
         #                              B = 0.8·(0.2·1.0)  + 0.2·0.8 = 0.32·pool.
         np.testing.assert_allclose(rewards[0], POOL_SOL_BTC * 0.44, atol=1e-6)
@@ -2148,7 +2148,7 @@ class TestVolumeWeighting:
 
     def test_below_floor_direction_falls_back_to_crown_only(self, tmp_path: Path):
         """A direction clearing less than MIN_DIRECTION_VOLUME on its SOL side is
-        scored as zero-volume: w_a folds to 1.0 and volume_factor stays neutral,
+        scored as zero-volume: w_a folds to 1.0 and fill_ratio stays neutral,
         so a dust swap neither pays the w_b slice nor penalizes the crown holder."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a', 'hk_b'])
         v = make_validator(tmp_path, hotkeys)
@@ -2169,7 +2169,7 @@ class TestVolumeWeighting:
         self.insert_volume(v, 'hk_b', from_amount=1_000_000_000, to_amount=1_000_000_000)
         rewards, _ = calculate_miner_rewards(v, v.block)
         # Same shape as test_idle_crown_holder_loses_alpha: A holds all crown,
-        # serves none of the (at-floor) volume → w_a·pool·vol_factor(0.5).
+        # serves none of the (at-floor) volume → w_a·pool·fill_ratio(0.5).
         np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 0.8 * 0.5, atol=1e-6)
         v.state_store.close()
 
@@ -2217,7 +2217,7 @@ class TestVolumeWeighting:
 
 
 class TestRewardShapeWeights:
-    """Reward = eligible × [w_a·crown + w_b·quality_volume]. Phase C set the live
+    """Reward = eligible × [w_a·crown + w_b·execution]. Phase C set the live
     weights to w_a=0.8/w_b=0.2; a larger w_b shifts weight toward realized
     volume. A solo crown holder with full volume share earns the whole pool for
     any w_a+w_b=1 (both components equal the pool there)."""
@@ -2253,15 +2253,15 @@ class TestRewardShapeWeights:
         component, so a volume-serving crown holder earns strictly more than it
         does under the w_b=0 baseline."""
         # Pin w_a=1.0 across both runs and vary only w_b (0 → 0.5) so the delta
-        # isolates the added quality-volume term (weights need not sum to 1 here —
+        # isolates the added execution term (weights need not sum to 1 here —
         # this is a formula sanity check, not a distribution).
         monkeypatch.setattr(scoring_mod, 'REWARD_WEIGHT_CROWN', 1.0)
-        monkeypatch.setattr(scoring_mod, 'REWARD_WEIGHT_QUALITY_VOLUME', 0.0)
+        monkeypatch.setattr(scoring_mod, 'REWARD_WEIGHT_EXECUTION', 0.0)
         v_base = self._solo_crown_with_volume(tmp_path / 'base')
         baseline, _ = calculate_miner_rewards(v_base, v_base.block)
         v_base.state_store.close()
 
-        monkeypatch.setattr(scoring_mod, 'REWARD_WEIGHT_QUALITY_VOLUME', 0.5)
+        monkeypatch.setattr(scoring_mod, 'REWARD_WEIGHT_EXECUTION', 0.5)
         v_vol = self._solo_crown_with_volume(tmp_path / 'vol')
         weighted, _ = calculate_miner_rewards(v_vol, v_vol.block)
         v_vol.state_store.close()
@@ -2272,7 +2272,7 @@ class TestRewardShapeWeights:
 
 
 class TestCrevReference:
-    """C-rev — the on-chain trimmed reference gates the quality-volume slice,
+    """C-rev — the on-chain trimmed reference gates the execution slice,
     replacing the external feed. The solo holder executes tao→btc at a realized
     500 TAO/BTC; seeding the network's clearing-rate history around 500 sets the
     reference (the 500 outlier is trimmed when other rates dominate), and the
@@ -2377,7 +2377,7 @@ class TestCapacityVolumeInteraction:
         # B serves the market's (floor-clearing) volume so A's vol_share = 0.
         v.state_store.insert_clearing_rate(9_900, 'hk_b', 'btc', 'sol', 1_000_000_000, 1_000_000_000)
         rewards, _ = calculate_miner_rewards(v, v.block)
-        # A: w_a 0.8 × pool × crown 1.0 × eligible 1 × capacity 0.5 × volume_factor 0.5.
+        # A: w_a 0.8 × pool × crown 1.0 × eligible 1 × capacity 0.5 × fill_ratio 0.5.
         # A serves no volume (B does), so A's w_b slice is 0 → only the crown term.
         np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 0.8 * 1.0 * 0.5 * 0.5, atol=1e-6)
         v.state_store.close()


### PR DESCRIPTION
## Summary
Pure rename, zero behavior: the crown slice's participation multiplier is fill_ratio, the w_b slice is the execution component, and the weight constant is REWARD_WEIGHT_EXECUTION — the same words the miner_scores schema, das API, and UI use.

Stacked on #529 (diff is the top commit only).