### PR TITLE
feat(cli): surface pool contention + odds on bid, name the winner on a lost draw

### DIFF
--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -273,8 +273,7 @@ def swap_now_command(
                 'spent (non-refundable); do NOT send funds. Re-run to bid on the next round.'
             )
         fail(
-            '  The draw did not resolve in the bid window (no seat drawn yet). '
-            'Do NOT send funds; re-run to try again.'
+            '  The draw did not resolve in the bid window (no seat drawn yet). Do NOT send funds; re-run to try again.'
         )
 
     # Phase 3 — FINALIZE against the PINNED rate (not the live quote, which can drift after the bid).

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -9,7 +9,7 @@ unrouted taker never waits on validator liveness."""
 
 import json
 import time
-from typing import List, Optional
+from typing import List, NamedTuple, Optional
 
 import click
 
@@ -49,6 +49,33 @@ def _candidate_miners(client, from_chain: str, to_chain: str) -> List[MinerCandi
         collateral = client.get_collateral_lamports(q.miner) or 0
         out.append(MinerCandidate(miner=q.miner, rate_display=rate_display_from_fixed(q.rate), collateral=collateral))
     return out
+
+
+class PoolContention(NamedTuple):
+    """A read-only snapshot of a miner's live bid pool, so a taker can see — BEFORE it pays the
+    non-refundable reservation fee — whether it is bidding into an already-open, contested round and
+    roughly what its draw odds are."""
+
+    is_open: bool  # a pool round is open AND still in its bid window
+    bidders: int  # distinct bids already in the round (before you join)
+    closes_in: int  # seconds until the window closes
+    weighted_rivals: int  # existing bidders that are weighted validators (0 => the draw is uniform)
+
+
+def _pool_contention(client, miner, cfg) -> PoolContention:
+    """Best-effort read of the miner's pool. Visibility only — never raises, so a decode/RPC hiccup
+    can't block a bid; on any surprise it reports 'not open' and the taker proceeds as before."""
+    try:
+        pool = client.get_pool(miner)
+        now = int(time.time())
+        if int(getattr(pool, 'opened_at', 0)) == 0 or now > int(getattr(pool, 'closes_at', 0)):
+            return PoolContention(False, 0, 0, 0)
+        reqs = list(getattr(pool, 'requests', []))
+        weighted = {bytes(v.key) for v in getattr(cfg, 'validators', []) if int(getattr(v, 'weight', 0)) > 0}
+        weighted_rivals = sum(1 for r in reqs if bytes(r.router) in weighted)
+        return PoolContention(True, len(reqs), max(0, int(pool.closes_at) - now), weighted_rivals)
+    except Exception:  # noqa: BLE001 - visibility only; a bad read must not stop the swap
+        return PoolContention(False, 0, 0, 0)
 
 
 # Minimum reservation life required before we'll instruct a send. The reservation must outlive
@@ -107,6 +134,19 @@ def _poll_drawn(client, miner, user, timeout_secs: int):
         if _drawn_unfilled(resv):
             return resv if str(resv.router) == us else None  # seated: us, or someone else won
         time.sleep(3)
+    return None
+
+
+def _lost_seat_to(client, miner, user) -> Optional[str]:
+    """Best-effort: after `_poll_drawn` returns None, tell the two failure modes apart. Returns the
+    winning router (as a string) if a *different* taker holds the freshly-drawn seat — i.e. you lost
+    the draw — or None if no seat is drawn yet (the draw simply didn't resolve in the window)."""
+    try:
+        resv = client.get_reservation(miner)
+    except Exception:  # noqa: BLE001 - message quality only; fall back to the generic reason
+        return None
+    if _drawn_unfilled(resv) and str(resv.router) != str(user):
+        return str(resv.router)
     return None
 
 
@@ -195,6 +235,27 @@ def swap_now_command(
         f'\n  Swap [cyan]{amount_opt} {from_chain.upper()}[/cyan] -> ~[cyan]{recv:.8g} {to_chain.upper()}[/cyan]'
         f'  (miner [dim]{str(cand.miner)[:8]}…[/dim], rate {cand.rate_display} per SOL)\n'
     )
+
+    # Pool contention — surface it BEFORE the fee-charging bid so the taker isn't bidding blind into
+    # an already-open, contested round. The reservation fee is non-refundable even on a losing draw.
+    contention = _pool_contention(client, cand.miner, cfg)
+    if contention.is_open:
+        fee_sol = int(getattr(cfg, 'reservation_fee_lamports', 0)) / 10 ** get_chain(NUMERAIRE_CHAIN).decimals
+        if contention.weighted_rivals > 0:
+            console.print(
+                f'  [yellow]This miner already has an open bid pool[/yellow]: {contention.bidders} bidder(s), '
+                f'closes in {contention.closes_in}s — and a weighted validator is bidding, so an unrouted '
+                f'taker is very unlikely to win this draw.'
+            )
+        else:
+            odds = 100.0 / (contention.bidders + 1)
+            console.print(
+                f'  [yellow]This miner already has an open bid pool[/yellow]: {contention.bidders} taker(s) '
+                f'bidding, closes in {contention.closes_in}s. Joining makes {contention.bidders + 1}; the draw '
+                f'is uniform, so ~[cyan]{odds:.0f}%[/cyan] odds to win the seat.'
+            )
+        console.print(f'  [dim]A losing bid still spends the {fee_sol:g} SOL reservation fee.[/dim]')
+
     if not skip_confirm and not click.confirm('  Bid on this miner on-chain?', default=False):
         return
 
@@ -205,8 +266,14 @@ def swap_now_command(
     # Phase 2 — self-crank the draw until we're seated (unfilled reservation, router == us).
     drawn = _poll_drawn(client, cand.miner, user, timeout_secs=pool_window + 120)
     if drawn is None:
+        winner = _lost_seat_to(client, cand.miner, user)
+        if winner:
+            fail(
+                f'  You lost the draw — the seat went to [dim]{winner[:8]}…[/dim]. Your reservation fee is '
+                'spent (non-refundable); do NOT send funds. Re-run to bid on the next round.'
+            )
         fail(
-            '  You were not seated (another bidder won, or the draw did not resolve in time). '
+            '  The draw did not resolve in the bid window (no seat drawn yet). '
             'Do NOT send funds; re-run to try again.'
         )
 

--- a/tests/test_swap_now_reservation.py
+++ b/tests/test_swap_now_reservation.py
@@ -194,3 +194,84 @@ def test_crank_reraises_a_real_error():
     client.resolve_pool.side_effect = RuntimeError("tx 5abc failed: {'InstructionError': [0, {'Custom': 6022}]}")
     with pytest.raises(RuntimeError):
         _self_crank_resolve(client, 'miner-pubkey')
+
+
+# ── pool-contention visibility (feat): surface a contested/already-open pool + the lost-draw reason ──
+# `swap now` used to bid blind and, on a loss, print one ambiguous "not seated" message. These cover
+# the read-only helpers that back the new pre-bid notice (odds + fee warning) and the specific
+# lost-the-draw-to-<router> reason. Both are best-effort: a bad read must never block or crash a swap.
+
+_A = bytes([1] * 32)
+_B = bytes([2] * 32)
+_V = bytes([7] * 32)
+
+
+def _pool(opened_at, closes_at, routers):
+    return types.SimpleNamespace(
+        opened_at=opened_at, closes_at=closes_at,
+        requests=[types.SimpleNamespace(router=r) for r in routers],
+    )
+
+
+def test_pool_contention_reports_an_open_uniform_pool():
+    from allways.cli.swap_commands.swap import _pool_contention
+
+    now = int(time.time())
+    client = MagicMock()
+    client.get_pool.return_value = _pool(now - 10, now + 40, [_A, _B])  # 2 takers, still in window
+    c = _pool_contention(client, 'miner', types.SimpleNamespace(validators=[]))
+    assert c.is_open and c.bidders == 2 and c.weighted_rivals == 0
+    assert 30 <= c.closes_in <= 40
+
+
+def test_pool_contention_flags_a_weighted_validator_rival():
+    from allways.cli.swap_commands.swap import _pool_contention
+
+    now = int(time.time())
+    client = MagicMock()
+    client.get_pool.return_value = _pool(now - 5, now + 30, [_V, _B])
+    cfg = types.SimpleNamespace(validators=[types.SimpleNamespace(key=_V, weight=100)])
+    c = _pool_contention(client, 'miner', cfg)
+    assert c.is_open and c.bidders == 2 and c.weighted_rivals == 1  # the validator dominates the draw
+
+
+def test_pool_contention_treats_a_closed_window_as_not_open():
+    from allways.cli.swap_commands.swap import _pool_contention
+
+    now = int(time.time())
+    client = MagicMock()
+    client.get_pool.return_value = _pool(now - 100, now - 40, [_A])  # window already passed
+    assert _pool_contention(client, 'miner', types.SimpleNamespace(validators=[])).is_open is False
+
+
+def test_pool_contention_never_raises_on_a_bad_read():
+    from allways.cli.swap_commands.swap import _pool_contention
+
+    client = MagicMock()
+    client.get_pool.side_effect = RuntimeError('rpc down')  # must degrade to "not open", never crash a bid
+    assert _pool_contention(client, 'miner', types.SimpleNamespace(validators=[])).is_open is False
+
+
+def test_lost_seat_to_names_the_rival_that_won_the_draw():
+    from allways.cli.swap_commands.swap import _lost_seat_to
+
+    now = int(time.time())
+    client = MagicMock()
+    # a freshly-drawn, not-yet-filled seat (reserved_until==0, created_at==0, finalize_by ahead) held
+    # by a DIFFERENT router than us -> we lost the draw to it.
+    client.get_reservation.return_value = types.SimpleNamespace(
+        reserved_until=0, created_at=0, finalize_by=now + 100, router='RIVAL'
+    )
+    assert _lost_seat_to(client, 'miner', 'ME') == 'RIVAL'
+
+
+def test_lost_seat_to_is_none_when_no_seat_is_drawn_yet():
+    from allways.cli.swap_commands.swap import _lost_seat_to
+
+    now = int(time.time())
+    client = MagicMock()
+    # drawn window already lapsed -> not a live drawn seat -> "draw didn't resolve" branch, not "lost"
+    client.get_reservation.return_value = types.SimpleNamespace(
+        reserved_until=0, created_at=0, finalize_by=now - 100, router='RIVAL'
+    )
+    assert _lost_seat_to(client, 'miner', 'ME') is None

--- a/tests/test_swap_now_reservation.py
+++ b/tests/test_swap_now_reservation.py
@@ -208,7 +208,8 @@ _V = bytes([7] * 32)
 
 def _pool(opened_at, closes_at, routers):
     return types.SimpleNamespace(
-        opened_at=opened_at, closes_at=closes_at,
+        opened_at=opened_at,
+        closes_at=closes_at,
         requests=[types.SimpleNamespace(router=r) for r in routers],
     )
 


### PR DESCRIPTION
## What

Two read-only visibility improvements to `alw swap now` around multi-taker reservation pools. Today the CLI bids **blind** and, on a loss, prints a single ambiguous *"not seated (another bidder won, or the draw did not resolve in time)"* message — you can't tell whether you're bidding into a contested pool, what your odds are, or which failure actually happened.

## Changes

**Before the (fee-charging) bid** — new `_pool_contention()` reads the miner's live pool (best-effort; a bad read degrades to "not open" and never blocks the bid). If a round is already open it prints:
- bidder count + seconds-to-close,
- draw odds: uniform `~1/(N+1)` among plain takers, or a distinct warning if a **weighted validator** is bidding (an unrouted taker effectively can't win that draw — matches `resolve_pool`'s weighting, where a plain taker's weight is 0 and `pick_weighted` only falls back to uniform when *all* weights are 0),
- a reminder that the reservation fee is **non-refundable** on a loss.

**On a lost draw** — new `_lost_seat_to()` distinguishes *"you lost the draw — seat went to \<router\>"* from *"the draw did not resolve in the window"*.

## Safety

Purely additive visibility. The send-safety invariant is unchanged: we still only finalize/instruct-a-send when **we** hold the drawn seat (`_poll_drawn` semantics untouched). Both helpers swallow read errors so they can never abort a swap.

## Tests

Adds coverage for `_pool_contention` (open uniform pool, weighted-validator rival, closed window, bad-read degradation) and `_lost_seat_to` (names a rival winner; None when no live seat is drawn). Full `test_swap_now_reservation.py` + `test_rpc_retry.py` green; ruff clean.

## Note

Surfaced while running mainnet BTC swaps — the mechanics work (fair random draw, no fund-loss on a loss), this just makes contention/odds visible instead of leaving the taker to infer them. Multi-taker contention is still untested live (single actor on mainnet today); this is the UX to make that legible when it happens.