### PR TITLE
chore(contract): cut over to fresh program id 6JVBEj5w…

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -9,7 +9,7 @@ NETUID_FINNEY = 7
 # allways_swap_manager program address. Committed default is the devnet deployment;
 # override with ALLWAYS_PROGRAM_ID. Must match the deployed program — a mismatch derives
 # different PDAs, so every account merely reads as absent instead of erroring.
-PROGRAM_ID = 'EhFT382UbUyzD56vv4kFJE3shtxqDgfpwErhJ7L1qeMf'
+PROGRAM_ID = '6JVBEj5w27J2SVjERmv2c7wXgFee9nSSBKUJevHehyBD'
 
 # ─── Polling ──────────────────────────────────────────────
 # Bittensor base-neuron heartbeat, not the scoring/forward cadence.

--- a/smart-contracts/solana/Anchor.toml
+++ b/smart-contracts/solana/Anchor.toml
@@ -6,17 +6,17 @@ resolution = true
 skip-lint = false
 
 [programs.localnet]
-allways_swap_manager = "EhFT382UbUyzD56vv4kFJE3shtxqDgfpwErhJ7L1qeMf"
+allways_swap_manager = "6JVBEj5w27J2SVjERmv2c7wXgFee9nSSBKUJevHehyBD"
 
 # Same program id across all clusters (persistent keypair in custody; see
 # alw-utils/dev-environment/solana/migration-runbook.md). deploy.sh drives the
 # cluster/wallet via --provider.cluster/--provider.wallet, so these are for
 # `anchor deploy --provider.cluster devnet` / IDL tooling parity.
 [programs.devnet]
-allways_swap_manager = "EhFT382UbUyzD56vv4kFJE3shtxqDgfpwErhJ7L1qeMf"
+allways_swap_manager = "6JVBEj5w27J2SVjERmv2c7wXgFee9nSSBKUJevHehyBD"
 
 [programs.mainnet]
-allways_swap_manager = "EhFT382UbUyzD56vv4kFJE3shtxqDgfpwErhJ7L1qeMf"
+allways_swap_manager = "6JVBEj5w27J2SVjERmv2c7wXgFee9nSSBKUJevHehyBD"
 
 [provider]
 cluster = "localnet"

--- a/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
@@ -14,7 +14,7 @@ pub use constants::*;
 pub use instructions::*;
 pub use state::*;
 
-declare_id!("EhFT382UbUyzD56vv4kFJE3shtxqDgfpwErhJ7L1qeMf");
+declare_id!("6JVBEj5w27J2SVjERmv2c7wXgFee9nSSBKUJevHehyBD");
 
 #[program]
 pub mod allways_swap_manager {


### PR DESCRIPTION
Program-id cutover per CUTOVER_TO_NEW_PROGRAM_ID.md — fresh program, not an upgrade.

- `declare_id!` in `lib.rs`
- `Anchor.toml` localnet/devnet/mainnet entries
- `allways/constants.py` `PROGRAM_ID`

Old id `EhFT382UbUyzD56vv4kFJE3shtxqDgfpwErhJ7L1qeMf` has zero remaining references outside the runbook doc. Rebuilt `.so` first, then ran the suite: **112 pass**; verified the new id's raw bytes are in `target/deploy/allways_swap_manager.so` and the old id's are not.

Includes #535 (finalize refuses consumed reservation) since it branches off current `contract-v2`.