### PR TITLE
feat(contract): floor posted rates to 5 sig figs to end the sub-perceptible crown war

### DIFF
--- a/allways/cli/swap_commands/numeraire.py
+++ b/allways/cli/swap_commands/numeraire.py
@@ -30,6 +30,7 @@ from allways.cli.swap_commands.helpers import (
 from allways.cli.swap_commands.pair import write_rate_posted_flag
 from allways.constants import LAUNCH_SPOKES, NUMERAIRE_CHAIN, RATE_PRECISION
 from allways.solana.client import SolanaClientError
+from allways.utils.rate import quantize_rate_display, quantize_rate_fixed
 
 
 @dataclass
@@ -149,7 +150,8 @@ def quotes_command(spread_bps, dry_run, yes, **spoke_opts):
                 )
             else:
                 note = f'[dim]free (was {was:g})[/dim]'
-        console.print(f'  {sp.from_chain.upper()} → {sp.to_chain.upper()}: [green]{sp.rate:g}[/green]   {note}')
+        disp = quantize_rate_display(sp.rate)  # mirror the on-chain floor so preview == stored
+        console.print(f'  {sp.from_chain.upper()} → {sp.to_chain.upper()}: [green]{disp:g}[/green]   {note}')
 
     if total_fee:
         console.print(
@@ -168,7 +170,14 @@ def quotes_command(spread_bps, dry_run, yes, **spoke_opts):
     for sp in specs:
         try:
             with loading(f'Publishing {sp.from_chain.upper()} → {sp.to_chain.upper()}...'):
-                client.set_quote(sp.from_chain, sp.to_chain, sp.from_addr, sp.to_addr, int(sp.rate * RATE_PRECISION), 0)
+                client.set_quote(
+                    sp.from_chain,
+                    sp.to_chain,
+                    sp.from_addr,
+                    sp.to_addr,
+                    quantize_rate_fixed(int(sp.rate * RATE_PRECISION)),
+                    0,
+                )
             posted += 1
         except SolanaClientError as e:
             console.print(f'[red]Failed {sp.from_chain.upper()} → {sp.to_chain.upper()}: {e}[/red]')

--- a/allways/cli/swap_commands/pair.py
+++ b/allways/cli/swap_commands/pair.py
@@ -17,6 +17,7 @@ from allways.cli.swap_commands.helpers import (
 )
 from allways.constants import RATE_PRECISION
 from allways.solana.client import SolanaClientError
+from allways.utils.rate import quantize_rate_display, quantize_rate_fixed
 
 # Default per-direction liquidity (u128) posted with a quote; the taker discovery path is Phase 9.
 DEFAULT_QUOTE_LIQUIDITY = 0
@@ -157,6 +158,11 @@ def post_pair(
         if rates_from_args:
             rate, counter_rate = counter_rate, rate
 
+    # Floor to RATE_SIG_FIGS up front (mirrors the on-chain floor in set_quote) so the preview below
+    # and the posted value both show exactly what the chain will store.
+    rate = quantize_rate_display(rate)
+    counter_rate = quantize_rate_display(counter_rate)
+
     # The bt wallet is only needed for the running-miner refresh flag (keyed by hotkey); the quote
     # write is signed by the Solana keypair.
     _, wallet, _, _ = get_cli_context(need_client=False)
@@ -221,7 +227,7 @@ def post_pair(
                     to_chain,
                     from_addr,
                     to_addr,
-                    int(r * RATE_PRECISION),
+                    quantize_rate_fixed(int(r * RATE_PRECISION)),
                     DEFAULT_QUOTE_LIQUIDITY,
                 )
             posted += 1

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -29,9 +29,10 @@ BTC_TO_SAT = 100_000_000
 # Fixed-point scale for the miner rate: stored u128 = display_rate * RATE_PRECISION.
 # Single source of truth, mirrors constants.rs (1e18).
 RATE_PRECISION = 10**18
-# Significant digits enforced on every committed rate. Normalized at the CLI
-# (post) and again at the validator (parse) so scoring buckets, consensus
-# hashes, and contract storage all agree on the same canonical string.
+# Significant figures every posted rate is floored to. Enforced on-chain in set_quote
+# (quantize_rate_sig_figs); the CLI mirrors it (quantize_rate_fixed) so previews match what is
+# stored, and the validator floors on ingest to close the pre-redeploy migration window. Below
+# this precision an undercut is imperceptible to takers, so the crown ignores it (equal buckets tie).
 RATE_SIG_FIGS = 5
 
 # ─── Transaction Fees ────────────────────────────────────

--- a/allways/utils/rate.py
+++ b/allways/utils/rate.py
@@ -16,6 +16,27 @@ def normalize_rate(rate: float) -> str:
     return f'{rate:.{RATE_SIG_FIGS}g}'
 
 
+def quantize_rate_fixed(rate_fixed: int) -> int:
+    """Floor a fixed-point rate (display × RATE_PRECISION) to RATE_SIG_FIGS significant figures.
+
+    Integer-exact mirror of the contract's ``quantize_rate_sig_figs`` (set_quote.rs): both floor the
+    same way, so the CLI previews and posts exactly what the chain will store and the validator's crown
+    ingest agrees byte-for-byte. Floor, not round — a rate can never gain a tick by rounding up.
+    """
+    if rate_fixed <= 0:
+        return 0
+    digits = len(str(rate_fixed))
+    if digits <= RATE_SIG_FIGS:
+        return rate_fixed
+    pow10 = 10 ** (digits - RATE_SIG_FIGS)
+    return rate_fixed // pow10 * pow10
+
+
+def quantize_rate_display(rate: float) -> float:
+    """Display-domain convenience: the RATE_SIG_FIGS-floored rate as a float, for CLI previews."""
+    return quantize_rate_fixed(int(rate * RATE_PRECISION)) / RATE_PRECISION
+
+
 def calculate_to_amount(
     from_amount: int,
     rate,

--- a/allways/validator/event_index.py
+++ b/allways/validator/event_index.py
@@ -26,6 +26,7 @@ from allways import dev_signal
 from allways.classes import ActivityTransition, MinerActivity
 from allways.constants import RATE_PRECISION
 from allways.solana.events import EventRecord
+from allways.utils.rate import quantize_rate_fixed
 from allways.validator.state_store import ValidatorStateStore
 
 # Swap-lifecycle events → MinerActivity edges. A reserved miner enters FULFILLING on
@@ -122,7 +123,10 @@ class SolanaEventIndex:
             self.state_store.insert_collateral_event(block_time, hotkey, total)
             return True
         if name == 'QuoteSet':
-            rate = int(rec.fields['rate']) / RATE_PRECISION
+            # Floor to RATE_SIG_FIGS on ingest, matching the contract's on-chain floor. Redundant for
+            # post-redeploy quotes (already floored at set_quote) but closes the migration window where a
+            # pre-redeploy full-precision quote could still snipe the crown.
+            rate = quantize_rate_fixed(int(rec.fields['rate'])) / RATE_PRECISION
             self.state_store.insert_rate_event(
                 hotkey, self._chain(rec, 'from_chain'), self._chain(rec, 'to_chain'), rate, block_time
             )

--- a/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
@@ -98,6 +98,27 @@ pub const NUMERAIRE_CHAIN: &str = "sol";
 /// only stores/copies the value; routability/validity is judged off-chain (`is_executable_rate`).
 pub const RATE_PRECISION: u128 = 1_000_000_000_000_000_000; // 1e18
 
+/// Significant figures every posted rate is floored to on-chain (`quantize_rate_sig_figs`). The crown
+/// is ranked off-chain on the raw stored rate, so without a tick two miners can undercut in a
+/// sub-perceptible digit to capture the whole crown for free; flooring to display precision makes any
+/// crown-winning improvement one a taker can actually see. Mirrored off-chain as `RATE_SIG_FIGS`.
+pub const RATE_SIG_FIGS: u32 = 5;
+
+/// Floor `rate` (fixed-point, display × RATE_PRECISION) to RATE_SIG_FIGS significant figures — zeros
+/// every digit below the top RATE_SIG_FIGS. Pure integer math (no floats — non-deterministic in BPF);
+/// floor not round, so a rate can never gain a tick by rounding and the reconstruction can't overflow.
+pub fn quantize_rate_sig_figs(rate: u128) -> u128 {
+    if rate == 0 {
+        return 0;
+    }
+    let digits = rate.ilog10() + 1;
+    if digits <= RATE_SIG_FIGS {
+        return rate;
+    }
+    let pow = 10u128.pow(digits - RATE_SIG_FIGS);
+    rate / pow * pow
+}
+
 /// Basis-points denominator (10_000 bps = 1.00×). Shared by every ×-multiplier below.
 pub const BPS_DENOMINATOR: u64 = 10_000;
 
@@ -235,6 +256,24 @@ mod tests {
         assert_eq!(quote_update_fee(86_400), 0);
         // Clock skew (negative elapsed) → most-expensive tier, never free.
         assert_eq!(quote_update_fee(-100), QUOTE_UPDATE_FEE_TIER1_LAMPORTS);
+    }
+
+    #[test]
+    fn quantize_rate_floors_to_sig_figs() {
+        let p = RATE_PRECISION;
+        // Zero and mantissas already within RATE_SIG_FIGS pass through untouched.
+        assert_eq!(quantize_rate_sig_figs(0), 0);
+        assert_eq!(quantize_rate_sig_figs(12_345), 12_345);
+        assert_eq!(quantize_rate_sig_figs(345 * p), 345 * p);
+        // Floor, never round: 1.23459 → 1.2345 (not 1.2346).
+        assert_eq!(quantize_rate_sig_figs(1_234_590_000_000_000_000), 1_234_500_000_000_000_000);
+        assert_eq!(quantize_rate_sig_figs(123_456), 123_450);
+        // Sub-perceptible undercuts within one 5-sf bucket collapse to the SAME value → tie & split,
+        // never a free crown steal. 5.00001 and 5.00002 both floor to 5.0.
+        assert_eq!(quantize_rate_sig_figs(5_000_010_000_000_000_000), 5 * p);
+        assert_eq!(quantize_rate_sig_figs(5_000_020_000_000_000_000), 5 * p);
+        // A genuine 5-sf improvement survives as a distinct (better) bucket.
+        assert_ne!(quantize_rate_sig_figs(5 * p), quantize_rate_sig_figs(4_999_900_000_000_000_000));
     }
 
     #[test]

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/confirm_swap.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/confirm_swap.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 
-use crate::consensus::{record_vote, reset_round, swap_request_hash};
+use crate::consensus::{record_vote, swap_request_hash};
 use crate::constants::{
     COLLATERAL_SEED, CONFIG_SEED, FEE_DIVISOR, MINER_SEED, REQ_CONFIRM, STATS_SEED, SWAP_SEED,
     TREASURY_SEED, VOTE_SEED,
@@ -153,7 +153,11 @@ pub fn handler(
             .checked_add(to_amount)
             .ok_or(ErrorCode::Overflow)?;
 
-        reset_round(&mut ctx.accounts.vote_round);
+        // Close the per-swap round (unique swap_key seed → never reused) and refund its rent to the
+        // validator instead of parking it on-chain forever. Safe: the swap closes just below in this
+        // same terminal branch, and `swap` is resolved before `vote_round` in the accounts struct, so a
+        // straggler validator's late confirm reverts on the gone swap before it could re-create the round.
+        ctx.accounts.vote_round.close(ctx.accounts.validator.to_account_info())?;
         ctx.accounts.swap.close(ctx.accounts.validator.to_account_info())?;
 
         emit!(SwapCompleted {

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/set_quote.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/set_quote.rs
@@ -1,7 +1,9 @@
 use anchor_lang::prelude::*;
 use anchor_lang::system_program::{transfer, Transfer};
 
-use crate::constants::{quote_update_fee, MAX_ADDR_LEN, MAX_CHAIN_LEN, QUOTE_SEED, TREASURY_SEED};
+use crate::constants::{
+    quote_update_fee, quantize_rate_sig_figs, MAX_ADDR_LEN, MAX_CHAIN_LEN, QUOTE_SEED, TREASURY_SEED,
+};
 use crate::error::ErrorCode;
 use crate::events::QuoteSet;
 use crate::state::{MinerQuote, Treasury};
@@ -46,8 +48,8 @@ pub fn handler(
 ) -> Result<()> {
     // Mechanical sanity only — chains/addrs are opaque bounded strings. The rate is an opaque
     // fixed-point integer (display × RATE_PRECISION); the contract stores whatever the miner posts
-    // and never computes with it — routability/validity is the off-chain layer's call
-    // (`is_executable_rate`), so there is deliberately no on-chain rate check.
+    // (floored to RATE_SIG_FIGS, below) and never computes with it — routability/validity is the
+    // off-chain layer's call (`is_executable_rate`), so there is no on-chain rate *validity* check.
     require!(
         !from_chain.is_empty()
             && !to_chain.is_empty()
@@ -64,6 +66,12 @@ pub fn handler(
         ErrorCode::StringTooLong
     );
     require!(from_chain != to_chain, ErrorCode::SameChain);
+
+    // Floor to RATE_SIG_FIGS significant figures before it is stored OR emitted, so the pinned swap
+    // rate, the off-chain crown ranking, and the indexer/UI all read the same canonical value. A
+    // sub-perceptible undercut collapses into the incumbent's bucket (tie & split) instead of stealing
+    // the crown for free; a real 5-sf improvement still wins.
+    let rate = quantize_rate_sig_figs(rate);
 
     let now = Clock::get()?.unix_timestamp;
     let miner_key = ctx.accounts.miner.key();

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/timeout_swap.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/timeout_swap.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 
-use crate::consensus::{record_vote, reset_round, swap_request_hash};
+use crate::consensus::{record_vote, swap_request_hash};
 use crate::constants::{COLLATERAL_SEED, CONFIG_SEED, MINER_SEED, REQ_TIMEOUT, SWAP_SEED, VOTE_SEED};
 use crate::error::ErrorCode;
 use crate::events::SwapTimedOut;
@@ -105,7 +105,11 @@ pub fn handler(ctx: Context<TimeoutSwap>, swap_key: [u8; 32]) -> Result<()> {
         ctx.accounts.miner_state.failed_swaps =
             ctx.accounts.miner_state.failed_swaps.saturating_add(1);
 
-        reset_round(&mut ctx.accounts.vote_round);
+        // Close the per-swap round (unique swap_key seed → never reused) and refund its rent to the
+        // validator instead of parking it on-chain forever. Safe: the swap closes just below in this
+        // same terminal branch, and `swap` is resolved before `vote_round` in the accounts struct, so a
+        // straggler validator's late timeout reverts on the gone swap before it could re-create the round.
+        ctx.accounts.vote_round.close(ctx.accounts.validator.to_account_info())?;
         ctx.accounts.swap.close(ctx.accounts.validator.to_account_info())?;
 
         emit!(SwapTimedOut {

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_swap.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_swap.rs
@@ -654,6 +654,11 @@ fn test_fulfill_confirm_fee_and_invariant() {
     // realized VWAP = to/from = 1.5
     assert_eq!(st.total_to_amount * 1_000 / st.total_from_amount, 1_500, "realized VWAP 1.5");
     assert!(svm.get_account(&swap_pda(&swap_key("srctx1"))).is_none(), "swap closed");
+    // The per-swap confirm round is closed (rent refunded to a validator), not parked on-chain forever.
+    assert!(
+        svm.get_account(&vote_pda(REQ_CONFIRM, swap_key("srctx1").as_ref())).is_none(),
+        "confirm vote round closed on quorum"
+    );
     assert!(invariant_holds(&svm, &miner.pubkey(), rent), "collateral-vault invariant after fee");
 }
 
@@ -689,6 +694,11 @@ fn test_timeout_slash_refund_and_invariant() {
     // a timed-out swap accrues NO direction stats (timeout_swap has no stats account)
     assert!(svm.get_account(&stats_pda(&miner.pubkey(), FROM_CHAIN, TO_CHAIN)).is_none(), "no stats on timeout");
     assert!(svm.get_account(&swap_pda(&swap_key("srctx1"))).is_none(), "swap closed");
+    // The per-swap timeout round is closed (rent refunded to a validator), not parked on-chain forever.
+    assert!(
+        svm.get_account(&vote_pda(REQ_TIMEOUT, swap_key("srctx1").as_ref())).is_none(),
+        "timeout vote round closed on quorum"
+    );
     assert!(invariant_holds(&svm, &miner.pubkey(), rent), "collateral-vault invariant after slash");
 }
 

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -4,7 +4,14 @@ from decimal import Decimal
 
 from allways.chains import get_chain
 from allways.constants import BTC_TO_SAT, RATE_PRECISION, TAO_TO_RAO
-from allways.utils.rate import apply_fee_deduction, calculate_to_amount, is_executable_rate, normalize_rate
+from allways.utils.rate import (
+    apply_fee_deduction,
+    calculate_to_amount,
+    is_executable_rate,
+    normalize_rate,
+    quantize_rate_display,
+    quantize_rate_fixed,
+)
 
 # Chain decimals
 TAO_DEC = 9
@@ -388,3 +395,33 @@ class TestIsExecutableRate:
         """If only min_swap is set (max_swap=0), any rate above the floor
         symmetry still passes. Mirrors test_max_unset_only_lower_bound_enforced."""
         assert is_executable_rate(1e-8, 'sol', 'btc', self.MIN, 0) is True
+
+
+class TestQuantizeRate:
+    """quantize_rate_fixed floors to RATE_SIG_FIGS (=5) sig figs, mirroring the on-chain
+    quantize_rate_sig_figs (set_quote.rs). Keep these cases in lockstep with the Rust unit test."""
+
+    P = RATE_PRECISION
+
+    def test_zero_and_small_pass_through(self):
+        assert quantize_rate_fixed(0) == 0
+        assert quantize_rate_fixed(-5) == 0
+        assert quantize_rate_fixed(12_345) == 12_345  # <= 5 digits, untouched
+
+    def test_floors_never_rounds(self):
+        # 1.23459 → 1.2345 (floor, not 1.2346); 123456 → 123450.
+        assert quantize_rate_fixed(1_234_590_000_000_000_000) == 1_234_500_000_000_000_000
+        assert quantize_rate_fixed(123_456) == 123_450
+
+    def test_sub_perceptible_undercut_collapses_to_same_bucket(self):
+        # 5.00001 and 5.00002 both floor to 5.0 → they tie & split, no free crown steal.
+        assert quantize_rate_fixed(5_000_010_000_000_000_000) == 5 * self.P
+        assert quantize_rate_fixed(5_000_020_000_000_000_000) == 5 * self.P
+
+    def test_genuine_5sf_improvement_survives(self):
+        assert quantize_rate_fixed(4_999_900_000_000_000_000) != quantize_rate_fixed(5 * self.P)
+
+    def test_display_helper_round_trips(self):
+        assert quantize_rate_display(5.00001) == 5.0
+        assert quantize_rate_display(1.23459) == 1.2345
+        assert quantize_rate_display(0.0) == 0.0


### PR DESCRIPTION
## Problem

The crown is ranked **off-chain** on the raw stored rate — strict best-rate-wins, bucketed by exact rate value, ties split evenly (`scoring.py` `crown_holders_at_instant`). `set_quote` stored a **full-precision `u128`** with no tick (`state.rs` comment: "deliberately no on-chain rate check").

So two miners could undercut in a **sub-perceptible digit** (e.g. the 9th sig fig) to land in a distinct, strictly-better bucket and capture the **entire** crown for a direction — for free, with **zero benefit to takers**. A rate war with no floor. The only friction was the anti-flashing churn fee, which taxes *rapid* re-quotes but doesn't stop a slow, invisible undercut.

`RATE_SIG_FIGS = 5` and `normalize_rate()` already existed and *claimed* (in comments) to be enforced on post and parse — but neither the CLI post path nor the validator ingest actually applied it. It was display-only.

## Fix

Floor every posted rate to `RATE_SIG_FIGS` (=5) significant figures **at the source**, so a crown-winning improvement is always one a taker can actually see; sub-perceptible undercuts collapse into the incumbent's bucket and **tie & split** instead of stealing the crown.

- **Contract** — `quantize_rate_sig_figs` (pure integer `ilog10` + floor, no floats — non-deterministic in BPF; floor not round so no tick-gaming and no overflow), applied in `set_quote` **before the rate is stored *or* emitted**, so the pinned swap rate, off-chain crown ranking, and indexer/UI all read one canonical value.
- **CLI** — mirror the floor (`quantize_rate_fixed`) so previews and posts match exactly what the chain stores.
- **Validator** — floor on `QuoteSet` ingest too. Redundant post-redeploy, but **closes the migration window** where a pre-redeploy full-precision quote could still snipe the crown before it re-posts.
- Fix the stale `RATE_SIG_FIGS` comment that claimed enforcement already existed.

## Decisions

- **Hardcoded constant, not a `Config` field** — `Config` is a live singleton account ending in `bump: u8`, so adding a field is a borsh layout migration on the existing account. Keeping it a const keeps the redeploy free of an account migration. Can be promoted to `Config` later if we ever want to retune the tick without a program upgrade.
- **No IDL / client change** — `set_quote`'s signature (`rate: u128`) and the `QuoteSet` event shape are unchanged; only the stored value is floored. The alw-utils indexer needs no change.
- **5 sig figs preserved** from the existing constant — not repicking precision here.

## Test / verify

- Rust: `cargo test -p allways_swap_manager --lib quantize` → ok.
- Python: `pytest tests/test_rate.py` → 62 passed (includes new `TestQuantizeRate`, kept in lockstep with the Rust cases).
- Import smoke on validator + both CLI modules.

## Rollout

Requires a **contract redeploy** (testnet netuid19 → mainnet netuid7) for the on-chain floor to take effect. The validator-side ingest floor and CLI mirror take effect on normal deploy and already neutralize the war for the crown independent of the contract, so the redeploy is about canonical storage + execution/UI consistency, not a hard dependency for stopping the bleed.