### PR TITLE
Directional rate surfaces, canonical storage docs, M2 volume dedup

### DIFF
--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -229,21 +229,6 @@ def print_json(data) -> None:
     click.echo(json.dumps(data, indent=2, default=str))
 
 
-def effective_rate(from_chain: str, to_chain: str, rate_display: str) -> str:
-    """Directional 'to per 1 from' rate for display. Stored quotes are canonical 'dest per 1 hub', which
-    reads backwards for a spoke→hub direction (BTC→SOL stored 0.0021 really means ~476 SOL per BTC).
-    Return the reciprocal for spoke→hub so `amount × shown-rate ≈ you receive` always reconciles."""
-    from allways.constants import NUMERAIRE_CHAIN
-
-    try:
-        r = float(rate_display)
-    except (TypeError, ValueError):
-        return rate_display
-    if to_chain == NUMERAIRE_CHAIN and r > 0:
-        r = 1.0 / r
-    return f'{r:.8g}'
-
-
 def safe_read(fn: Callable, what: str = 'read from Solana'):
     """Run a client read, converting any RPC/decode/transport failure into a clean non-zero `fail`.
 

--- a/allways/cli/swap_commands/miner_commands.py
+++ b/allways/cli/swap_commands/miner_commands.py
@@ -10,7 +10,6 @@ from allways.cli.dendrite_lite import discover_validators, resolve_dendrite_time
 from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
     console,
-    effective_rate,
     fail,
     from_lamports,
     get_cli_context,
@@ -20,6 +19,7 @@ from allways.cli.swap_commands.helpers import (
 from allways.cli.validator_rejections import render_and_aggregate
 from allways.constants import RATE_PRECISION
 from allways.solana.client import SolanaClientError, swap_from_solana, swap_key_from_tx_hash
+from allways.utils.rate import directional_rate
 
 
 @click.group('miner', cls=StyledGroup)
@@ -81,7 +81,7 @@ def miner_status(pubkey: str):
         console.print('[bold]Posted Quotes[/bold]\n')
         for q in quotes:
             src_up, dst_up = q.from_chain.upper(), q.to_chain.upper()
-            rd = effective_rate(q.from_chain, q.to_chain, f'{q.rate / RATE_PRECISION:g}')
+            rd = directional_rate(q.from_chain, q.to_chain, f'{q.rate / RATE_PRECISION:g}')
             console.print(f'  {src_up} → {dst_up}: [green]{rd} {dst_up}/{src_up}[/green]')
             console.print(f'    receive on {src_up}: [dim]{q.miner_from_addr}[/dim]')
             console.print(f'    send on {dst_up}:    [dim]{q.miner_to_addr}[/dim]')

--- a/allways/cli/swap_commands/miner_commands.py
+++ b/allways/cli/swap_commands/miner_commands.py
@@ -16,8 +16,8 @@ from allways.cli.swap_commands.helpers import (
     get_solana_cli_context,
     loading,
 )
+from allways.cli.swap_commands.swap_intake import rate_display_from_fixed
 from allways.cli.validator_rejections import render_and_aggregate
-from allways.constants import RATE_PRECISION
 from allways.solana.client import SolanaClientError, swap_from_solana, swap_key_from_tx_hash
 from allways.utils.rate import directional_rate
 
@@ -81,7 +81,7 @@ def miner_status(pubkey: str):
         console.print('[bold]Posted Quotes[/bold]\n')
         for q in quotes:
             src_up, dst_up = q.from_chain.upper(), q.to_chain.upper()
-            rd = directional_rate(q.from_chain, q.to_chain, f'{q.rate / RATE_PRECISION:g}')
+            rd = directional_rate(q.from_chain, q.to_chain, rate_display_from_fixed(q.rate))
             console.print(f'  {src_up} → {dst_up}: [green]{rd} {dst_up}/{src_up}[/green]')
             console.print(f'    receive on {src_up}: [dim]{q.miner_from_addr}[/dim]')
             console.print(f'    send on {dst_up}:    [dim]{q.miner_to_addr}[/dim]')

--- a/allways/cli/swap_commands/pair.py
+++ b/allways/cli/swap_commands/pair.py
@@ -17,7 +17,7 @@ from allways.cli.swap_commands.helpers import (
 )
 from allways.constants import RATE_PRECISION
 from allways.solana.client import SolanaClientError
-from allways.utils.rate import directional_rate, quantize_rate_display, quantize_rate_fixed
+from allways.utils.rate import canonical_rate, directional_rate, quantize_rate_display, quantize_rate_fixed
 
 # Default per-direction liquidity (u128) posted with a quote; the taker discovery path is Phase 9.
 DEFAULT_QUOTE_LIQUIDITY = 0
@@ -36,13 +36,6 @@ def prompt_chain(label: str, exclude: str | None = None) -> str:
             return value
         reason = 'already selected' if value == exclude else 'unsupported'
         console.print(f'[red]Invalid: {reason}. Choose from: {choices}[/red]')
-
-
-def canonical_rate(directional: float, leg_from: str, canon_from: str) -> float:
-    """Directional 'to per 1 from' of a leg → canonical 'dest per 1 canonical source'."""
-    if leg_from == canon_from or directional == 0:
-        return directional
-    return 1 / directional
 
 
 def prompt_rates(canon_from: str, canon_to: str) -> tuple:
@@ -77,7 +70,7 @@ def prompt_rates(canon_from: str, canon_to: str) -> tuple:
                 console.print('[red]At least one direction must have a positive rate[/red]')
             else:
                 break
-    return fwd, canonical_rate(rev, canon_to, canon_from)
+    return fwd, canonical_rate(canon_to, canon_from, rev)
 
 
 @click.command('pair', cls=StyledCommand)
@@ -159,8 +152,8 @@ def post_pair(
         if rate == 0 and not counter_rate:
             fail('At least one direction must have a positive rate')
         # Positional rates are directional ('to per 1 from' of their own leg); the chain stores canonical.
-        rate = canonical_rate(rate, src_chain, canon_from)
-        counter_rate = rate if counter_rate is None else canonical_rate(counter_rate, dst_chain, canon_from)
+        rate = canonical_rate(src_chain, dst_chain, rate)
+        counter_rate = rate if counter_rate is None else canonical_rate(dst_chain, src_chain, counter_rate)
 
     # Normalize to canonical direction. Rates are already canonical values per leg, so the swap just
     # keeps each value attached to its own leg. Interactive prompts asked in canonical order — no swap.

--- a/allways/cli/swap_commands/pair.py
+++ b/allways/cli/swap_commands/pair.py
@@ -17,7 +17,7 @@ from allways.cli.swap_commands.helpers import (
 )
 from allways.constants import RATE_PRECISION
 from allways.solana.client import SolanaClientError
-from allways.utils.rate import quantize_rate_display, quantize_rate_fixed
+from allways.utils.rate import directional_rate, quantize_rate_display, quantize_rate_fixed
 
 # Default per-direction liquidity (u128) posted with a quote; the taker discovery path is Phase 9.
 DEFAULT_QUOTE_LIQUIDITY = 0
@@ -38,12 +38,22 @@ def prompt_chain(label: str, exclude: str | None = None) -> str:
         console.print(f'[red]Invalid: {reason}. Choose from: {choices}[/red]')
 
 
+def canonical_rate(directional: float, leg_from: str, canon_from: str) -> float:
+    """Directional 'to per 1 from' of a leg → canonical 'dest per 1 canonical source'."""
+    if leg_from == canon_from or directional == 0:
+        return directional
+    return 1 / directional
+
+
 def prompt_rates(canon_from: str, canon_to: str) -> tuple:
-    """Prompt for direction-specific rates. 0 = don't offer that direction; at least one must be positive."""
+    """Prompt directional 'what the user receives per 1 they send' rates for each leg.
+
+    Returns canonical values for the (canon_from→canon_to, canon_to→canon_from) legs.
+    0 = don't offer that direction; at least one must be positive."""
     src_up, dst_up = canon_from.upper(), canon_to.upper()
-    console.print(f"\n[dim]Rates in {dst_up} per 1 {src_up} (0 = don't offer)[/dim]")
-    fwd_label = f'  {src_up} to {dst_up} (user sends {src_up}, miner returns {dst_up})'
-    rev_label = f'  {dst_up} to {src_up} (user sends {dst_up}, miner returns {src_up})'
+    console.print("\n[dim]Each rate is what the user receives per 1 they send (0 = don't offer)[/dim]")
+    fwd_label = f'  {src_up} to {dst_up}, in {dst_up} per 1 {src_up}'
+    rev_label = f'  {dst_up} to {src_up}, in {src_up} per 1 {dst_up}'
     while True:
         fwd = click.prompt(fwd_label, type=FINITE_FLOAT)
         if fwd < 0:
@@ -51,7 +61,10 @@ def prompt_rates(canon_from: str, canon_to: str) -> tuple:
         else:
             break
     if fwd > 0:
-        rev = click.prompt(rev_label, type=FINITE_FLOAT, default=fwd)
+        same = f'  {dst_up} to {src_up} at the same effective price (~{1 / fwd:.8g} {src_up} per 1 {dst_up})?'
+        if click.confirm(same, default=True):
+            return fwd, fwd
+        rev = click.prompt(rev_label, type=FINITE_FLOAT)
         if rev < 0:
             console.print('[red]Rate cannot be negative, using 0 (not offered)[/red]')
             rev = 0.0
@@ -64,7 +77,7 @@ def prompt_rates(canon_from: str, canon_to: str) -> tuple:
                 console.print('[red]At least one direction must have a positive rate[/red]')
             else:
                 break
-    return fwd, rev
+    return fwd, canonical_rate(rev, canon_to, canon_from)
 
 
 @click.command('pair', cls=StyledCommand)
@@ -91,17 +104,17 @@ def post_pair(
     [dim]All arguments are optional — if omitted, you'll be prompted interactively.[/dim]
 
     [dim]Arguments:
-        SRC_CHAIN       Source chain ID (e.g. btc, tao)
+        SRC_CHAIN       Source chain ID (e.g. sol, btc)
         SRC_ADDR        Your receiving address on source chain
-        DST_CHAIN       Destination chain ID (e.g. tao, btc)
+        DST_CHAIN       Destination chain ID (e.g. btc, sol)
         DST_ADDR        Your sending address on destination chain
-        RATE            source→dest rate (e.g. TAO per 1 BTC for btc-tao pair)
-        COUNTER_RATE    dest→source rate (optional, defaults to RATE)[/dim]
+        RATE            src→dst rate, in DST per 1 SRC — what the user receives per 1 they send
+        COUNTER_RATE    dst→src rate, in SRC per 1 DST (optional, defaults to the same effective price)[/dim]
 
     [dim]Examples:
-        $ alw miner post                                            (interactive wizard)
-        $ alw miner post btc bc1q...abc tao 5Cxyz...def 340 350     (direction-specific rates)
-        $ alw miner post btc bc1q...abc tao 5Cxyz...def 345         (same rate both ways)[/dim]
+        $ alw miner post                                                (interactive wizard)
+        $ alw miner post sol So1...abc btc bc1q...def 0.0021 470        (direction-specific rates)
+        $ alw miner post sol So1...abc btc bc1q...def 0.0021            (same effective price both ways)[/dim]
     """
     # --- Determine chains ---
     if src_chain is None:
@@ -141,16 +154,16 @@ def post_pair(
     elif rate < 0:
         fail('Rate cannot be negative')
     else:
-        if counter_rate is None:
-            counter_rate = rate
-        elif counter_rate < 0:
+        if counter_rate is not None and counter_rate < 0:
             fail('Rate cannot be negative')
-        if rate == 0 and counter_rate == 0:
+        if rate == 0 and not counter_rate:
             fail('At least one direction must have a positive rate')
+        # Positional rates are directional ('to per 1 from' of their own leg); the chain stores canonical.
+        rate = canonical_rate(rate, src_chain, canon_from)
+        counter_rate = rate if counter_rate is None else canonical_rate(counter_rate, dst_chain, canon_from)
 
-    # Normalize to canonical direction.
-    # Positional args: RATE = user's source→dest, so swap rates to match canonical order.
-    # Interactive prompts: already asked in canonical order, no rate swap needed.
+    # Normalize to canonical direction. Rates are already canonical values per leg, so the swap just
+    # keeps each value attached to its own leg. Interactive prompts asked in canonical order — no swap.
     if src_chain != canon_from:
         console.print(f'[dim]Normalizing pair direction to canonical form ({canon_from} -> {canon_to}).[/dim]')
         src_chain, dst_chain = dst_chain, src_chain
@@ -174,17 +187,17 @@ def post_pair(
     console.print('\n[bold]Publishing trading pair quotes[/bold]\n')
     console.print(f'  [cyan]{src_name}[/cyan]:  {src_addr}')
     console.print(f'  [cyan]{dst_name}[/cyan]:  {dst_addr}')
-    if rate == counter_rate and rate > 0:
-        console.print(f'  Rate:       [green]1 {src_up} = {rate:g} {dst_up} (both directions)[/green]')
+    if rate > 0:
+        fwd_disp = directional_rate(src_chain, dst_chain, f'{rate:g}')
+        console.print(f'  {src_up} → {dst_up}: [green]1 {src_up} = {fwd_disp} {dst_up}[/green]')
     else:
-        if rate > 0:
-            console.print(f'  {src_up} → {dst_up}: [green]1 {src_up} = {rate:g} {dst_up}[/green]')
-        else:
-            console.print(f'  {src_up} → {dst_up}: [yellow]not offered[/yellow]')
-        if counter_rate > 0:
-            console.print(f'  {dst_up} → {src_up}: [green]1 {src_up} = {counter_rate:g} {dst_up}[/green]')
-        else:
-            console.print(f'  {dst_up} → {src_up}: [yellow]not offered[/yellow]')
+        console.print(f'  {src_up} → {dst_up}: [yellow]not offered[/yellow]')
+    if counter_rate > 0:
+        rev_disp = directional_rate(dst_chain, src_chain, f'{counter_rate:g}')
+        same = ' [dim](same effective price)[/dim]' if counter_rate == rate else ''
+        console.print(f'  {dst_up} → {src_up}: [green]1 {dst_up} = {rev_disp} {src_up}[/green]{same}')
+    else:
+        console.print(f'  {dst_up} → {src_up}: [yellow]not offered[/yellow]')
     console.print(f'  Pubkey:     [dim]{client.keypair.pubkey()}[/dim]\n')
 
     # Per-direction churn fee for updating an existing quote (creation is free); keyed on each

--- a/allways/cli/swap_commands/pair.py
+++ b/allways/cli/swap_commands/pair.py
@@ -22,6 +22,11 @@ from allways.utils.rate import canonical_rate, directional_rate, quantize_rate_d
 # Default per-direction liquidity (u128) posted with a quote; the taker discovery path is Phase 9.
 DEFAULT_QUOTE_LIQUIDITY = 0
 
+# Both legs share the canonical denomination, so their ratio is the effective round-trip spread.
+# Real spreads are a few percent; an accidentally inverted COUNTER_RATE (each rate is directional
+# for its OWN leg) lands ~1/rate² off — orders of magnitude past this and instantly arbitrageable.
+MAX_LEG_SPREAD_RATIO = 4
+
 
 def prompt_chain(label: str, exclude: str | None = None) -> str:
     """Prompt the user to pick a chain from SUPPORTED_CHAINS."""
@@ -168,6 +173,19 @@ def post_pair(
     # and the posted value both show exactly what the chain will store.
     rate = quantize_rate_display(rate)
     counter_rate = quantize_rate_display(counter_rate)
+
+    if rate > 0 and counter_rate > 0:
+        spread = max(rate, counter_rate) / min(rate, counter_rate)
+        if spread > MAX_LEG_SPREAD_RATIO:
+            console.print(
+                f'[red]Your two rates disagree by {spread:,.0f}× — that is not a spread, one of them is '
+                f'almost certainly inverted.[/red]\n'
+                f'[dim]Each rate is directional for its own leg: RATE = {canon_to.upper()} per 1 '
+                f'{canon_from.upper()}, COUNTER_RATE = {canon_from.upper()} per 1 {canon_to.upper()}. '
+                f'Posting this would be instantly arbitrageable against your collateral. '
+                f'To intentionally post extreme legs, post each direction separately (0 = not offered).[/dim]'
+            )
+            fail('Refusing to post inconsistent rates.')
 
     # The bt wallet is only needed for the running-miner refresh flag (keyed by hotkey); the quote
     # write is signed by the Solana keypair.

--- a/allways/cli/swap_commands/quote.py
+++ b/allways/cli/swap_commands/quote.py
@@ -14,7 +14,6 @@ from allways.chains import SUPPORTED_CHAINS, get_chain
 from allways.cli.swap_commands.helpers import (
     FINITE_FLOAT,
     console,
-    effective_rate,
     fail,
     from_lamports,
     get_solana_cli_context,
@@ -32,7 +31,7 @@ from allways.cli.swap_commands.swap_intake import (
     to_smallest_units,
 )
 from allways.constants import FEE_DIVISOR
-from allways.utils.rate import apply_fee_deduction, is_executable_rate
+from allways.utils.rate import apply_fee_deduction, directional_rate, is_executable_rate
 
 
 def _prompt_or_fail(value, prompt_text, opt, cast=str):
@@ -123,7 +122,7 @@ def quote_command(from_chain: str, to_chain: str, amount: float, as_json: bool):
                 'offers': [
                     {
                         'miner': str(c.miner),
-                        'rate': effective_rate(from_chain, to_chain, c.rate_display),
+                        'rate': directional_rate(from_chain, to_chain, c.rate_display),
                         'rate_unit': f'{to_chain.upper()} per {from_chain.upper()}',
                         'receive': recv / 10**to_dec,
                         'collateral_sol': from_lamports(c.collateral),
@@ -158,7 +157,7 @@ def quote_command(from_chain: str, to_chain: str, amount: float, as_json: bool):
         is_best = str(c.miner) == best_miner
         table.add_row(
             Text(str(c.miner)[:12] + '…', style='bold cyan' if is_best else 'cyan'),
-            effective_rate(from_chain, to_chain, c.rate_display),
+            directional_rate(from_chain, to_chain, c.rate_display),
             f'{recv / 10**to_dec:.8g}',
             f'{from_lamports(c.collateral):.2f} SOL',
             '★ best' if is_best else '',

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -32,7 +32,7 @@ from allways.cli.swap_commands.swap_intake import (
 )
 from allways.constants import FEE_DIVISOR, NUMERAIRE_CHAIN
 from allways.solana.rpc import TransientRpcError
-from allways.utils.rate import apply_fee_deduction
+from allways.utils.rate import apply_fee_deduction, directional_rate
 
 
 @click.group('swap', cls=StyledGroup, show_disclaimer=True)
@@ -220,9 +220,10 @@ def swap_now_command(
     # `alw swap quote`. The gross `to_amount` is what gets pinned on-chain, not what you receive.
     recv = apply_fee_deduction(amts.to_amount, FEE_DIVISOR) / 10 ** get_chain(to_chain).decimals
 
+    rate_disp = directional_rate(from_chain, to_chain, cand.rate_display)
     console.print(
         f'\n  Swap [cyan]{amount_opt} {from_chain.upper()}[/cyan] -> ~[cyan]{recv:.8g} {to_chain.upper()}[/cyan]'
-        f'  (miner [dim]{str(cand.miner)[:8]}…[/dim], rate {cand.rate_display} per SOL)\n'
+        f'  (miner [dim]{str(cand.miner)[:8]}…[/dim], rate {rate_disp} {to_chain.upper()}/{from_chain.upper()})\n'
     )
 
     # Resume a seat this taker already holds rather than paying for a second bid: a prior run may have

--- a/allways/cli/swap_commands/swap_intake.py
+++ b/allways/cli/swap_commands/swap_intake.py
@@ -12,7 +12,7 @@ from typing import List, Optional, Tuple
 
 from allways.chains import canonical_pair, get_chain
 from allways.constants import NUMERAIRE_CHAIN, RATE_PRECISION, required_collateral
-from allways.utils.rate import calculate_to_amount, is_executable_rate, normalize_rate
+from allways.utils.rate import calculate_to_amount, is_executable_rate, normalize_rate, quantize_rate_fixed
 
 
 @dataclass
@@ -35,8 +35,11 @@ def to_smallest_units(amount: float, chain: str) -> int:
 
 
 def rate_display_from_fixed(rate_fixed: int) -> str:
-    """On-chain u128 fixed-point rate → canonical display string (matches normalize_rate)."""
-    return normalize_rate(rate_fixed / RATE_PRECISION)
+    """On-chain u128 fixed-point rate → canonical display string, floored to RATE_SIG_FIGS first.
+
+    Mirrors the contract's set_quote floor and the crown ingest, so display/reserve/scoring agree
+    even for quotes grandfathered from before the on-chain floor (rounding could disagree there)."""
+    return normalize_rate(quantize_rate_fixed(rate_fixed) / RATE_PRECISION)
 
 
 def candidate_miners(client, from_chain: str, to_chain: str) -> List[MinerCandidate]:

--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -65,11 +65,12 @@ def _rate(q) -> str:
 
 
 def _max_rate(entry) -> float:
-    """Highest numeric rate the miner posts (coarse cross-direction proxy for `--sort rate`)."""
+    """Highest DIRECTIONAL rate the miner posts (coarse cross-direction proxy for `--sort rate`),
+    matching the numbers the rate column renders."""
     rates = []
     for q in entry.quotes:
         try:
-            rates.append(float(rate_display_from_fixed(q.rate)))
+            rates.append(float(_rate(q)))
         except (TypeError, ValueError):
             continue
     return max(rates) if rates else 0.0

--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -23,7 +23,6 @@ from allways.cli.swap_commands.helpers import (
     STATUS_STYLES,
     ZERO_SWAP_KEY,
     console,
-    effective_rate,
     fail,
     from_lamports,
     get_solana_cli_context,
@@ -36,6 +35,7 @@ from allways.cli.swap_commands.helpers import (
 )
 from allways.cli.swap_commands.swap_intake import rate_display_from_fixed
 from allways.solana.client import swap_from_solana
+from allways.utils.rate import directional_rate
 
 MINER_SORT_FIELDS = ['uid', 'rate', 'capacity', 'status']
 MINER_STATUS_CHOICES = ['available', 'offline', 'in-swap', 'reserved', 'cooldown']
@@ -60,8 +60,8 @@ def _quote_dir(q) -> str:
 
 
 def _rate(q) -> str:
-    """Effective directional rate ('to per 1 from') for display — see helpers.effective_rate."""
-    return effective_rate(q.from_chain, q.to_chain, rate_display_from_fixed(q.rate))
+    """Directional 'to per 1 from' rate for display — see utils.rate.directional_rate."""
+    return directional_rate(q.from_chain, q.to_chain, rate_display_from_fixed(q.rate))
 
 
 def _max_rate(entry) -> float:

--- a/allways/utils/rate.py
+++ b/allways/utils/rate.py
@@ -37,6 +37,16 @@ def quantize_rate_display(rate: float) -> float:
     return quantize_rate_fixed(int(rate * RATE_PRECISION)) / RATE_PRECISION
 
 
+def canonical_rate(from_chain: str, to_chain: str, directional: float) -> float:
+    """Directional 'to per 1 from' of the (from → to) leg → canonical 'dest per 1 canonical source'.
+
+    Inverse of ``directional_rate`` — the input boundary where human-typed rates become the one
+    number the chain stores. 0 (direction not offered) passes through."""
+    if directional == 0 or from_chain == canonical_pair(from_chain, to_chain)[0]:
+        return directional
+    return 1 / directional
+
+
 def directional_rate(from_chain: str, to_chain: str, rate_display: str) -> str:
     """Directional 'to per 1 from' rate for display. Stored quotes are canonical 'dest per 1 canonical
     source', which reads backwards for a reverse direction (BTC→SOL stored 0.0021 really means ~476

--- a/allways/utils/rate.py
+++ b/allways/utils/rate.py
@@ -37,6 +37,19 @@ def quantize_rate_display(rate: float) -> float:
     return quantize_rate_fixed(int(rate * RATE_PRECISION)) / RATE_PRECISION
 
 
+def directional_rate(from_chain: str, to_chain: str, rate_display: str) -> str:
+    """Directional 'to per 1 from' rate for display. Stored quotes are canonical 'dest per 1 canonical
+    source', which reads backwards for a reverse direction (BTC→SOL stored 0.0021 really means ~476
+    SOL per BTC). Return the reciprocal there so `amount × shown-rate ≈ you receive` always reconciles."""
+    try:
+        r = float(rate_display)
+    except (TypeError, ValueError):
+        return rate_display
+    if r > 0 and from_chain != canonical_pair(from_chain, to_chain)[0]:
+        r = 1.0 / r
+    return f'{r:.8g}'
+
+
 def calculate_to_amount(
     from_amount: int,
     rate,

--- a/allways/validator/event_index.py
+++ b/allways/validator/event_index.py
@@ -96,7 +96,9 @@ class SolanaEventIndex:
                 dev_signal.emit('swap_outcome', swap_key=bytes(rec.fields['swap_key']).hex(), outcome=outcome)
             # SwapCompleted is the only swap event carrying realized legs — persist
             # them as a clearing-rate sample for the windowed volume read, in
-            # addition to closing the fulfillment above.
+            # addition to closing the fulfillment above. Its `rate` field is
+            # deliberately ignored: the attest gate already refused any swap whose
+            # legs disagree with the pinned rate, and the legs are the realized truth.
             if name == 'SwapCompleted':
                 self.state_store.insert_clearing_rate(
                     block_time,

--- a/allways/validator/event_index.py
+++ b/allways/validator/event_index.py
@@ -107,6 +107,7 @@ class SolanaEventIndex:
                     self._chain(rec, 'to_chain'),
                     int(rec.fields['from_amount']),
                     int(rec.fields['to_amount']),
+                    bytes(rec.fields['swap_key']).hex(),
                 )
             return True
         if name == 'StaleClaimClosed':

--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -514,10 +514,13 @@ class ValidatorStateStore:
             cols = [row[1] for row in conn.execute('PRAGMA table_info(swap_outcomes)')]
             if cols and 'outcome' not in cols:
                 conn.execute('DROP TABLE swap_outcomes')
-            # Pre-M2 deployments lack the clearing_rates idempotency key.
+            # Pre-M2 deployments lack the clearing_rates idempotency key. Purge unkeyed rows:
+            # NULL keys never collide with ON CONFLICT(swap_key), so a post-upgrade replay would
+            # double-count them — a one-time <=2h volume gap buys a safe dedup invariant.
             cols = [row[1] for row in conn.execute('PRAGMA table_info(clearing_rates)')]
             if cols and 'swap_key' not in cols:
                 conn.execute('ALTER TABLE clearing_rates ADD COLUMN swap_key TEXT')
+                conn.execute('DELETE FROM clearing_rates')
             conn.executescript(
                 """
                 CREATE TABLE IF NOT EXISTS rate_events (

--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -295,15 +295,18 @@ class ValidatorStateStore:
         to_chain: str,
         from_amount: int,
         to_amount: int,
+        swap_key: str,
     ) -> None:
-        """Persist one completed swap's realized legs. ``block_num`` is the unix
-        ``blockTime``; the legs are stored as decimal strings (u128-safe)."""
+        """Persist one completed swap's realized legs, keyed by ``swap_key`` hex so a
+        cursor-reset / RPC-prune re-ingest can't double-count volume. ``block_num`` is
+        the unix ``blockTime``; the legs are stored as decimal strings (u128-safe)."""
         self._execute(
             """
-            INSERT INTO clearing_rates (block_num, hotkey, from_chain, to_chain, from_amount, to_amount)
-            VALUES (?, ?, ?, ?, ?, ?)
+            INSERT INTO clearing_rates (block_num, hotkey, from_chain, to_chain, from_amount, to_amount, swap_key)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(swap_key) DO NOTHING
             """,
-            (block_num, hotkey, from_chain, to_chain, str(int(from_amount)), str(int(to_amount))),
+            (block_num, hotkey, from_chain, to_chain, str(int(from_amount)), str(int(to_amount)), swap_key),
         )
 
     def get_clearing_volumes(self, start_time: int, end_time: int) -> Dict[Tuple[str, str], Dict[str, Tuple[int, int]]]:
@@ -511,6 +514,10 @@ class ValidatorStateStore:
             cols = [row[1] for row in conn.execute('PRAGMA table_info(swap_outcomes)')]
             if cols and 'outcome' not in cols:
                 conn.execute('DROP TABLE swap_outcomes')
+            # Pre-M2 deployments lack the clearing_rates idempotency key.
+            cols = [row[1] for row in conn.execute('PRAGMA table_info(clearing_rates)')]
+            if cols and 'swap_key' not in cols:
+                conn.execute('ALTER TABLE clearing_rates ADD COLUMN swap_key TEXT')
             conn.executescript(
                 """
                 CREATE TABLE IF NOT EXISTS rate_events (
@@ -575,10 +582,15 @@ class ValidatorStateStore:
                     from_chain  TEXT NOT NULL,
                     to_chain    TEXT NOT NULL,
                     from_amount TEXT NOT NULL,
-                    to_amount   TEXT NOT NULL
+                    to_amount   TEXT NOT NULL,
+                    swap_key    TEXT
                 );
                 CREATE INDEX IF NOT EXISTS idx_clearing_rates_dir_block
                     ON clearing_rates(from_chain, to_chain, block_num);
+                -- Idempotency key: NULL only on pre-migration rows (SQLite UNIQUE
+                -- admits multiple NULLs); every new insert carries the swap_key.
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_clearing_rates_swap_key
+                    ON clearing_rates(swap_key);
 
                 -- Terminal outcome per swap (SwapCompleted | SwapTimedOut), keyed by
                 -- swap_key hex. Terminal swap PDAs are closed on-chain, so this is the

--- a/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
@@ -161,7 +161,7 @@ pub struct Reservation {
     pub miner_from_addr: String,
     #[max_len(MAX_ADDR_LEN)]
     pub miner_to_addr: String,
-    /// Fixed-point rate = display_rate × RATE_PRECISION (1e18); see constants::RATE_PRECISION.
+    /// Canonical rate (see `MinerQuote::rate`); fixed-point = display_rate × RATE_PRECISION (1e18).
     pub rate: u128,
     /// Reservation creation time, unix seconds. The **source-freshness lower bound**: the user's
     /// deposit must be mined after this (a replayed prior-swap deposit predates it → rejected by the
@@ -213,7 +213,7 @@ pub struct Swap {
     pub miner_from_addr: String,
     #[max_len(MAX_ADDR_LEN)]
     pub miner_to_addr: String,
-    /// Fixed-point rate = display_rate × RATE_PRECISION (1e18); see constants::RATE_PRECISION.
+    /// Canonical rate (see `MinerQuote::rate`); fixed-point = display_rate × RATE_PRECISION (1e18).
     pub rate: u128,
     /// Collateral-backed swap size, collateral-currency smallest unit (SOL lamports) — fee/slash basis.
     pub collateral_amount: u64,
@@ -261,8 +261,9 @@ pub struct MinerQuote {
     /// Where the miner sends the destination asset (on `to_chain`).
     #[max_len(MAX_ADDR_LEN)]
     pub miner_to_addr: String,
-    /// Offered rate, dest per 1 source, for THIS direction. Fixed-point = display_rate ×
-    /// RATE_PRECISION (1e18) — exact, no string parse; see constants::RATE_PRECISION.
+    /// Offered rate, canonical 'dest per 1 canonical source' (hub pinned as source) in BOTH direction
+    /// PDAs — never per-direction; direction is applied off-chain via `is_reverse`. Fixed-point =
+    /// display_rate × RATE_PRECISION (1e18) — exact, no string parse; see constants::RATE_PRECISION.
     pub rate: u128,
     /// Advertised depth in the asset's own units (u128 to cover wei-scale).
     pub liquidity: u128,
@@ -361,7 +362,7 @@ pub struct Pool {
     pub miner_from_addr: String,
     #[max_len(MAX_ADDR_LEN)]
     pub miner_to_addr: String,
-    /// Fixed-point rate = display_rate × RATE_PRECISION (1e18); see constants::RATE_PRECISION.
+    /// Canonical rate (see `MinerQuote::rate`); fixed-point = display_rate × RATE_PRECISION (1e18).
     pub rate: u128,
     /// Unix seconds the pool opened (0 = available/empty slot).
     pub opened_at: i64,

--- a/tests/test_cli_miner_solana.py
+++ b/tests/test_cli_miner_solana.py
@@ -143,12 +143,44 @@ def test_post_pair_calls_set_quote_with_scaled_rate():
         patch('allways.cli.swap_commands.pair.get_solana_cli_context', return_value=({}, c)),
         patch('allways.cli.swap_commands.pair.write_rate_posted_flag'),
     ):
-        # btc bc1qsrc tao 5dst 345 (same rate both directions)
+        # btc bc1qsrc tao 5dst 345 (same effective price both directions)
         res = CliRunner().invoke(post_pair, ['btc', 'bc1qsrc', 'tao', '5dst', '345', '--yes'])
     assert res.exit_code == 0, res.output
-    # Two directions posted (rate + counter both 345), rate scaled by RATE_PRECISION.
+    # Two directions posted (rate + counter both canonical 345), rate scaled by RATE_PRECISION.
     assert c.set_quote.call_count == 2
     first = c.set_quote.call_args_list[0].args
     assert first[4] == int(345 * RATE_PRECISION)
     # forward direction keeps src addr on from-leg, dst addr on to-leg
     assert (first[0], first[1], first[2], first[3]) == ('btc', 'tao', 'bc1qsrc', '5dst')
+
+
+def test_post_pair_directional_counter_rate_posts_canonical():
+    wallet = SimpleNamespace(hotkey=SimpleNamespace(ss58_address='5Fhotkey'))
+    c = _client()
+    with (
+        patch('allways.cli.swap_commands.pair.get_cli_context', return_value=({}, wallet, None, None)),
+        patch('allways.cli.swap_commands.pair.get_solana_cli_context', return_value=({}, c)),
+        patch('allways.cli.swap_commands.pair.write_rate_posted_flag'),
+    ):
+        # COUNTER_RATE is directional (BTC per 1 TAO); the chain stores canonical (TAO per 1 BTC).
+        res = CliRunner().invoke(post_pair, ['btc', 'bc1qsrc', 'tao', '5dst', '345', '0.003', '--yes'])
+    assert res.exit_code == 0, res.output
+    counter = c.set_quote.call_args_list[1].args
+    assert (counter[0], counter[1]) == ('tao', 'btc')
+    assert counter[4] == 33333 * 10**16  # 1/0.003 = 333.33…, floored to 5 sig figs
+
+
+def test_post_pair_rejects_inverted_counter_rate():
+    """Old-style canonical COUNTER_RATE (pre-directional automation) must hard-fail, not post
+    an instantly arbitrageable reverse quote — even with --yes."""
+    wallet = SimpleNamespace(hotkey=SimpleNamespace(ss58_address='5Fhotkey'))
+    c = _client()
+    with (
+        patch('allways.cli.swap_commands.pair.get_cli_context', return_value=({}, wallet, None, None)),
+        patch('allways.cli.swap_commands.pair.get_solana_cli_context', return_value=({}, c)),
+        patch('allways.cli.swap_commands.pair.write_rate_posted_flag'),
+    ):
+        res = CliRunner().invoke(post_pair, ['btc', 'bc1qsrc', 'tao', '5dst', '345', '345', '--yes'])
+    assert res.exit_code != 0
+    assert 'inverted' in res.output
+    c.set_quote.assert_not_called()

--- a/tests/test_event_index.py
+++ b/tests/test_event_index.py
@@ -305,6 +305,24 @@ class TestIngestClearingRate:
         assert store.get_clearing_volumes(0, 100) == {}
         store.close()
 
+    def test_reingested_swap_counts_volume_once(self, tmp_path: Path):
+        """M2: a cursor-reset replay of the same SwapCompleted must not double volume."""
+        store = make_store(tmp_path)
+        idx = SolanaEventIndex(store)
+        completed = rec(
+            'SwapCompleted',
+            miner='pk_a',
+            block_time=10,
+            from_chain='btc',
+            to_chain='tao',
+            from_amount=100,
+            to_amount=200,
+        )
+        idx.ingest([completed], ATTR)
+        idx.ingest([completed], ATTR)
+        assert store.get_clearing_volumes(0, 100)[('btc', 'tao')]['hk_a'] == (100, 200)
+        store.close()
+
     def test_prune_drops_old_samples(self, tmp_path: Path):
         store = make_store(tmp_path)
         idx = SolanaEventIndex(store)
@@ -314,6 +332,7 @@ class TestIngestClearingRate:
                     'SwapCompleted',
                     miner='pk_a',
                     block_time=100,
+                    swap_key=bytes([1] * 32),
                     from_chain='btc',
                     to_chain='tao',
                     from_amount=1,
@@ -323,6 +342,7 @@ class TestIngestClearingRate:
                     'SwapCompleted',
                     miner='pk_a',
                     block_time=900,
+                    swap_key=bytes([2] * 32),
                     from_chain='btc',
                     to_chain='tao',
                     from_amount=3,

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -7,6 +7,7 @@ from allways.constants import BTC_TO_SAT, RATE_PRECISION, TAO_TO_RAO
 from allways.utils.rate import (
     apply_fee_deduction,
     calculate_to_amount,
+    directional_rate,
     is_executable_rate,
     normalize_rate,
     quantize_rate_display,
@@ -279,6 +280,25 @@ class TestNormalizeRate:
         """Pre-existing :g behavior — sub-1e-4 values switch to scientific.
         Documented so a future change to fixed-point doesn't silently break."""
         assert normalize_rate(1e-6) == '1e-06'
+
+
+class TestDirectionalRate:
+    """Canonical stored rate → directional 'to per 1 from' display."""
+
+    def test_forward_is_identity(self):
+        assert directional_rate('sol', 'btc', '0.0021') == '0.0021'
+
+    def test_reverse_is_reciprocal(self):
+        assert directional_rate('btc', 'sol', '0.0021') == f'{1 / 0.0021:.8g}'
+
+    def test_legacy_non_hub_pair_reverse(self):
+        # canonical_pair(btc, tao) = (btc, tao): tao→btc is the reverse leg
+        assert directional_rate('tao', 'btc', '345') == f'{1 / 345:.8g}'
+        assert directional_rate('btc', 'tao', '345') == '345'
+
+    def test_zero_and_non_numeric_pass_through(self):
+        assert directional_rate('btc', 'sol', '0') == '0'
+        assert directional_rate('btc', 'sol', 'n/a') == 'n/a'
 
 
 class TestIsExecutableRate:

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -333,7 +333,7 @@ class TestGetClearingVolumes:
             )
             conn.execute(
                 'INSERT INTO clearing_rates (block_num, hotkey, from_chain, to_chain, from_amount, to_amount)'
-                " VALUES (9_600, 'hk_old', 'btc', 'sol', '1', '1')"
+                " VALUES (9600, 'hk_old', 'btc', 'sol', '1', '1')"
             )
         store = ValidatorStateStore(db_path=db)
         store.insert_clearing_rate(9_800, 'hk_a', 'btc', 'sol', 300, 600, 'sk_new')

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -318,8 +318,9 @@ class TestGetClearingVolumes:
         assert store.get_clearing_volumes(9_700, 10_000)[('btc', 'sol')]['hk_a'] == (300, 600)
         store.close()
 
-    def test_pre_m2_db_gains_swap_key_column(self, tmp_path: Path):
-        # A deployed DB created before the idempotency key must be migrated in place.
+    def test_pre_m2_db_migrates_and_purges_unkeyed_rows(self, tmp_path: Path):
+        # A pre-idempotency DB gains the column in place; its NULL-key rows are purged
+        # (NULLs never collide with ON CONFLICT, so a replay would double-count them).
         import sqlite3
 
         db = tmp_path / 'state.db'
@@ -336,8 +337,9 @@ class TestGetClearingVolumes:
             )
         store = ValidatorStateStore(db_path=db)
         store.insert_clearing_rate(9_800, 'hk_a', 'btc', 'sol', 300, 600, 'sk_new')
+        store.insert_clearing_rate(9_800, 'hk_a', 'btc', 'sol', 300, 600, 'sk_new')  # replay → no-op
         vols = store.get_clearing_volumes(9_500, 10_000)
-        assert vols[('btc', 'sol')] == {'hk_old': (1, 1), 'hk_a': (300, 600)}
+        assert vols[('btc', 'sol')] == {'hk_a': (300, 600)}
         store.close()
 
     def test_u128_scale_legs_sum_exactly(self, tmp_path: Path):

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
+from uuid import uuid4
 
 import numpy as np
 import pytest
@@ -285,9 +286,9 @@ class TestGetClearingVolumes:
 
     def test_sums_per_direction_and_hotkey(self, tmp_path: Path):
         store = self._store(tmp_path)
-        store.insert_clearing_rate(9_800, 'hk_a', 'btc', 'sol', 300, 600)
-        store.insert_clearing_rate(9_900, 'hk_a', 'btc', 'sol', 100, 200)
-        store.insert_clearing_rate(9_850, 'hk_b', 'sol', 'btc', 100, 50)
+        store.insert_clearing_rate(9_800, 'hk_a', 'btc', 'sol', 300, 600, 'sk1')
+        store.insert_clearing_rate(9_900, 'hk_a', 'btc', 'sol', 100, 200, 'sk2')
+        store.insert_clearing_rate(9_850, 'hk_b', 'sol', 'btc', 100, 50, 'sk3')
         vols = store.get_clearing_volumes(9_700, 10_000)
         assert vols[('btc', 'sol')]['hk_a'] == (400, 800)
         assert vols[('sol', 'btc')]['hk_b'] == (100, 50)
@@ -295,26 +296,56 @@ class TestGetClearingVolumes:
 
     def test_window_boundaries_start_exclusive_end_inclusive(self, tmp_path: Path):
         store = self._store(tmp_path)
-        store.insert_clearing_rate(9_700, 'hk_a', 'btc', 'sol', 1, 1)  # at start — excluded
-        store.insert_clearing_rate(9_701, 'hk_a', 'btc', 'sol', 10, 10)  # just inside
-        store.insert_clearing_rate(10_000, 'hk_a', 'btc', 'sol', 100, 100)  # at end — included
-        store.insert_clearing_rate(10_001, 'hk_a', 'btc', 'sol', 1_000, 1_000)  # past end — excluded
+        store.insert_clearing_rate(9_700, 'hk_a', 'btc', 'sol', 1, 1, 'sk4')  # at start — excluded
+        store.insert_clearing_rate(9_701, 'hk_a', 'btc', 'sol', 10, 10, 'sk5')  # just inside
+        store.insert_clearing_rate(10_000, 'hk_a', 'btc', 'sol', 100, 100, 'sk6')  # at end — included
+        store.insert_clearing_rate(10_001, 'hk_a', 'btc', 'sol', 1_000, 1_000, 'sk7')  # past end — excluded
         vols = store.get_clearing_volumes(9_700, 10_000)
         assert vols[('btc', 'sol')]['hk_a'] == (110, 110)
         store.close()
 
     def test_empty_window(self, tmp_path: Path):
         store = self._store(tmp_path)
-        store.insert_clearing_rate(9_000, 'hk_a', 'btc', 'sol', 5, 5)
+        store.insert_clearing_rate(9_000, 'hk_a', 'btc', 'sol', 5, 5, 'sk8')
         assert store.get_clearing_volumes(9_700, 10_000) == {}
+        store.close()
+
+    def test_reingest_same_swap_key_counts_once(self, tmp_path: Path):
+        # M2: cursor-reset / RPC-prune re-ingest of the same SwapCompleted must not double volume.
+        store = self._store(tmp_path)
+        store.insert_clearing_rate(9_800, 'hk_a', 'btc', 'sol', 300, 600, 'dup')
+        store.insert_clearing_rate(9_800, 'hk_a', 'btc', 'sol', 300, 600, 'dup')
+        assert store.get_clearing_volumes(9_700, 10_000)[('btc', 'sol')]['hk_a'] == (300, 600)
+        store.close()
+
+    def test_pre_m2_db_gains_swap_key_column(self, tmp_path: Path):
+        # A deployed DB created before the idempotency key must be migrated in place.
+        import sqlite3
+
+        db = tmp_path / 'state.db'
+        with sqlite3.connect(db) as conn:
+            conn.execute(
+                """CREATE TABLE clearing_rates (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT, block_num INTEGER NOT NULL,
+                    hotkey TEXT NOT NULL, from_chain TEXT NOT NULL, to_chain TEXT NOT NULL,
+                    from_amount TEXT NOT NULL, to_amount TEXT NOT NULL)"""
+            )
+            conn.execute(
+                'INSERT INTO clearing_rates (block_num, hotkey, from_chain, to_chain, from_amount, to_amount)'
+                " VALUES (9_600, 'hk_old', 'btc', 'sol', '1', '1')"
+            )
+        store = ValidatorStateStore(db_path=db)
+        store.insert_clearing_rate(9_800, 'hk_a', 'btc', 'sol', 300, 600, 'sk_new')
+        vols = store.get_clearing_volumes(9_500, 10_000)
+        assert vols[('btc', 'sol')] == {'hk_old': (1, 1), 'hk_a': (300, 600)}
         store.close()
 
     def test_u128_scale_legs_sum_exactly(self, tmp_path: Path):
         # Legs are TEXT in SQLite; summing in Python keeps u128-scale integers
         # exact where SQL SUM would round through float.
         store = self._store(tmp_path)
-        store.insert_clearing_rate(9_800, 'hk_a', 'btc', 'sol', 10**30 + 7, 1)
-        store.insert_clearing_rate(9_900, 'hk_a', 'btc', 'sol', 3, 1)
+        store.insert_clearing_rate(9_800, 'hk_a', 'btc', 'sol', 10**30 + 7, 1, 'sk9')
+        store.insert_clearing_rate(9_900, 'hk_a', 'btc', 'sol', 3, 1, 'sk10')
         assert store.get_clearing_volumes(9_700, 10_000)[('btc', 'sol')]['hk_a'] == (10**30 + 10, 2)
         store.close()
 
@@ -1971,6 +2002,7 @@ class TestVolumeWeighting:
             to_chain,
             from_amount,
             from_amount if to_amount is None else to_amount,
+            uuid4().hex,
         )
 
     def test_idle_network_no_penalty(self, tmp_path: Path):
@@ -2190,7 +2222,7 @@ class TestCapacityVolumeInteraction:
         )
         conn.commit()
         # B serves the market's (floor-clearing) volume so A's vol_share = 0.
-        v.state_store.insert_clearing_rate(9_900, 'hk_b', 'btc', 'sol', 1_000_000_000, 1_000_000_000)
+        v.state_store.insert_clearing_rate(9_900, 'hk_b', 'btc', 'sol', 1_000_000_000, 1_000_000_000, 'sk12')
         rewards, _ = calculate_miner_rewards(v, v.block)
         # A: pool × crown 1.0 × eligible 1 × capacity 0.5 × fill_ratio 0.5 (B serves the volume).
         np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 1.0 * 0.5 * 0.5, atol=1e-6)
@@ -2213,7 +2245,7 @@ class TestCapacityVolumeInteraction:
                 (hk, from_c, to_c, rate, 0),
             )
         conn.commit()
-        v.state_store.insert_clearing_rate(9_900, 'hk_b', 'sol', 'btc', 1_500_000_000, 1_500_000_000)
+        v.state_store.insert_clearing_rate(9_900, 'hk_b', 'sol', 'btc', 1_500_000_000, 1_500_000_000, 'sk13')
         rewards, _ = calculate_miner_rewards(v, v.block)
         np.testing.assert_allclose(rewards.sum(), 1.0, atol=1e-6)
         v.state_store.close()
@@ -2553,7 +2585,7 @@ class TestScoreSnapshots:
             ('hk_a', 'btc', 'sol', 0.00020, 0),
         )
         conn.commit()
-        v.state_store.insert_clearing_rate(9_900, 'hk_a', 'btc', 'sol', 5_000_000_000_000, 1_000_000_000)
+        v.state_store.insert_clearing_rate(9_900, 'hk_a', 'btc', 'sol', 5_000_000_000_000, 1_000_000_000, 'sk14')
         v.database_storage.is_enabled.return_value = True
         return v
 

--- a/tests/test_swap_intake.py
+++ b/tests/test_swap_intake.py
@@ -9,6 +9,7 @@ import pytest
 from allways.cli.swap_commands.swap_intake import (
     MinerCandidate,
     compute_intake_amounts,
+    rate_display_from_fixed,
     required_collateral,
     select_best_miner,
     swap_viable,
@@ -16,6 +17,15 @@ from allways.cli.swap_commands.swap_intake import (
 )
 
 SOL = 1_000_000_000  # 1 SOL in lamports (9 dec)
+
+
+def test_rate_display_from_fixed_floors_to_sig_figs():
+    """Grandfathered pre-floor quotes must display FLOORED (matching set_quote + crown ingest),
+    never rounded — rounding could show a rate one tick above what scoring/reserve use."""
+    clean = 21 * 10**14  # 0.0021 × RATE_PRECISION, exact
+    assert rate_display_from_fixed(clean) == '0.0021'
+    dirty = 34512999 * 10**13  # 345.12999: would ROUND to 345.13; must floor to 345.12
+    assert rate_display_from_fixed(dirty) == '345.12'
 
 
 def test_to_smallest_units():


### PR DESCRIPTION
Execution of the rate-unification plan: canonical inside ("spoke per 1 SOL", byte-identical chain to scoring), directional outside ("to per 1 from" on every human surface).

- Promote effective_rate to utils/rate.py:directional_rate; add canonical_rate (input boundary); all CLI taker/miner surfaces render directionally with TO/FROM units
- alw miner post: wizard and positional RATE/COUNTER_RATE are now directional per leg (BREAKING for positional COUNTER_RATE automation: previously interpreted canonical; reverse leg is now inverted at the boundary). Omitted counter still means same effective price
- state.rs: document canonical denomination on MinerQuote/Pool/Reservation/Swap rate fields (comment-only)
- rate_display_from_fixed floors to 5 sig figs (grandfathered pre-floor quotes displayed one tick above reserve/scoring); miner status routed through it
- event_index: document why SwapCompleted.rate is ignored (attest gate enforces it)
- M2: clearing_rates keyed by swap_key (UNIQUE + ON CONFLICT DO NOTHING), in-place migration purges unkeyed rows so replays can't double volume
- alw view miners --sort rate sorts the directional values it displays

Tests: 699 passed (docker py3.12), ruff clean. E2E sol-btc and btc-sol full-lifecycle PASS on local stack.