### PR TITLE
Add SOLANA_RPC_API_KEY env var composing the RPC URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,10 @@ LOG_LEVEL=info
 # Read by the miner, validator, and `alw`. Unset uses http://127.0.0.1:8899.
 SOLANA_RPC_URL=
 
+# Optional keyed-provider API key (e.g. Helius) — composed onto SOLANA_RPC_URL as
+# the api-key query param, so the URL stays a plain endpoint.
+# SOLANA_RPC_API_KEY=
+
 # Solana signer for miner/admin commands (collateral, quotes, config are keyed by this
 # pubkey — not the bt wallet). Unset falls back to `alw config set solana-keypair`,
 # then the solana-CLI default ~/.solana/id.json.

--- a/allways/chain_providers/solana.py
+++ b/allways/chain_providers/solana.py
@@ -1,5 +1,4 @@
 import base64
-import os
 import time
 from typing import Any, List, Optional, Tuple
 
@@ -11,7 +10,7 @@ from solders.signature import Signature
 
 from allways.chain_providers.base import ChainProvider, ProviderUnreachableError, TransactionInfo
 from allways.chains import CHAIN_SOL, ChainDefinition
-from allways.solana.rpc import SolanaRpc
+from allways.solana.rpc import SolanaRpc, resolve_rpc_url
 
 LOG_SOL = '[Solana]'
 
@@ -36,7 +35,7 @@ class SolanaProvider(ChainProvider):
     def __init__(
         self, solana_rpc_url: Optional[str] = None, solana_keypair: Optional[Keypair] = None, timeout: int = 30
     ):
-        self.rpc_url = solana_rpc_url or os.environ.get('SOLANA_RPC_URL', 'http://127.0.0.1:8899')
+        self.rpc_url = resolve_rpc_url(solana_rpc_url)
         self.rpc = SolanaRpc(self.rpc_url, timeout=timeout)
         self.keypair = solana_keypair
 

--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -17,7 +17,7 @@ from rich.text import Text
 from allways.classes import SwapStatus
 from allways.constants import NETUID_FINNEY, TAO_TO_RAO
 from allways.solana.client import SolanaClientError
-from allways.solana.rpc import SolanaRpcError
+from allways.solana.rpc import SolanaRpcError, resolve_rpc_url
 
 ALLWAYS_DIR = Path.home() / '.allways'
 CONFIG_FILE = ALLWAYS_DIR / 'config.json'
@@ -45,19 +45,17 @@ ENV_BUNDLES = {
 
 def resolve_solana_rpc(config: dict) -> str:
     """Solana RPC precedence: SOLANA_RPC_URL env / solana-rpc config (raw URL — paid/custom) win;
-    else the solana-network name resolves to a public endpoint; else localnet default."""
-    raw = os.environ.get('SOLANA_RPC_URL') or config.get('solana-rpc')
-    if raw:
-        return raw
+    else the solana-network name resolves to a public endpoint; else localnet default.
+    ``SOLANA_RPC_API_KEY`` is composed onto whichever endpoint wins (``resolve_rpc_url``)."""
+    url = os.environ.get('SOLANA_RPC_URL') or config.get('solana-rpc')
     name = config.get('solana-network')
-    if name:
+    if not url and name:
         url = SOLANA_NETWORKS.get(name)
-        if url:
-            return url
-        console.print(
-            f'[yellow]Unknown solana-network {name!r} (expected {list(SOLANA_NETWORKS)}); using localnet.[/yellow]'
-        )
-    return 'http://127.0.0.1:8899'
+        if not url:
+            console.print(
+                f'[yellow]Unknown solana-network {name!r} (expected {list(SOLANA_NETWORKS)}); using localnet.[/yellow]'
+            )
+    return resolve_rpc_url(url)
 
 
 def resolve_solana_keypair_path(config: dict) -> str:

--- a/allways/solana/rpc.py
+++ b/allways/solana/rpc.py
@@ -5,11 +5,26 @@ into the existing `asyncio.to_thread` pattern. Account data is returned base64-d
 """
 
 import base64
+import os
 import time
 from typing import Any, List, Optional, Tuple
 
 import base58
 import requests
+
+
+def resolve_rpc_url(explicit: Optional[str] = None) -> str:
+    """The SOL RPC endpoint every consumer (neurons, provider, CLI) resolves through.
+
+    ``explicit`` (or ``SOLANA_RPC_URL``) is the endpoint; ``SOLANA_RPC_API_KEY`` is composed on as
+    the ``api-key`` query param (the keyed-provider convention, e.g. Helius), so operators set a
+    plain URL and a key instead of splicing the key into the URL. A URL already carrying an
+    ``api-key`` is left alone. Defaults to localnet."""
+    url = explicit or os.environ.get('SOLANA_RPC_URL') or 'http://127.0.0.1:8899'
+    key = os.environ.get('SOLANA_RPC_API_KEY')
+    if key and 'api-key=' not in url:
+        url = f'{url}{"&" if "?" in url else "?"}api-key={key}'
+    return url
 
 
 class SolanaRpcError(Exception):

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -26,6 +26,7 @@ from allways.miner.fulfillment import SwapFulfiller  # noqa: E402
 from allways.miner.swap_poller import SwapPoller  # noqa: E402
 from allways.solana import keys  # noqa: E402
 from allways.solana.client import AllwaysSolanaClient  # noqa: E402
+from allways.solana.rpc import resolve_rpc_url  # noqa: E402
 from neurons.base.miner import BaseMinerNeuron  # noqa: E402
 
 
@@ -43,7 +44,7 @@ class Miner(BaseMinerNeuron):
         self.unlock_coldkey()
 
         # Solana program client (signer = the miner's Solana keypair; separate from the bt wallet).
-        solana_rpc_url = os.environ.get('SOLANA_RPC_URL', 'http://127.0.0.1:8899')
+        solana_rpc_url = resolve_rpc_url()
         self.solana_client = AllwaysSolanaClient(solana_rpc_url, keypair=keys.load_or_create())
         self.solana_pubkey = self.solana_client.keypair.pubkey()
         # SOL swap-leg provider signs the dest leg with the same Solana keypair (peer-to-peer

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -33,6 +33,7 @@ from allways.constants import (  # noqa: E402
 from allways.solana import keys  # noqa: E402
 from allways.solana.client import AllwaysSolanaClient  # noqa: E402
 from allways.solana.events import SolanaEventIngest  # noqa: E402
+from allways.solana.rpc import resolve_rpc_url  # noqa: E402
 from allways.validator.axon_handlers import (  # noqa: E402
     blacklist_miner_activate,
     blacklist_swap_confirm,
@@ -73,7 +74,7 @@ class Validator(BaseValidatorNeuron):
 
         # One rpc-url source of truth shared by every SOL consumer: the chain
         # providers (source-leg verification) and the solana_client below.
-        solana_rpc_url = os.environ.get('SOLANA_RPC_URL', 'http://127.0.0.1:8899')
+        solana_rpc_url = resolve_rpc_url()
         self.chain_providers = create_chain_providers(
             check=True, require_send=False, subtensor=self.subtensor, solana_rpc_url=solana_rpc_url
         )

--- a/tests/test_network_config.py
+++ b/tests/test_network_config.py
@@ -22,6 +22,11 @@ from allways.cli.swap_commands.helpers import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _no_ambient_api_key(monkeypatch):
+    monkeypatch.delenv('SOLANA_RPC_API_KEY', raising=False)
+
+
 def test_solana_name_resolves_to_endpoint(monkeypatch):
     monkeypatch.delenv('SOLANA_RPC_URL', raising=False)
     assert resolve_solana_rpc({'solana-network': 'devnet'}) == SOLANA_NETWORKS['devnet']
@@ -47,6 +52,30 @@ def test_solana_unset_defaults_localnet(monkeypatch):
 def test_solana_unknown_name_falls_back_localnet(monkeypatch):
     monkeypatch.delenv('SOLANA_RPC_URL', raising=False)
     assert resolve_solana_rpc({'solana-network': 'nope'}) == 'http://127.0.0.1:8899'
+
+
+def test_api_key_composes_onto_resolved_endpoint(monkeypatch):
+    monkeypatch.setenv('SOLANA_RPC_URL', 'https://mainnet.helius-rpc.com')
+    monkeypatch.setenv('SOLANA_RPC_API_KEY', 'k1')
+    assert resolve_solana_rpc({}) == 'https://mainnet.helius-rpc.com?api-key=k1'
+
+
+def test_api_key_appends_with_ampersand_when_query_present(monkeypatch):
+    monkeypatch.setenv('SOLANA_RPC_URL', 'https://rpc.example/x?tier=pro')
+    monkeypatch.setenv('SOLANA_RPC_API_KEY', 'k1')
+    assert resolve_solana_rpc({}) == 'https://rpc.example/x?tier=pro&api-key=k1'
+
+
+def test_api_key_leaves_already_keyed_url_alone(monkeypatch):
+    monkeypatch.setenv('SOLANA_RPC_URL', 'https://rpc.example/?api-key=inline')
+    monkeypatch.setenv('SOLANA_RPC_API_KEY', 'k1')
+    assert resolve_solana_rpc({}) == 'https://rpc.example/?api-key=inline'
+
+
+def test_api_key_composes_onto_network_name(monkeypatch):
+    monkeypatch.delenv('SOLANA_RPC_URL', raising=False)
+    monkeypatch.setenv('SOLANA_RPC_API_KEY', 'k1')
+    assert resolve_solana_rpc({'solana-network': 'devnet'}) == SOLANA_NETWORKS['devnet'] + '?api-key=k1'
 
 
 def test_env_bundles_cover_all_three_chains():


### PR DESCRIPTION
Keyed providers currently require splicing the key into SOLANA_RPC_URL (`?api-key=...`). This adds an optional `SOLANA_RPC_API_KEY` env var composed onto the endpoint as the `api-key` query param, so configs keep a plain URL and the key stays its own value.

- `resolve_rpc_url` in `allways/solana/rpc.py` is the single resolver; miner, validator, the SOL chain provider, and the CLI (`resolve_solana_rpc`) all route through it
- Idempotent: a URL already carrying `api-key=` is left alone; unset key changes nothing
- `.env.example` documents the new var; unit tests cover composition and precedence

Tests: full suite, 737 passed. Docs updated in allways-docs-ui PR #61.