### PR TITLE
feat(cli): wire set-finalize-window; give BTC a replay-freshness grace

### DIFF
--- a/allways/chains.py
+++ b/allways/chains.py
@@ -39,6 +39,9 @@ CHAIN_BTC = ChainDefinition(
     min_confirmations=2,
     # 1000 sat, not the bare 546 P2PKH dust line: margin vs higher dustrelayfee / wallet quirks, and a tighter executable-rate ceiling.
     min_onchain_amount=1000,
+    # Only BTC needs a grace: a block's timestamp need only beat the median of the last 11, so it can lag
+    # wall clock (or go backwards) and stamp an honest deposit before reservation.created_at → false replay.
+    replay_grace_secs=300,
 )
 CHAIN_TAO = ChainDefinition(
     id='tao',

--- a/allways/cli/swap_commands/admin.py
+++ b/allways/cli/swap_commands/admin.py
@@ -151,6 +151,31 @@ def set_pool_window(secs: int):
     )
 
 
+@admin_group.command('set-finalize-window', show_disclaimer=True)
+@click.argument('secs', type=int)
+def set_finalize_window(secs: int):
+    """Set the post-draw finalize window in seconds (how long the seat winner has to fill its reservation).
+
+    [dim]The draw creates an UNFILLED reservation; only its router may call finalize_reservation, and only
+    within this window. Too short and a slow RPC round-trip forfeits the seat (fee spent, miner held busy
+    until reaped). The contract clamps this to [15, 300].[/dim]
+
+    [dim]Examples:
+        $ alw admin set-finalize-window 180[/dim]
+    """
+    if not 15 <= secs <= 300:
+        fail('Seconds must be within [15, 300] (the contract clamps this range)')
+    _run_setter(
+        title='Set Finalize Window',
+        getter=lambda c: c.get_config().finalize_window_secs,
+        setter=lambda c: c.set_finalize_window(secs),
+        noun='finalize window',
+        format_current=lambda v: secs_str(v),
+        new_display=secs_str(secs),
+        success_msg=f'Finalize window set to {secs_str(secs)}',
+    )
+
+
 @admin_group.command('set-weights-interval', show_disclaimer=True)
 @click.argument('secs', type=int)
 def set_weights_interval(secs: int):

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -30,7 +30,8 @@ from allways.cli.swap_commands.swap_intake import (
     select_best_miner,
     to_smallest_units,
 )
-from allways.constants import NUMERAIRE_CHAIN
+from allways.constants import FEE_DIVISOR, NUMERAIRE_CHAIN
+from allways.utils.rate import apply_fee_deduction
 
 
 @click.group('swap', cls=StyledGroup, show_disclaimer=True)
@@ -70,16 +71,29 @@ def _self_crank_resolve(client, miner) -> None:
             raise
 
 
+def _drawn_unfilled(resv) -> bool:
+    """A seat freshly won by the draw and not yet named. `created_at == 0` is load-bearing: a
+    reservation that was filled and then consumed also has `reserved_until == 0`, but carries a
+    non-zero `created_at` — matching it would finalize against a dead window. Same guard as the
+    contract's `close_unfilled_reservation`."""
+    if resv is None:
+        return False
+    return (
+        int(resv.reserved_until) == 0
+        and int(resv.created_at) == 0
+        and int(resv.finalize_by) > time.time()
+    )
+
+
 def _poll_drawn(client, miner, user, timeout_secs: int):
-    """Poll until THIS taker's bid draws its UNFILLED reservation (router == us, reserved_until == 0,
-    finalize_by armed), self-cranking `resolve_pool` each pass. Returns the drawn reservation, or None
-    on timeout / if a different router won the seat."""
+    """Poll until THIS taker's bid draws its UNFILLED reservation, self-cranking `resolve_pool` each
+    pass. Returns the drawn reservation, or None on timeout / if a different router won the seat."""
     us = str(user)
     deadline = time.time() + timeout_secs
     while time.time() < deadline:
         _self_crank_resolve(client, miner)
         resv = client.get_reservation(miner)
-        if resv is not None and int(resv.reserved_until) == 0 and int(resv.finalize_by) != 0:
+        if _drawn_unfilled(resv):
             return resv if str(resv.router) == us else None  # seated: us, or someone else won
         time.sleep(3)
     return None
@@ -162,7 +176,9 @@ def swap_now_command(
     if best is None:
         fail('No miner can fund an executable swap for that amount within bounds.')
     cand, amts = best
-    recv = amts.to_amount / 10 ** get_chain(to_chain).decimals
+    # Quote the NET dest leg — the miner delivers `to_amount` less the protocol fee, same as
+    # `alw swap quote`. The gross `to_amount` is what gets pinned on-chain, not what you receive.
+    recv = apply_fee_deduction(amts.to_amount, FEE_DIVISOR) / 10 ** get_chain(to_chain).decimals
 
     console.print(
         f'\n  Swap [cyan]{amount_opt} {from_chain.upper()}[/cyan] -> ~[cyan]{recv:.8g} {to_chain.upper()}[/cyan]'
@@ -190,7 +206,7 @@ def swap_now_command(
     resv = _poll_reservation(client, cand.miner, timeout_secs=30)
     if resv is None or str(resv.user) != str(user):
         fail('  Finalize did not produce a live reservation for you. Do NOT send funds; re-run.')
-    recv = int(resv.to_amount) / 10 ** get_chain(to_chain).decimals
+    recv = apply_fee_deduction(int(resv.to_amount), FEE_DIVISOR) / 10 ** get_chain(to_chain).decimals
     console.print(f'[green]  Seat filled[/green] — receiving ~[cyan]{recv:.8g} {to_chain.upper()}[/cyan].')
     # Never instruct a send the reservation can't outlive: a deposit that lands after reserved_until
     # yields no claim, and the funds are stranded (straight to the miner — no escrow, no Swap, no


### PR DESCRIPTION
Three related gaps, all surfaced while writing the mainnet runbook.

## 1. `alw admin set-finalize-window` — the knob existed, nothing exposed it

The contract has `set_finalize_window` (clamped `[15, 300]`) and `client.set_finalize_window` exists, but there was **no `alw admin` subcommand**. So the live 60s default could only be changed with a Python one-liner — not something you want to reach for in a mainnet incident.

60s is the window the seat winner has between `resolve_pool` and `finalize_reservation`. On devnet over public RPC this already loses seats (`_poll_drawn` sleeps 3s/pass; a slow round-trip forfeits the fee and leaves the miner busy until reaped). Mainnet RPC won't be kinder.

Mirrors the existing `set-pool-window` setter, and guards the contract's clamp client-side so an out-of-range value is a clear message rather than a revert:

```
$ alw admin --yes set-finalize-window 600
Seconds must be within [15, 300] (the contract clamps this range)

$ alw admin set-finalize-window 180
  Current: 60s (~1m)
  New:     180s (~3m)
```

## 2. BTC `replay_grace_secs = 300`

`replay_grace_secs` was a `ChainDefinition` default of `0` that **no chain overrode**.

A Bitcoin block's timestamp need only exceed the median of the previous 11 blocks (MTP), so it can lag wall clock or move backwards. An honest deposit mined into such a block stamps *before* `reservation.created_at`, `is_tx_fresh` judges it a replay, it is never attested, and the reservation lapses — **with the taker's unescrowed funds already at the miner.** Forward drift is benign (`>=` passes); the downward correction is what bites. Observed on testnet4: timestamps ~105 min ahead of real time.

**Why 300 and not the ~1h MTP worst case.** The grace *is* the replay window. When a swap completes its `Swap` PDA is closed, freeing the `swap_key` derived from the deposit txid — and `post-tx` is permissionless, so that old txid could be re-relayed against a **new** reservation pinning the same `from_addr` / `miner_from_addr` / `from_amount`. The miner would deliver twice for one deposit. A BTC swap needs 2 confirmations (~20 min) plus fulfilment, so an identical repeat cannot come back around inside 5 minutes.

The two attackers are asymmetric: exploiting a small grace requires colluding with a *Bitcoin* block producer to stamp at the MTP floor; exploiting a large grace requires only watching the chain. Favor the smaller window.

SOL and TAO stay at `0` — their block timestamps are chain-clock accurate, and `>=` already admits a same-second deposit.

## 3. `swap now` — `_drawn_unfilled` and net-fee quoting

`created_at == 0` is load-bearing. A reservation that was **filled and then consumed** also has `reserved_until == 0`, so the old predicate (`reserved_until == 0 && finalize_by != 0`) matched a dead seat and finalized against an expired window → `FinalizeWindowExpired` (6047). Symptom: the first swap after a fresh deploy works, every later one fails. Same guard the contract's `close_unfilled_reservation` uses.

Also quotes the **net** dest leg: the miner delivers `to_amount` less the protocol fee, matching `alw swap quote`. The gross `to_amount` is what gets pinned on-chain, not what you receive.

## Verification

- `ruff check` clean; **284 tests pass**.
- `set-finalize-window` registers, clamps, and reads the live `finalize_window_secs` (60s) off `EhFT382…`. No tx sent.
- Freshness boundary: a block 299s behind the floor is fresh, 301s is not, and an unconfirmed tx (`block_time is None`) still fails closed.