### PR TITLE
fix(cli): retry transient RPC faults so a flaky node can't abort a swap

### DIFF
--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -31,6 +31,7 @@ from allways.cli.swap_commands.swap_intake import (
     to_smallest_units,
 )
 from allways.constants import FEE_DIVISOR, NUMERAIRE_CHAIN
+from allways.solana.rpc import TransientRpcError
 from allways.utils.rate import apply_fee_deduction
 
 
@@ -75,6 +76,9 @@ def _self_crank_resolve(client, miner) -> None:
     resolved/filled) are expected and retried on the next poll."""
     try:
         client.resolve_pool(miner)
+    except TransientRpcError:
+        return  # RPC hiccup while nudging the pool — the poll loop re-cranks and re-reads the real
+        # outcome (the reservation). If this resolve_pool actually landed, the next pass sees the seat.
     except Exception as e:  # noqa: BLE001
         msg = str(e)
         benign = any(n in msg for n in _BENIGN_CRANK_NAMES) or any(f"'Custom': {c}" in msg for c in _BENIGN_CRANK_CODES)

--- a/allways/solana/rpc.py
+++ b/allways/solana/rpc.py
@@ -16,6 +16,29 @@ class SolanaRpcError(Exception):
     pass
 
 
+class TransientRpcError(SolanaRpcError):
+    """A transient transport/server fault — request timeout, HTTP 429/5xx, or a JSON-RPC transient code
+    (-32603 internal error, -32005 node-unhealthy/behind, block-not-yet-available, …). Idempotent reads
+    are retried automatically inside `_call`; a state-changing re-send is left to the caller, since the
+    request may already have landed. Subclasses SolanaRpcError so existing `except SolanaRpcError`
+    handlers keep working."""
+
+
+# JSON-RPC error codes that mean "try again", not "your request was malformed / the tx failed".
+_TRANSIENT_RPC_CODES = frozenset({-32603, -32005, -32004, -32014, -32016})
+# HTTP statuses that are the provider hiccuping, not a client-side error.
+_TRANSIENT_HTTP_STATUS = frozenset({429, 500, 502, 503, 504})
+# Side-effect-free methods (+ read-only simulate) — safe to auto-retry. sendTransaction and
+# requestAirdrop are deliberately excluded: a duplicate submit is the caller's decision (the pool crank
+# already re-sends on its next pass, and a double resolve_pool reverts benignly).
+_RETRYABLE_METHODS = frozenset({
+    'getAccountInfo', 'getProgramAccounts', 'getSlot', 'getBalance', 'getLatestBlockhash',
+    'getSignaturesForAddress', 'getTransaction', 'getSignatureStatuses', 'simulateTransaction',
+})
+_MAX_READ_RETRIES = 4
+_RETRY_BACKOFF_BASE = 0.25  # seconds; doubles each attempt → 0.25, 0.5, 1.0, 2.0
+
+
 class SolanaRpc:
     def __init__(self, url: str, timeout: int = 30):
         self.url = url
@@ -26,12 +49,30 @@ class SolanaRpc:
     def _call(self, method: str, params: list) -> Any:
         self._id += 1
         payload = {'jsonrpc': '2.0', 'id': self._id, 'method': method, 'params': params}
-        resp = self._session.post(self.url, json=payload, timeout=self.timeout)
-        resp.raise_for_status()
-        body = resp.json()
-        if 'error' in body:
-            raise SolanaRpcError(f'{method}: {body["error"]}')
-        return body['result']
+        attempt = 0
+        while True:
+            try:
+                resp = self._session.post(self.url, json=payload, timeout=self.timeout)
+                if resp.status_code in _TRANSIENT_HTTP_STATUS:
+                    raise TransientRpcError(f'{method}: HTTP {resp.status_code}')
+                resp.raise_for_status()
+                body = resp.json()
+                if 'error' in body:
+                    err = body['error']
+                    code = err.get('code') if isinstance(err, dict) else None
+                    if code in _TRANSIENT_RPC_CODES:
+                        raise TransientRpcError(f'{method}: {err}')
+                    raise SolanaRpcError(f'{method}: {err}')
+                return body['result']
+            except (requests.Timeout, requests.ConnectionError) as e:
+                transient: TransientRpcError = TransientRpcError(f'{method}: {type(e).__name__}: {e}')
+            except TransientRpcError as e:
+                transient = e
+            # Retry side-effect-free reads with exponential backoff; surface everything else at once.
+            attempt += 1
+            if method not in _RETRYABLE_METHODS or attempt > _MAX_READ_RETRIES:
+                raise transient
+            time.sleep(_RETRY_BACKOFF_BASE * (2 ** (attempt - 1)))
 
     # --- reads ---
     def get_account_info(self, pubkey, commitment: str = 'confirmed') -> Optional[bytes]:
@@ -121,10 +162,17 @@ class SolanaRpc:
         return res['value']
 
     def confirm(self, signature: str, timeout: float = 30.0, poll: float = 0.4) -> dict:
-        """Block until the signature reaches `confirmed`; raise on error or timeout."""
+        """Block until the signature reaches `confirmed`; raise on tx error or timeout. A transient RPC
+        fault while polling the status is retried until the deadline: a status we cannot read is
+        'unknown', not 'failed', and must never be mistaken for a failed tx (that false negative is what
+        aborted an in-flight swap origination whose tx had actually landed)."""
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
-            status = self.get_signature_statuses([signature])[0]
+            try:
+                status = self.get_signature_statuses([signature])[0]
+            except TransientRpcError:
+                time.sleep(poll)
+                continue
             if status is not None:
                 if status.get('err') is not None:
                     raise SolanaRpcError(f'tx {signature} failed: {status["err"]}')

--- a/allways/solana/rpc.py
+++ b/allways/solana/rpc.py
@@ -31,10 +31,19 @@ _TRANSIENT_HTTP_STATUS = frozenset({429, 500, 502, 503, 504})
 # Side-effect-free methods (+ read-only simulate) — safe to auto-retry. sendTransaction and
 # requestAirdrop are deliberately excluded: a duplicate submit is the caller's decision (the pool crank
 # already re-sends on its next pass, and a double resolve_pool reverts benignly).
-_RETRYABLE_METHODS = frozenset({
-    'getAccountInfo', 'getProgramAccounts', 'getSlot', 'getBalance', 'getLatestBlockhash',
-    'getSignaturesForAddress', 'getTransaction', 'getSignatureStatuses', 'simulateTransaction',
-})
+_RETRYABLE_METHODS = frozenset(
+    {
+        'getAccountInfo',
+        'getProgramAccounts',
+        'getSlot',
+        'getBalance',
+        'getLatestBlockhash',
+        'getSignaturesForAddress',
+        'getTransaction',
+        'getSignatureStatuses',
+        'simulateTransaction',
+    }
+)
 _MAX_READ_RETRIES = 4
 _RETRY_BACKOFF_BASE = 0.25  # seconds; doubles each attempt → 0.25, 0.5, 1.0, 2.0
 

--- a/tests/test_rpc_retry.py
+++ b/tests/test_rpc_retry.py
@@ -1,0 +1,117 @@
+"""Regression: transient RPC faults must not abort an in-flight swap.
+
+The first mainnet BTC origination crashed when `getSignatureStatuses` returned a JSON-RPC -32603
+Internal error mid-crank: `_call` raised it as fatal, it escaped the outcome-driven `_poll_drawn`
+loop, and the CLI died — even though the bid had landed and the pool had already drawn the taker.
+
+Now: idempotent reads retry on transient faults inside `_call`; `confirm` treats an unreadable status
+as "unknown, keep polling" (never "failed"); state-changing sends are NOT auto-retried (a duplicate
+submit is the caller's call).
+"""
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from allways.solana.rpc import (
+    _MAX_READ_RETRIES,
+    SolanaRpc,
+    SolanaRpcError,
+    TransientRpcError,
+)
+
+
+class _Resp:
+    def __init__(self, *, status_code=200, body=None):
+        self.status_code = status_code
+        self._body = body if body is not None else {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(str(self.status_code))
+
+    def json(self):
+        return self._body
+
+
+def _rpc(responses):
+    rpc = SolanaRpc('http://rpc.test')
+    rpc._session = MagicMock()
+    rpc._session.post.side_effect = responses
+    return rpc
+
+
+def _err(code):
+    return {'error': {'code': code, 'message': 'boom'}}
+
+
+def _ok(result):
+    return {'result': result}
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    monkeypatch.setattr('allways.solana.rpc.time.sleep', lambda *_: None)
+
+
+def test_call_retries_transient_rpc_code_then_succeeds():
+    rpc = _rpc([_Resp(body=_err(-32603)), _Resp(body=_err(-32603)), _Resp(body=_ok({'value': [None]}))])
+    assert rpc._call('getSignatureStatuses', [['sig'], {}]) == {'value': [None]}
+    assert rpc._session.post.call_count == 3
+
+
+def test_call_retries_transient_http_status():
+    rpc = _rpc([_Resp(status_code=503), _Resp(body=_ok(7))])
+    assert rpc._call('getSlot', [{}]) == 7
+    assert rpc._session.post.call_count == 2
+
+
+def test_call_retries_transport_timeout():
+    rpc = _rpc([requests.Timeout('slow'), _Resp(body=_ok(9))])
+    assert rpc._call('getBalance', ['pk', {}]) == 9
+    assert rpc._session.post.call_count == 2
+
+
+def test_call_does_not_retry_deterministic_error():
+    rpc = _rpc([_Resp(body=_err(-32602))])  # invalid params — a bug, not a hiccup
+    with pytest.raises(SolanaRpcError) as ei:
+        rpc._call('getAccountInfo', ['pk', {}])
+    assert not isinstance(ei.value, TransientRpcError)
+    assert rpc._session.post.call_count == 1
+
+
+def test_call_does_not_auto_retry_send_transaction():
+    # A transient on a send surfaces immediately (typed) — the caller decides whether a re-submit is safe.
+    rpc = _rpc([_Resp(body=_err(-32603))])
+    with pytest.raises(TransientRpcError):
+        rpc._call('sendTransaction', ['rawtx', {}])
+    assert rpc._session.post.call_count == 1  # exactly once — no double submit
+
+
+def test_call_gives_up_after_max_retries():
+    rpc = _rpc([_Resp(body=_err(-32603))] * (_MAX_READ_RETRIES + 1))
+    with pytest.raises(TransientRpcError):
+        rpc._call('getSlot', [{}])
+    assert rpc._session.post.call_count == _MAX_READ_RETRIES + 1
+
+
+def test_confirm_tolerates_transient_status_read_then_confirms():
+    rpc = SolanaRpc('http://rpc.test')
+    calls = {'n': 0}
+
+    def flaky(_sigs):
+        calls['n'] += 1
+        if calls['n'] < 3:
+            raise TransientRpcError('getSignatureStatuses: -32603')
+        return [{'err': None, 'confirmationStatus': 'confirmed'}]
+
+    rpc.get_signature_statuses = flaky
+    assert rpc.confirm('sig', timeout=5, poll=0)['confirmationStatus'] == 'confirmed'
+    assert calls['n'] == 3  # kept polling through the transient reads instead of raising
+
+
+def test_confirm_still_raises_on_a_real_tx_error():
+    rpc = SolanaRpc('http://rpc.test')
+    rpc.get_signature_statuses = lambda _sigs: [{'err': {'InstructionError': [0, {'Custom': 6001}]}}]
+    with pytest.raises(SolanaRpcError):
+        rpc.confirm('sig', timeout=5, poll=0)

--- a/tests/test_rpc_retry.py
+++ b/tests/test_rpc_retry.py
@@ -8,6 +8,7 @@ Now: idempotent reads retry on transient faults inside `_call`; `confirm` treats
 as "unknown, keep polling" (never "failed"); state-changing sends are NOT auto-retried (a duplicate
 submit is the caller's call).
 """
+
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/test_swap_now_reservation.py
+++ b/tests/test_swap_now_reservation.py
@@ -90,7 +90,10 @@ def test_poll_drawn_self_heals_when_the_crank_keeps_flaking_but_the_seat_is_draw
     The outcome-driven loop must return it rather than die on the nudge exception."""
     us = 'ME'
     drawn = types.SimpleNamespace(  # unfilled seat won by us: reserved_until==0, created_at==0, live
-        reserved_until=0, created_at=0, finalize_by=int(time.time()) + 120, router=us,
+        reserved_until=0,
+        created_at=0,
+        finalize_by=int(time.time()) + 120,
+        router=us,
     )
     client = MagicMock()
     client.resolve_pool.side_effect = TransientRpcError('boom')  # crank flakes on every pass

--- a/tests/test_swap_now_reservation.py
+++ b/tests/test_swap_now_reservation.py
@@ -12,7 +12,13 @@ import types
 from unittest.mock import MagicMock, patch
 
 from allways.cli.swap_commands.helpers import live_unclaimed
-from allways.cli.swap_commands.swap import _SEND_MARGIN_SECS, _poll_reservation
+from allways.cli.swap_commands.swap import (
+    _SEND_MARGIN_SECS,
+    _poll_drawn,
+    _poll_reservation,
+    _self_crank_resolve,
+)
+from allways.solana.rpc import TransientRpcError
 
 EMPTY = bytes(32)
 
@@ -68,6 +74,30 @@ def test_send_margin_does_not_scale_with_confirmation_depth():
     btc = get_chain('btc')
     assert btc.min_confirmations * btc.seconds_per_block > _SEND_MARGIN_SECS
     assert _SEND_MARGIN_SECS < 480 - 80  # clears a fresh reservation post-draw, on any source chain
+
+
+def test_self_crank_swallows_a_transient_rpc_fault():
+    """A transient RPC fault while nudging the pool must not abort origination — the resolve_pool may
+    already have landed. It is swallowed so the poll loop re-cranks and re-reads the real outcome. This
+    is the exact fault (getSignatureStatuses -32603 mid-crank) that crashed the first mainnet BTC swap."""
+    client = MagicMock()
+    client.resolve_pool.side_effect = TransientRpcError('getSignatureStatuses: -32603 Internal error')
+    _self_crank_resolve(client, 'miner')  # must NOT raise
+
+
+def test_poll_drawn_self_heals_when_the_crank_keeps_flaking_but_the_seat_is_drawn():
+    """End-to-end: every crank nudge throws a transient RPC error, yet the pool still draws our seat.
+    The outcome-driven loop must return it rather than die on the nudge exception."""
+    us = 'ME'
+    drawn = types.SimpleNamespace(  # unfilled seat won by us: reserved_until==0, created_at==0, live
+        reserved_until=0, created_at=0, finalize_by=int(time.time()) + 120, router=us,
+    )
+    client = MagicMock()
+    client.resolve_pool.side_effect = TransientRpcError('boom')  # crank flakes on every pass
+    client.get_reservation.side_effect = [None, drawn]  # not drawn yet, then drawn to us
+    with patch('allways.cli.swap_commands.swap.time.sleep'):
+        got = _poll_drawn(client, 'miner', us, timeout_secs=100)
+    assert got is drawn
 
 
 def _run_swap_now(reserved_until, from_chain='btc'):


### PR DESCRIPTION
## What & why

The first mainnet BTC swap origination **crashed mid-crank** when Helius returned a JSON-RPC `-32603 Internal error` on `getSignatureStatuses`. `rpc._call` raised it as fatal, it escaped the outcome-driven `_poll_drawn` loop, and `alw swap now` died — **even though the bid had landed and the pool had already drawn the taker's seat**, leaving it orphaned until it lapsed (reservation fee forfeited, miner briefly locked). Recovering required manual on-chain finalize/lapse.

**Root cause:** the crank is *already* a tolerant, outcome-driven retry loop, but `_self_crank_resolve` only classified benign **contract** races (`PoolNotClosed`, `'Custom': 6044`, …) as retriable. A transient **transport** fault was miscategorized as fatal and allowed to escape the loop.

## Fix (scoped to the read/confirm path — no double-submit risk)

- **`rpc.py`** — add `TransientRpcError` (subclass of `SolanaRpcError`, so existing handlers still catch it). `_call` now **retries idempotent reads** (`getAccountInfo`, `getSignatureStatuses`, `getProgramAccounts`, …) on transient faults — JSON-RPC `-32603/-32005/-32004/-32014/-32016`, HTTP `429/5xx`, request timeouts — with bounded exponential backoff (0.25→2s, 4 tries). `sendTransaction`/`requestAirdrop` are **deliberately excluded**: a duplicate submit is the caller's decision.
- **`rpc.confirm`** — a status we cannot read is treated as *"unknown, keep polling"*, never *"failed"*. A flaky status read can no longer be mistaken for a failed tx (the exact false negative behind the crash).
- **`swap._self_crank_resolve`** — swallows a transient nudge error; the poll loop re-cranks and re-reads the reservation, **self-healing** if `resolve_pool` actually landed.

**Deliberately NOT changing** `client._send`'s resend loop: resending on a *confirm*-side transient could double-submit a tx that already landed. The read-side fixes above resolve the demonstrated failure without that ambiguity.

## Tests

- New `tests/test_rpc_retry.py`: read-retry-then-succeed, transient HTTP/timeout retry, **no** retry on deterministic errors (`-32602`) or on `sendTransaction`, backoff cap, and `confirm` tolerance (keeps polling through transient reads, still raises on a real tx `err`).
- Two crank regressions in `test_swap_now_reservation.py`: `_self_crank_resolve` swallows a transient; `_poll_drawn` returns the drawn seat even when every crank nudge flakes.
- **Full suite: 700 passed**, ruff clean.

## Context

Sibling of the pressure-test F3 (RPC timeout masking a successful call); distinct from the validator-side #544/#545. Surfaced live while running the first mainnet `btc→sol` / `sol→btc` swaps (both since completed successfully).