### PR TITLE
feat(contract): pin treasury withdrawals to the admin

### DIFF
--- a/allways/cli/swap_commands/admin.py
+++ b/allways/cli/swap_commands/admin.py
@@ -406,25 +406,31 @@ def remove_vali(pubkey: str):
 
 
 @admin_group.command('withdraw-treasury', show_disclaimer=True)
-@click.argument('recipient', type=str)
+@click.argument('recipient', type=str, required=False)
 @click.option('--amount', default=None, type=FINITE_FLOAT, help='Amount in SOL (default: withdraw the full balance)')
 @click.option('--yes', '-y', is_flag=True, help='Skip confirmation prompt')
-def withdraw_treasury(recipient: str, amount: float | None, yes: bool):
-    """Withdraw accrued protocol fees from the treasury to a recipient.
+def withdraw_treasury(recipient: str | None, amount: float | None, yes: bool):
+    """Withdraw accrued protocol fees from the treasury to the admin wallet.
 
     [dim]Replaces the ink! fee-recycle: on Solana fees accrue in a treasury PDA the admin draws down.
+    The contract pins the recipient to the admin; onward distribution is a second, admin-signed hop.
 
     Examples:
-        $ alw admin withdraw-treasury <pubkey>
-        $ alw admin withdraw-treasury <pubkey> --amount 1.5[/dim]
+        $ alw admin withdraw-treasury
+        $ alw admin withdraw-treasury --amount 1.5[/dim]
     """
-    pk = _parse_pubkey(recipient)
     _, client = get_solana_cli_context()
 
     try:
+        config = client.get_config()
         treasury = client.get_treasury()
     except SolanaClientError as e:
-        fail(f'Failed to read treasury: {e}')
+        fail(f'Failed to read config/treasury: {e}')
+    admin_pk = config.admin
+
+    pk = _parse_pubkey(recipient) if recipient is not None else admin_pk
+    if pk != admin_pk:
+        fail(f'The contract only allows treasury withdrawals to the admin ({admin_pk}). Omit RECIPIENT, or move the funds onward from the admin wallet afterwards.')
     total = treasury.total if treasury is not None else 0
 
     lamports = to_lamports(amount) if amount is not None else total

--- a/smart-contracts/solana/programs/allways_swap_manager/src/error.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/error.rs
@@ -125,4 +125,8 @@ pub enum ErrorCode {
     // --- A5: hotkey binding ---
     #[msg("This hotkey is already bound to a different pubkey (set-once)")]
     HotkeyAlreadyBound,
+
+    // --- Treasury hardening ---
+    #[msg("Treasury withdrawals may only be sent to the admin")]
+    TreasuryRecipientNotAdmin,
 }

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/withdraw_treasury.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/withdraw_treasury.rs
@@ -5,8 +5,8 @@ use crate::error::ErrorCode;
 use crate::events::TreasuryWithdrawn;
 use crate::state::{Config, Treasury};
 
-/// Admin withdraws accrued subnet revenue from the treasury to a recipient. Native-lamport move
-/// (treasury → recipient) + decrement of `total`, preserving the treasury invariant
+/// Admin withdraws accrued subnet revenue from the treasury to the admin wallet. Native-lamport
+/// move (treasury → admin) + decrement of `total`, preserving the treasury invariant
 /// (`lamports == rent + total`). Structurally cannot touch collateral — that lives in a separate PDA.
 #[derive(Accounts)]
 pub struct WithdrawTreasury<'info> {
@@ -18,8 +18,9 @@ pub struct WithdrawTreasury<'info> {
     #[account(mut, seeds = [TREASURY_SEED], bump = treasury.bump)]
     pub treasury: Account<'info, Treasury>,
 
-    /// CHECK: receives the withdrawn fees; admin chooses the destination.
-    #[account(mut)]
+    /// CHECK: pinned to the admin so a bad CLI argument or compromised tooling cannot route
+    /// fees to an arbitrary address; onward distribution is a second, admin-signed hop.
+    #[account(mut, constraint = recipient.key() == config.admin @ ErrorCode::TreasuryRecipientNotAdmin)]
     pub recipient: UncheckedAccount<'info>,
 }
 

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
@@ -842,15 +842,15 @@ fn onchain_withdraw_treasury_happy_path() {
     let treasury_before = read_treasury(&rpc).total;
     assert!(treasury_before >= fee, "treasury holds at least this swap's fee");
 
-    let recipient = Keypair::new().pubkey();
-    let recip_before = rpc.get_account(&recipient).map(|a| a.lamports).unwrap_or(0);
-    send(&rpc, withdraw_treasury_ix(&admin.pubkey(), &recipient, fee), &admin.pubkey(), &admin)
+    // Recipient is pinned to the admin on-chain; the admin also pays the tx fee.
+    let admin_before = rpc.get_account(&admin.pubkey()).map(|a| a.lamports).unwrap_or(0);
+    send(&rpc, withdraw_treasury_ix(&admin.pubkey(), &admin.pubkey(), fee), &admin.pubkey(), &admin)
         .expect("withdraw treasury");
 
     assert_eq!(
-        rpc.get_account(&recipient).map(|a| a.lamports).unwrap_or(0),
-        recip_before + fee,
-        "recipient received the fee"
+        rpc.get_account(&admin.pubkey()).map(|a| a.lamports).unwrap_or(0),
+        admin_before + fee - 5_000,
+        "admin received the fee (minus tx fee)"
     );
     assert_eq!(read_treasury(&rpc).total, treasury_before - fee, "treasury drained by fee");
 }

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_treasury.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_treasury.rs
@@ -22,6 +22,8 @@ const SYS: Pubkey = anchor_lang::solana_program::system_program::ID;
 const SLOT_HASHES_ID: Pubkey = Pubkey::from_str_const("SysvarS1otHashes111111111111111111111111111");
 const BASE_TS: i64 = 1_700_000_000;
 const SOL_AMOUNT: u64 = 2_000_000_000;
+// LiteSVM's default per-signature fee; the admin is both payer and recipient in the happy path.
+const TX_FEE: u64 = 5_000;
 
 fn pid() -> Pubkey {
     allways_swap_manager::id()
@@ -206,11 +208,11 @@ fn test_withdraw_treasury_happy_path() {
     // Treasury-side conservation: lamports above the rent reserve always equal `total`.
     let treasury_rent = lam(&svm, &treasury_pda()) - treasury(&svm).total;
 
-    let recipient = Keypair::new().pubkey();
-    let before = lam(&svm, &recipient);
-    send(&mut svm, withdraw_ix(&admin.pubkey(), &recipient, fee), &admin.pubkey(), &admin).expect("withdraw");
+    // Recipient is pinned to the admin on-chain; withdrawing is admin → admin.
+    let before = lam(&svm, &admin.pubkey());
+    send(&mut svm, withdraw_ix(&admin.pubkey(), &admin.pubkey(), fee), &admin.pubkey(), &admin).expect("withdraw");
 
-    assert_eq!(lam(&svm, &recipient), before + fee, "recipient received fees");
+    assert_eq!(lam(&svm, &admin.pubkey()), before + fee - TX_FEE, "admin received fees (minus tx fee)");
     assert_eq!(treasury(&svm).total, 0, "treasury drained");
     // Treasury conserves lamports: lamports == rent + total. (Per-miner collateral-vault conservation
     // is covered in test_collateral / test_swap.)
@@ -230,8 +232,17 @@ fn test_non_admin_cannot_withdraw() {
 #[test]
 fn test_cannot_overdraw_treasury() {
     let (mut svm, admin, fee) = setup_with_fee();
-    let recipient = Keypair::new().pubkey();
-    let res = send(&mut svm, withdraw_ix(&admin.pubkey(), &recipient, fee + 1), &admin.pubkey(), &admin);
+    let res = send(&mut svm, withdraw_ix(&admin.pubkey(), &admin.pubkey(), fee + 1), &admin.pubkey(), &admin);
     assert!(res.is_err(), "withdrawing more than treasury rejected");
     assert_eq!(treasury(&svm).total, fee, "treasury untouched");
+}
+
+#[test]
+fn test_withdraw_to_non_admin_recipient_rejected() {
+    let (mut svm, admin, fee) = setup_with_fee();
+    let recipient = Keypair::new().pubkey();
+    let res = send(&mut svm, withdraw_ix(&admin.pubkey(), &recipient, fee), &admin.pubkey(), &admin);
+    assert!(res.is_err(), "admin-signed withdrawal to a non-admin recipient rejected");
+    assert_eq!(treasury(&svm).total, fee, "treasury untouched");
+    assert_eq!(lam(&svm, &recipient), 0, "recipient received nothing");
 }

--- a/tests/test_cli_admin_solana.py
+++ b/tests/test_cli_admin_solana.py
@@ -64,17 +64,46 @@ def test_add_vali_calls_add_validator_with_weight(monkeypatch):
     assert str(args[0]) == pk and args[1] == 3
 
 
-def test_withdraw_treasury_defaults_to_full_balance(monkeypatch):
+def test_withdraw_treasury_defaults_to_admin_and_full_balance(monkeypatch):
     client = MagicMock()
+    admin_pk = Keypair().pubkey()
+    client.get_config.return_value = _config(admin=admin_pk)
     client.get_treasury.return_value = types.SimpleNamespace(total=2_000_000_000)  # 2 SOL
     _patch_client(monkeypatch, client)
-    pk = str(Keypair().pubkey())
 
-    result = CliRunner().invoke(admin.admin_group, ['withdraw-treasury', pk, '--yes'])
+    result = CliRunner().invoke(admin.admin_group, ['withdraw-treasury', '--yes'])
 
     assert result.exit_code == 0, result.output
     args = client.withdraw_treasury.call_args.args
-    assert str(args[0]) == pk and args[1] == 2_000_000_000
+    assert args[0] == admin_pk and args[1] == 2_000_000_000
+
+
+def test_withdraw_treasury_rejects_non_admin_recipient(monkeypatch):
+    client = MagicMock()
+    admin_pk = Keypair().pubkey()
+    client.get_config.return_value = _config(admin=admin_pk)
+    client.get_treasury.return_value = types.SimpleNamespace(total=2_000_000_000)
+    _patch_client(monkeypatch, client)
+    outsider = str(Keypair().pubkey())
+
+    result = CliRunner().invoke(admin.admin_group, ['withdraw-treasury', outsider, '--yes'])
+
+    assert result.exit_code != 0
+    assert 'only allows treasury withdrawals to the admin' in result.output
+    client.withdraw_treasury.assert_not_called()
+
+
+def test_withdraw_treasury_accepts_explicit_admin_recipient(monkeypatch):
+    client = MagicMock()
+    admin_pk = Keypair().pubkey()
+    client.get_config.return_value = _config(admin=admin_pk)
+    client.get_treasury.return_value = types.SimpleNamespace(total=2_000_000_000)
+    _patch_client(monkeypatch, client)
+
+    result = CliRunner().invoke(admin.admin_group, ['withdraw-treasury', str(admin_pk), '--yes'])
+
+    assert result.exit_code == 0, result.output
+    assert client.withdraw_treasury.call_args.args[0] == admin_pk
 
 
 def test_halt_skips_when_already_halted(monkeypatch):


### PR DESCRIPTION
Hardens `withdraw_treasury`: the recipient account is now constrained to `config.admin` (`TreasuryRecipientNotAdmin`, appended to the error enum to preserve indices).

**Threat model**: kills fat-finger recipients and compromised-tooling/blind-signing routing of the treasury in a single tx. It deliberately does NOT defend against admin-key theft (an attacker forwards from the admin wallet — that's what a multisig admin is for). Distribution becomes a second, admin-signed, auditable hop; with a Squads-vault admin on mainnet, fees land in the multisig automatically.

- Contract: constraint on `recipient` + new error code
- CLI: `alw admin withdraw-treasury` RECIPIENT now optional (defaults to admin); explicit non-admin fails fast with a clear message
- Tests: LiteSVM happy-path now admin→admin, new `test_withdraw_to_non_admin_recipient_rejected`, integration test updated; 3 new CLI tests (default-to-admin / reject-non-admin / explicit-admin)

**113 Rust + 26 Python tests pass.** Note: interacts with the missing `transfer_admin` — admin is fixed at `initialize`, so after this lands the treasury destination is too; choose the mainnet admin address accordingly.

Requires a devnet program upgrade to take effect on `6JVBEj5w…` (current deployed binary still allows arbitrary recipients).