### PR TITLE
fix(validator,cli): pin source sender in settlement loop; drop stale-read guard on halt/resume

### DIFF
--- a/allways/cli/swap_commands/admin.py
+++ b/allways/cli/swap_commands/admin.py
@@ -473,13 +473,9 @@ def halt_system():
     """
     _, client = get_solana_cli_context()
 
-    try:
-        if client.get_config().halted:
-            console.print('[yellow]System is already halted[/yellow]')
-            return
-    except SolanaClientError as e:
-        fail(f'Failed to read halt status: {e}')
-
+    # Do NOT gate on a pre-read of `halted` — against a load-balanced RPC a stale node can
+    # misreport the state and block a legitimate halt. Just submit; the on-chain state is the
+    # source of truth (setting halted=true when already halted is a harmless no-op).
     console.print('\n[bold red]Halt System[/bold red]\n')
     console.print('  This blocks new deposits / activations / reservation pools.')
     console.print('  Existing swaps continue to completion.\n')
@@ -505,13 +501,9 @@ def resume_system():
     """
     _, client = get_solana_cli_context()
 
-    try:
-        if not client.get_config().halted:
-            console.print('[yellow]System is not halted[/yellow]')
-            return
-    except SolanaClientError as e:
-        fail(f'Failed to read halt status: {e}')
-
+    # Do NOT gate on a pre-read of `halted` — a stale RPC node can misreport it and refuse a
+    # legitimate resume (observed on public devnet). Just submit; on-chain is the source of truth
+    # (setting halted=false when already live is a harmless no-op).
     console.print('\n[bold]Resume System[/bold]\n')
     console.print('  This allows new deposits / activations / pools again.\n')
 

--- a/allways/validator/solana_swap_loop.py
+++ b/allways/validator/solana_swap_loop.py
@@ -234,6 +234,7 @@ class SolanaSwapLoop:
             swap.miner_from_addr,
             int(swap.from_amount),
             block_hint=int(getattr(swap, 'from_tx_block', 0)),
+            sender=swap.user_from_addr,
         )
         if s_status == 'down':
             return SwapAction(SwapDecision.SKIP, reason='source provider unreachable')
@@ -309,13 +310,15 @@ class SolanaSwapLoop:
         if expected_to == 0 or abs(int(swap.to_amount) - expected_to) > 1:
             self._reject_logged(swap, expected_to)
             return SwapAction(SwapDecision.REJECT, reason=f'to_amount {swap.to_amount} != pinned-rate {expected_to}')
-        # Source deposit must exist, confirm, AND be fresh vs the Reservation before we'd attest.
+        # Source deposit must exist, confirm, be sent BY the reserved user, AND be fresh vs the
+        # Reservation before we'd attest — sender pin matches the relay's confirm_deposit check.
         s_status, info = self._fetch_leg(
             swap.from_chain,
             swap.from_tx_hash,
             swap.miner_from_addr,
             int(swap.from_amount),
             block_hint=int(getattr(swap, 'from_tx_block', 0)),
+            sender=swap.user_from_addr,
         )
         if s_status == 'down':
             return SwapAction(SwapDecision.SKIP, reason='source provider unreachable')


### PR DESCRIPTION
Two fixes surfaced during the swap-flow security scan.

## Validator — pin source sender in the settlement loop (`solana_swap_loop.py`)
The settlement loop re-verified the source deposit by **recipient + amount + freshness** but never pinned the **sender**, while the relay intake (`confirm_deposit`) already pins `expected_sender=reservation.from_addr`. Deferred-confirmation intake (#517) lets claims land **without** going through the strict relay, so the loop — not the relay — is the enforcement point, and the sender dimension was left unthreaded.

- Pass `sender=swap.user_from_addr` on both source `_fetch_leg` calls (`_decide_fulfilled`, `_decide_pending_attestation`).
- **Safe / no false-rejects:** `swap.user_from_addr` is copied verbatim from `reservation.from_addr` at `submit_swap_claim` — the exact value the relay already checks against. Holds for validator-routed swaps too (the routed user still sends from the named address).
- **Severity:** defense-in-depth. `submit_swap_claim` is validator-gated, so the gap requires a malicious/buggy validator; further bounded by the source-freshness floor and one-reservation-slot-per-miner.

## CLI — drop the stale-read guard on `halt` / `resume` (`admin.py`)
`alw admin danger halt`/`resume` gated on a pre-read of `halted`. Against a load-balanced RPC, a stale node can misreport it and **refuse a legitimate state change** — observed on public devnet, where `resume` printed "system is not halted" while the chain was halted at **finalized** commitment.

- Remove the pre-read guard from both commands; just submit. **On-chain state is the source of truth.**
- Disclaimer + confirm prompts are unchanged. Redundant same-state submits are harmless no-ops.

Both changes byte-compile; no other files touched.