### PR TITLE
fix(validator): reserve seam returns 422 (not 500) on a landed contract reject

### DIFF
--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -29,15 +29,26 @@ EMPTY_SWAP_KEY = b'\x00' * 32
 
 
 def _contract_reject_reason(err: Exception) -> Optional[str]:
-    """A deliberate on-chain program rejection (AnchorError / custom program error) is a normal domain
-    rejection — e.g. the miner got reserved between our pre-check and this tx (a race the contract, as
-    final arbiter, closes). Return a clean human reason so the seam answers 422, not a 500. Returns None
-    for a genuine transport/RPC fault, which must still surface as an error."""
+    """A deliberate on-chain program rejection is a normal domain rejection — e.g. the miner got
+    reserved between our pre-check and this tx (a race the contract, as final arbiter, closes). Return a
+    clean human reason so the seam answers 422, not a 500. Returns None for a genuine transport/RPC
+    fault, which must still surface as an error.
+
+    A program rejection surfaces two ways: a PRE-FLIGHT simulation reject carries the Anchor name /
+    'custom program error' text; a tx that is submitted and LANDS failed surfaces through the confirm
+    path as `{'InstructionError': [0, {'Custom': N}]}` — a numeric code with neither phrase. Both are
+    contract domain rejections (a transport fault has no Custom program code), so 422 for both."""
     s = str(err)
-    if 'custom program error' not in s.lower() and 'anchorerror' not in s.lower():
+    sl = s.lower()
+    if not ('custom program error' in sl or 'anchorerror' in sl or 'instructionerror' in sl or "'custom':" in sl):
         return None
     m = re.search(r'Error Message: ([^.\"\']+)', s)
-    return m.group(1).strip() if m else 'miner is not available for reservation right now'
+    if m:
+        return m.group(1).strip()
+    code = re.search(r"'Custom':\s*(\d+)", s)  # landed-tx form has no human message — surface the code
+    if code:
+        return f'miner is not available for reservation right now (contract error {code.group(1)})'
+    return 'miner is not available for reservation right now'
 
 
 def resolve_miner_pubkey(validator, miner_hotkey: str) -> Optional[Pubkey]:

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -111,6 +111,20 @@ def test_contract_rejection_returns_reject_not_raise():
     assert not r.ok and 'active reservation' in r.reason.lower()
 
 
+def test_contract_rejection_code_only_form_returns_reject():
+    # Same race, but the reject tx LANDS failed instead of failing pre-flight: the confirm path
+    # surfaces only `{'InstructionError': [0, {'Custom': 6022}]}` — no Anchor name, no 'custom program
+    # error' text. Must still be a 422 domain reject, not a 500 crash (the F2-class code-only miss).
+    client = FakeClient()
+
+    def _raise(*_a, **_k):
+        raise RuntimeError("tx 5abc failed: {'InstructionError': [0, {'Custom': 6022}]}")
+
+    client.open_or_request = _raise
+    r = _reserve(client)
+    assert not r.ok and '6022' in r.reason
+
+
 def test_transport_error_still_raises():
     # A genuine RPC/transport fault is NOT a domain rejection — it must propagate (seam → 500), not be
     # silently swallowed as a normal rejection.


### PR DESCRIPTION
## What
The offering HTTP seam answered **500** (looks like a validator failure) for a **routine contract rejection** of a reserve-on-behalf — e.g. the miner got reserved by another taker between our pre-check and the tx (a `MinerReserved` race the contract arbitrates). It should be a **422** ("miner unavailable, try another").

## Why
`_contract_reject_reason` recognized a program rejection only when the error carried the Anchor **name** / `custom program error` text (the pre-flight simulation form). A reject tx that is **submitted and lands failed** surfaces through the confirm path as `{'InstructionError': [0, {'Custom': N}]}` — a numeric code with neither phrase. That code-only form returned `None` → `reserve_on_behalf` re-raised → seam `_send(500)`.

**Exact same root-cause class as the CLI crank fix (#544):** matching Anchor errors by text only, missing the numeric-code form a landed-then-failed tx produces.

## Fix
Also match `InstructionError` / `{'Custom': N}`; surface the code as the reason when there's no human `Error Message`. A genuine transport/RPC fault (no `Custom` code) still returns `None` → still raises → still 500. One function, `reserve_engine.py`.

## Scope / urgency
Validator-side. The 422-vs-500 only surfaces on the **opt-in** offering seam (`ALLWAYS_SEAM_SECRET`); generic validators don't run it. So **low urgency** — a correctness/UX fix for operators running the web-app offering (a 500 makes a normal race look like an outage and can trigger bad client retries).

## Tests
- New: a landed `{'Custom': 6022}` reject returns `ok=False` (→ 422), not a raise.
- Unchanged and passing: the name-form reject test and the transport-fault test (still raises → 500). 39 reserve/seam/axon tests pass.

Found during the F2 sibling-bug sweep this session.