### PR TITLE
fix(validator): TTL the cached chain tip so non-clearing callers can't freeze it

### DIFF
--- a/allways/chain_providers/base.py
+++ b/allways/chain_providers/base.py
@@ -1,3 +1,4 @@
+import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Optional, Tuple
@@ -141,19 +142,30 @@ class ChainProvider(ABC):
 
         return tx_info
 
+    # A cached tip is reused for at most this long. The validator clears it each forward pass (one
+    # getSlot/pass); this TTL is the safety net for callers that never clear (e.g. the miner), so the
+    # tip can never freeze — it self-refreshes at least this often. Slightly longer than a subtensor
+    # block so a validator pass stays on one fetch.
+    _TIP_TTL_SECONDS = 15.0
+
     def cached_block_height(self) -> Optional[int]:
-        """Chain tip for the current forward pass. Fetched once via ``get_current_block_height`` and
-        reused, so per-tx confirmation math costs one tip lookup per pass instead of one per leg.
-        Cleared each pass by ``clear_pass_tip``; a failed fetch (None) is not cached, so it retries.
-        A start-of-pass tip biases confirmations slightly low — conservative, never a false confirm."""
+        """Chain tip, cached so per-tx confirmation math shares one lookup instead of one per leg.
+
+        The validator clears this each pass (``clear_pass_tip``) → one ``getSlot`` per pass. The TTL
+        caps staleness for callers that never clear (the miner), so the tip can never freeze. A start-
+        of-pass/slightly-stale tip biases confirmations low — conservative, never a false confirm. A
+        failed fetch (None) is not cached, so it retries."""
         tip = getattr(self, '_pass_tip', None)
-        if tip is None:
-            tip = self.get_current_block_height()
+        if tip is not None and time.monotonic() - getattr(self, '_pass_tip_ts', 0.0) < self._TIP_TTL_SECONDS:
+            return tip
+        tip = self.get_current_block_height()
+        if tip is not None:
             self._pass_tip = tip
+            self._pass_tip_ts = time.monotonic()
         return tip
 
     def clear_pass_tip(self) -> None:
-        """Reset the per-pass tip cache — called once per forward pass."""
+        """Expire the cached tip — the validator calls this once per pass for a fresh start-of-pass tip."""
         self._pass_tip = None
 
     @abstractmethod


### PR DESCRIPTION
## Bug
The tip hoist (#542) caches the tip and clears it via `clear_pass_tip()`, which **only the validator forward loop calls**. The **miner** also reaches `_confirmations` (via `fulfillment.verify_transaction(require_confirmed=True)`) but never clears — so on a long-lived provider its tip **freezes at the first value**. Any tx at a slot beyond that frozen tip then computes `max(0, frozen_tip - slot + 1) = 0` confirmations **forever**, so the miner would never see a source leg confirm and never fulfill.

## Fix
Cache the tip with a **15s TTL**:
- Validator still `clear_pass_tip()`s each pass → **one `getSlot`/pass** (unchanged).
- The TTL caps staleness for callers that never clear (miner) → the tip **can't freeze**, self-refreshing at least every 15s.
- Staleness only biases confirmations *low* → conservative, never a false/premature confirm.

## Tests
- Validator: 4 legs in a pass → 1 `getSlot`; new pass re-fetches.
- Miner (no clear): after the chain advances past the TTL, `_confirmations` refetches and returns the correct higher count (1 → 101) instead of freezing at 1.
- 82 provider/loop tests pass.

Follow-up to #542; needed before deploying the miner.