### PR TITLE
perf(validator): hoist the SOL chain tip out of the per-leg confirmation loop

### DIFF
--- a/allways/chain_providers/base.py
+++ b/allways/chain_providers/base.py
@@ -141,6 +141,21 @@ class ChainProvider(ABC):
 
         return tx_info
 
+    def cached_block_height(self) -> Optional[int]:
+        """Chain tip for the current forward pass. Fetched once via ``get_current_block_height`` and
+        reused, so per-tx confirmation math costs one tip lookup per pass instead of one per leg.
+        Cleared each pass by ``clear_pass_tip``; a failed fetch (None) is not cached, so it retries.
+        A start-of-pass tip biases confirmations slightly low — conservative, never a false confirm."""
+        tip = getattr(self, '_pass_tip', None)
+        if tip is None:
+            tip = self.get_current_block_height()
+            self._pass_tip = tip
+        return tip
+
+    def clear_pass_tip(self) -> None:
+        """Reset the per-pass tip cache — called once per forward pass."""
+        self._pass_tip = None
+
     @abstractmethod
     def get_current_block_height(self) -> Optional[int]:
         """Chain tip block height. None on transient backend failure."""

--- a/allways/chain_providers/solana.py
+++ b/allways/chain_providers/solana.py
@@ -143,10 +143,13 @@ class SolanaProvider(ChainProvider):
         return int(post[i]) - int(pre[i])
 
     def _confirmations(self, slot: Optional[int]) -> int:
-        """Confirmations = slots since the tx's slot (the tx slot counts as 1). 0 if unknown."""
+        """Confirmations = slots since the tx's slot (the tx slot counts as 1). 0 if unknown.
+
+        Reads the pass-cached tip so N legs in one forward pass share a single ``getSlot`` instead
+        of one each — the getSlot count drops from per-leg to per-pass."""
         if slot is None:
             return 0
-        tip = self.get_current_block_height()
+        tip = self.cached_block_height()
         if tip is None:
             return 0
         return max(0, tip - int(slot) + 1)

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -76,6 +76,7 @@ def clear_provider_caches(self: Validator) -> None:
     for provider in self.chain_providers.values():
         if hasattr(provider, 'clear_cache'):
             provider.clear_cache()
+        provider.clear_pass_tip()  # reset the per-pass hoisted chain tip (one getSlot/pass, not per-leg)
 
 
 def ingest_solana_events(self: Validator) -> None:


### PR DESCRIPTION
## What
Cache the Solana chain tip once per forward pass instead of calling `getSlot` for every leg's confirmation math.

Today `solana._confirmations()` (via `fetch_matching_tx`→`_build_tx_info`) calls `get_current_block_height()`→`getSlot` **per SOL leg**, so `getSlot` scales with live-swap count — even though the tip is the same integer for every leg in the pass.

## How
- `ChainProvider.cached_block_height()` (base): fetch the tip via `get_current_block_height()` on first use in a pass, reuse thereafter; `clear_pass_tip()` resets it.
- `clear_provider_caches()` (forward.py) clears it each pass — the existing per-pass hook.
- `solana._confirmations()` reads `cached_block_height()`.

## Effect
`getSlot` drops from **per-leg → per-pass** (worst case 256 → 1 per pass). This is the `getSlot` half of the validator's Helius load (worst case ~3.7M/day).

## Safety
- **Behaviour-preserving.** A start-of-pass tip biases confirmations *slightly low* within the pass — conservative: it can only ever **delay** a confirm by one pass, never cause a false/premature confirm.
- A failed tip fetch (None) is **not** cached, so it retries per-leg as before.
- Generic on the base class; BTC/TAO can opt into the same hoist later (this PR wires only SOL).

## Tests
- 86 pass across `test_solana_provider`, `test_solana_provider_integration`, `test_solana_swap_loop`, `test_self_transfer_guard`.
- Behavioural check: 5 legs in a pass → 1 `getSlot`; new pass re-fetches; confirmations math unchanged.

Part of the RPC-cost work (opt #1). Follow-ups: #2 (terminal/Fulfilled memoization) and #5 (gPA→getMultipleAccounts) tracked separately.