### PR TITLE
perf(miner): fetch one Swap snapshot per poll instead of one per status

### DIFF
--- a/allways/miner/swap_poller.py
+++ b/allways/miner/swap_poller.py
@@ -1,9 +1,9 @@
 """Polls the Solana program for swaps assigned to this miner.
 
 Solana keys swaps by `swap_key` (== keccak(from_tx_hash)) and exposes them through a single
-`getProgramAccounts` snapshot per status, so there is no incremental cursor and no per-id transient
-miss to defend against (the old ink! poller scanned `get_swap(id)` one id at a time): each poll is an
-atomic, authoritative view. Whether a swap has already been handled is tracked by ``SwapFulfiller``'s
+`getProgramAccounts` snapshot per poll, partitioned by status locally, so there is no incremental
+cursor and no per-id transient miss to defend against (the old ink! poller scanned `get_swap(id)`
+one id at a time): each poll is an atomic, authoritative view. Whether a swap has already been handled is tracked by ``SwapFulfiller``'s
 persistent send cache — this poller reports raw on-chain state only.
 """
 
@@ -39,9 +39,11 @@ class SwapPoller:
             self.last_poll_ok = False
             return [], []
 
-    def _mine(self, status: str) -> List[SolanaSwap]:
+    def _mine(self, rows, status: str) -> List[SolanaSwap]:
         out = []
-        for _pubkey, acct in self.client.get_swaps(status=status):
+        for _pubkey, acct in rows:
+            if type(acct.status).__name__ != status:
+                continue
             if _as_pubkey(acct.miner) != self.miner_pubkey:
                 continue
             swap = swap_from_solana(acct)
@@ -55,8 +57,11 @@ class SwapPoller:
         return out
 
     def poll_inner(self) -> Tuple[List[SolanaSwap], List[SolanaSwap]]:
-        active = self._mine('Active')
-        fulfilled = self._mine('Fulfilled')
+        # One snapshot fetch, partitioned locally — both statuses come from the same atomic view
+        # (and half the getProgramAccounts of fetching per status).
+        rows = self.client.get_swaps()
+        active = self._mine(rows, 'Active')
+        fulfilled = self._mine(rows, 'Fulfilled')
         # Forget keys no longer present so a reused-tx swap re-logs; bounded to the live set.
         live = {s.key_hex for s in active} | {s.key_hex for s in fulfilled}
         # A key that was known but is no longer Active/Fulfilled left the miner's live set — the swap

--- a/tests/test_swap_poller.py
+++ b/tests/test_swap_poller.py
@@ -41,12 +41,8 @@ def _acct(miner_bytes: bytes, from_tx_hash: str, status_name: str = 'Active'):
 
 def _client(active=(), fulfilled=()):
     client = MagicMock()
-
-    def get_swaps(status=None):
-        rows = active if status == 'Active' else fulfilled if status == 'Fulfilled' else []
-        return [(f'pda{i}', a) for i, a in enumerate(rows)]
-
-    client.get_swaps.side_effect = get_swaps
+    rows = [*active, *fulfilled]
+    client.get_swaps.side_effect = lambda status=None: [(f'pda{i}', a) for i, a in enumerate(rows)]
     return client
 
 
@@ -69,6 +65,17 @@ def test_filters_to_this_miner_and_splits_active_fulfilled():
     assert [s.from_tx_hash for s in active] == ['aa']  # 'bb' belongs to another miner
     assert [s.from_tx_hash for s in fulfilled] == ['cc']
     assert active[0].status == 'Active' and fulfilled[0].status == 'Fulfilled'
+
+
+def test_poll_fetches_one_snapshot():
+    me = Keypair().pubkey()
+    client = _client(
+        active=[_acct(bytes(me), 'aa')],
+        fulfilled=[_acct(bytes(me), 'cc', 'Fulfilled')],
+    )
+    poller = SwapPoller(client, me)
+    poller.poll()
+    assert client.get_swaps.call_count == 1
 
 
 def test_empty_when_no_swaps_for_miner():


### PR DESCRIPTION
## What

`SwapPoller.poll_inner` called `client.get_swaps(status=...)` twice per pass — once for `Active`, once for `Fulfilled`. But `get_swaps` filters by status **client-side after downloading the full `Swap` account set** (`client.py:193-197`), so every 12s poll issued two identical `getProgramAccounts` and decoded the same snapshot twice.

Now the poller fetches the snapshot once and `_mine` partitions it locally using the exact same `type(acct.status).__name__` comparison the client filter used — behaviour-identical.

## Why

- **Halves the miner's idle RPC floor: ~14.4k → ~7.2k requests/day** (~216k/mo). This is the number that keeps a free-tier Helius key (1M credits/mo) comfortably sufficient for one miner, per the docs update in allways-docs-ui#60 — headroom goes from ~2.3× to ~4.6×.
- **Removes a snapshot race.** Both statuses previously came from two snapshots one RPC round-trip apart, so a swap flipping Active→Fulfilled mid-poll could appear in both lists for a pass (harmless — the send cache is idempotent — but off-model). One atomic snapshot is what the module docstring already promised.

## Safety

- `client.get_swaps` signature and all other callers (validator `solana_swap_loop`, CLI `view`/`miner_commands`) untouched.
- Failure semantics unchanged: `poll()`'s try/except already aborted the whole poll if either fetch failed; one fetch behaves the same, `last_poll_ok` / reconnect-after-3 logic unaffected.
- `known`-set bookkeeping, discovery logging, and send-cache cleanup operate on the same returned lists.

## Testing

- New `test_poll_fetches_one_snapshot` pins `get_swaps.call_count == 1` per poll.
- Test mock updated to serve one combined snapshot (matching the real client).
- Full unit suite: **723 passed**.