### PR TITLE
Denominate capacity by the 1.1x collateral requirement

### DIFF
--- a/allways/cli/swap_commands/swap_intake.py
+++ b/allways/cli/swap_commands/swap_intake.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
 from allways.chains import canonical_pair, get_chain
-from allways.constants import COLLATERAL_REQUIREMENT_BPS, NUMERAIRE_CHAIN, RATE_PRECISION
+from allways.constants import NUMERAIRE_CHAIN, RATE_PRECISION, required_collateral
 from allways.utils.rate import calculate_to_amount, is_executable_rate, normalize_rate
 
 
@@ -68,11 +68,6 @@ def compute_intake_amounts(from_chain: str, to_chain: str, from_amount: int, rat
     )
     collateral_amount = from_amount if from_chain == NUMERAIRE_CHAIN else to_amount
     return IntakeAmounts(collateral_amount=collateral_amount, from_amount=from_amount, to_amount=to_amount)
-
-
-def required_collateral(collateral_amount: int) -> int:
-    """Lamports a miner must hold to back ``collateral_amount`` (1.10×). Mirrors the contract."""
-    return collateral_amount * COLLATERAL_REQUIREMENT_BPS // 10_000
 
 
 def swap_viable(collateral_amount: int, collateral: int, min_swap: int, max_swap: int) -> Tuple[bool, str]:

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -129,6 +129,11 @@ SWAP_OUTCOME_RETENTION_SECS = 7 * 86400
 # COLLATERAL_REQUIREMENT_BPS (constants.rs) — keep in sync. 11_000 = 1.10×.
 COLLATERAL_REQUIREMENT_BPS = 11_000
 
+
+def required_collateral(collateral_amount: int) -> int:
+    """Lamports a miner must hold to back ``collateral_amount`` (1.10×). Mirrors the contract."""
+    return collateral_amount * COLLATERAL_REQUIREMENT_BPS // 10_000
+
 # ─── Emission Recycling ────────────────────────────────────
 RECYCLE_UID = 53  # Subnet owner UID
 

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -134,6 +134,7 @@ def required_collateral(collateral_amount: int) -> int:
     """Lamports a miner must hold to back ``collateral_amount`` (1.10×). Mirrors the contract."""
     return collateral_amount * COLLATERAL_REQUIREMENT_BPS // 10_000
 
+
 # ─── Emission Recycling ────────────────────────────────────
 RECYCLE_UID = 53  # Subnet owner UID
 

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -55,6 +55,7 @@ from allways.constants import (
     SCORING_WINDOW_SECS,
     SWAP_OUTCOME_RETENTION_SECS,
     VOLUME_WEIGHT_ALPHA,
+    required_collateral,
 )
 from allways.utils.rate import is_executable_rate, min_executable_sol_leg
 from allways.validator.binding import build_attribution
@@ -766,12 +767,14 @@ def snapshot_current_miner_scores(self: Validator, at_time: Optional[int] = None
 
 
 def capacity_factor(collateral_rao: int, max_swap_amount_rao: int) -> float:
-    """min(1, collateral / max_swap). Fail-safe to 1.0 when bounds unset."""
+    """min(1, collateral / required_collateral(max_swap)) — full credit means holding enough
+    to actually accept a max_swap fill at the contract's 1.10× gate. Fail-safe to 1.0 when
+    bounds unset."""
     if max_swap_amount_rao <= 0:
         return 1.0
     if collateral_rao <= 0:
         return 0.0
-    return min(1.0, collateral_rao / max_swap_amount_rao)
+    return min(1.0, collateral_rao / required_collateral(max_swap_amount_rao))
 
 
 def fill_ratio(

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -1625,24 +1625,31 @@ class TestHaltShortCircuit:
 
 
 class TestCapacityFactorHelper:
-    """Direct unit tests for the capacity_factor pure function."""
+    """Direct unit tests for the capacity_factor pure function. Full credit requires
+    backing a max_swap fill at the contract's 1.10× gate: denominator = 1.1 × max_swap."""
 
-    def test_at_max_swap_is_full(self):
+    def test_at_required_collateral_is_full(self):
         from allways.validator.scoring import capacity_factor
 
-        assert capacity_factor(500_000_000, 500_000_000) == 1.0
+        assert capacity_factor(550_000_000, 500_000_000) == 1.0
 
-    def test_half_max_swap_is_half(self):
+    def test_at_max_swap_is_under_full(self):
+        """Collateral == max_swap can't actually accept a max_swap fill (needs 1.1×)."""
         from allways.validator.scoring import capacity_factor
 
-        assert capacity_factor(250_000_000, 500_000_000) == 0.5
+        assert capacity_factor(500_000_000, 500_000_000) == 500_000_000 / 550_000_000
 
-    def test_quarter_max_swap_is_quarter(self):
+    def test_half_required_is_half(self):
         from allways.validator.scoring import capacity_factor
 
-        assert capacity_factor(125_000_000, 500_000_000) == 0.25
+        assert capacity_factor(275_000_000, 500_000_000) == 0.5
 
-    def test_above_max_swap_caps_at_one(self):
+    def test_quarter_required_is_quarter(self):
+        from allways.validator.scoring import capacity_factor
+
+        assert capacity_factor(137_500_000, 500_000_000) == 0.25
+
+    def test_above_required_caps_at_one(self):
         from allways.validator.scoring import capacity_factor
 
         assert capacity_factor(2_000_000_000, 500_000_000) == 1.0
@@ -1743,13 +1750,13 @@ class TestCapacityWeighting:
         conn.commit()
 
     def test_full_capacity_pays_baseline(self, tmp_path: Path):
-        """Miner with collateral = max_swap earns the full per-direction pool."""
+        """Miner with collateral = 1.1 x max_swap earns the full per-direction pool."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
         v = make_validator(
             tmp_path,
             hotkeys,
             max_swap_amount=500_000_000,
-            collaterals={'hk_a': 500_000_000},
+            collaterals={'hk_a': 550_000_000},
         )
         self.seed_sol_btc_crown(v, 'hk_a')
         rewards, _ = calculate_miner_rewards(v, v.block)
@@ -1758,13 +1765,13 @@ class TestCapacityWeighting:
         v.state_store.close()
 
     def test_quarter_capacity_pays_quarter(self, tmp_path: Path):
-        """Collateral at 1/4 of max swap → 1/4 reward, 3/4 recycles."""
+        """Collateral at 1/4 of required (1.1 x max_swap) → 1/4 reward, 3/4 recycles."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
         v = make_validator(
             tmp_path,
             hotkeys,
             max_swap_amount=500_000_000,
-            collaterals={'hk_a': 125_000_000},
+            collaterals={'hk_a': 137_500_000},
         )
         self.seed_sol_btc_crown(v, 'hk_a')
         rewards, _ = calculate_miner_rewards(v, v.block)
@@ -1812,7 +1819,7 @@ class TestCapacityWeighting:
             tmp_path,
             hotkeys,
             max_swap_amount=500_000_000,
-            collaterals={'hk_a': 500_000_000, 'hk_b': 100_000_000},
+            collaterals={'hk_a': 550_000_000, 'hk_b': 110_000_000},
         )
         conn = v.state_store.require_connection()
         for hk in ('hk_a', 'hk_b'):
@@ -2366,7 +2373,7 @@ class TestCapacityVolumeInteraction:
             tmp_path,
             hotkeys,
             max_swap_amount=500_000_000,
-            collaterals={'hk_a': 250_000_000},
+            collaterals={'hk_a': 275_000_000},
         )
         conn = v.state_store.require_connection()
         conn.execute(
@@ -2499,17 +2506,17 @@ class TestHistoricalCollateralReplay:
             hotkeys,
             block=10_000,
             max_swap_amount=500_000_000,
-            collaterals={'hk_a': 100_000_000},  # held throughout the window
+            collaterals={'hk_a': 110_000_000},  # held throughout the window
         )
         self.seed_sol_btc_crown(v, 'hk_a')
         # Top-up fires *after* window_end (= 10_000). Window is (9_700, 10_000].
         v.event_watcher.apply_event(
             10_500,
             'CollateralPosted',
-            {'miner': 'hk_a', 'amount': 400_000_000, 'total': 500_000_000},
+            {'miner': 'hk_a', 'amount': 440_000_000, 'total': 550_000_000},
         )
         rewards, _ = calculate_miner_rewards(v, v.block)
-        # capacity_factor = 100M / 500M = 0.2; pool 0.5 → reward 0.1.
+        # capacity_factor = 110M / (1.1 × 500M) = 0.2; pool 0.5 → reward 0.1.
         np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 0.2, atol=1e-6)
         v.state_store.close()
 
@@ -2524,7 +2531,7 @@ class TestHistoricalCollateralReplay:
             hotkeys,
             block=10_000,
             max_swap_amount=500_000_000,
-            collaterals={'hk_a': 125_000_000},  # window-start anchor
+            collaterals={'hk_a': 137_500_000},  # window-start anchor (0.25 × required)
         )
         self.seed_sol_btc_crown(v, 'hk_a')
         # SCORING_WINDOW_BLOCKS = 300 → window is (9_700, 10_000]. Midpoint
@@ -2532,7 +2539,7 @@ class TestHistoricalCollateralReplay:
         v.event_watcher.apply_event(
             9_850,
             'CollateralPosted',
-            {'miner': 'hk_a', 'amount': 375_000_000, 'total': 500_000_000},
+            {'miner': 'hk_a', 'amount': 412_500_000, 'total': 550_000_000},
         )
         rewards, _ = calculate_miner_rewards(v, v.block)
         # First 150 blocks at cap 0.25, next 150 at cap 1.0 → mean cap 0.625.

--- a/tests/test_solana_scoring_integration.py
+++ b/tests/test_solana_scoring_integration.py
@@ -33,7 +33,7 @@ import bittensor as bt
 import pytest
 from solders.keypair import Keypair
 
-from allways.constants import DIRECTION_POOLS, RATE_PRECISION, RECYCLE_UID
+from allways.constants import DIRECTION_POOLS, RATE_PRECISION, RECYCLE_UID, required_collateral
 from allways.solana.client import AllwaysSolanaClient
 from allways.solana.events import SolanaEventIngest
 from allways.solana.rpc import SolanaRpc
@@ -125,7 +125,7 @@ def _activate_miner(admin, validators, rate_int):
     miner = Keypair()
     _airdrop(miner.pubkey(), 10)
     mclient = AllwaysSolanaClient(RPC, keypair=miner)
-    collateral = MAX_SWAP_RAO  # == max_swap → capacity_factor 1.0
+    collateral = required_collateral(MAX_SWAP_RAO)  # 1.1 × max_swap → capacity_factor 1.0
     mclient.post_collateral(collateral)
     mclient.set_quote('btc', 'sol', 'minerBTC', 'minerSOL', rate_int, 1_000)
     hk = _hotkey()


### PR DESCRIPTION
capacity_factor scored 1.0 at collateral = max_swap, but accepting a max_swap-sized fill requires 1.1× at the contract's gate — miners got full capacity credit for a band they couldn't fully serve (~9% over-credit).

- `required_collateral` moves from swap_intake to `constants.py` (single shared 1.10× helper, next to COLLATERAL_REQUIREMENT_BPS)
- `capacity_factor` denominator: `max_swap` → `required_collateral(max_swap)`
- Capacity tests reseeded to 1.1×-required values; added the collateral==max_swap boundary case

Found in the IM config review (IM_CONFIG_REVIEW.md, finding 3). Tests: full suite, 734 passed. Miner guide capacity wording gets the matching update on the docs branch.