### PR TITLE
Security hardening batch: contract items (H3, M4, L3, L4a, M1, M3, L1)

### DIFF
--- a/allways/solana/client.py
+++ b/allways/solana/client.py
@@ -340,9 +340,13 @@ class AllwaysSolanaClient:
 
     # ---------- representative writes (miner-side, no consensus) ----------
     def bind_hotkey(self, hotkey: bytes, hotkey_sig: bytes) -> str:
+        """Registered miners only: the program requires an existing MinerState with collateral >=
+        min_collateral (H3 squat gate), so `post_collateral` must have run before binding."""
         miner = self.keypair.pubkey()
         metas = [
             AccountMeta(miner, True, True),
+            AccountMeta(pdas.config_pda(self.program_id), False, False),
+            AccountMeta(pdas.miner_state_pda(miner, self.program_id), False, False),
             AccountMeta(pdas.binding_pda(miner, self.program_id), False, True),
             AccountMeta(pdas.hotkey_binding_pda(hotkey, self.program_id), False, True),
             AccountMeta(SYSTEM_PROGRAM, False, False),
@@ -527,6 +531,7 @@ class AllwaysSolanaClient:
         )
         metas = [
             AccountMeta(miner, True, False),
+            AccountMeta(pdas.miner_state_pda(miner, self.program_id), False, True),
             AccountMeta(pdas.swap_pda(swap_key, self.program_id), False, True),
         ]
         return self._send([self._ix('mark_fulfilled', args, metas)])

--- a/smart-contracts/solana/programs/allways_swap_manager/src/consensus.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/consensus.rs
@@ -76,7 +76,14 @@ pub fn record_vote<'info>(
     require!(round.voters.len() < MAX_VALIDATORS, ErrorCode::ValidatorSetFull);
     round.voters.push(validator);
 
-    let votes = round.voters.len() as u64;
+    // Tally only voters still in the CURRENT validator set: a validator removed mid-round must not
+    // keep counting toward quorum (its recorded vote would otherwise outlive its membership), and the
+    // threshold denominator is the live set, so numerator and denominator stay consistent.
+    let votes = round
+        .voters
+        .iter()
+        .filter(|voter| config.validators.iter().any(|v| &v.key == *voter))
+        .count() as u64;
     let total = config.validators.len() as u64;
     let threshold = config.consensus_threshold_percent as u64;
     Ok(votes.saturating_mul(100) >= threshold.saturating_mul(total))

--- a/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
@@ -76,9 +76,12 @@ pub const REQ_TIMEOUT: u8 = 7;
 /// Global (non-per-target) round for the validator-weight vector.
 pub const REQ_SET_WEIGHTS: u8 = 8;
 
-/// Slots the draw's seed slot is pinned ahead of the arming crank. Small: the pool has already
-/// closed, so this only has to be far enough ahead that the slot is unproduced when pinned.
-pub const SEED_SLOT_DELAY_SLOTS: u64 = 4;
+/// Slots the draw's seed slot is pinned ahead of the arming crank. Three leader windows (4 slots
+/// each) ahead, so the seed slot never lands in the window of the leader who included the arming tx.
+/// Residual: the seed slot's own leader can still bias its block hash (schedule is public), but that
+/// only buys a reservation hold — funds still need a real deposit + vote quorum. Must stay far below
+/// the ~512-slot SlotHashes window or every draw would re-arm forever.
+pub const SEED_SLOT_DELAY_SLOTS: u64 = 12;
 
 /// Bounded max lengths for stored strings.
 pub const MAX_ADDR_LEN: usize = 80;
@@ -193,6 +196,15 @@ pub const FEE_DIVISOR: u64 = 100;
 /// pool-open (which now busies the miner for the window + reservation TTL, #485) isn't cheap to grief.
 pub const RESERVATION_FEE_LAMPORTS: u64 = 20_000_000;
 
+/// Floor for `set_reservation_fee` — the fee is the only anti-grief brake on pool-opens (each one
+/// busies a miner for window + finalize + TTL), so the admin key must not be able to zero it.
+pub const RESERVATION_FEE_LAMPORTS_MIN: u64 = 1_000_000; // 0.001 SOL
+
+const _: () = assert!(
+    RESERVATION_FEE_LAMPORTS >= RESERVATION_FEE_LAMPORTS_MIN,
+    "seed reservation fee must satisfy its own floor"
+);
+
 /// Initial reservation-lottery pooling window (seconds). Seeds `Config.pool_window_secs` — how long
 /// a pool gathers contending requests before the stake-weighted draw. Must stay well below the
 /// reservation TTL. Runtime-adjustable via `set_pool_window` (dev seeds 5s for fast swaps).
@@ -239,6 +251,32 @@ const _: () = assert!(
     "MAX_TOTAL_EXTENSION_SECS must be within [30 min, 140 min]"
 );
 
+// Confirmation grace granted by `mark_fulfilled`: a miner who broadcast the dest tx near the deadline
+// must not be slashable while that tx confirms, so fulfillment slides `timeout_at` to at least
+// now + the dest chain's expected confirmation window (never shortened, capped by `max_extend_at`).
+// Sized to each chain's finality gate: BTC 2 confs (~20 min) + one slow block; SOL 32 slots (~13 s);
+// TAO 6 blocks (~72 s).
+pub const FULFILL_GRACE_BTC_SECS: i64 = 1_800;
+pub const FULFILL_GRACE_SOL_SECS: i64 = 120;
+pub const FULFILL_GRACE_TAO_SECS: i64 = 180;
+/// Unknown dest chain: one conservative default rather than 0 (0 would silently reopen the
+/// paid-and-slashed window the moment a new chain is added off-chain before this table learns it).
+pub const FULFILL_GRACE_DEFAULT_SECS: i64 = 600;
+
+/// Confirmation grace (seconds) for a destination chain, by chain id. Case-insensitive so a
+/// differently-cased chain string degrades to the right window, not silently to the default.
+pub fn fulfillment_grace_secs(to_chain: &str) -> i64 {
+    if to_chain.eq_ignore_ascii_case("btc") {
+        FULFILL_GRACE_BTC_SECS
+    } else if to_chain.eq_ignore_ascii_case("sol") {
+        FULFILL_GRACE_SOL_SECS
+    } else if to_chain.eq_ignore_ascii_case("tao") {
+        FULFILL_GRACE_TAO_SECS
+    } else {
+        FULFILL_GRACE_DEFAULT_SECS
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -274,6 +312,25 @@ mod tests {
         assert_eq!(quantize_rate_sig_figs(5_000_020_000_000_000_000), 5 * p);
         // A genuine 5-sf improvement survives as a distinct (better) bucket.
         assert_ne!(quantize_rate_sig_figs(5 * p), quantize_rate_sig_figs(4_999_900_000_000_000_000));
+    }
+
+    #[test]
+    fn fulfillment_grace_covers_every_chain() {
+        assert_eq!(fulfillment_grace_secs("btc"), FULFILL_GRACE_BTC_SECS);
+        assert_eq!(fulfillment_grace_secs("BTC"), FULFILL_GRACE_BTC_SECS);
+        assert_eq!(fulfillment_grace_secs("sol"), FULFILL_GRACE_SOL_SECS);
+        assert_eq!(fulfillment_grace_secs("tao"), FULFILL_GRACE_TAO_SECS);
+        // An unknown chain must get a real grace, never 0 (that would reopen paid-and-slashed).
+        assert_eq!(fulfillment_grace_secs("eth"), FULFILL_GRACE_DEFAULT_SECS);
+        assert!(FULFILL_GRACE_DEFAULT_SECS > 0);
+    }
+
+    #[test]
+    fn seed_slot_delay_clears_a_leader_window_but_not_slothashes() {
+        // Must clear at least one full 4-slot leader window past the arming tx's window...
+        assert!(SEED_SLOT_DELAY_SLOTS > 8);
+        // ...and stay far inside the ~512-slot SlotHashes ring or draws would re-arm forever.
+        assert!(SEED_SLOT_DELAY_SLOTS < 128);
     }
 
     #[test]

--- a/smart-contracts/solana/programs/allways_swap_manager/src/error.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/error.rs
@@ -27,7 +27,7 @@ pub enum ErrorCode {
     ValidatorSetFull,
     #[msg("Validator not found in the set")]
     ValidatorNotFound,
-    #[msg("Consensus threshold must be 1..=100")]
+    #[msg("Consensus threshold must be 51..=100 (majority floor)")]
     InvalidThreshold,
     #[msg("Validator has already voted in this round")]
     AlreadyVoted,
@@ -129,4 +129,12 @@ pub enum ErrorCode {
     // --- Treasury hardening ---
     #[msg("Treasury withdrawals may only be sent to the admin")]
     TreasuryRecipientNotAdmin,
+
+    // --- Security hardening batch (self-dealing / identity / weights round) ---
+    #[msg("Taker and miner must be different accounts")]
+    SelfSwapNotAllowed,
+    #[msg("Taker pubkey must not be the default address")]
+    InvalidUser,
+    #[msg("round_key does not match the keccak hash of the submitted weights snapshot")]
+    WeightsRoundKeyMismatch,
 }

--- a/smart-contracts/solana/programs/allways_swap_manager/src/events.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/events.rs
@@ -104,6 +104,16 @@ pub struct SwapTimeoutExtended {
     pub timeout_at: i64,
 }
 
+/// `mark_fulfilled` slid `timeout_at` forward to cover the destination chain's confirmation window
+/// (so a miner who paid just before the deadline can't be slashed while the tx confirms). Post-value
+/// like every deadline event. Separate from `SwapTimeoutExtended` — no validator is involved.
+#[event]
+pub struct FulfillmentGraceApplied {
+    pub swap_key: [u8; 32],
+    pub miner: Pubkey,
+    pub timeout_at: i64,
+}
+
 // --- Phase 6: treasury ---
 
 #[event]
@@ -153,7 +163,8 @@ pub struct HotkeyBound {
 /// Miner active-state transitions. Emitted so validators can replay the per-instant `active` history for
 /// the crown capacity integral from deterministic logs alone (the `MinerState.active` flag carries no
 /// history). `MinerActivated` fires on `vote_activate` quorum; `MinerDeactivated` on `vote_deactivate`
-/// quorum or self-`deactivate`.
+/// quorum, self-`deactivate`, or `apply_penalty`'s auto-deactivation (fee/slash dropping collateral
+/// below the minimum — previously silent, which desynced event-driven scorers from chain state).
 #[event]
 pub struct MinerActivated {
     pub miner: Pubkey,

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/admin.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/admin.rs
@@ -97,6 +97,7 @@ pub fn set_reservation_ttl(ctx: Context<AdminConfig>, secs: i64) -> Result<()> {
 }
 
 pub fn set_reservation_fee(ctx: Context<AdminConfig>, lamports: u64) -> Result<()> {
+    crate::validate::reservation_fee(lamports)?;
     ctx.accounts.config.reservation_fee_lamports = lamports;
     msg!("reservation_fee_lamports = {}", lamports);
     Ok(())

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/bind_hotkey.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/bind_hotkey.rs
@@ -1,9 +1,9 @@
 use anchor_lang::prelude::*;
 
-use crate::constants::{BIND_SEED, HOTKEY_BIND_SEED};
+use crate::constants::{BIND_SEED, CONFIG_SEED, HOTKEY_BIND_SEED, MINER_SEED};
 use crate::error::ErrorCode;
 use crate::events::HotkeyBound;
-use crate::state::{Binding, HotkeyBinding};
+use crate::state::{Binding, Config, HotkeyBinding, MinerState};
 
 /// A miner links its Solana pubkey to its Bittensor hotkey by storing the hotkey + an sr25519 signature
 /// (by the hotkey, over the miner pubkey). The contract only STORES these — sr25519 verification is too
@@ -11,11 +11,30 @@ use crate::state::{Binding, HotkeyBinding};
 /// The set-once `hotkey_binding` marker enforces hotkey→≤1 pubkey on-chain: the first pubkey to claim a
 /// hotkey owns it forever, so a struck pubkey can't rotate + re-bind the same hotkey to dodge strikes.
 /// The same miner may re-bind in place (refresh sig / change hotkey). Not halt-gated — identity, no value.
+///
+/// Gated to registered miners (MinerState exists + collateral >= min_collateral): the set-once marker
+/// is claimable exactly once per hotkey, so a free, unauthenticated `bind_hotkey` would let anyone
+/// enumerate metagraph hotkeys and squat them all, locking real miners out of their identity. The
+/// gate prices each claimed hotkey at a full collateral stake held by an attributable on-chain miner.
+/// Residual: a funded miner can still claim a hotkey that isn't theirs — the validator's off-chain
+/// sr25519 verify rejects the binding for scoring, so the squat earns nothing but still blocks; that
+/// deeper fix (validator-attested claims) was weighed and deferred.
 #[derive(Accounts)]
 #[instruction(hotkey: [u8; 32])]
 pub struct BindHotkey<'info> {
     #[account(mut)]
     pub miner: Signer<'info>,
+
+    #[account(seeds = [CONFIG_SEED], bump = config.bump)]
+    pub config: Account<'info, Config>,
+
+    /// Must already exist (created by `post_collateral`) — binding is for registered miners only.
+    #[account(
+        seeds = [MINER_SEED, miner.key().as_ref()],
+        bump = miner_state.bump,
+        constraint = miner_state.miner == miner.key(),
+    )]
+    pub miner_state: Account<'info, MinerState>,
 
     #[account(
         init_if_needed,
@@ -41,6 +60,13 @@ pub struct BindHotkey<'info> {
 }
 
 pub fn handler(ctx: Context<BindHotkey>, hotkey: [u8; 32], hotkey_sig: [u8; 64]) -> Result<()> {
+    // Registered-miner gate: claiming a hotkey requires a live collateral stake, so squatting the
+    // metagraph costs min_collateral per identity instead of rent.
+    require!(
+        ctx.accounts.miner_state.collateral >= ctx.accounts.config.min_collateral,
+        ErrorCode::InsufficientCollateral
+    );
+
     let now = Clock::get()?.unix_timestamp;
     let miner = ctx.accounts.miner.key();
     let binding_bump = ctx.bumps.binding;

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/confirm_swap.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/confirm_swap.rs
@@ -112,7 +112,9 @@ pub fn handler(
         let from_chain = ctx.accounts.swap.from_chain.clone();
         let to_chain = ctx.accounts.swap.to_chain.clone();
         let rate = ctx.accounts.swap.rate;
-        let fee = collateral_amount / FEE_DIVISOR;
+        // Floor at 1 lamport so a sub-100-lamport swap can't complete fee-free (integer division
+        // would truncate 1% of dust to 0); apply_penalty still clamps to available collateral.
+        let fee = (collateral_amount / FEE_DIVISOR).max(1);
         let min_collateral = ctx.accounts.config.min_collateral;
 
         let actual_fee = apply_penalty(&mut ctx.accounts.miner_state, min_collateral, fee, now)?;

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/finalize_reservation.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/finalize_reservation.rs
@@ -58,6 +58,13 @@ pub fn handler(
         ErrorCode::StringTooLong
     );
 
+    // Self-dealing guard: a miner may not be its own taker. Two tiny self-swaps would otherwise buy
+    // permanent eligibility (successful_swaps >= 2) and pad fill volume at zero real cost. A sybil
+    // (second wallet, same operator) is out of on-chain reach — the scorer's volume exclusion owns
+    // that half. Also reject the default pubkey: a timeout would "refund" the slash to the burn address.
+    require!(user != ctx.accounts.miner.key(), ErrorCode::SelfSwapNotAllowed);
+    require!(user != Pubkey::default(), ErrorCode::InvalidUser);
+
     let now = Clock::get()?.unix_timestamp;
     let cfg = &ctx.accounts.config;
 

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/mark_fulfilled.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/mark_fulfilled.rs
@@ -1,16 +1,30 @@
 use anchor_lang::prelude::*;
 
-use crate::constants::{MAX_TX_LEN, SWAP_SEED};
+use crate::constants::{fulfillment_grace_secs, MAX_TX_LEN, MINER_SEED, SWAP_SEED};
 use crate::error::ErrorCode;
-use crate::events::SwapFulfilled;
-use crate::state::{Swap, SwapStatus};
+use crate::events::{FulfillmentGraceApplied, SwapFulfilled};
+use crate::state::{MinerState, Swap, SwapStatus};
 
 /// Miner records that they sent the destination funds. Records only the tx hash/block — `to_amount`
 /// is the pinned reservation value and is no longer miner-supplied (v2 cleanup). Active → Fulfilled.
+///
+/// Fulfillment also slides `timeout_at` to at least now + the destination chain's confirmation window
+/// (capped by the frozen `max_extend_at` ceiling, never shortened): a miner who broadcast just before
+/// the deadline was previously slashable while the tx confirmed — paid AND slashed. The grace is
+/// one-shot (Active → Fulfilled happens once), so a fake fulfillment buys a bounded delay at most —
+/// which is why `timeout_swap` deliberately stays callable on Fulfilled swaps.
 #[derive(Accounts)]
 #[instruction(swap_key: [u8; 32])]
 pub struct MarkFulfilled<'info> {
     pub miner: Signer<'info>,
+
+    #[account(
+        mut,
+        seeds = [MINER_SEED, miner.key().as_ref()],
+        bump = miner_state.bump,
+        constraint = miner_state.miner == miner.key(),
+    )]
+    pub miner_state: Account<'info, MinerState>,
 
     #[account(
         mut,
@@ -40,6 +54,19 @@ pub fn handler(
     swap.to_tx_block = to_tx_block;
     swap.status = SwapStatus::Fulfilled;
     swap.fulfilled_at = now;
+
+    // Confirmation grace: forward-only and ceiling-capped, mirroring extend_timeout's invariants.
+    // Also covers a late fulfillment (now past timeout_at with no timeout quorum yet) — exactly the
+    // delivered-then-slashed case this exists for. busy_until follows so the miner stays locked
+    // (no deactivate/withdraw) through the extended deadline.
+    let target = now
+        .saturating_add(fulfillment_grace_secs(&swap.to_chain))
+        .min(swap.max_extend_at);
+    if target > swap.timeout_at {
+        swap.timeout_at = target;
+        ctx.accounts.miner_state.busy_until = ctx.accounts.miner_state.busy_until.max(target);
+        emit!(FulfillmentGraceApplied { swap_key, miner, timeout_at: target });
+    }
 
     emit!(SwapFulfilled {
         swap_key,

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/vote_initiate.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/vote_initiate.rs
@@ -73,6 +73,9 @@ pub fn handler(ctx: Context<VoteInitiate>, swap_key: [u8; 32]) -> Result<()> {
         require!(resv.claimed_swap_key == swap_key, ErrorCode::NotPending);
         // Never obligate a removed miner (defense-in-depth; resolve_pool also refuses an inactive miner).
         require!(ctx.accounts.miner_state.active, ErrorCode::MinerNotActive);
+        // Self-dealing backstop (finalize_reservation is the primary guard; this also covers
+        // reservations filled before that guard deployed).
+        require!(ctx.accounts.swap.user != ctx.accounts.swap.miner, ErrorCode::SelfSwapNotAllowed);
         // Obligation gate: miner must hold the over-collateralization requirement before being bound.
         require!(
             ctx.accounts.miner_state.collateral

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/vote_set_weights.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/vote_set_weights.rs
@@ -9,7 +9,12 @@ use crate::state::{Config, VoteRound};
 /// A validator votes to set the full validator-weight vector. Validators submit a vector index-aligned
 /// to `Config.validators`; on quorum the weights are saved. Everyone votes the same snapshot
 /// (hash-bound on keys+weights), so divergent vectors never co-count.
+///
+/// The round PDA is keyed by `round_key` (= the snapshot hash, checked in the handler), NOT a global
+/// singleton: competing proposals get separate rounds that coexist, so one junk vote can no longer
+/// park a wrong hash in the shared round and freeze weight updates for the whole round TTL.
 #[derive(Accounts)]
+#[instruction(weights: Vec<u64>, round_key: [u8; 32])]
 pub struct VoteSetWeights<'info> {
     #[account(mut)]
     pub validator: Signer<'info>,
@@ -17,12 +22,11 @@ pub struct VoteSetWeights<'info> {
     #[account(mut, seeds = [CONFIG_SEED], bump = config.bump)]
     pub config: Account<'info, Config>,
 
-    /// Global singleton round — no per-target pubkey (all validators vote the same weight snapshot).
     #[account(
         init_if_needed,
         payer = validator,
         space = 8 + VoteRound::INIT_SPACE,
-        seeds = [VOTE_SEED, &[REQ_SET_WEIGHTS]],
+        seeds = [VOTE_SEED, &[REQ_SET_WEIGHTS], round_key.as_ref()],
         bump,
     )]
     pub vote_round: Account<'info, VoteRound>,
@@ -30,7 +34,7 @@ pub struct VoteSetWeights<'info> {
     pub system_program: Program<'info, System>,
 }
 
-pub fn handler(ctx: Context<VoteSetWeights>, weights: Vec<u64>) -> Result<()> {
+pub fn handler(ctx: Context<VoteSetWeights>, weights: Vec<u64>, round_key: [u8; 32]) -> Result<()> {
     let now = Clock::get()?.unix_timestamp;
 
     // Cadence floor (anti-thrash): can't re-set faster than the min interval; first update is always allowed.
@@ -46,7 +50,10 @@ pub fn handler(ctx: Context<VoteSetWeights>, weights: Vec<u64>) -> Result<()> {
         ErrorCode::InvalidWeightsVector
     );
 
+    // The PDA seed must BE the snapshot hash — otherwise a voter could route an arbitrary weights
+    // vector into another proposal's round and taint its bound_hash.
     let bound = weights_hash(&ctx.accounts.config.validators, &weights);
+    require!(round_key == bound, ErrorCode::WeightsRoundKeyMismatch);
     let validator = ctx.accounts.validator.key();
     let round_bump = ctx.bumps.vote_round;
 

--- a/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
@@ -106,10 +106,15 @@ pub mod allways_swap_manager {
         admin::set_max_total_extension(ctx, secs)
     }
     // --- Consensus-governed validator weights ---
-    /// A validator submits the full weight vector (index-aligned to `Config.validators`); on quorum
-    /// the weights are saved. Validators read stake off-chain and converge on one snapshot.
-    pub fn vote_set_weights(ctx: Context<VoteSetWeights>, weights: Vec<u64>) -> Result<()> {
-        vote_set_weights::handler(ctx, weights)
+    /// A validator submits the full weight vector (index-aligned to `Config.validators`) plus
+    /// `round_key` = the snapshot hash, which keys the vote-round PDA (competing proposals coexist);
+    /// on quorum the weights are saved. Validators read stake off-chain and converge on one snapshot.
+    pub fn vote_set_weights(
+        ctx: Context<VoteSetWeights>,
+        weights: Vec<u64>,
+        round_key: [u8; 32],
+    ) -> Result<()> {
+        vote_set_weights::handler(ctx, weights, round_key)
     }
 
     // --- Miner activation consensus ---

--- a/smart-contracts/solana/programs/allways_swap_manager/src/penalty.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/penalty.rs
@@ -1,6 +1,7 @@
 use anchor_lang::prelude::*;
 
 use crate::error::ErrorCode;
+use crate::events::MinerDeactivated;
 use crate::state::MinerState;
 
 /// Deduct up to `amount` from the miner's collateral (clamped to available) and auto-deactivate the
@@ -25,6 +26,10 @@ pub fn apply_penalty(
     if miner_state.collateral < min_collateral && miner_state.active {
         miner_state.active = false;
         miner_state.deactivation_at = now;
+        // Without this emit the scorer — which rebuilds the active set purely from
+        // MinerActivated/MinerDeactivated events — keeps paying crown to a miner the chain
+        // already considers inactive, until some later vote event happens to fire.
+        emit!(MinerDeactivated { miner: miner_state.miner, at: now });
     }
     Ok(actual)
 }

--- a/smart-contracts/solana/programs/allways_swap_manager/src/validate.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/validate.rs
@@ -5,13 +5,14 @@ use anchor_lang::prelude::*;
 
 use crate::constants::{
     FINALIZE_WINDOW_SECS_MAX, FINALIZE_WINDOW_SECS_MIN, MAX_TOTAL_EXTENSION_SECS_MAX,
-    MAX_TOTAL_EXTENSION_SECS_MIN,
+    MAX_TOTAL_EXTENSION_SECS_MIN, RESERVATION_FEE_LAMPORTS_MIN,
 };
 use crate::error::ErrorCode;
 
-/// Quorum threshold as a percent of the validator set.
+/// Quorum threshold as a percent of the validator set. Floored at a majority: anything below 51 lets
+/// a single validator (or a sub-majority clique) pass votes alone once the set has >1 member.
 pub fn consensus_threshold(percent: u8) -> Result<()> {
-    require!((1..=100).contains(&percent), ErrorCode::InvalidThreshold);
+    require!((51..=100).contains(&percent), ErrorCode::InvalidThreshold);
     Ok(())
 }
 
@@ -49,15 +50,24 @@ pub fn weights_update_min_interval(secs: i64) -> Result<()> {
     Ok(())
 }
 
-/// Min swap size: 0 = unbounded, else a sane dust floor.
+/// Min swap size: always at least a dust floor. No 0-means-unbounded escape — a zero minimum lets
+/// dust-sized swaps whose 1% fee truncates to nothing through, and it's an anti-grief brake the
+/// admin key must not be able to release.
 pub fn min_swap_amount(amount: u64) -> Result<()> {
-    require!(amount == 0 || amount >= 1000, ErrorCode::InvalidAmount);
+    require!(amount >= 1000, ErrorCode::InvalidAmount);
     Ok(())
 }
 
-/// Swap-size bounds must not be contradictory (0 on either side = unbounded).
+/// Reservation fee: floored, never zero — it's the only cost on opening a pool, which busies a miner
+/// for the whole window + finalize + TTL.
+pub fn reservation_fee(lamports: u64) -> Result<()> {
+    require!(lamports >= RESERVATION_FEE_LAMPORTS_MIN, ErrorCode::InvalidAmount);
+    Ok(())
+}
+
+/// Swap-size bounds must not be contradictory (max 0 = unbounded above; min has a hard floor).
 pub fn swap_bounds(min: u64, max: u64) -> Result<()> {
-    require!(min == 0 || max == 0 || min <= max, ErrorCode::InvalidBounds);
+    require!(max == 0 || min <= max, ErrorCode::InvalidBounds);
     Ok(())
 }
 

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
@@ -93,8 +93,9 @@ fn resv_pda(m: &Pubkey) -> Pubkey {
 fn pool_pda(m: &Pubkey) -> Pubkey {
     Pubkey::find_program_address(&[b"pool", m.as_ref()], &pid()).0
 }
-fn weights_round_pda() -> Pubkey {
-    Pubkey::find_program_address(&[b"vote", &[REQ_SET_WEIGHTS]], &pid()).0
+/// Weights rounds are keyed by the snapshot hash (`round_key`) so competing proposals coexist.
+fn weights_round_pda(round_key: &[u8; 32]) -> Pubkey {
+    Pubkey::find_program_address(&[b"vote", &[REQ_SET_WEIGHTS], round_key], &pid()).0
 }
 fn swap_pda(key: &[u8; 32]) -> Pubkey {
     Pubkey::find_program_address(&[b"swap", key], &pid()).0
@@ -178,7 +179,7 @@ fn init_ix(admin: &Pubkey) -> Instruction {
             max_collateral: 0,
             fulfillment_timeout_secs: TIMEOUT_SECS,
             consensus_threshold_percent: THRESHOLD,
-            min_swap_amount: 0,
+            min_swap_amount: 1000,
             max_swap_amount: 0,
             reservation_ttl_secs: TTL_SECS,
         }
@@ -354,7 +355,7 @@ fn fulfill_ix(miner: &Pubkey, from_tx_hash: &str) -> Instruction {
             to_tx_block: 200,
         }
         .data(),
-        allways_swap_manager::accounts::MarkFulfilled { miner: *miner, swap: swap_pda(&key) }
+        allways_swap_manager::accounts::MarkFulfilled { miner: *miner, miner_state: miner_pda(miner), swap: swap_pda(&key) }
             .to_account_metas(None),
     )
 }
@@ -400,14 +401,19 @@ fn withdraw_treasury_ix(admin: &Pubkey, recipient: &Pubkey, amount: u64) -> Inst
         .to_account_metas(None),
     )
 }
-fn vote_weights_ix(validator: &Pubkey, weights: Vec<u64>) -> Instruction {
+fn vote_weights_ix(validator: &Pubkey, val_keys: &[Pubkey], weights: Vec<u64>) -> Instruction {
+    let infos: Vec<allways_swap_manager::state::ValidatorInfo> = val_keys
+        .iter()
+        .map(|k| allways_swap_manager::state::ValidatorInfo { key: *k, weight: 0 })
+        .collect();
+    let round_key = allways_swap_manager::consensus::weights_hash(&infos, &weights);
     Instruction::new_with_bytes(
         pid(),
-        &allways_swap_manager::instruction::VoteSetWeights { weights }.data(),
+        &allways_swap_manager::instruction::VoteSetWeights { weights, round_key }.data(),
         allways_swap_manager::accounts::VoteSetWeights {
             validator: *validator,
             config: config_pda(),
-            vote_round: weights_round_pda(),
+            vote_round: weights_round_pda(&round_key),
             system_program: SYSTEM_PROGRAM,
         }
         .to_account_metas(None),
@@ -575,9 +581,10 @@ fn onchain_vote_set_weights_quorum() {
     let mut weights: Vec<u64> = cfg.validators.iter().map(|v| v.weight).collect();
     weights[0] = 42;
 
-    send(&rpc, vote_weights_ix(&vals[0].pubkey(), weights.clone()), &vals[0].pubkey(), &vals[0])
+    let keys: Vec<Pubkey> = cfg.validators.iter().map(|v| v.key).collect();
+    send(&rpc, vote_weights_ix(&vals[0].pubkey(), &keys, weights.clone()), &vals[0].pubkey(), &vals[0])
         .expect("weights v0");
-    send(&rpc, vote_weights_ix(&vals[1].pubkey(), weights.clone()), &vals[1].pubkey(), &vals[1])
+    send(&rpc, vote_weights_ix(&vals[1].pubkey(), &keys, weights.clone()), &vals[1].pubkey(), &vals[1])
         .expect("weights v1");
 
     let after = read_config(&rpc);
@@ -909,6 +916,8 @@ fn bind_ix(miner: &Pubkey, hotkey: [u8; 32], hotkey_sig: [u8; 64]) -> Instructio
         &allways_swap_manager::instruction::BindHotkey { hotkey, hotkey_sig }.data(),
         allways_swap_manager::accounts::BindHotkey {
             miner: *miner,
+            config: config_pda(),
+            miner_state: miner_pda(miner),
             binding: bind_pda(miner),
             hotkey_binding: hkbind_pda(&hotkey),
             system_program: SYSTEM_PROGRAM,
@@ -999,6 +1008,11 @@ fn onchain_bind_hotkey() {
     let hotkey = [9u8; 32];
     let sig = [3u8; 64];
 
+    // Binding is gated to registered miners: an unregistered pubkey is rejected, then registration
+    // (collateral >= min_collateral) unlocks it.
+    let unregistered = send(&rpc, bind_ix(&miner.pubkey(), hotkey, sig), &miner.pubkey(), &miner);
+    assert!(unregistered.is_err(), "bind before post_collateral must be rejected");
+    send(&rpc, post_ix(&miner.pubkey(), COLLATERAL), &miner.pubkey(), &miner).expect("post collateral");
     send(&rpc, bind_ix(&miner.pubkey(), hotkey, sig), &miner.pubkey(), &miner).expect("bind_hotkey");
 
     let a = rpc.get_account(&bind_pda(&miner.pubkey())).expect("binding account");

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_binding.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_binding.rs
@@ -2,8 +2,9 @@
 //   cargo test -p allways_swap_manager --test test_binding
 //
 // bind_hotkey is miner-signed and per-miner (one Binding PDA). It only STORES the hotkey + sr25519
-// sig (the validator verifies off-chain), reads no config, and overwrites in place on re-bind. No
-// `initialize` is needed.
+// sig (the validator verifies off-chain) and overwrites in place on re-bind. Since the H3 squat
+// gate it is registered-miners-only: the caller needs a MinerState with collateral >= min_collateral,
+// so `initialize` + `post_collateral` run in setup.
 use {
     anchor_lang::{
         prelude::Pubkey, solana_program::instruction::Instruction, AccountDeserialize,
@@ -18,9 +19,22 @@ use {
 };
 
 const SYSTEM_PROGRAM: Pubkey = anchor_lang::solana_program::system_program::ID;
+const MIN_COLLATERAL: u64 = 1_000_000_000; // 1 SOL — makes the registration gate meaningful
 
 fn pid() -> Pubkey {
     allways_swap_manager::id()
+}
+fn config_pda() -> Pubkey {
+    Pubkey::find_program_address(&[b"config"], &pid()).0
+}
+fn treasury_pda() -> Pubkey {
+    Pubkey::find_program_address(&[b"treasury"], &pid()).0
+}
+fn miner_pda(miner: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&[b"miner", miner.as_ref()], &pid()).0
+}
+fn collateral_vault_pda(miner: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&[b"collateral", miner.as_ref()], &pid()).0
 }
 fn bind_pda(miner: &Pubkey) -> Pubkey {
     Pubkey::find_program_address(&[b"bind", miner.as_ref()], &pid()).0
@@ -29,6 +43,7 @@ fn hkbind_pda(hotkey: &[u8; 32]) -> Pubkey {
     Pubkey::find_program_address(&[b"hkbind", hotkey], &pid()).0
 }
 fn send(svm: &mut LiteSVM, ix: Instruction, payer: &Pubkey, signer: &Keypair) -> Result<(), String> {
+    svm.expire_blockhash();
     let blockhash = svm.latest_blockhash();
     let msg = Message::new_with_blockhash(&[ix], Some(payer), &blockhash);
     let tx = VersionedTransaction::try_new(VersionedMessage::Legacy(msg), &[signer]).unwrap();
@@ -40,8 +55,24 @@ fn bind_ix(miner: &Pubkey, hotkey: [u8; 32], hotkey_sig: [u8; 64]) -> Instructio
         &allways_swap_manager::instruction::BindHotkey { hotkey, hotkey_sig }.data(),
         allways_swap_manager::accounts::BindHotkey {
             miner: *miner,
+            config: config_pda(),
+            miner_state: miner_pda(miner),
             binding: bind_pda(miner),
             hotkey_binding: hkbind_pda(&hotkey),
+            system_program: SYSTEM_PROGRAM,
+        }
+        .to_account_metas(None),
+    )
+}
+fn post_ix(miner: &Pubkey, amount: u64) -> Instruction {
+    Instruction::new_with_bytes(
+        pid(),
+        &allways_swap_manager::instruction::PostCollateral { amount }.data(),
+        allways_swap_manager::accounts::PostCollateral {
+            miner: *miner,
+            config: config_pda(),
+            miner_state: miner_pda(miner),
+            collateral_vault: collateral_vault_pda(miner),
             system_program: SYSTEM_PROGRAM,
         }
         .to_account_metas(None),
@@ -51,17 +82,49 @@ fn read_binding(svm: &LiteSVM, miner: &Pubkey) -> Binding {
     let a = svm.get_account(&bind_pda(miner)).unwrap();
     Binding::try_deserialize(&mut a.data.as_slice()).unwrap()
 }
-fn setup() -> (LiteSVM, Keypair) {
+
+fn setup() -> LiteSVM {
     let mut svm = LiteSVM::new();
     svm.add_program(pid(), include_bytes!("../../../target/deploy/allways_swap_manager.so")).unwrap();
+
+    let admin = Keypair::new();
+    svm.airdrop(&admin.pubkey(), 100_000_000_000).unwrap();
+    let ix = Instruction::new_with_bytes(
+        pid(),
+        &allways_swap_manager::instruction::Initialize {
+            min_collateral: MIN_COLLATERAL,
+            max_collateral: 0,
+            fulfillment_timeout_secs: 100,
+            consensus_threshold_percent: 66,
+            min_swap_amount: 1000,
+            max_swap_amount: 0,
+            reservation_ttl_secs: 1_800,
+        }
+        .data(),
+        allways_swap_manager::accounts::Initialize {
+            admin: admin.pubkey(),
+            config: config_pda(),
+            treasury: treasury_pda(),
+            system_program: SYSTEM_PROGRAM,
+        }
+        .to_account_metas(None),
+    );
+    send(&mut svm, ix, &admin.pubkey(), &admin).expect("initialize");
+    svm
+}
+
+/// A funded keypair with collateral posted — a "registered" miner allowed through the bind gate.
+fn registered_miner(svm: &mut LiteSVM) -> Keypair {
     let miner = Keypair::new();
     svm.airdrop(&miner.pubkey(), 10_000_000_000).unwrap();
-    (svm, miner)
+    send(svm, post_ix(&miner.pubkey(), MIN_COLLATERAL), &miner.pubkey(), &miner).expect("post");
+    miner
 }
 
 #[test]
 fn test_bind_creates_pda() {
-    let (mut svm, miner) = setup();
+    let mut svm = setup();
+    let miner = registered_miner(&mut svm);
     let hotkey = [9u8; 32];
     let sig = [3u8; 64];
     send(&mut svm, bind_ix(&miner.pubkey(), hotkey, sig), &miner.pubkey(), &miner).expect("bind");
@@ -74,8 +137,29 @@ fn test_bind_creates_pda() {
 }
 
 #[test]
+fn test_bind_requires_registration() {
+    // H3 squat gate: no MinerState → rejected; MinerState below min_collateral → rejected;
+    // topping up to the minimum unlocks the bind. Claiming a hotkey costs a real stake.
+    let mut svm = setup();
+    let squatter = Keypair::new();
+    svm.airdrop(&squatter.pubkey(), 10_000_000_000).unwrap();
+
+    let no_state = send(&mut svm, bind_ix(&squatter.pubkey(), [8u8; 32], [1u8; 64]), &squatter.pubkey(), &squatter);
+    assert!(no_state.is_err(), "bind with no MinerState must be rejected");
+
+    send(&mut svm, post_ix(&squatter.pubkey(), MIN_COLLATERAL / 2), &squatter.pubkey(), &squatter).expect("post half");
+    let under = send(&mut svm, bind_ix(&squatter.pubkey(), [8u8; 32], [1u8; 64]), &squatter.pubkey(), &squatter);
+    assert!(under.is_err(), "bind below min_collateral must be rejected");
+
+    send(&mut svm, post_ix(&squatter.pubkey(), MIN_COLLATERAL / 2), &squatter.pubkey(), &squatter).expect("post rest");
+    send(&mut svm, bind_ix(&squatter.pubkey(), [8u8; 32], [1u8; 64]), &squatter.pubkey(), &squatter)
+        .expect("bind unlocks at min_collateral");
+}
+
+#[test]
 fn test_rebind_overwrites_in_place() {
-    let (mut svm, miner) = setup();
+    let mut svm = setup();
+    let miner = registered_miner(&mut svm);
     send(&mut svm, bind_ix(&miner.pubkey(), [1u8; 32], [1u8; 64]), &miner.pubkey(), &miner).expect("bind1");
     // re-bind with a different hotkey/sig overwrites the same PDA
     let hotkey2 = [2u8; 32];
@@ -92,12 +176,12 @@ fn test_rebind_overwrites_in_place() {
 fn test_hotkey_pinned_to_first_pubkey() {
     // Set-once reverse marker: a second, different pubkey can't claim a hotkey already bound — closes
     // the strike-dodge (rotate to a fresh pubkey + re-bind the same hotkey). The owner can still re-bind.
-    let (mut svm, miner_a) = setup();
+    let mut svm = setup();
+    let miner_a = registered_miner(&mut svm);
     let hotkey = [7u8; 32];
     send(&mut svm, bind_ix(&miner_a.pubkey(), hotkey, [1u8; 64]), &miner_a.pubkey(), &miner_a).expect("A binds");
 
-    let miner_b = Keypair::new();
-    svm.airdrop(&miner_b.pubkey(), 10_000_000_000).unwrap();
+    let miner_b = registered_miner(&mut svm);
     let res = send(&mut svm, bind_ix(&miner_b.pubkey(), hotkey, [2u8; 64]), &miner_b.pubkey(), &miner_b);
     assert!(res.is_err(), "a different pubkey must not claim an already-bound hotkey");
 

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_collateral.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_collateral.rs
@@ -51,7 +51,7 @@ fn setup(max_collateral: u64) -> (LiteSVM, Pubkey) {
             max_collateral,
             fulfillment_timeout_secs: 100,
             consensus_threshold_percent: 66,
-            min_swap_amount: 0,
+            min_swap_amount: 1000,
             max_swap_amount: 0,
             reservation_ttl_secs: 1_800,
         }

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_consensus.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_consensus.rs
@@ -59,7 +59,7 @@ fn init_ix(admin: &Pubkey, min_collateral: u64, threshold: u8) -> Instruction {
             max_collateral: 0,
             fulfillment_timeout_secs: 100,
             consensus_threshold_percent: threshold,
-            min_swap_amount: 0,
+            min_swap_amount: 1000,
             max_swap_amount: 0,
             reservation_ttl_secs: 1_800,
         }
@@ -175,6 +175,83 @@ fn fund_miner(svm: &mut LiteSVM, collateral: u64) -> Keypair {
         send(svm, post_ix(&miner.pubkey(), 1), &miner.pubkey(), &miner).expect("post");
     }
     miner
+}
+
+fn remove_validator_ix(admin: &Pubkey, v: Pubkey) -> Instruction {
+    Instruction::new_with_bytes(
+        pid(),
+        &allways_swap_manager::instruction::RemoveValidator { validator: v }.data(),
+        allways_swap_manager::accounts::AdminConfig {
+            admin: *admin,
+            config: config_pda(),
+        }
+        .to_account_metas(None),
+    )
+}
+fn set_threshold_ix(admin: &Pubkey, percent: u8) -> Instruction {
+    Instruction::new_with_bytes(
+        pid(),
+        &allways_swap_manager::instruction::SetConsensusThreshold { percent }.data(),
+        allways_swap_manager::accounts::AdminConfig {
+            admin: *admin,
+            config: config_pda(),
+        }
+        .to_account_metas(None),
+    )
+}
+
+/// Like `setup` but also returns the admin (for set mutations mid-test).
+fn setup_with_admin(threshold: u8, n: usize) -> (LiteSVM, Keypair, Vec<Keypair>) {
+    let mut svm = LiteSVM::new();
+    svm.add_program(pid(), include_bytes!("../../../target/deploy/allways_swap_manager.so")).unwrap();
+    let admin = Keypair::new();
+    svm.airdrop(&admin.pubkey(), 100_000_000_000).unwrap();
+    send(&mut svm, init_ix(&admin.pubkey(), 0, threshold), &admin.pubkey(), &admin).expect("initialize");
+    let mut validators = Vec::new();
+    for _ in 0..n {
+        let v = Keypair::new();
+        svm.airdrop(&v.pubkey(), 100_000_000_000).unwrap();
+        send(&mut svm, add_validator_ix(&admin.pubkey(), v.pubkey()), &admin.pubkey(), &admin).expect("add validator");
+        validators.push(v);
+    }
+    (svm, admin, validators)
+}
+
+#[test]
+fn test_threshold_floored_at_majority() {
+    // Sub-majority thresholds let a single validator (or minority clique) pass votes alone.
+    let (mut svm, admin, _vals) = setup_with_admin(66, 1);
+    assert!(send(&mut svm, set_threshold_ix(&admin.pubkey(), 50), &admin.pubkey(), &admin).is_err(), "50 rejected");
+    assert!(send(&mut svm, set_threshold_ix(&admin.pubkey(), 1), &admin.pubkey(), &admin).is_err(), "1 rejected");
+    send(&mut svm, set_threshold_ix(&admin.pubkey(), 51), &admin.pubkey(), &admin).expect("51 is the floor");
+
+    // initialize enforces the same rule (shared validator).
+    let mut svm2 = LiteSVM::new();
+    svm2.add_program(pid(), include_bytes!("../../../target/deploy/allways_swap_manager.so")).unwrap();
+    let admin2 = Keypair::new();
+    svm2.airdrop(&admin2.pubkey(), 100_000_000_000).unwrap();
+    let r = send(&mut svm2, init_ix(&admin2.pubkey(), 0, 50), &admin2.pubkey(), &admin2);
+    assert!(r.is_err(), "initialize below the majority floor must be rejected");
+}
+
+#[test]
+fn test_removed_validator_vote_no_longer_counts() {
+    // 3 validators at 66% → quorum needs 2. v0 votes, then is REMOVED: its recorded vote must not
+    // keep counting (after removal the live set is 2, threshold needs 2 of 2).
+    let (mut svm, admin, vals) = setup_with_admin(66, 3);
+    let miner = fund_miner(&mut svm, 0);
+
+    send(&mut svm, vote_activate_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0]).expect("v0");
+    send(&mut svm, remove_validator_ix(&admin.pubkey(), vals[0].pubkey()), &admin.pubkey(), &admin).expect("remove v0");
+
+    send(&mut svm, vote_activate_ix(&vals[1].pubkey(), &miner.pubkey()), &vals[1].pubkey(), &vals[1]).expect("v1");
+    assert!(
+        !miner_active(&svm, &miner.pubkey()),
+        "removed validator's stale vote must not combine with one live vote into quorum"
+    );
+
+    send(&mut svm, vote_activate_ix(&vals[2].pubkey(), &miner.pubkey()), &vals[2].pubkey(), &vals[2]).expect("v2");
+    assert!(miner_active(&svm, &miner.pubkey()), "two LIVE votes reach quorum");
 }
 
 #[test]

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_extensions.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_extensions.rs
@@ -107,7 +107,7 @@ fn init_ix(admin: &Pubkey) -> Instruction {
             max_collateral: 0,
             fulfillment_timeout_secs: TIMEOUT_SECS,
             consensus_threshold_percent: 66,
-            min_swap_amount: 0,
+            min_swap_amount: 1000,
             max_swap_amount: 0,
             reservation_ttl_secs: TTL,
         }
@@ -290,7 +290,7 @@ fn fulfill_ix(miner: &Pubkey, from_tx_hash: &str) -> Instruction {
             to_tx_block: 200,
         }
         .data(),
-        allways_swap_manager::accounts::MarkFulfilled { miner: *miner, swap: swap_pda(&key) }
+        allways_swap_manager::accounts::MarkFulfilled { miner: *miner, miner_state: miner_pda(miner), swap: swap_pda(&key) }
             .to_account_metas(None),
     )
 }

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_initialize.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_initialize.rs
@@ -34,7 +34,7 @@ fn test_initialize_creates_config() {
             max_collateral: 500_000_000,
             fulfillment_timeout_secs: 12_600,
             consensus_threshold_percent: 66,
-            min_swap_amount: 0,
+            min_swap_amount: 1000,
             max_swap_amount: 0,
             reservation_ttl_secs: 1_800,
         }

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_quote.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_quote.rs
@@ -61,7 +61,7 @@ fn setup() -> (LiteSVM, Pubkey) {
             max_collateral: 0,
             fulfillment_timeout_secs: 100,
             consensus_threshold_percent: 66,
-            min_swap_amount: 0,
+            min_swap_amount: 1000,
             max_swap_amount: 0,
             reservation_ttl_secs: 1_800,
         }

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_reservation.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_reservation.rs
@@ -115,7 +115,9 @@ fn init_ix(admin: &Pubkey, min_swap: u64, max_swap: u64, ttl: i64) -> Instructio
             max_collateral: 0,
             fulfillment_timeout_secs: 100,
             consensus_threshold_percent: 66,
-            min_swap_amount: min_swap,
+            // min_swap_amount has a hard 1000-lamport floor (no 0-unbounded escape); callers passing
+            // 0 mean "no meaningful bound", which the dust floor satisfies for every SOL-scale fill.
+            min_swap_amount: min_swap.max(1000),
             max_swap_amount: max_swap,
             reservation_ttl_secs: ttl,
         }
@@ -647,6 +649,48 @@ fn test_swap_amount_bounds_cannot_be_contradictory() {
     assert!(send(&mut svm, set_max_swap_ix(&admin.pubkey(), 500_000_000), &admin.pubkey(), &admin).is_err(), "max < min rejected");
     assert!(send(&mut svm, set_min_swap_ix(&admin.pubkey(), 6_000_000_000), &admin.pubkey(), &admin).is_err(), "min > max rejected");
     send(&mut svm, set_max_swap_ix(&admin.pubkey(), 8_000_000_000), &admin.pubkey(), &admin).expect("widening max is allowed");
+}
+
+fn set_reservation_fee_ix(admin: &Pubkey, lamports: u64) -> Instruction {
+    Instruction::new_with_bytes(
+        pid(),
+        &allways_swap_manager::instruction::SetReservationFee { lamports }.data(),
+        allways_swap_manager::accounts::AdminConfig { admin: *admin, config: config_pda() }.to_account_metas(None),
+    )
+}
+
+#[test]
+fn test_admin_cannot_zero_anti_grief_brakes() {
+    // min_swap_amount and reservation_fee are the brakes on dust swaps / free pool-open griefing;
+    // the admin key must not be able to release either (L4a).
+    let (mut svm, admin, _vals, _miner) = setup(1_000_000_000, 5_000_000_000);
+    assert!(send(&mut svm, set_min_swap_ix(&admin.pubkey(), 0), &admin.pubkey(), &admin).is_err(), "min_swap 0 rejected");
+    assert!(send(&mut svm, set_min_swap_ix(&admin.pubkey(), 999), &admin.pubkey(), &admin).is_err(), "below dust floor rejected");
+    send(&mut svm, set_min_swap_ix(&admin.pubkey(), 1000), &admin.pubkey(), &admin).expect("dust floor is the minimum");
+
+    assert!(send(&mut svm, set_reservation_fee_ix(&admin.pubkey(), 0), &admin.pubkey(), &admin).is_err(), "fee 0 rejected");
+    assert!(send(&mut svm, set_reservation_fee_ix(&admin.pubkey(), 999_999), &admin.pubkey(), &admin).is_err(), "below fee floor rejected");
+    send(&mut svm, set_reservation_fee_ix(&admin.pubkey(), 1_000_000), &admin.pubkey(), &admin).expect("fee floor is the minimum");
+}
+
+#[test]
+fn test_finalize_rejects_self_swap_and_default_user() {
+    // M1: a miner naming ITSELF as taker would buy eligibility (successful_swaps) with wash swaps;
+    // the default pubkey as taker would burn a timeout refund. Both rejected at the fill.
+    let (mut svm, _admin, vals, miner) = setup(0, 0);
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL"), &vals[0].pubkey(), &vals[0]).expect("bid");
+    set_clock(&mut svm, BASE_TS + POOL_WINDOW_SECS + 1);
+    arm_and_resolve(&mut svm, &vals[0], &miner.pubkey()).expect("resolve");
+
+    let self_fill = finalize_btc_sol(&mut svm, &vals[0], &miner.pubkey(), &miner.pubkey(), "u", "uSOL", 2_000_000_000, 1);
+    assert!(self_fill.is_err(), "user == miner must be rejected");
+
+    let burn_fill = finalize_btc_sol(&mut svm, &vals[0], &miner.pubkey(), &Pubkey::default(), "u", "uSOL", 2_000_000_000, 1);
+    assert!(burn_fill.is_err(), "default-pubkey taker must be rejected");
+
+    let user = Keypair::new().pubkey();
+    finalize_btc_sol(&mut svm, &vals[0], &miner.pubkey(), &user, "u", "uSOL", 2_000_000_000, 1)
+        .expect("distinct taker fills normally");
 }
 // NOTE: the old `test_update_reflected_in_reservation` was removed — under two-phase a bid carries no
 // amounts, so there is no bid content to "reflect". The winner names amounts at finalize instead

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_swap.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_swap.rs
@@ -5,7 +5,9 @@ use {
         prelude::Pubkey, solana_program::clock::Clock, solana_program::instruction::Instruction,
         AccountDeserialize, InstructionData, ToAccountMetas,
     },
-    allways_swap_manager::constants::{POOL_WINDOW_SECS, RESERVATION_FEE_LAMPORTS},
+    allways_swap_manager::constants::{
+        FULFILL_GRACE_SOL_SECS, MAX_TOTAL_EXTENSION_SECS, POOL_WINDOW_SECS, RESERVATION_FEE_LAMPORTS,
+    },
     allways_swap_manager::state::{MinerDirectionStats, MinerState, Pool, Reservation, Swap, SwapStatus, Treasury},
     litesvm::LiteSVM,
     solana_hash::Hash,
@@ -116,7 +118,7 @@ fn init_ix(admin: &Pubkey) -> Instruction {
             max_collateral: 0,
             fulfillment_timeout_secs: TIMEOUT_SECS,
             consensus_threshold_percent: 66,
-            min_swap_amount: 0,
+            min_swap_amount: 1000,
             max_swap_amount: 0,
             reservation_ttl_secs: TTL,
         }
@@ -344,7 +346,7 @@ fn fulfill_ix(miner: &Pubkey, from_tx_hash: &str) -> Instruction {
             to_tx_block: 200,
         }
         .data(),
-        allways_swap_manager::accounts::MarkFulfilled { miner: *miner, swap: swap_pda(&key) }
+        allways_swap_manager::accounts::MarkFulfilled { miner: *miner, miner_state: miner_pda(miner), swap: swap_pda(&key) }
             .to_account_metas(None),
     )
 }
@@ -614,6 +616,68 @@ fn test_stale_claim_reap() {
     assert!(svm.get_account(&swap_pda(&key)).is_none(), "stale claim closed");
     let r = Reservation::try_deserialize(&mut svm.get_account(&resv_pda(&miner.pubkey())).unwrap().data.as_slice()).unwrap();
     assert_eq!(r.claimed_swap_key, [0u8; 32], "claim slot freed");
+}
+
+fn read_swap(svm: &LiteSVM, key: &[u8; 32]) -> Swap {
+    let a = svm.get_account(&swap_pda(key)).unwrap();
+    Swap::try_deserialize(&mut a.data.as_slice()).unwrap()
+}
+
+#[test]
+fn test_early_fulfill_leaves_timeout_untouched() {
+    // Grace is a floor on remaining runway, not an add-on: fulfilling with plenty of deadline left
+    // must not move timeout_at (a fake early fulfillment buys nothing).
+    let (mut svm, vals, miner, _rent) = setup();
+    do_initiate(&mut svm, &vals, &miner.pubkey(), "srctx1");
+    let key = swap_key("srctx1");
+
+    set_clock(&mut svm, BASE_TS + 10);
+    send(&mut svm, fulfill_ix(&miner.pubkey(), "srctx1"), &miner.pubkey(), &miner).expect("fulfill");
+    assert_eq!(read_swap(&svm, &key).timeout_at, BASE_TS + TIMEOUT_SECS, "timeout unchanged");
+}
+
+#[test]
+fn test_fulfill_near_deadline_grants_confirmation_grace() {
+    // L1: a miner who broadcast the dest tx just before the deadline must not stay slashable while
+    // it confirms — mark_fulfilled slides timeout_at to now + the dest chain's conf window.
+    let (mut svm, vals, miner, _rent) = setup();
+    do_initiate(&mut svm, &vals, &miner.pubkey(), "srctx1");
+    let key = swap_key("srctx1");
+
+    let fulfill_ts = BASE_TS + TIMEOUT_SECS - 30; // 30s of runway left
+    set_clock(&mut svm, fulfill_ts);
+    send(&mut svm, fulfill_ix(&miner.pubkey(), "srctx1"), &miner.pubkey(), &miner).expect("fulfill");
+
+    let s = read_swap(&svm, &key);
+    let expected = fulfill_ts + FULFILL_GRACE_SOL_SECS; // dest leg is SOL
+    assert_eq!(s.timeout_at, expected, "timeout slid to now + dest conf window");
+    assert_eq!(s.status, SwapStatus::Fulfilled);
+    assert_eq!(
+        miner_state(&svm, &miner.pubkey()).busy_until,
+        expected,
+        "busy lock follows the extended deadline"
+    );
+
+    // The grace only defers: past it, the timeout path still slashes normally.
+    set_clock(&mut svm, expected + 1);
+    send(&mut svm, timeout_ix(&vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER, "srctx1"), &vals[0].pubkey(), &vals[0]).expect("t0");
+    send(&mut svm, timeout_ix(&vals[1].pubkey(), &miner.pubkey(), &LOTTERY_USER, "srctx1"), &vals[1].pubkey(), &vals[1]).expect("t1");
+    assert!(svm.get_account(&swap_pda(&key)).is_none(), "swap closed by timeout after the grace");
+}
+
+#[test]
+fn test_fulfill_grace_capped_by_frozen_ceiling() {
+    // The grace obeys the same frozen max_extend_at ceiling as validator extensions — a late
+    // fulfillment can never push the deadline past it.
+    let (mut svm, vals, miner, _rent) = setup();
+    do_initiate(&mut svm, &vals, &miner.pubkey(), "srctx1");
+    let key = swap_key("srctx1");
+
+    let ceiling = BASE_TS + TIMEOUT_SECS + MAX_TOTAL_EXTENSION_SECS; // frozen at initiate
+    let fulfill_ts = ceiling - 50; // now + grace would land past the ceiling
+    set_clock(&mut svm, fulfill_ts);
+    send(&mut svm, fulfill_ix(&miner.pubkey(), "srctx1"), &miner.pubkey(), &miner).expect("fulfill");
+    assert_eq!(read_swap(&svm, &key).timeout_at, ceiling, "grace clamped to max_extend_at");
 }
 
 #[test]

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_treasury.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_treasury.rs
@@ -107,7 +107,7 @@ fn setup_with_fee() -> (LiteSVM, Keypair, u64) {
         pid(),
         &allways_swap_manager::instruction::Initialize {
             min_collateral: 1_000_000_000, max_collateral: 0, fulfillment_timeout_secs: 3_600,
-            consensus_threshold_percent: 66, min_swap_amount: 0, max_swap_amount: 0, reservation_ttl_secs: 1_800,
+            consensus_threshold_percent: 66, min_swap_amount: 1000, max_swap_amount: 0, reservation_ttl_secs: 1_800,
         }.data(),
         allways_swap_manager::accounts::Initialize { admin: admin.pubkey(), config: cfg(), treasury: treasury_pda(), system_program: SYS }.to_account_metas(None),
     ), &admin.pubkey(), &admin).expect("init");
@@ -184,7 +184,7 @@ fn setup_with_fee() -> (LiteSVM, Keypair, u64) {
 
     send(&mut svm, Instruction::new_with_bytes(pid(),
         &allways_swap_manager::instruction::MarkFulfilled { swap_key: key, to_tx_hash: "d".to_string(), to_tx_block: 1 }.data(),
-        allways_swap_manager::accounts::MarkFulfilled { miner: miner.pubkey(), swap: swap_pda(&key) }.to_account_metas(None),
+        allways_swap_manager::accounts::MarkFulfilled { miner: miner.pubkey(), miner_state: miner_pda(&miner.pubkey()), swap: swap_pda(&key) }.to_account_metas(None),
     ), &miner.pubkey(), &miner).expect("fulfill");
 
     let confirm = |svm: &mut LiteSVM, v: &Keypair| {

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_validator_weight.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_validator_weight.rs
@@ -58,7 +58,7 @@ fn setup() -> (LiteSVM, Pubkey, Keypair) {
             max_collateral: 0,
             fulfillment_timeout_secs: 100,
             consensus_threshold_percent: 66,
-            min_swap_amount: 0,
+            min_swap_amount: 1000,
             max_swap_amount: 0,
             reservation_ttl_secs: 1_800,
         }
@@ -100,8 +100,18 @@ fn test_add_validator_stores_weight() {
 
 // ─── Phase 10: consensus-governed weights (vote_set_weights) ────────────────────
 
-fn weights_round_pda(program_id: &Pubkey) -> Pubkey {
-    Pubkey::find_program_address(&[b"vote", &[REQ_SET_WEIGHTS]], program_id).0
+/// The round is keyed by the snapshot hash (competing proposals coexist; a junk vote can't freeze
+/// the singleton round). Mirrors `consensus::weights_hash`: keccak(REQ || keys || weights LE).
+fn weights_round_key(val_keys: &[Pubkey], weights: &[u64]) -> [u8; 32] {
+    let infos: Vec<allways_swap_manager::state::ValidatorInfo> = val_keys
+        .iter()
+        .map(|k| allways_swap_manager::state::ValidatorInfo { key: *k, weight: 0 })
+        .collect();
+    allways_swap_manager::consensus::weights_hash(&infos, weights)
+}
+
+fn weights_round_pda(program_id: &Pubkey, round_key: &[u8; 32]) -> Pubkey {
+    Pubkey::find_program_address(&[b"vote", &[REQ_SET_WEIGHTS], round_key], program_id).0
 }
 
 /// init (clock at BASE_TS, threshold 66) + n validators with weight 1. Returns their keypairs.
@@ -119,14 +129,20 @@ fn setup_vals(n: usize) -> (LiteSVM, Pubkey, Vec<Keypair>) {
     (svm, program_id, vals)
 }
 
-fn vote_weights_ix(program_id: &Pubkey, validator: &Pubkey, weights: Vec<u64>) -> Instruction {
+fn vote_weights_ix(
+    program_id: &Pubkey,
+    validator: &Pubkey,
+    val_keys: &[Pubkey],
+    weights: Vec<u64>,
+) -> Instruction {
+    let round_key = weights_round_key(val_keys, &weights);
     Instruction::new_with_bytes(
         *program_id,
-        &allways_swap_manager::instruction::VoteSetWeights { weights }.data(),
+        &allways_swap_manager::instruction::VoteSetWeights { weights, round_key }.data(),
         allways_swap_manager::accounts::VoteSetWeights {
             validator: *validator,
             config: config_pda(program_id),
-            vote_round: weights_round_pda(program_id),
+            vote_round: weights_round_pda(program_id, &round_key),
             system_program: SYSTEM_PROGRAM,
         }
         .to_account_metas(None),
@@ -143,63 +159,109 @@ fn last_weights_update(svm: &LiteSVM, program_id: &Pubkey) -> i64 {
     Config::try_deserialize(&mut a.data.as_slice()).unwrap().last_weights_update
 }
 
+/// Validator-set pubkeys in config order (the hash binds keys in this order).
+fn val_keys(vals: &[Keypair]) -> Vec<Pubkey> {
+    vals.iter().map(|v| v.pubkey()).collect()
+}
+
 #[test]
 fn test_vote_set_weights_quorum() {
     let (mut svm, program_id, vals) = setup_vals(3); // 2-of-3
+    let keys = val_keys(&vals);
     let new = vec![10u64, 20, 30];
 
-    send(&mut svm, vote_weights_ix(&program_id, &vals[0].pubkey(), new.clone()), &vals[0].pubkey(), &vals[0]).expect("v0");
+    send(&mut svm, vote_weights_ix(&program_id, &vals[0].pubkey(), &keys, new.clone()), &vals[0].pubkey(), &vals[0]).expect("v0");
     assert_eq!(all_weights(&svm, &program_id), vec![1, 1, 1], "below quorum → unchanged");
 
-    send(&mut svm, vote_weights_ix(&program_id, &vals[1].pubkey(), new.clone()), &vals[1].pubkey(), &vals[1]).expect("v1");
+    send(&mut svm, vote_weights_ix(&program_id, &vals[1].pubkey(), &keys, new.clone()), &vals[1].pubkey(), &vals[1]).expect("v1");
     assert_eq!(all_weights(&svm, &program_id), new, "quorum → weights applied (index-aligned)");
     assert_eq!(last_weights_update(&svm, &program_id), BASE_TS, "cadence stamp set");
 }
 
 #[test]
-fn test_vote_set_weights_hash_binding() {
+fn test_vote_set_weights_divergent_vectors_never_co_count() {
     let (mut svm, program_id, vals) = setup_vals(3);
-    send(&mut svm, vote_weights_ix(&program_id, &vals[0].pubkey(), vec![10, 20, 30]), &vals[0].pubkey(), &vals[0]).expect("v0");
-    // second validator submits a DIFFERENT vector → rejected by the bound hash, no quorum.
-    let mism = send(&mut svm, vote_weights_ix(&program_id, &vals[1].pubkey(), vec![10, 20, 31]), &vals[1].pubkey(), &vals[1]);
-    assert!(mism.is_err(), "divergent weight vectors must not co-count");
-    assert_eq!(all_weights(&svm, &program_id), vec![1, 1, 1], "unchanged");
+    let keys = val_keys(&vals);
+    send(&mut svm, vote_weights_ix(&program_id, &vals[0].pubkey(), &keys, vec![10, 20, 30]), &vals[0].pubkey(), &vals[0]).expect("v0");
+    // A different vector lands in its OWN hash-keyed round — accepted, but the two never co-count.
+    send(&mut svm, vote_weights_ix(&program_id, &vals[1].pubkey(), &keys, vec![10, 20, 31]), &vals[1].pubkey(), &vals[1])
+        .expect("divergent vector opens its own round");
+    assert_eq!(all_weights(&svm, &program_id), vec![1, 1, 1], "neither proposal has quorum → unchanged");
+}
+
+#[test]
+fn test_vote_set_weights_junk_vote_cannot_freeze_updates() {
+    // The old singleton round let one junk vote park a wrong hash and block every honest vote for the
+    // round TTL (30 min). Hash-keyed rounds: the junk proposal coexists and the honest one completes.
+    let (mut svm, program_id, vals) = setup_vals(3);
+    let keys = val_keys(&vals);
+    send(&mut svm, vote_weights_ix(&program_id, &vals[2].pubkey(), &keys, vec![9, 9, 9]), &vals[2].pubkey(), &vals[2]).expect("junk vote");
+
+    let agreed = vec![10u64, 20, 30];
+    send(&mut svm, vote_weights_ix(&program_id, &vals[0].pubkey(), &keys, agreed.clone()), &vals[0].pubkey(), &vals[0]).expect("v0");
+    send(&mut svm, vote_weights_ix(&program_id, &vals[1].pubkey(), &keys, agreed.clone()), &vals[1].pubkey(), &vals[1]).expect("v1");
+    assert_eq!(all_weights(&svm, &program_id), agreed, "honest quorum lands despite the junk proposal");
+}
+
+#[test]
+fn test_vote_set_weights_round_key_must_match_weights() {
+    // The PDA seed must BE the snapshot hash — a mismatched round_key would let a voter route an
+    // arbitrary vector into another proposal's round.
+    let (mut svm, program_id, vals) = setup_vals(3);
+    let keys = val_keys(&vals);
+    let lying_key = weights_round_key(&keys, &[1, 2, 3]); // hash of a DIFFERENT vector
+    let ix = Instruction::new_with_bytes(
+        program_id,
+        &allways_swap_manager::instruction::VoteSetWeights { weights: vec![10, 20, 30], round_key: lying_key }.data(),
+        allways_swap_manager::accounts::VoteSetWeights {
+            validator: vals[0].pubkey(),
+            config: config_pda(&program_id),
+            vote_round: weights_round_pda(&program_id, &lying_key),
+            system_program: SYSTEM_PROGRAM,
+        }
+        .to_account_metas(None),
+    );
+    let r = send(&mut svm, ix, &vals[0].pubkey(), &vals[0]);
+    assert!(r.is_err(), "round_key != keccak(snapshot) must be rejected");
 }
 
 #[test]
 fn test_vote_set_weights_wrong_length_rejected() {
     let (mut svm, program_id, vals) = setup_vals(3);
-    let r = send(&mut svm, vote_weights_ix(&program_id, &vals[0].pubkey(), vec![10, 20]), &vals[0].pubkey(), &vals[0]);
+    let keys = val_keys(&vals);
+    let r = send(&mut svm, vote_weights_ix(&program_id, &vals[0].pubkey(), &keys, vec![10, 20]), &vals[0].pubkey(), &vals[0]);
     assert!(r.is_err(), "weights length must match the validator set");
 }
 
 #[test]
 fn test_vote_set_weights_non_validator_rejected() {
-    let (mut svm, program_id, _vals) = setup_vals(3);
+    let (mut svm, program_id, vals) = setup_vals(3);
+    let keys = val_keys(&vals);
     let outsider = Keypair::new();
     svm.airdrop(&outsider.pubkey(), 10_000_000_000).unwrap();
-    let r = send(&mut svm, vote_weights_ix(&program_id, &outsider.pubkey(), vec![10, 20, 30]), &outsider.pubkey(), &outsider);
+    let r = send(&mut svm, vote_weights_ix(&program_id, &outsider.pubkey(), &keys, vec![10, 20, 30]), &outsider.pubkey(), &outsider);
     assert!(r.is_err(), "non-validator cannot vote weights");
 }
 
 #[test]
 fn test_vote_set_weights_cadence_floor() {
     let (mut svm, program_id, vals) = setup_vals(3);
+    let keys = val_keys(&vals);
     let first = vec![10u64, 20, 30];
 
     // First update succeeds (last_weights_update starts at 0).
-    send(&mut svm, vote_weights_ix(&program_id, &vals[0].pubkey(), first.clone()), &vals[0].pubkey(), &vals[0]).expect("v0");
-    send(&mut svm, vote_weights_ix(&program_id, &vals[1].pubkey(), first.clone()), &vals[1].pubkey(), &vals[1]).expect("v1");
+    send(&mut svm, vote_weights_ix(&program_id, &vals[0].pubkey(), &keys, first.clone()), &vals[0].pubkey(), &vals[0]).expect("v0");
+    send(&mut svm, vote_weights_ix(&program_id, &vals[1].pubkey(), &keys, first.clone()), &vals[1].pubkey(), &vals[1]).expect("v1");
     assert_eq!(all_weights(&svm, &program_id), first);
 
     // Immediate re-vote → rejected by the cadence floor (even the first voter).
-    let too_soon = send(&mut svm, vote_weights_ix(&program_id, &vals[0].pubkey(), vec![5, 5, 5]), &vals[0].pubkey(), &vals[0]);
+    let too_soon = send(&mut svm, vote_weights_ix(&program_id, &vals[0].pubkey(), &keys, vec![5, 5, 5]), &vals[0].pubkey(), &vals[0]);
     assert!(too_soon.is_err(), "update faster than the floor must be rejected");
 
     // Warp past the floor → a fresh update succeeds.
     set_clock(&mut svm, BASE_TS + WEIGHTS_MIN_INTERVAL + 1);
     let second = vec![7u64, 8, 9];
-    send(&mut svm, vote_weights_ix(&program_id, &vals[0].pubkey(), second.clone()), &vals[0].pubkey(), &vals[0]).expect("v0b");
-    send(&mut svm, vote_weights_ix(&program_id, &vals[1].pubkey(), second.clone()), &vals[1].pubkey(), &vals[1]).expect("v1b");
+    send(&mut svm, vote_weights_ix(&program_id, &vals[0].pubkey(), &keys, second.clone()), &vals[0].pubkey(), &vals[0]).expect("v0b");
+    send(&mut svm, vote_weights_ix(&program_id, &vals[1].pubkey(), &keys, second.clone()), &vals[1].pubkey(), &vals[1]).expect("v1b");
     assert_eq!(all_weights(&svm, &program_id), second, "update allowed once the floor elapsed");
 }

--- a/tests/test_solana_client_integration.py
+++ b/tests/test_solana_client_integration.py
@@ -94,7 +94,7 @@ def test_b0_round_trip(client):
         max_collateral=0,
         fulfillment_timeout_secs=12_600,
         consensus_threshold_percent=66,
-        min_swap_amount=0,
+        min_swap_amount=1000,  # hard dust floor — 0-unbounded was removed (L4a)
         max_swap_amount=0,
         reservation_ttl_secs=1_800,
     )

--- a/tests/test_solana_vote_builders.py
+++ b/tests/test_solana_vote_builders.py
@@ -185,6 +185,7 @@ def test_mark_fulfilled_ix(client):
     )
     assert _metas(ix) == [
         (client.keypair.pubkey(), True, False),
+        (pdas.miner_state_pda(client.keypair.pubkey(), PID), False, True),
         (pdas.swap_pda(SK, PID), False, True),
     ]
 


### PR DESCRIPTION
Contract-side hardening from the Solana-migration review, batched into one program change + IDL regen. Stays entirely in the Rust program and Solana client — no `scoring.py` / `rate.py` changes (coordinated split with the in-flight scoring work).

## Items

| Item | Change |
|---|---|
| **H3** | `bind_hotkey` requires a registered miner (`collateral >= min_collateral`) so the set-once hotkey marker can't be squatted across the public metagraph |
| **M4** | consensus threshold floored at majority (51); quorum tallies only *current-set* voters (a removed validator's stale vote can't count); weights round keyed by the snapshot hash so a divergent/junk vote can't freeze updates |
| **L3** | `SEED_SLOT_DELAY_SLOTS` 4 → 12 (clears a leader window; still far below the SlotHashes ring) |
| **L4a** | confirm fee floored at 1 lamport; `min_swap_amount` (no 0-unbounded escape) and `reservation_fee` floored so admin can't zero the anti-grief brakes |
| **M1** | `require!(user != miner)` + reject the default pubkey at `finalize_reservation`, with a `vote_initiate` backstop |
| **M3** | `apply_penalty` auto-deactivation now emits `MinerDeactivated` so event-driven scorers don't keep paying an inactive miner |
| **L1** | `mark_fulfilled` slides `timeout_at` to now + the dest chain's confirmation window (capped by the frozen ceiling); `timeout_swap` stays callable on Fulfilled so a fake fulfill can't dodge a slash |

## Tests
- 126 Rust LiteSVM tests, all green (new regressions for the H3 gate, M4 threshold/removed-voter/junk-vote coexistence, M1 self-swap + default-pubkey reject, L1 grace + ceiling cap, L4a floors)
- 691 Python tests green (client account-meta updates for `bind_hotkey`, `mark_fulfilled`, `vote_set_weights`)
- IDL + Python client regenerated for the changed instruction shapes

## Deploy note
Program change → needs a redeploy + the regenerated IDL. On this machine `anchor build` requires `--ignore-keys` (deploy keypair vs `declare_id!` mismatch); the program ID was not modified.