### PR TITLE
fix(cli): RPC-resilient origination + post-tx propagation grace

### DIFF
--- a/allways/cli/swap_commands/post_tx.py
+++ b/allways/cli/swap_commands/post_tx.py
@@ -13,6 +13,8 @@ taker who won the draw, because ``Reservation.from_addr`` is pinned at reserve t
 relay the confirm, but only the winner's deposit verifies.
 """
 
+import time
+
 import click
 
 from allways.cli.dendrite_lite import (
@@ -33,6 +35,21 @@ from allways.cli.swap_commands.helpers import (
 )
 from allways.cli.validator_rejections import render_and_aggregate
 from allways.synapses import SwapConfirmSynapse
+
+# Bounded auto-retry of the deposit relay. The relay is idempotent (validators re-verify the same
+# on-chain deposit each time), so when nothing is accepted for a *non-deterministic* reason — the
+# deposit hasn't propagated to validators' source-chain nodes yet (`tx_not_found`), a 429, or a
+# timeout — we wait briefly and re-broadcast. A BTC deposit takes seconds to reach a validator's
+# bitcoind, so `post-tx` fired immediately after broadcast otherwise fails on the first pass.
+_RELAY_ATTEMPTS = 3
+_RELAY_WAIT_SECS = 30
+
+
+def _should_retry_relay(info) -> bool:
+    """Retry a zero-accept relay only when the aggregator says the failure is NOT deterministic —
+    i.e. a re-broadcast could plausibly succeed (propagation lag / rate-limit / timeout). A genuine
+    mismatch (wrong amount/recipient, expired reservation) is `deterministic=True` → fail fast."""
+    return info is not None and not info.accepted and not getattr(info, 'deterministic', False)
 
 
 def _find_reservations(client, user, miner_hint, require_user):
@@ -185,10 +202,19 @@ def post_tx_command(tx_hash: str, tx_block: int, miner_hint: str):
         return
 
     wallet = get_ephemeral_wallet()  # transport-only throwaway hotkey; auth is the on-chain deposit
-    with loading(f'Relaying deposit to {len(validator_axons)} validator(s)...'):
-        responses = broadcast_synapse(wallet, validator_axons, synapse, timeout=60.0)
+    info = None
+    for attempt in range(_RELAY_ATTEMPTS):
+        with loading(f'Relaying deposit to {len(validator_axons)} validator(s)...'):
+            responses = broadcast_synapse(wallet, validator_axons, synapse, timeout=60.0)
+        info = render_and_aggregate(console, responses, label='V', context={'miner_hotkey': miner_hotkey})
+        if attempt == _RELAY_ATTEMPTS - 1 or not _should_retry_relay(info):
+            break
+        console.print(
+            f'  [dim]No validator has seen the deposit yet (propagation lag) — retrying in '
+            f'{_RELAY_WAIT_SECS}s [{attempt + 1}/{_RELAY_ATTEMPTS - 1}]…[/dim]'
+        )
+        time.sleep(_RELAY_WAIT_SECS)
 
-    info = render_and_aggregate(console, responses, label='V', context={'miner_hotkey': miner_hotkey})
     if info.accepted:
         clear_pending_swap()
         console.print(

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -236,10 +236,20 @@ def swap_now_command(
         f'  (miner [dim]{str(cand.miner)[:8]}…[/dim], rate {cand.rate_display} per SOL)\n'
     )
 
-    # Pool contention — surface it BEFORE the fee-charging bid so the taker isn't bidding blind into
-    # an already-open, contested round. The reservation fee is non-refundable even on a losing draw.
+    # Resume a seat this taker already holds rather than paying for a second bid: a prior run may have
+    # bid + drawn (or even finalized) but crashed on a transient RPC before instructing the send. The
+    # reused per-miner reservation makes `swap now` idempotent for THIS taker — recover it, don't re-bid.
+    existing = client.get_reservation(cand.miner)
+    resume_live = live_unclaimed(existing) and str(getattr(existing, 'user', '')) == str(user)
+    resume_drawn = (
+        not resume_live and _drawn_unfilled(existing) and str(getattr(existing, 'router', '')) == str(user)
+    )
+    resuming = resume_live or resume_drawn
+
+    # Pool contention — surface it BEFORE the fee-charging bid so the taker isn't bidding blind into an
+    # already-open, contested round (skipped when resuming, since no new bid is placed).
     contention = _pool_contention(client, cand.miner, cfg)
-    if contention.is_open:
+    if contention.is_open and not resuming:
         fee_sol = int(getattr(cfg, 'reservation_fee_lamports', 0)) / 10 ** get_chain(NUMERAIRE_CHAIN).decimals
         if contention.weighted_rivals > 0:
             console.print(
@@ -256,40 +266,50 @@ def swap_now_command(
             )
         console.print(f'  [dim]A losing bid still spends the {fee_sol:g} SOL reservation fee.[/dim]')
 
-    if not skip_confirm and not click.confirm('  Bid on this miner on-chain?', default=False):
+    if not resuming and not skip_confirm and not click.confirm('  Bid on this miner on-chain?', default=False):
         return
 
-    # Phase 1 — BID (pair only; no taker, no amounts).
-    sig = client.open_or_request(cand.miner, from_chain, to_chain)
-    console.print(f'[green]  Bid placed[/green] (tx {sig[:16]}…). Cranking the draw…')
+    # Phases 1-3 — obtain a live reservation held by us: resume an existing seat if we have one,
+    # otherwise bid, self-crank the draw, and finalize against the PINNED rate.
+    if resume_live:
+        console.print('[green]  Resuming the reservation you already hold[/green] (skipping bid + finalize).')
+        resv = existing
+    else:
+        if resume_drawn:
+            console.print('[green]  Resuming the seat you already drew[/green] (skipping bid); finalizing…')
+            drawn = existing
+        else:
+            # Phase 1 — BID (pair only; no taker, no amounts).
+            sig = client.open_or_request(cand.miner, from_chain, to_chain)
+            console.print(f'[green]  Bid placed[/green] (tx {sig[:16]}…). Cranking the draw…')
 
-    # Phase 2 — self-crank the draw until we're seated (unfilled reservation, router == us).
-    drawn = _poll_drawn(client, cand.miner, user, timeout_secs=pool_window + 120)
-    if drawn is None:
-        winner = _lost_seat_to(client, cand.miner, user)
-        if winner:
-            fail(
-                f'  You lost the draw — the seat went to [dim]{winner[:8]}…[/dim]. Your reservation fee is '
-                'spent (non-refundable); do NOT send funds. Re-run to bid on the next round.'
-            )
-        fail(
-            '  The draw did not resolve in the bid window (no seat drawn yet). Do NOT send funds; re-run to try again.'
+            # Phase 2 — self-crank the draw until we're seated (unfilled reservation, router == us).
+            drawn = _poll_drawn(client, cand.miner, user, timeout_secs=pool_window + 120)
+            if drawn is None:
+                winner = _lost_seat_to(client, cand.miner, user)
+                if winner:
+                    fail(
+                        f'  You lost the draw — the seat went to [dim]{winner[:8]}…[/dim]. Your reservation fee is '
+                        'spent (non-refundable); do NOT send funds. Re-run to bid on the next round.'
+                    )
+                fail(
+                    '  The draw did not resolve in the bid window (no seat drawn yet). Do NOT send funds; re-run to try again.'
+                )
+
+        # Phase 3 — FINALIZE against the PINNED rate (not the live quote, which can drift after the bid).
+        fill = compute_intake_amounts(from_chain, to_chain, from_amount, rate_display_from_fixed(drawn.rate))
+        client.finalize_reservation(
+            cand.miner,
+            user,
+            user_from_addr,
+            receive_address_opt,
+            fill.collateral_amount,
+            fill.from_amount,
+            fill.to_amount,
         )
-
-    # Phase 3 — FINALIZE against the PINNED rate (not the live quote, which can drift after the bid).
-    fill = compute_intake_amounts(from_chain, to_chain, from_amount, rate_display_from_fixed(drawn.rate))
-    client.finalize_reservation(
-        cand.miner,
-        user,
-        user_from_addr,
-        receive_address_opt,
-        fill.collateral_amount,
-        fill.from_amount,
-        fill.to_amount,
-    )
-    resv = _poll_reservation(client, cand.miner, timeout_secs=30)
-    if resv is None or str(resv.user) != str(user):
-        fail('  Finalize did not produce a live reservation for you. Do NOT send funds; re-run.')
+        resv = _poll_reservation(client, cand.miner, timeout_secs=30)
+        if resv is None or str(resv.user) != str(user):
+            fail('  Finalize did not produce a live reservation for you. Do NOT send funds; re-run.')
     recv = apply_fee_deduction(int(resv.to_amount), FEE_DIVISOR) / 10 ** get_chain(to_chain).decimals
     console.print(f'[green]  Seat filled[/green] — receiving ~[cyan]{recv:.8g} {to_chain.upper()}[/cyan].')
     # Never instruct a send the reservation can't outlive: a deposit that lands after reserved_until

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -241,9 +241,7 @@ def swap_now_command(
     # reused per-miner reservation makes `swap now` idempotent for THIS taker — recover it, don't re-bid.
     existing = client.get_reservation(cand.miner)
     resume_live = live_unclaimed(existing) and str(getattr(existing, 'user', '')) == str(user)
-    resume_drawn = (
-        not resume_live and _drawn_unfilled(existing) and str(getattr(existing, 'router', '')) == str(user)
-    )
+    resume_drawn = not resume_live and _drawn_unfilled(existing) and str(getattr(existing, 'router', '')) == str(user)
     resuming = resume_live or resume_drawn
 
     # Pool contention — surface it BEFORE the fee-charging bid so the taker isn't bidding blind into an

--- a/allways/solana/client.py
+++ b/allways/solana/client.py
@@ -202,13 +202,13 @@ class AllwaysSolanaClient:
         instructions: List[Instruction],
         signers: Optional[List[Keypair]] = None,
         skip_preflight: bool = False,
-        retries: int = 5,
+        retries: int = 8,
     ) -> str:
         if self.keypair is None:
             raise SolanaClientError('client has no keypair; cannot send transactions')
         signers = signers or [self.keypair]
         last_err: Optional[Exception] = None
-        for _ in range(retries):
+        for attempt in range(retries):
             blockhash = Hash.from_string(self.rpc.get_latest_blockhash())
             tx = Transaction.new_signed_with_payer(instructions, self.keypair.pubkey(), signers, blockhash)
             try:
@@ -219,11 +219,15 @@ class AllwaysSolanaClient:
                 msg = str(e).lower()
                 # Match the actual staleness signature only — NOT the substring 'blockhash', which also
                 # appears in the `replacementBlockhash` field of every program-error payload (that would
-                # retry a deterministic contract rejection 5× and bury it as a "blockhash retries" error).
+                # retry a deterministic contract rejection and bury it as a "blockhash retries" error).
+                # A BlockhashNotFound tx never entered the ledger, so re-signing with a FRESH blockhash
+                # can't double-submit — safe to retry hard. Exponential backoff (~0.5→4s, ~23s total)
+                # rides out a sustained degraded-RPC window that the old 5×0.5s (~2.5s) blew straight
+                # through, orphaning a paid-for seat mid-origination.
                 if 'blockhash not found' not in msg and 'block height exceeded' not in msg:
                     raise
                 last_err = e
-                time.sleep(0.5)
+                time.sleep(min(4.0, 0.5 * 2**attempt))
         raise SolanaClientError(f'send failed after {retries} blockhash retries: {last_err}')
 
     def _ix(self, name: str, arg_bytes: bytes, metas: List[AccountMeta]) -> Instruction:

--- a/tests/test_post_tx_relay_retry.py
+++ b/tests/test_post_tx_relay_retry.py
@@ -4,6 +4,7 @@ A BTC deposit fired at `post-tx` immediately after broadcast hasn't propagated t
 bitcoind yet, so the first relay is rejected `tx_not_found` (deterministic=False) — a re-broadcast a
 few seconds later succeeds. A genuine mismatch (wrong amount/recipient, expired reservation) is
 deterministic=True and must fail fast, not spin."""
+
 import types
 
 from allways.cli.swap_commands.post_tx import _should_retry_relay

--- a/tests/test_post_tx_relay_retry.py
+++ b/tests/test_post_tx_relay_retry.py
@@ -1,0 +1,29 @@
+"""`post-tx` auto-retries a zero-accept relay only when the failure is non-deterministic.
+
+A BTC deposit fired at `post-tx` immediately after broadcast hasn't propagated to validators'
+bitcoind yet, so the first relay is rejected `tx_not_found` (deterministic=False) — a re-broadcast a
+few seconds later succeeds. A genuine mismatch (wrong amount/recipient, expired reservation) is
+deterministic=True and must fail fast, not spin."""
+import types
+
+from allways.cli.swap_commands.post_tx import _should_retry_relay
+
+
+def _info(accepted, deterministic):
+    return types.SimpleNamespace(accepted=accepted, deterministic=deterministic)
+
+
+def test_retry_when_zero_accept_and_not_deterministic():
+    assert _should_retry_relay(_info(0, False)) is True  # propagation lag / rate-limit / timeout
+
+
+def test_no_retry_when_reject_is_deterministic():
+    assert _should_retry_relay(_info(0, True)) is False  # wrong amount/recipient — resend can't help
+
+
+def test_no_retry_once_a_validator_accepts():
+    assert _should_retry_relay(_info(1, False)) is False  # quorum already progressing
+
+
+def test_no_retry_on_missing_info():
+    assert _should_retry_relay(None) is False

--- a/tests/test_send_blockhash_retry.py
+++ b/tests/test_send_blockhash_retry.py
@@ -1,0 +1,66 @@
+"""Regression: a sustained BlockhashNotFound window must not abort a send mid-origination.
+
+`client._send` retries ONLY the blockhash-staleness class — a BlockhashNotFound tx never entered the
+ledger, so re-signing with a FRESH blockhash can't double-submit — now with exponential backoff and
+more attempts (was 5×0.5s ≈ 2.5s, which a prolonged degraded-RPC window blew straight through,
+orphaning a paid-for reservation seat). Any other send fault still raises immediately (a landed tx
+might exist → a blind resend is the caller's call, not ours)."""
+from unittest.mock import MagicMock
+
+import pytest
+from solders.instruction import Instruction
+from solders.keypair import Keypair
+from solders.pubkey import Pubkey
+
+from allways.solana.client import AllwaysSolanaClient, SolanaClientError
+
+_BH = '11111111111111111111111111111111'  # a valid 32-byte base58 value (parses as a Hash)
+
+
+def _client(monkeypatch):
+    monkeypatch.setattr('allways.solana.client.time.sleep', lambda *_: None)  # no real backoff waits
+    c = AllwaysSolanaClient('http://rpc.test', program_id=Pubkey.default(), keypair=Keypair())
+    c.rpc = MagicMock()
+    c.rpc.get_latest_blockhash.return_value = _BH
+    c.rpc.confirm.return_value = {}
+    return c
+
+
+def _ix():
+    return Instruction(Pubkey.default(), b'', [])
+
+
+def test_send_retries_blockhash_not_found_then_succeeds(monkeypatch):
+    c = _client(monkeypatch)
+    c.rpc.send_transaction.side_effect = [
+        RuntimeError('Transaction simulation failed: Blockhash not found'),
+        RuntimeError('blockhash not found'),
+        'okSig',
+    ]
+    assert c._send([_ix()]) == 'okSig'
+    assert c.rpc.send_transaction.call_count == 3
+    assert c.rpc.get_latest_blockhash.call_count == 3  # a FRESH blockhash each attempt (why resend is safe)
+
+
+def test_send_rides_out_a_long_degraded_window(monkeypatch):
+    # 6 straight BlockhashNotFound then success — the old 5-attempt cap would have failed here.
+    c = _client(monkeypatch)
+    c.rpc.send_transaction.side_effect = [RuntimeError('Blockhash not found')] * 6 + ['okSig']
+    assert c._send([_ix()]) == 'okSig'
+    assert c.rpc.send_transaction.call_count == 7
+
+
+def test_send_gives_up_after_retries_on_persistent_blockhash(monkeypatch):
+    c = _client(monkeypatch)
+    c.rpc.send_transaction.side_effect = RuntimeError('Blockhash not found')
+    with pytest.raises(SolanaClientError):
+        c._send([_ix()], retries=4)
+    assert c.rpc.send_transaction.call_count == 4
+
+
+def test_send_does_not_retry_a_non_blockhash_error(monkeypatch):
+    c = _client(monkeypatch)
+    c.rpc.send_transaction.side_effect = RuntimeError('custom program error: 0x1771')
+    with pytest.raises(RuntimeError):
+        c._send([_ix()])
+    assert c.rpc.send_transaction.call_count == 1  # a deterministic reject surfaces at once — no resend

--- a/tests/test_send_blockhash_retry.py
+++ b/tests/test_send_blockhash_retry.py
@@ -5,6 +5,7 @@ ledger, so re-signing with a FRESH blockhash can't double-submit — now with ex
 more attempts (was 5×0.5s ≈ 2.5s, which a prolonged degraded-RPC window blew straight through,
 orphaning a paid-for reservation seat). Any other send fault still raises immediately (a landed tx
 might exist → a blind resend is the caller's call, not ours)."""
+
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/test_swap_now_reservation.py
+++ b/tests/test_swap_now_reservation.py
@@ -120,6 +120,7 @@ def _run_swap_now(reserved_until, from_chain='btc'):
     client.get_config.return_value = types.SimpleNamespace(
         min_swap_amount=1, max_swap_amount=10**18, pool_window_secs=60
     )
+    client.get_reservation.return_value = None  # no seat held yet -> normal bid path (not a resume)
     client.open_or_request.return_value = 'sig' * 8
     amts = types.SimpleNamespace(collateral_amount=10**9, from_amount=5000, to_amount=10**9)
     cand = types.SimpleNamespace(miner='miner-pk', rate_display='0.0021', collateral=10**10)
@@ -276,3 +277,71 @@ def test_lost_seat_to_is_none_when_no_seat_is_drawn_yet():
         reserved_until=0, created_at=0, finalize_by=now - 100, router='RIVAL'
     )
     assert _lost_seat_to(client, 'miner', 'ME') is None
+
+
+# ── resumability: recover an already-held seat instead of paying for a second bid ────────────────────
+# A prior `swap now` can bid + draw (or even finalize) and then crash on a transient RPC before it
+# instructs the send. Re-running must RESUME the reused per-miner reservation for this taker — not
+# re-bid (double fee) — by reading `get_reservation` up front.
+
+def _run_resume(existing, poll_resv):
+    from click.testing import CliRunner
+
+    from allways.cli.swap_commands.swap import swap_now_command
+
+    user = '68ToGUYjjYpqi7Atx7QyhbybR2RCfo2tkmgcoNR3DxYF'
+    client = MagicMock()
+    client.keypair.pubkey.return_value = user
+    client.get_config.return_value = types.SimpleNamespace(
+        min_swap_amount=1, max_swap_amount=10**18, pool_window_secs=60
+    )
+    client.get_reservation.return_value = existing
+    cand = types.SimpleNamespace(miner='miner-pk', rate_display='0.0021', collateral=10**10)
+    amts = types.SimpleNamespace(collateral_amount=10**9, from_amount=5000, to_amount=10**9)
+    argv = ['--from', 'btc', '--to', 'sol', '--amount', '0.00005', '--from-address', 'tb1qsrc', '--receive-address', user, '--yes']
+    with (
+        patch('allways.cli.swap_commands.swap.get_solana_cli_context', return_value=(None, client)),
+        patch('allways.cli.swap_commands.swap._candidate_miners', return_value=[cand]),
+        patch('allways.cli.swap_commands.swap.select_best_miner', return_value=(cand, amts)),
+        patch('allways.cli.swap_commands.swap._poll_drawn', return_value=None),  # unused on a resume; keeps the foreign-seat fall-through fast
+        patch('allways.cli.swap_commands.swap._poll_reservation', return_value=poll_resv),
+        patch('allways.cli.swap_commands.swap._save_pending'),
+    ):
+        return client, CliRunner().invoke(swap_now_command, argv)
+
+
+def test_swap_now_resumes_a_drawn_seat_without_re_bidding():
+    now = int(time.time())
+    user = '68ToGUYjjYpqi7Atx7QyhbybR2RCfo2tkmgcoNR3DxYF'
+    # a seat drawn to us but not finalized (reserved_until==0, created_at==0, finalize_by ahead)
+    drawn = types.SimpleNamespace(reserved_until=0, created_at=0, finalize_by=now + 120, router=user, rate=int(0.0021 * 10**18))
+    live = _resv(now + 400, user=user)  # what finalize produces (returned by the patched _poll_reservation)
+    client, result = _run_resume(drawn, poll_resv=live)
+    assert result.exit_code == 0, result.output
+    assert 'Resuming the seat you already drew' in result.output
+    assert 'Reserved.' in result.output
+    client.open_or_request.assert_not_called()  # NO second bid / second fee
+    client.finalize_reservation.assert_called_once()  # but it did finalize the held seat
+
+
+def test_swap_now_resumes_a_live_reservation_without_bidding_or_finalizing():
+    now = int(time.time())
+    user = '68ToGUYjjYpqi7Atx7QyhbybR2RCfo2tkmgcoNR3DxYF'
+    live = _resv(now + 400, user=user)  # already finalized, ours, unclaimed — just needs the send
+    client, result = _run_resume(live, poll_resv=None)
+    assert result.exit_code == 0, result.output
+    assert 'Resuming the reservation you already hold' in result.output
+    assert 'Reserved.' in result.output
+    client.open_or_request.assert_not_called()
+    client.finalize_reservation.assert_not_called()
+
+
+def test_swap_now_does_not_resume_a_foreign_seat():
+    now = int(time.time())
+    other = 'SOMEONE_ELSE'
+    # a live reservation owned by a different taker must NOT be treated as ours -> falls through to bid
+    foreign = _resv(now + 400, user=other)
+    client, result = _run_resume(foreign, poll_resv=_resv(now + 400, user='68ToGUYjjYpqi7Atx7QyhbybR2RCfo2tkmgcoNR3DxYF'))
+    # with no _poll_drawn patched, the bid path runs its self-crank; we only assert it did NOT short-circuit
+    # into a resume (no "Resuming" banner) — it treated the foreign seat as not-ours.
+    assert 'Resuming' not in result.output

--- a/tests/test_swap_now_reservation.py
+++ b/tests/test_swap_now_reservation.py
@@ -284,6 +284,7 @@ def test_lost_seat_to_is_none_when_no_seat_is_drawn_yet():
 # instructs the send. Re-running must RESUME the reused per-miner reservation for this taker — not
 # re-bid (double fee) — by reading `get_reservation` up front.
 
+
 def _run_resume(existing, poll_resv):
     from click.testing import CliRunner
 
@@ -298,12 +299,26 @@ def _run_resume(existing, poll_resv):
     client.get_reservation.return_value = existing
     cand = types.SimpleNamespace(miner='miner-pk', rate_display='0.0021', collateral=10**10)
     amts = types.SimpleNamespace(collateral_amount=10**9, from_amount=5000, to_amount=10**9)
-    argv = ['--from', 'btc', '--to', 'sol', '--amount', '0.00005', '--from-address', 'tb1qsrc', '--receive-address', user, '--yes']
+    argv = [
+        '--from',
+        'btc',
+        '--to',
+        'sol',
+        '--amount',
+        '0.00005',
+        '--from-address',
+        'tb1qsrc',
+        '--receive-address',
+        user,
+        '--yes',
+    ]
     with (
         patch('allways.cli.swap_commands.swap.get_solana_cli_context', return_value=(None, client)),
         patch('allways.cli.swap_commands.swap._candidate_miners', return_value=[cand]),
         patch('allways.cli.swap_commands.swap.select_best_miner', return_value=(cand, amts)),
-        patch('allways.cli.swap_commands.swap._poll_drawn', return_value=None),  # unused on a resume; keeps the foreign-seat fall-through fast
+        patch(
+            'allways.cli.swap_commands.swap._poll_drawn', return_value=None
+        ),  # unused on a resume; keeps the foreign-seat fall-through fast
         patch('allways.cli.swap_commands.swap._poll_reservation', return_value=poll_resv),
         patch('allways.cli.swap_commands.swap._save_pending'),
     ):
@@ -314,7 +329,9 @@ def test_swap_now_resumes_a_drawn_seat_without_re_bidding():
     now = int(time.time())
     user = '68ToGUYjjYpqi7Atx7QyhbybR2RCfo2tkmgcoNR3DxYF'
     # a seat drawn to us but not finalized (reserved_until==0, created_at==0, finalize_by ahead)
-    drawn = types.SimpleNamespace(reserved_until=0, created_at=0, finalize_by=now + 120, router=user, rate=int(0.0021 * 10**18))
+    drawn = types.SimpleNamespace(
+        reserved_until=0, created_at=0, finalize_by=now + 120, router=user, rate=int(0.0021 * 10**18)
+    )
     live = _resv(now + 400, user=user)  # what finalize produces (returned by the patched _poll_reservation)
     client, result = _run_resume(drawn, poll_resv=live)
     assert result.exit_code == 0, result.output
@@ -341,7 +358,9 @@ def test_swap_now_does_not_resume_a_foreign_seat():
     other = 'SOMEONE_ELSE'
     # a live reservation owned by a different taker must NOT be treated as ours -> falls through to bid
     foreign = _resv(now + 400, user=other)
-    client, result = _run_resume(foreign, poll_resv=_resv(now + 400, user='68ToGUYjjYpqi7Atx7QyhbybR2RCfo2tkmgcoNR3DxYF'))
+    client, result = _run_resume(
+        foreign, poll_resv=_resv(now + 400, user='68ToGUYjjYpqi7Atx7QyhbybR2RCfo2tkmgcoNR3DxYF')
+    )
     # with no _poll_drawn patched, the bid path runs its self-crank; we only assert it did NOT short-circuit
     # into a resume (no "Resuming" banner) — it treated the foreign seat as not-ours.
     assert 'Resuming' not in result.output


### PR DESCRIPTION
## Why

Two resilience gaps surfaced during the mainnet BTC swap run (both **retry + graceful-fallback**, no protocol change):

1. **Origination aborted on a sustained `BlockhashNotFound` window.** `alw swap now` crashed *after* the bid landed and the pool drew us → orphaned a paid-for seat → cost a sunk 0.02 SOL fee.
2. **`post-tx` raced BTC mempool propagation** — relaying immediately after broadcasting the deposit → "source tx not visible" before it reached validators' bitcoind.

## Changes

### 1a — `client._send`: ride out a longer blockhash window
Retried blockhash-staleness at 5×0.5s (~2.5s), no backoff. Bumped to **8 attempts with exponential backoff (~23s total)**. **Safe by construction:** a `BlockhashNotFound` tx never entered the ledger, so re-signing with a *fresh* blockhash each attempt can't double-submit. Every other send fault still raises immediately (a landed tx might exist → a blind resend stays the caller's call, exactly as #547 intended).

### 1b — `swap now` is resumable
Before bidding, it reads the reused per-miner `Reservation`. If **this taker** already holds:
- a **drawn-unfilled** seat → skip the bid, finalize it;
- a **live** reservation → skip bid+finalize, print the send instruction.

So a crash between bid and send is recovered on re-run instead of paying for a second bid. A seat owned by a *different* taker is never resumed (falls through to a normal bid). This is the `originate_swap.py` recovery logic I used during the run, folded into the CLI.

### 2 — `post-tx` propagation grace
The relay is idempotent (validators re-verify the same on-chain deposit), so a **zero-accept** result whose aggregate reason is **non-deterministic** (`tx_not_found` / 429 / timeout — all `RejectionInfo.deterministic == False`) is auto-retried up to **3×/30s**. A deterministic mismatch (wrong amount/recipient, expired reservation) still **fails fast**. Uses the aggregator's existing `deterministic` classification, so scoping is exact.

## Safety

Send-safety invariant unchanged — a source send is still gated on **this taker holding the live reservation**. The blockhash retry is provably non-double-submitting; resume never touches a foreign seat; the post-tx retry only fires on classified-transient failures.

## Tests

- `_send`: retries a BlockhashNotFound then succeeds (fresh blockhash each attempt), rides a 6-fail window, gives up after N, **does not** retry a non-blockhash error.
- `swap now`: resume-from-drawn (no re-bid, does finalize), resume-from-live (no re-bid, no finalize), don't-resume-foreign.
- `post-tx`: retry predicate (retry iff zero-accept & non-deterministic).

Full suite **722 passed**, ruff clean.

## Context

Follow-up to the mainnet 10-swap run (all settled, exact-sat reconciled). These are the two robustness gaps from that run's findings; the only real cost incurred was one sunk 0.02 SOL fee from 1a, which this closes. Builds on #547 (read-side RPC hardening) and #548 (pool-contention visibility).