### PR TITLE
fix(contract): finalize_reservation must refuse a consumed reservation

### DIFF
--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/finalize_reservation.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/finalize_reservation.rs
@@ -61,9 +61,15 @@ pub fn handler(
     let now = Clock::get()?.unix_timestamp;
     let cfg = &ctx.accounts.config;
 
-    // Fill exactly once, and only inside the finalize window.
+    // Fill exactly once, and only inside the finalize window. Both sentinels are load-bearing:
+    // `reserved_until == 0` alone means "not currently live", which a reservation CONSUMED by
+    // `vote_initiate` also satisfies (it zeroes reserved_until and frees the claim slot). Only
+    // `created_at == 0` says "drawn but never filled". Without it, the seat winner could re-fill a
+    // consumed reservation while `finalize_by` is still ahead, minting a second live hold on a miner
+    // that already has an active swap — and each fill's 1.10x collateral gate is checked in isolation.
+    // Same guard `close_unfilled_reservation` relies on; do not let these two drift apart.
     require!(
-        ctx.accounts.reservation.reserved_until == 0,
+        ctx.accounts.reservation.reserved_until == 0 && ctx.accounts.reservation.created_at == 0,
         ErrorCode::AlreadyFilled
     );
     require!(

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_swap.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_swap.rs
@@ -871,3 +871,54 @@ fn test_stats_separate_per_direction() {
         "reverse-direction stats PDA not created"
     );
 }
+
+/// A reservation CONSUMED by `vote_initiate` (reserved_until back to 0, claim slot cleared) must not be
+/// re-fillable — even while `finalize_by` is still in the future.
+///
+/// `created_at != 0` is the only field distinguishing a consumed reservation from a fresh drawn seat;
+/// both carry `reserved_until == 0`. It is the exact guard `close_unfilled_reservation` relies on.
+/// Without the same guard here, the seat winner can mint a SECOND live reservation on a miner that
+/// already has an active swap — and each fill's 1.10x collateral gate is checked in isolation, so the
+/// miner ends up backing two obligations with collateral sized for one.
+///
+/// Reaching the overlap needs the whole finalize -> claim -> quorum path to land inside the finalize
+/// window. At the 60s default that is impractical, which is why `finalize_by` alone has masked this so
+/// far. `set-finalize-window` (settable to 300s) widens it, so the invariant is made explicit here
+/// rather than left to a timing coincidence.
+#[test]
+fn test_finalize_refuses_a_reservation_already_consumed_by_initiate() {
+    let (mut svm, _admin, vals, miner, _rr) = setup_full(COLLATERAL);
+
+    // setup_full leaves the clock past finalize_by; step back inside the window so this test exercises
+    // the created_at guard rather than the deadline.
+    let finalize_by = reservation_acct(&svm, &miner.pubkey()).finalize_by;
+    set_clock(&mut svm, finalize_by - 5);
+
+    // Drive the filled reservation to an Active swap. vote_initiate consumes it.
+    do_initiate(&mut svm, &vals, &miner.pubkey(), "srctx1");
+
+    let now = svm.get_sysvar::<Clock>().unix_timestamp;
+    let r = reservation_acct(&svm, &miner.pubkey());
+    assert_eq!(r.reserved_until, 0, "vote_initiate consumed the reservation");
+    assert_eq!(r.claimed_swap_key, [0u8; 32], "and freed the claim slot");
+    assert_ne!(r.created_at, 0, "but it WAS filled — not a fresh drawn seat");
+    assert!(now <= r.finalize_by, "and the finalize window is still open (the dangerous overlap)");
+    assert!(miner_state(&svm, &miner.pubkey()).has_active_swap, "miner is mid-swap");
+
+    let res = send(
+        &mut svm,
+        finalize_ix(&vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER),
+        &vals[0].pubkey(),
+        &vals[0],
+    );
+    assert!(res.is_err(), "a consumed reservation must not be re-filled inside its finalize window");
+    assert_eq!(
+        reservation_acct(&svm, &miner.pubkey()).reserved_until,
+        0,
+        "reservation stays consumed — no second live hold on a miner with an active swap"
+    );
+}
+
+fn reservation_acct(svm: &LiteSVM, miner: &Pubkey) -> Reservation {
+    Reservation::try_deserialize(&mut svm.get_account(&resv_pda(miner)).unwrap().data.as_slice()).unwrap()
+}


### PR DESCRIPTION
## The bug

`finalize_reservation` gates re-fills on two things:

```rust
require!(reservation.reserved_until == 0, AlreadyFilled);
require!(now <= reservation.finalize_by, FinalizeWindowExpired);
```

But `reserved_until == 0` only means **"not currently live"** — and a reservation *consumed* by `vote_initiate` also satisfies it. That instruction does both:

```rust
ctx.accounts.reservation.reserved_until = 0;          // consume the reservation
ctx.accounts.reservation.claimed_swap_key = [0u8; 32]; // and free the claim slot
```

The only field separating a **consumed** reservation from a **fresh drawn seat** is `created_at` — `resolve_pool` sets it to `0`, `finalize_reservation` stamps it.

So the sole thing preventing a re-fill was `finalize_by` having already elapsed by the time a swap reached quorum. That is an **implicit timing invariant, not a guard.**

Inside the overlap, the seat winner (the accounts struct already constrains `reservation.router == router.key()`) can call `finalize_reservation` a second time on the consumed reservation and mint a **second live hold on a miner that already has `has_active_swap`**. Each fill's `required_collateral` (1.10×) gate is evaluated in isolation, so the miner ends up backing two obligations with collateral sized for one. `vote_initiate` has no `!has_active_swap` check — concurrency is enforced entirely by the single-per-miner `Reservation` PDA, which this defeats.

## Why now

Reaching the overlap requires finalize → claim → `vote_initiate` quorum to all land inside the finalize window. At the **60s default that is impractical**, which is why it has stayed masked and why nobody has hit it.

**allways#534 wired `alw admin set-finalize-window`, settable up to 300s.** That widens the window fivefold. The invariant should be explicit rather than a coincidence of two unrelated timings.

## The fix

One line, mirroring the guard its sibling already has:

```rust
require!(
    reservation.reserved_until == 0 && reservation.created_at == 0,
    ErrorCode::AlreadyFilled
);
```

`close_unfilled_reservation` already carries the identical check, with a comment saying exactly why:

> `created_at == 0` is the load-bearing guard: a reservation filled then consumed by `vote_initiate` also has `reserved_until == 0`, but `created_at != 0` — so this can't free a miner whose swap is in flight.

Both sites now carry that comment and a note not to let them drift apart.

## Verification — reproduced before fixing

New LiteSVM regression test drives `setup_full` → `finalize` → `claim` → `vote_initiate` with the clock held **inside** `finalize_by`, asserts the dangerous overlap actually exists (`reserved_until == 0`, `created_at != 0`, `now <= finalize_by`, `has_active_swap == true`), then attempts a second finalize.

- **Against the unfixed program it FAILED** — the re-fill succeeded, exactly as predicted.
- With the guard it passes, and the reservation stays consumed.

Rebuilt `target/deploy/allways_swap_manager.so` before running: the tests `include_bytes!` that artifact, so a stale `.so` would have passed for the wrong reason.

```
cargo test -p allways_swap_manager
112 passed; 0 failed  (was 111)
```

No existing test regresses — a fresh drawn seat has `created_at == 0` and finalizes normally.

## Deploy note

This is a contract change, so it needs a devnet redeploy/upgrade to take effect. Given the `deploy.sh` custody situation (alw-utils#96, `MAINNET_RUNBOOK.md` §0.1), it should ride whatever redeploy resolves the program-keypair question rather than forcing one on its own.