### PR TITLE
perf(validator): stop re-fetching the source leg for Fulfilled swaps (P0)

### DIFF
--- a/allways/validator/solana_swap_loop.py
+++ b/allways/validator/solana_swap_loop.py
@@ -225,19 +225,17 @@ class SolanaSwapLoop:
         return SwapAction(SwapDecision.EXTEND_TIMEOUT, target) if target else SwapAction(SwapDecision.WAIT)
 
     def _decide_fulfilled(self, swap: Any, now: int, overdue: bool) -> SwapAction:
-        """Verify source (user funded miner) + dest (miner delivered 99% to user, fresh). CONFIRM when both
-        verify; EXTEND_TIMEOUT a valid-but-unconfirmed dest near timeout; TIMEOUT an overdue swap whose dest
-        is absent/mismatched (the contract slashes Fulfilled too). Source freshness was gated at attestation."""
-        s_status, _ = self._fetch_leg(
-            swap.from_chain,
-            swap.from_tx_hash,
-            swap.miner_from_addr,
-            int(swap.from_amount),
-            block_hint=int(getattr(swap, 'from_tx_block', 0)),
-            sender=swap.user_from_addr,
-        )
-        if s_status == 'down':
-            return SwapAction(SwapDecision.SKIP, reason='source provider unreachable')
+        """Verify the DEST leg (miner delivered 99% to user, fresh) and decide. CONFIRM when dest verifies;
+        EXTEND_TIMEOUT a valid-but-unconfirmed dest near timeout; TIMEOUT an overdue swap whose dest is
+        absent/mismatched (the contract slashes Fulfilled too).
+
+        The SOURCE leg is NOT re-fetched here. A swap can only reach Fulfilled via PendingAttestation →
+        attest quorum (`vote_initiate`, which verifies source + freshness) → Active → `mark_fulfilled`, so
+        the source was already verified, freshness-checked, and frozen — a confirmed tx can't regress.
+        Re-fetching it every 12s pass added only RPC load, and worse: a transient node-view gap on that
+        re-fetch could return non-`ok` and slash an already-attested payout (the same false-negative class
+        as the dest-leg stale-view issue). Source is therefore a settled `ok` by construction."""
+        s_status = 'ok'  # source verified + frozen at attestation (Fulfilled ⟹ attested); see docstring
         d_status, d_info = self._fetch_leg(
             swap.to_chain,
             swap.to_tx_hash,

--- a/tests/test_solana_swap_loop.py
+++ b/tests/test_solana_swap_loop.py
@@ -104,16 +104,25 @@ def test_expected_user_receives_is_99_percent():
     assert loop.expected_user_receives(make_swap(to_amount=10_000)) == 9_900
 
 
-def test_fulfilled_both_legs_ok_confirms_and_checks_99_percent_dest():
+def test_fulfilled_confirms_and_fetches_only_the_dest_leg():
     loop, providers = loop_with(result=True)
     swap = make_swap(status='Fulfilled', to_amount=1000)
     assert loop.decide(swap, now=1500).decision == SwapDecision.CONFIRM
     # dest leg verified against 99% of to_amount, not the full amount
     dest_call = providers['sol'].calls[-1]
     assert dest_call.amount == 990 and dest_call.recipient == 'userSOL'
-    # source leg verified against the full from_amount to the miner
-    src_call = providers['btc'].calls[-1]
-    assert src_call.amount == 500 and src_call.recipient == 'minerBTC'
+    # P0: the SOURCE leg is NOT re-fetched for a Fulfilled swap — it was already verified + frozen at
+    # attestation. Fulfilled must make exactly ONE leg fetch (dest only).
+    assert providers['btc'].calls == [], 'Fulfilled re-fetched the source leg — should be dest-only'
+
+
+def test_fulfilled_source_provider_down_still_confirms():
+    # P0 behavior note: a source-provider OUTAGE no longer blocks confirming an already-attested payout,
+    # because the source isn't re-fetched. (Pre-P0 this SKIPped on the source `down` guard.)
+    loop, providers = loop_with(result=True)
+    providers['btc'].result = 'unreachable'  # source provider down — must be irrelevant now
+    assert loop.decide(make_swap(status='Fulfilled'), now=1500).decision == SwapDecision.CONFIRM
+    assert providers['btc'].calls == []  # source never touched
 
 
 def test_fulfilled_dest_pending_far_from_timeout_waits():


### PR DESCRIPTION
Implements **P0** from the RPC-optimization doc — the surgical version.

## What
`_decide_fulfilled` re-fetched **both** legs every ~12s pass. But a swap can only reach `Fulfilled` via `PendingAttestation → attest quorum (vote_initiate, verifies source + freshness) → Active → mark_fulfilled` (verified in-contract: `mark_fulfilled.rs:33` requires `Active`; `Active` is set only by `vote_initiate.rs:110`). So the source leg was **already verified, freshness-checked, and frozen** — a confirmed tx can't regress. Re-fetching it added only RPC load.

Traced every use of `s_status` in the function — nothing load-bearing survives removal:
- `if s_status == 'down': SKIP` — a guard we actively want gone (a source RPC blip shouldn't block confirming an attested payout).
- the CONFIRM gate `s_status == 'ok'` — true by construction for a Fulfilled swap.
- `src={s_status}` in two reason strings — cosmetic.
- the discarded source info (`s_status, _ =`) — never used.

So: drop the source re-fetch, hardcode `s_status = 'ok'`, decision hinges on the dest leg only.

## Why it's more than a cost saver
Pre-P0, a **transient node-view gap** on the source re-fetch could return non-`ok` and, if the swap were overdue, fall through to `TIMEOUT` → **slash an already-attested payout**. That's the same false-negative class as the dest-leg stale-view issue we've been chasing (F1). P0 removes that path on the source side.

## Savings
~one leg-fetch per Fulfilled swap per pass — roughly 25–50% of the `getTransaction` bill depending on direction mix and how long swaps sit in Fulfilled.

## Behavior change (correct, called out)
A source-provider **outage no longer SKIPs** a Fulfilled swap; confirming an attested payout no longer depends on source-leg liveness. Strictly better.

## Risk
Minimal — pure deletion, validator-only, no new state / cache / TTL (that's the optional P1), no miner or contract surface. Same low-risk flavor as the BTC-tip hoist (#544).

## Tests
- `test_fulfilled_confirms_and_fetches_only_the_dest_leg` — Fulfilled makes exactly one leg fetch (dest), source provider untouched.
- `test_fulfilled_source_provider_down_still_confirms` — source outage no longer blocks confirm.
- 139 validator/swap tests pass.