### PR TITLE
Finalize routed reservation wins from the validator sweep

### DIFF
--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -11,6 +11,7 @@ import bittensor as bt
 from allways import dev_signal
 from allways.utils.logging import log_crown_winners
 from allways.validator.binding import build_attribution
+from allways.validator.reserve_engine import finalize_won_seats
 from allways.validator.scoring import (
     due_for_scoring,
     score_and_reward_miners,
@@ -44,6 +45,11 @@ async def forward(self: Validator) -> None:
     resolved = await asyncio.to_thread(self.solana_swap_loop.resolve_pools_once, now)
     if resolved:
         bt.logging.info(f'forward step #{self.step}: resolved {len(resolved)} reservation pool(s)')
+    # Routed-reservation sweep right after the crank: won seats are freshest here, spending
+    # the least of the finalize window on queued on-behalf users.
+    finalized = await asyncio.to_thread(finalize_won_seats, self, now)
+    if finalized:
+        bt.logging.info(f'forward step #{self.step}: finalized {len(finalized)} routed seat(s)')
     decisions = await asyncio.to_thread(self.solana_swap_loop.run_once, now)
     bt.logging.info(
         f'forward step #{self.step} @ block {self.block}: solana swap loop processed {len(decisions)} live swap(s)'

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -144,9 +144,6 @@ def reserve_on_behalf(
 
     # Two-phase: this places a BID only (the pair). The taker + amounts computed above are a
     # pre-flight viability check; naming them on-chain is the winner's `finalize_reservation` step.
-    # NOTE: the validator-side finalize/reap sweep is a follow-up wave — until it lands, a
-    # validator-routed reservation draws but expires unfilled (reaped by close_unfilled_reservation).
-    _ = (user_pk, user_from_addr, user_to_addr)  # consumed at finalize (next wave)
     try:
         sig = client.open_or_request(miner_pk, from_chain, to_chain)
     except Exception as e:
@@ -154,9 +151,91 @@ def reserve_on_behalf(
         if reason is None:
             raise
         return ReserveResult(False, reason)
+    # The entry landed — queue the user's details for `finalize_won_seats`. Persisted (not held in
+    # memory) so a validator restart inside the pool/finalize window still honors the routing promise.
+    validator.state_store.upsert_routed_request(
+        str(miner_pk), from_chain, to_chain, str(user_pk), user_from_addr, user_to_addr, from_amount, now
+    )
     pool = client.get_pool(miner_pk)
     closes_at = int(getattr(pool, 'closes_at', 0) or 0) if pool else 0
     return ReserveResult(True, '', closes_at, sig)
+
+
+# Staleness backstop for queued routed requests: pool window + finalize window + generous slack.
+# A queue whose reservation never materializes (miner never drawn, RPC blind spot) dies here.
+ROUTED_REQUEST_TTL_SECS = 900
+
+
+def draw_pool_winner(requests: list) -> dict:
+    """Select which queued user gets a won seat. FIFO for now — a deliberate stub:
+    selection policy (user stake weighting, priority fees, batching) evolves HERE
+    without touching the sweep or the persistence around it."""
+    return requests[0]
+
+
+def finalize_won_seats(validator, now: int) -> list:
+    """The routed-reservation sweep: for every miner-direction with queued requests, check the
+    reservation and act once its outcome is known. Won a drawn seat → finalize it on-chain for
+    ``draw_pool_winner``'s pick (amounts recomputed from the PINNED rate, mirroring the CLI's
+    native Phase 3) and drop the queue — non-selected users' clients see another user pinned and
+    re-request. Lost / filled by another router / finalize window lapsed → drop the queue. A
+    transient RPC fault keeps the queue for the next step's retry (inside the finalize window).
+    Returns the miners finalized this pass."""
+    store = validator.state_store
+    client = validator.solana_client
+    read_only = validator.solana_swap_loop.read_only
+    me = str(client.keypair.pubkey())
+    finalized: list = []
+    for miner, from_chain, to_chain in store.distinct_routed_pools():
+        try:
+            resv = client.get_reservation(Pubkey.from_string(miner))
+        except Exception as e:
+            bt.logging.warning(f'routed sweep {miner[:8]}: reservation read failed, retrying next step: {e}')
+            continue
+        drawn_unfilled = resv is not None and int(resv.reserved_until) == 0 and int(resv.finalize_by) != 0
+        won = (
+            drawn_unfilled
+            and now <= int(resv.finalize_by)
+            and str(resv.router) == me
+            and resv.from_chain == from_chain
+            and resv.to_chain == to_chain
+        )
+        if not won:
+            # No seat we can fill: not drawn yet (pool still open/uncranked) → wait; anything
+            # terminal (lost, filled, lapsed) → drop. The TTL backstop clears the never-drawn.
+            if drawn_unfilled and now <= int(resv.finalize_by):
+                store.delete_routed_requests(miner, from_chain, to_chain)  # another router's seat
+            elif resv is not None and (int(resv.reserved_until) != 0 or int(resv.finalize_by) != 0):
+                store.delete_routed_requests(miner, from_chain, to_chain)  # filled or lapsed
+            continue
+        req = draw_pool_winner(store.pending_routed_requests(miner, from_chain, to_chain))
+        if read_only:
+            bt.logging.info(f'routed sweep {miner[:8]}: WOULD finalize for {req["user_pubkey"][:8]} (read-only)')
+            continue
+        try:
+            fill = compute_intake_amounts(from_chain, to_chain, req['from_amount'], rate_display_from_fixed(resv.rate))
+            client.finalize_reservation(
+                Pubkey.from_string(miner),
+                Pubkey.from_string(req['user_pubkey']),
+                req['user_from_addr'],
+                req['user_to_addr'],
+                fill.collateral_amount,
+                fill.from_amount,
+                fill.to_amount,
+            )
+        except Exception as e:
+            reason = _contract_reject_reason(e) or (str(e) if isinstance(e, ValueError) else None)
+            if reason is None:
+                bt.logging.warning(f'routed sweep {miner[:8]}: finalize transport fault, retrying next step: {e}')
+                continue
+            bt.logging.warning(f'routed sweep {miner[:8]}: finalize rejected ({reason}), dropping queue')
+            store.delete_routed_requests(miner, from_chain, to_chain)
+            continue
+        bt.logging.info(f'routed sweep {miner[:8]}: finalized seat for {req["user_pubkey"][:8]} (FIFO of queue)')
+        store.delete_routed_requests(miner, from_chain, to_chain)
+        finalized.append(miner)
+    store.prune_routed_requests(now - ROUTED_REQUEST_TTL_SECS)
+    return finalized
 
 
 @dataclass

--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -6,7 +6,9 @@ events via ``SolanaEventIndex`` and keyed by unix ``blockTime``),
 ``clearing_rates`` (per-swap realized legs from ``SwapCompleted``, backing the
 windowed volume read), ``swap_outcomes`` (terminal completed/timed_out
 truth per swap_key, backing the seam's stage disambiguation after the swap PDA
-closes), and ``solana_event_meta`` (the event-ingest cursor).
+closes), ``routed_requests`` (queued on-behalf reservation details awaiting
+finalize — the one table NOT rebuildable from chain), and
+``solana_event_meta`` (the event-ingest cursor).
 Single connection guarded by one lock; opened with ``check_same_thread=False``.
 ``busy_timeout`` is set before ``journal_mode=WAL`` because the WAL flip takes a
 brief exclusive lock that concurrent openers would otherwise hit as "database is
@@ -357,6 +359,78 @@ class ValidatorStateStore:
             return
         self._execute('DELETE FROM swap_outcomes WHERE block_time < ?', (cutoff_block,))
 
+    # ─── routed_requests (on-behalf reservation queue) ──────────────────
+    # The ONLY table not rebuildable from chain events: a routed user's details
+    # exist nowhere else until the won seat is finalized on-chain.
+
+    def upsert_routed_request(
+        self,
+        miner: str,
+        from_chain: str,
+        to_chain: str,
+        user_pubkey: str,
+        user_from_addr: str,
+        user_to_addr: str,
+        from_amount: int,
+        created_at: int,
+    ) -> None:
+        """Persist one routed reservation request. A retry from the same user for the
+        same (miner, direction) refreshes addresses/amount but keeps its original
+        ``created_at`` — a retry never loses its FIFO position."""
+        self._execute(
+            """
+            INSERT INTO routed_requests
+                (miner, from_chain, to_chain, user_pubkey, user_from_addr, user_to_addr, from_amount, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(miner, from_chain, to_chain, user_pubkey) DO UPDATE SET
+                user_from_addr = excluded.user_from_addr,
+                user_to_addr = excluded.user_to_addr,
+                from_amount = excluded.from_amount
+            """,
+            (miner, from_chain, to_chain, user_pubkey, user_from_addr, user_to_addr, str(int(from_amount)), created_at),
+        )
+
+    def pending_routed_requests(self, miner: str, from_chain: str, to_chain: str) -> List[dict]:
+        """A miner-direction's queued requests, oldest first (the FIFO order
+        ``draw_pool_winner`` selects from)."""
+        rows = self._fetchall(
+            """
+            SELECT user_pubkey, user_from_addr, user_to_addr, from_amount, created_at FROM routed_requests
+            WHERE miner = ? AND from_chain = ? AND to_chain = ?
+            ORDER BY created_at ASC, id ASC
+            """,
+            (miner, from_chain, to_chain),
+        )
+        return [
+            {
+                'user_pubkey': r['user_pubkey'],
+                'user_from_addr': r['user_from_addr'],
+                'user_to_addr': r['user_to_addr'],
+                'from_amount': int(r['from_amount']),
+                'created_at': r['created_at'],
+            }
+            for r in rows
+        ]
+
+    def distinct_routed_pools(self) -> List[Tuple[str, str, str]]:
+        """The (miner, from_chain, to_chain) keys with pending requests — the
+        finalize sweep's iteration set."""
+        rows = self._fetchall('SELECT DISTINCT miner, from_chain, to_chain FROM routed_requests')
+        return [(r['miner'], r['from_chain'], r['to_chain']) for r in rows]
+
+    def delete_routed_requests(self, miner: str, from_chain: str, to_chain: str) -> None:
+        """Drop a miner-direction's whole queue — called on any terminal outcome
+        (finalized, lost, expired). Non-selected users re-request via their client."""
+        self._execute(
+            'DELETE FROM routed_requests WHERE miner = ? AND from_chain = ? AND to_chain = ?',
+            (miner, from_chain, to_chain),
+        )
+
+    def prune_routed_requests(self, cutoff_time: int) -> None:
+        """Staleness backstop: drop rows older than ``cutoff_time`` so a dead
+        miner (pool never drawn, reservation never seen) can't pin a queue."""
+        self._execute('DELETE FROM routed_requests WHERE created_at < ?', (cutoff_time,))
+
     def get_solana_event_cursor(self) -> Optional[str]:
         """Last ingested Solana tx signature (the SolanaEventIngest cursor).
         ``None`` on a fresh DB so the first poll starts from the prune horizon."""
@@ -589,6 +663,24 @@ class ValidatorStateStore:
                     outcome     TEXT NOT NULL,
                     block_time  INTEGER NOT NULL
                 );
+
+                -- Routed reservation requests awaiting their draw (on-behalf flow).
+                -- The ONLY table not rebuildable from chain events: the user's
+                -- details live here alone until finalize_reservation publishes
+                -- them. from_amount is TEXT (u128-safe), created_at is the FIFO key.
+                CREATE TABLE IF NOT EXISTS routed_requests (
+                    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                    miner          TEXT NOT NULL,
+                    from_chain     TEXT NOT NULL,
+                    to_chain       TEXT NOT NULL,
+                    user_pubkey    TEXT NOT NULL,
+                    user_from_addr TEXT NOT NULL,
+                    user_to_addr   TEXT NOT NULL,
+                    from_amount    TEXT NOT NULL,
+                    created_at     INTEGER NOT NULL
+                );
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_routed_requests_key
+                    ON routed_requests(miner, from_chain, to_chain, user_pubkey);
 
                 CREATE TABLE IF NOT EXISTS solana_event_meta (
                     key     TEXT PRIMARY KEY,

--- a/tests/test_finalize_sweep.py
+++ b/tests/test_finalize_sweep.py
@@ -1,0 +1,191 @@
+"""Unit tests for the routed-reservation finalize sweep (`finalize_won_seats`).
+
+Mocks the solana_client; no chain. The sweep must finalize a won drawn seat for the FIFO
+queued user at the PINNED rate, drop queues on every terminal outcome (lost, filled,
+lapsed, contract-rejected), and retain them across transient faults and read-only mode.
+"""
+
+from types import SimpleNamespace
+
+from solders.keypair import Keypair as SolKeypair
+
+from allways.constants import RATE_PRECISION
+from allways.validator.reserve_engine import ROUTED_REQUEST_TTL_SECS, draw_pool_winner, finalize_won_seats
+from allways.validator.state_store import ValidatorStateStore
+
+NOW = 1_000_000
+MINER = str(SolKeypair().pubkey())
+USER_A = str(SolKeypair().pubkey())
+USER_B = str(SolKeypair().pubkey())
+RATE_FIXED = int(0.0021 * RATE_PRECISION)  # sol->btc: 0.0021 BTC per 1 SOL
+
+
+class SweepClient:
+    """get_reservation + finalize_reservation, with a keypair identity for the router check."""
+
+    def __init__(self, reservation):
+        self.keypair = SolKeypair()
+        self._reservation = reservation
+        self.finalized = []
+
+    def get_reservation(self, miner):
+        return self._reservation
+
+    def finalize_reservation(
+        self, miner, user, user_from_addr, user_to_addr, collateral_amount, from_amount, to_amount
+    ):
+        self.finalized.append(
+            (str(miner), str(user), user_from_addr, user_to_addr, collateral_amount, from_amount, to_amount)
+        )
+        return 'finalizesig'
+
+
+def _drawn_seat(client, *, router=None, finalize_by=NOW + 100, reserved_until=0, from_chain='sol', to_chain='btc'):
+    return SimpleNamespace(
+        router=router if router is not None else client.keypair.pubkey(),
+        from_chain=from_chain,
+        to_chain=to_chain,
+        rate=RATE_FIXED,
+        reserved_until=reserved_until,
+        finalize_by=finalize_by,
+    )
+
+
+def _validator(tmp_path, client, *, read_only=False):
+    store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+    return SimpleNamespace(
+        state_store=store, solana_client=client, solana_swap_loop=SimpleNamespace(read_only=read_only)
+    )
+
+
+def _queue(store, user, *, created_at=NOW - 10, from_amount=1_000_000_000):
+    store.upsert_routed_request(MINER, 'sol', 'btc', user, f'{user[:6]}src', f'{user[:6]}dst', from_amount, created_at)
+
+
+def test_won_seat_finalizes_fifo_user_at_pinned_rate(tmp_path):
+    client = SweepClient(None)
+    client._reservation = _drawn_seat(client)
+    v = _validator(tmp_path, client)
+    _queue(v.state_store, USER_B, created_at=NOW - 5)
+    _queue(v.state_store, USER_A, created_at=NOW - 50)  # oldest → FIFO winner
+    assert finalize_won_seats(v, NOW) == [MINER]
+    assert len(client.finalized) == 1
+    miner, user, _src, _dst, collateral_amount, from_amount, to_amount = client.finalized[0]
+    assert (miner, user) == (MINER, USER_A)
+    # sol source: collateral leg == from leg; dest derived from the PINNED rate (1 SOL → 0.0021 BTC).
+    assert collateral_amount == from_amount == 1_000_000_000
+    assert to_amount == 210_000
+    # Whole queue dropped: winner served, losers re-request via their clients.
+    assert v.state_store.distinct_routed_pools() == []
+    v.state_store.close()
+
+
+def test_draw_pool_winner_is_fifo_stub():
+    oldest = {'user_pubkey': USER_A, 'created_at': 1}
+    assert draw_pool_winner([oldest, {'user_pubkey': USER_B, 'created_at': 2}]) is oldest
+
+
+def test_seat_lost_to_other_router_drops_queue_without_tx(tmp_path):
+    client = SweepClient(None)
+    client._reservation = _drawn_seat(client, router=SolKeypair().pubkey())
+    v = _validator(tmp_path, client)
+    _queue(v.state_store, USER_A)
+    assert finalize_won_seats(v, NOW) == []
+    assert not client.finalized
+    assert v.state_store.distinct_routed_pools() == []
+    v.state_store.close()
+
+
+def test_lapsed_finalize_window_drops_queue(tmp_path):
+    client = SweepClient(None)
+    client._reservation = _drawn_seat(client, finalize_by=NOW - 1)
+    v = _validator(tmp_path, client)
+    _queue(v.state_store, USER_A)
+    assert finalize_won_seats(v, NOW) == []
+    assert not client.finalized and v.state_store.distinct_routed_pools() == []
+    v.state_store.close()
+
+
+def test_already_filled_reservation_drops_queue(tmp_path):
+    client = SweepClient(None)
+    client._reservation = _drawn_seat(client, reserved_until=NOW + 300)
+    v = _validator(tmp_path, client)
+    _queue(v.state_store, USER_A)
+    assert finalize_won_seats(v, NOW) == []
+    assert not client.finalized and v.state_store.distinct_routed_pools() == []
+    v.state_store.close()
+
+
+def test_undrawn_pool_keeps_queue_for_next_step(tmp_path):
+    # No reservation yet (pool still open / crank pending) → wait, don't drop.
+    client = SweepClient(None)
+    v = _validator(tmp_path, client)
+    _queue(v.state_store, USER_A)
+    assert finalize_won_seats(v, NOW) == []
+    assert v.state_store.distinct_routed_pools() == [(MINER, 'sol', 'btc')]
+    v.state_store.close()
+
+
+def test_transient_finalize_fault_retains_queue(tmp_path):
+    client = SweepClient(None)
+    client._reservation = _drawn_seat(client)
+
+    def _raise(*_a, **_k):
+        raise RuntimeError('connection refused')
+
+    client.finalize_reservation = _raise
+    v = _validator(tmp_path, client)
+    _queue(v.state_store, USER_A)
+    assert finalize_won_seats(v, NOW) == []
+    assert v.state_store.distinct_routed_pools() == [(MINER, 'sol', 'btc')]  # retry next step
+    v.state_store.close()
+
+
+def test_contract_rejection_drops_queue(tmp_path):
+    client = SweepClient(None)
+    client._reservation = _drawn_seat(client)
+
+    def _raise(*_a, **_k):
+        raise RuntimeError(
+            'AnchorError ... Error Message: Miner already has an active reservation. custom program error'
+        )
+
+    client.finalize_reservation = _raise
+    v = _validator(tmp_path, client)
+    _queue(v.state_store, USER_A)
+    assert finalize_won_seats(v, NOW) == []
+    assert v.state_store.distinct_routed_pools() == []
+    v.state_store.close()
+
+
+def test_read_only_mode_finalizes_nothing_and_retains_queue(tmp_path):
+    client = SweepClient(None)
+    client._reservation = _drawn_seat(client)
+    v = _validator(tmp_path, client, read_only=True)
+    _queue(v.state_store, USER_A)
+    assert finalize_won_seats(v, NOW) == []
+    assert not client.finalized
+    assert v.state_store.distinct_routed_pools() == [(MINER, 'sol', 'btc')]
+    v.state_store.close()
+
+
+def test_stale_queue_pruned_by_ttl_backstop(tmp_path):
+    client = SweepClient(None)  # miner never drawn — reservation stays None forever
+    v = _validator(tmp_path, client)
+    _queue(v.state_store, USER_A, created_at=NOW - ROUTED_REQUEST_TTL_SECS - 1)
+    assert finalize_won_seats(v, NOW) == []
+    assert v.state_store.distinct_routed_pools() == []
+    v.state_store.close()
+
+
+def test_upsert_retry_keeps_fifo_position(tmp_path):
+    store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+    store.upsert_routed_request(MINER, 'sol', 'btc', USER_A, 'src1', 'dst1', 100, created_at=NOW - 50)
+    store.upsert_routed_request(MINER, 'sol', 'btc', USER_B, 'src2', 'dst2', 200, created_at=NOW - 20)
+    # A retries with fresh details — position (created_at) must survive, fields must refresh.
+    store.upsert_routed_request(MINER, 'sol', 'btc', USER_A, 'src1b', 'dst1b', 150, created_at=NOW)
+    queue = store.pending_routed_requests(MINER, 'sol', 'btc')
+    assert [r['user_pubkey'] for r in queue] == [USER_A, USER_B]
+    assert queue[0]['created_at'] == NOW - 50
+    assert (queue[0]['user_from_addr'], queue[0]['from_amount']) == ('src1b', 150)
+    store.close()

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -4,7 +4,9 @@ Mocks the solana_client; no chain. Asserts eligibility gating, SOL-numeraire amo
 a joiner quotes against the PINNED pool rate (not the live quote) so it stays rate-consistent for D1.
 """
 
+import tempfile
 import threading
+from pathlib import Path
 from types import SimpleNamespace
 
 import bittensor as bt
@@ -12,6 +14,7 @@ from solders.keypair import Keypair as SolKeypair
 
 from allways.constants import RATE_PRECISION
 from allways.validator.reserve_engine import reserve_on_behalf
+from allways.validator.state_store import ValidatorStateStore
 
 HK = bt.Keypair.create_from_seed('0x' + '11' * 32)
 HOTKEY = HK.ss58_address
@@ -66,32 +69,39 @@ class FakeClient:
 
 
 def _validator(client):
-    return SimpleNamespace(solana_client=client, axon_lock=threading.RLock())
+    store = ValidatorStateStore(db_path=Path(tempfile.mkdtemp()) / 'state.db')
+    return SimpleNamespace(solana_client=client, axon_lock=threading.RLock(), state_store=store)
 
 
 def _reserve(client, from_amount=1_000_000_000):
     # sol->btc: user sends 1 SOL, receives btc
-    return reserve_on_behalf(
-        _validator(client), HOTKEY, 'sol', 'btc', USER_PK, str(USER_PK), 'userBTCaddr', from_amount
-    )
+    validator = _validator(client)
+    result = reserve_on_behalf(validator, HOTKEY, 'sol', 'btc', USER_PK, str(USER_PK), 'userBTCaddr', from_amount)
+    return result, validator.state_store
 
 
-def test_open_happy_path():
-    # Two-phase: reserve_on_behalf places a BID after a viability pre-check. The taker + amounts
-    # are named later at finalize (next wave), so the on-chain bid carries only the pair.
+def test_open_happy_path_persists_routed_request():
+    # Two-phase: reserve_on_behalf places a BID after a viability pre-check, then queues the
+    # user's details for finalize_won_seats (the winner names the fill at finalize).
     client = FakeClient()
-    r = _reserve(client)
+    r, store = _reserve(client)
     assert r.ok and r.pool_closes_at == FUTURE
     assert client.calls == [('open_or_request', 'sol', 'btc')]
+    queued = store.pending_routed_requests(str(MINER_PK), 'sol', 'btc')
+    assert len(queued) == 1
+    assert queued[0]['user_pubkey'] == USER_PK
+    assert queued[0]['from_amount'] == 1_000_000_000
+    store.close()
 
 
 def test_inactive_miner_rejects():
-    r = _reserve(FakeClient(active=False))
+    r, store = _reserve(FakeClient(active=False))
     assert not r.ok and 'not active' in r.reason
+    assert store.distinct_routed_pools() == []  # nothing queued on rejection
 
 
 def test_busy_miner_open_rejects():
-    r = _reserve(FakeClient(has_active_swap=True))
+    r, _ = _reserve(FakeClient(has_active_swap=True))
     assert not r.ok and 'busy' in r.reason
 
 
@@ -107,8 +117,9 @@ def test_contract_rejection_returns_reject_not_raise():
         )
 
     client.open_or_request = _raise
-    r = _reserve(client)
+    r, store = _reserve(client)
     assert not r.ok and 'active reservation' in r.reason.lower()
+    assert store.distinct_routed_pools() == []  # a failed entry queues nothing
 
 
 def test_contract_rejection_code_only_form_returns_reject():
@@ -121,7 +132,7 @@ def test_contract_rejection_code_only_form_returns_reject():
         raise RuntimeError("tx 5abc failed: {'InstructionError': [0, {'Custom': 6022}]}")
 
     client.open_or_request = _raise
-    r = _reserve(client)
+    r, _ = _reserve(client)
     assert not r.ok and '6022' in r.reason
 
 
@@ -144,13 +155,14 @@ def test_transport_error_still_raises():
 def test_no_quote_rejects():
     client = FakeClient()
     client.quote = None
-    r = _reserve(client)
+    r, _ = _reserve(client)
     assert not r.ok and 'no quote' in r.reason.lower()
 
 
 def test_low_collateral_rejects():
-    r = _reserve(FakeClient(collateral=1))
+    r, store = _reserve(FakeClient(collateral=1))
     assert not r.ok and 'collateral' in r.reason.lower()
+    assert store.distinct_routed_pools() == []
 
 
 def test_join_uses_pinned_pool_rate_not_live_quote():
@@ -160,7 +172,7 @@ def test_join_uses_pinned_pool_rate_not_live_quote():
     # contract at finalize (Rust suite) — the bid itself carries no amounts.
     pinned = SimpleNamespace(opened_at=1, closes_at=FUTURE, from_chain='sol', to_chain='btc', rate=_rate_fixed(0.0021))
     client = FakeClient(quote_rate=0.0099, pool=pinned)  # live quote drifted away from the pinned 0.0021
-    r = _reserve(client)
+    r, _ = _reserve(client)
     assert r.ok
     assert client.calls == [('open_or_request', 'sol', 'btc')]
 


### PR DESCRIPTION
Completes the routed reservation path. A validator-routed reservation previously dead-ended after the draw: reserve_on_behalf entered the pool but discarded the user's details, and no validator code called finalize_reservation — every routed win expired unfilled (fee burned, miner locked for nothing).

- reserve_on_behalf now persists the routed request (new routed_requests table — the one state.db table not rebuildable from chain, since the user's details exist nowhere else until finalize publishes them). Persisted only after the entry lands; a restart inside the pool/finalize window still honors the promise.
- finalize_won_seats (forward step, right after resolve_pools_once): for each queued miner-direction, if we won the drawn seat, finalize on-chain for draw_pool_winner's pick with amounts recomputed from the PINNED rate (mirrors the CLI's native Phase 3); drop the queue on any terminal outcome; retain it across transient RPC faults (retry inside the 150s window); WOULD-log in watch mode; 15-min TTL backstop.
- draw_pool_winner is a deliberate FIFO stub — the documented extension point for future selection policy (stake weighting, priority, batching) without touching the sweep.

Zero contract changes; both transports (axon synapse + HTTP seam) covered via the shared kernel.

Tests: full suite, 702 passed (11 new: persistence/no-persist-on-reject, FIFO, every seat outcome, transient vs contract-reject, read-only, TTL, upsert keeps FIFO position).