### PR TITLE
Sweep dead block-era constants and extract shared candidate builder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,9 +61,6 @@ MINER_BITTENSOR_COLDKEY_PASSWORD=
 # Unknown values refuse to start. Legacy VALIDATOR_DEV_MODE=1 still means 'watch'.
 # VALIDATOR_MODE=full
 
-# Raise on testnet where slower RPC stretches a forward step. Default 5.
-# VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE=5
-
 # ─── Validator: Weights & Biases ───────────────────────────
 # The validator opens a wandb run at startup that captures its console output.
 # Set WANDB_API_KEY to log online; unset runs offline (./wandb/), or pass

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -9,7 +9,7 @@ unrouted taker never waits on validator liveness."""
 
 import json
 import time
-from typing import List, NamedTuple, Optional
+from typing import NamedTuple, Optional
 
 import click
 
@@ -24,7 +24,7 @@ from allways.cli.swap_commands.helpers import (
     live_unclaimed,
 )
 from allways.cli.swap_commands.swap_intake import (
-    MinerCandidate,
+    candidate_miners,
     compute_intake_amounts,
     rate_display_from_fixed,
     select_best_miner,
@@ -38,17 +38,6 @@ from allways.utils.rate import apply_fee_deduction
 @click.group('swap', cls=StyledGroup, show_disclaimer=True)
 def swap_group():
     """Execute and manage cross-chain swaps."""
-
-
-def _candidate_miners(client, from_chain: str, to_chain: str) -> List[MinerCandidate]:
-    """All miners with a posted quote for this exact direction, with their collateral attached."""
-    out: List[MinerCandidate] = []
-    for _pk, q in client.get_all('MinerQuote'):
-        if q.from_chain != from_chain or q.to_chain != to_chain:
-            continue
-        collateral = client.get_collateral_lamports(q.miner) or 0
-        out.append(MinerCandidate(miner=q.miner, rate_display=rate_display_from_fixed(q.rate), collateral=collateral))
-    return out
 
 
 class PoolContention(NamedTuple):
@@ -220,7 +209,7 @@ def swap_now_command(
     pool_window = int(getattr(cfg, 'pool_window_secs', 60)) if cfg else 60
 
     from_amount = to_smallest_units(amount_opt, from_chain)
-    candidates = _candidate_miners(client, from_chain, to_chain)
+    candidates = candidate_miners(client, from_chain, to_chain)
     if not candidates:
         fail(f'No miners quoting {from_chain}->{to_chain} right now.')
     best = select_best_miner(candidates, from_chain, to_chain, from_amount, min_swap, max_swap)

--- a/allways/cli/swap_commands/swap_intake.py
+++ b/allways/cli/swap_commands/swap_intake.py
@@ -1,8 +1,10 @@
-"""Pure taker swap-intake math — miner selection + on-chain amount derivation. No network, no click.
+"""Taker swap-intake — miner selection + on-chain amount derivation. No click, no owned RPC config.
 
 Mirrors the contract: ``collateral_amount`` is the SOL leg (the bounded, collateral-backed notional). Uses the
 shared ``calculate_to_amount`` so the CLI's pinned amounts agree with the miner + validator byte-for-byte.
 Launch pairs always have a SOL leg (sol↔btc / sol↔tao); a pair without one is rejected here.
+The one network-touching helper (``candidate_miners``) takes the Solana client as a parameter, so the
+CLI taker path and the validator reserve engine build the same candidate set from the same reads.
 """
 
 from dataclasses import dataclass
@@ -35,6 +37,19 @@ def to_smallest_units(amount: float, chain: str) -> int:
 def rate_display_from_fixed(rate_fixed: int) -> str:
     """On-chain u128 fixed-point rate → canonical display string (matches normalize_rate)."""
     return normalize_rate(rate_fixed / RATE_PRECISION)
+
+
+def candidate_miners(client, from_chain: str, to_chain: str) -> List[MinerCandidate]:
+    """All miners with a posted quote for this exact direction, collateral attached.
+    Shared by the CLI taker path and the validator reserve engine so "who is
+    quotable" can never diverge between what a taker sees and what reserves."""
+    out: List[MinerCandidate] = []
+    for _pk, q in client.get_all('MinerQuote'):
+        if q.from_chain != from_chain or q.to_chain != to_chain:
+            continue
+        collateral = client.get_collateral_lamports(q.miner) or 0
+        out.append(MinerCandidate(miner=q.miner, rate_display=rate_display_from_fixed(q.rate), collateral=collateral))
+    return out
 
 
 def compute_intake_amounts(from_chain: str, to_chain: str, from_amount: int, rate_display: str) -> IntakeAmounts:

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -1,5 +1,3 @@
-import os
-
 from allways.classes import MinerActivity
 
 # ─── Network ───────────────────────────────────────────────
@@ -55,7 +53,6 @@ SCORING_WINDOW_BLOCKS = 300  # ~1 hour at 12s/block — scoring cadence and wind
 # seconds. The scoring *cadence* (due_for_scoring) stays subtensor-block-gated.
 SCORING_WINDOW_SECS = 3600  # ~1 hour — crown replay window width
 MAX_SCORING_BACKFILL_SECS = 2 * SCORING_WINDOW_SECS  # ~2 hours — backfill cap after a stall
-SCORING_EMA_ALPHA = 1.0  # Instantaneous — no smoothing across passes
 # Crown reward-state policy (D4): the only place that decides which MinerActivity
 # states earn crown. "All busy forfeits" = only AVAILABLE; add MinerActivity.FULFILLING
 # here to reward in-flight miners, with no other logic change.
@@ -140,54 +137,24 @@ EXTENSION_PADDING_SECONDS = 120  # safety buffer on top of confirmation time
 # Seconds, never blocks (the deadline axis is unix-seconds); >= the slowest chain's block time so a
 # bucket always spans at least one source block.
 EXTENSION_BUCKET_SECONDS = 600  # 10 min
-# Mirrors the contract's CHALLENGE_WINDOW_BLOCKS — must stay in sync with
-# smart-contracts/ink/lib.rs. Validators gate finalize calls on this locally
-# to avoid known-doomed txs; the contract is authoritative.
-CHALLENGE_WINDOW_BLOCKS = 8
-# Conservative upper bound on subtensor blocks elapsed per validator forward
-# step (base poll + per-step work + jitter). Used as a safety margin when
-# sizing extension targets so a single delayed step doesn't strand a propose
-# whose finalize window opens past the original reservation deadline.
-# Default sized for mainnet; testnet validators with slower/jankier RPC can
-# override via VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE env var.
-DEFAULT_VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE = 5
-VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE = max(
-    1,
-    int(
-        os.environ.get(
-            'VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE',
-            DEFAULT_VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE,
-        )
-    ),
-)
-# Vote to extend when this many blocks remain: a forward step to land each of
-# the propose and finalize txs, plus the challenge window between them.
-EXTEND_THRESHOLD_BLOCKS = 2 * VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE + CHALLENGE_WINDOW_BLOCKS
-
-# Cushion the miner subtracts from each swap's timeout before agreeing to
-# fulfill. Pinned to EXTEND_THRESHOLD_BLOCKS so the miner won't start a
-# fulfill inside the window where validators can no longer land a propose +
-# challenge before expiry. Not env-overridable: the right value is system-
-# determined (validator extension runway), not operator preference. Edit
-# this file directly if you need a different value.
-MINER_TIMEOUT_CUSHION_BLOCKS = EXTEND_THRESHOLD_BLOCKS
 
 # ─── Protocol Fee ──────────────────────────────────────────
 # Hardcoded 1% — matches the contract's immutable FEE_DIVISOR.
 FEE_DIVISOR = 100
 
-# Base fulfillment window (blocks); its seconds form is the sent-cache margin's base-window buffer.
-DEFAULT_FULFILLMENT_TIMEOUT_BLOCKS = 50  # ~10 min
+# Base fulfillment window (seconds, ~10 min) — the sent-cache margin's base-window buffer.
+DEFAULT_FULFILLMENT_TIMEOUT_SECS = 600
 
 # ─── Unix-axis miner runways (B4 — Solana) ────────────────
-# The Solana swap deadline (`Swap.timeout_at`) is unix-seconds, not a block height. Port the two
-# block-denominated miner runways to seconds via the subtensor block time so they keep the same
-# wall-clock meaning. Edit these directly if validator extension cadence changes.
-SECS_PER_BLOCK = 12
-MINER_TIMEOUT_CUSHION_SECS = MINER_TIMEOUT_CUSHION_BLOCKS * SECS_PER_BLOCK
+# The Solana swap deadline (`Swap.timeout_at`) is unix-seconds. Cushion the miner subtracts from
+# each swap's timeout before agreeing to fulfill, so it never starts a fulfill inside the span
+# where validators can no longer land an extension propose + challenge before expiry. Sized to
+# that runway — two validator forward steps plus the challenge window, at 12s subtensor blocks
+# ((2·5 + 8) × 12) — not operator preference; edit here if extension cadence changes.
+MINER_TIMEOUT_CUSHION_SECS = 216
 # Retain a miner's unmarked sent entry until past the contract's max extended deadline, else it can
 # discard then re-send a still-claimable swap (#461 double-send). The contract slides the deadline
 # cumulatively up to the extension ceiling, so cover that full budget plus one base window. Keep
 # CONTRACT_MAX_TOTAL_EXTENSION_SECS in sync with smart-contracts/solana/.../constants.rs.
 CONTRACT_MAX_TOTAL_EXTENSION_SECS = 8400  # 140 min — mirror of the contract's MAX_TOTAL_EXTENSION_SECS
-SENT_CACHE_DISCARD_MARGIN_SECS = CONTRACT_MAX_TOTAL_EXTENSION_SECS + DEFAULT_FULFILLMENT_TIMEOUT_BLOCKS * SECS_PER_BLOCK
+SENT_CACHE_DISCARD_MARGIN_SECS = CONTRACT_MAX_TOTAL_EXTENSION_SECS + DEFAULT_FULFILLMENT_TIMEOUT_SECS

--- a/allways/utils/config.py
+++ b/allways/utils/config.py
@@ -3,7 +3,7 @@ import os
 
 import bittensor as bt
 
-from allways.constants import MINER_POLL_INTERVAL_SECONDS, SCORING_EMA_ALPHA, VALIDATOR_POLL_INTERVAL_SECONDS
+from allways.constants import MINER_POLL_INTERVAL_SECONDS, VALIDATOR_POLL_INTERVAL_SECONDS
 from allways.utils.logging import setup_events_logger
 
 
@@ -95,7 +95,9 @@ def add_validator_args(cls, parser):
         '--neuron.moving_average_alpha',
         type=float,
         help='Moving average alpha parameter, how much to add of the new observation.',
-        default=SCORING_EMA_ALPHA,
+        # 1.0 = instantaneous, no smoothing across scoring passes — each round's
+        # rewards fully replace the previous scores. Operator-overridable.
+        default=1.0,
     )
 
     parser.add_argument(

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -8,7 +8,7 @@ invariants before it signs — the caller (offering or CLI) is never trusted.
 import re
 import time
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import Optional
 
 import bittensor as bt
 from bittensor import Keypair
@@ -16,7 +16,7 @@ from solders.pubkey import Pubkey
 
 from allways.chain_providers.base import ProviderUnreachableError
 from allways.cli.swap_commands.swap_intake import (
-    MinerCandidate,
+    candidate_miners,
     compute_intake_amounts,
     rate_display_from_fixed,
     select_best_miner,
@@ -233,18 +233,6 @@ class BestQuote:
     to_amount: int
 
 
-def _candidate_miners(validator, from_chain: str, to_chain: str) -> List[MinerCandidate]:
-    """All miners with a live quote for this exact direction, collateral attached."""
-    client = validator.solana_client
-    out: List[MinerCandidate] = []
-    for _pk, q in client.get_all('MinerQuote'):
-        if q.from_chain != from_chain or q.to_chain != to_chain:
-            continue
-        collateral = client.get_collateral_lamports(q.miner) or 0
-        out.append(MinerCandidate(miner=q.miner, rate_display=rate_display_from_fixed(q.rate), collateral=collateral))
-    return out
-
-
 def best_quote(validator, from_chain: str, to_chain: str, from_amount: int) -> Optional[BestQuote]:
     """Best executable quote for ``from_amount`` (source smallest-units): the miner giving the most dest.
 
@@ -254,7 +242,7 @@ def best_quote(validator, from_chain: str, to_chain: str, from_amount: int) -> O
     min_swap = int(getattr(cfg, 'min_swap_amount', 0) or 0)
     max_swap = int(getattr(cfg, 'max_swap_amount', 0) or 0)
     best = select_best_miner(
-        _candidate_miners(validator, from_chain, to_chain), from_chain, to_chain, from_amount, min_swap, max_swap
+        candidate_miners(client, from_chain, to_chain), from_chain, to_chain, from_amount, min_swap, max_swap
     )
     if best is None:
         return None

--- a/tests/test_swap_now_reservation.py
+++ b/tests/test_swap_now_reservation.py
@@ -130,7 +130,7 @@ def _run_swap_now(reserved_until, from_chain='btc'):
 
     with (
         patch('allways.cli.swap_commands.swap.get_solana_cli_context', return_value=(None, client)),
-        patch('allways.cli.swap_commands.swap._candidate_miners', return_value=[cand]),
+        patch('allways.cli.swap_commands.swap.candidate_miners', return_value=[cand]),
         patch('allways.cli.swap_commands.swap.select_best_miner', return_value=(cand, amts)),
         patch('allways.cli.swap_commands.swap._poll_drawn', return_value=drawn),
         patch('allways.cli.swap_commands.swap._poll_reservation', return_value=resv),
@@ -314,7 +314,7 @@ def _run_resume(existing, poll_resv):
     ]
     with (
         patch('allways.cli.swap_commands.swap.get_solana_cli_context', return_value=(None, client)),
-        patch('allways.cli.swap_commands.swap._candidate_miners', return_value=[cand]),
+        patch('allways.cli.swap_commands.swap.candidate_miners', return_value=[cand]),
         patch('allways.cli.swap_commands.swap.select_best_miner', return_value=(cand, amts)),
         patch(
             'allways.cli.swap_commands.swap._poll_drawn', return_value=None


### PR DESCRIPTION
## Summary
Stale sweep: the orphaned extension-vote block chain (CHALLENGE_WINDOW_BLOCKS, VALIDATOR_FORWARD_STEP_BLOCKS_ESTIMATE + its env override, EXTEND_THRESHOLD_BLOCKS, MINER_TIMEOUT_CUSHION_BLOCKS, SECS_PER_BLOCK) had no consumer left — the two live miner-side runways are pinned in seconds directly (MINER_TIMEOUT_CUSHION_SECS=216, DEFAULT_FULFILLMENT_TIMEOUT_SECS=600; identical values). The stale ink lib.rs sync pointer goes with them.

## Changes
- Delete SCORING_EMA_ALPHA (1.0 no-smoothing default inlined at its only consumer, the moving_average_alpha CLI arg)
- Extract the duplicated _candidate_miners into swap_intake.candidate_miners, shared by the CLI taker path and the validator reserve engine
- .env.example: drop the deleted env knob's doc lines
- RATE_PRECISION checked: single definition remains (audit item already resolved)

Independent of the scoring stack; 673 tests pass; run-suites fast matrix 3/3 PASS.