### PR TITLE
chore(solana): point the program id at the redeployed devnet address

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -9,7 +9,7 @@ NETUID_FINNEY = 7
 # allways_swap_manager program address. Committed default is the devnet deployment;
 # override with ALLWAYS_PROGRAM_ID. Must match the deployed program — a mismatch derives
 # different PDAs, so every account merely reads as absent instead of erroring.
-PROGRAM_ID = 'AKgfVK8zJVHuZwttdjU2CPykaHyTAvw5r9FUFUpM74JU'
+PROGRAM_ID = 'EhFT382UbUyzD56vv4kFJE3shtxqDgfpwErhJ7L1qeMf'
 
 # ─── Polling ──────────────────────────────────────────────
 # Bittensor base-neuron heartbeat, not the scoring/forward cadence.

--- a/smart-contracts/solana/Anchor.toml
+++ b/smart-contracts/solana/Anchor.toml
@@ -6,17 +6,17 @@ resolution = true
 skip-lint = false
 
 [programs.localnet]
-allways_swap_manager = "AKgfVK8zJVHuZwttdjU2CPykaHyTAvw5r9FUFUpM74JU"
+allways_swap_manager = "EhFT382UbUyzD56vv4kFJE3shtxqDgfpwErhJ7L1qeMf"
 
 # Same program id across all clusters (persistent keypair in custody; see
 # alw-utils/dev-environment/solana/migration-runbook.md). deploy.sh drives the
 # cluster/wallet via --provider.cluster/--provider.wallet, so these are for
 # `anchor deploy --provider.cluster devnet` / IDL tooling parity.
 [programs.devnet]
-allways_swap_manager = "AKgfVK8zJVHuZwttdjU2CPykaHyTAvw5r9FUFUpM74JU"
+allways_swap_manager = "EhFT382UbUyzD56vv4kFJE3shtxqDgfpwErhJ7L1qeMf"
 
 [programs.mainnet]
-allways_swap_manager = "AKgfVK8zJVHuZwttdjU2CPykaHyTAvw5r9FUFUpM74JU"
+allways_swap_manager = "EhFT382UbUyzD56vv4kFJE3shtxqDgfpwErhJ7L1qeMf"
 
 [provider]
 cluster = "localnet"

--- a/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
@@ -14,7 +14,7 @@ pub use constants::*;
 pub use instructions::*;
 pub use state::*;
 
-declare_id!("AKgfVK8zJVHuZwttdjU2CPykaHyTAvw5r9FUFUpM74JU");
+declare_id!("EhFT382UbUyzD56vv4kFJE3shtxqDgfpwErhJ7L1qeMf");
 
 #[program]
 pub mod allways_swap_manager {


### PR DESCRIPTION
## What

The devnet program was redeployed to a fresh address after the two-phase reservation change altered the `Pool` and `Reservation` account layouts (`init_if_needed` will not realloc an existing PDA, so a new program id was cheaper than migrating). The source tree still declared the old address.

```
AKgfVK8zJVHuZwttdjU2CPykaHyTAvw5r9FUFUpM74JU
-> EhFT382UbUyzD56vv4kFJE3shtxqDgfpwErhJ7L1qeMf
```

Four call sites move together because they are one value by construction — `deploy.sh:109` hard-refuses when `ALLWAYS_PROGRAM_ID != declare_id!`, and the migration runbook pins a single id across clusters:

- `smart-contracts/solana/programs/allways_swap_manager/src/lib.rs` — `declare_id!`
- `smart-contracts/solana/Anchor.toml` — localnet / devnet / mainnet
- `allways/allways/constants.py` — `PROGRAM_ID` (the fallback when `ALLWAYS_PROGRAM_ID` is unset)

## Why it mattered

Before this, no ref in the repo declared the id that devnet was actually running. A rebuild from `contract-v2` produced a binary whose `declare_id!` was `AKgf…`; Anchor's entrypoint would have rejected it at `EhFT…` with `DeclaredProgramIdMismatch`, and `deploy.sh` would have refused to ship it. The deployment was not reproducible from source.

## Verification

- `EhFT382…` confirmed live on devnet: `executable: true`, owner `BPFLoaderUpgradeable`, and currently serving `aw-indexer` on isaiah (`state: 2 miners`).
- **Rebuilt `target/deploy/allways_swap_manager.so` before testing.** The LiteSVM tests `include_bytes!` that artifact, so a stale `.so` would have kept the old id baked in and passed for the wrong reason.
- `cargo test -p allways_swap_manager` — **111 passed**, 0 failed, 17 ignored.

## Note on `[programs.mainnet]`

Changed along with the others, per the runbook's documented "same program id across all clusters" invariant. Nothing is deployed to mainnet, so this is a no-op today — but flagging it explicitly since it is the one line here that is not merely describing devnet reality.

## Follow-up (not in this PR)

`allways-ui` has the old id in two doc strings (`src/components/agents/AgentMarkdown.ts:21`, `public/llms.txt:18`). Separate repo, separate PR.