### PR TITLE
Add validator-routed mode to alw swap now

### DIFF
--- a/allways/cli/dendrite_lite.py
+++ b/allways/cli/dendrite_lite.py
@@ -2,18 +2,23 @@
 
 Users don't have TAO wallets. This module provides:
 - Ephemeral sr25519 keypair generation/storage for transport-layer auth
-- Validator discovery from metagraph
+- Validator discovery from metagraph (all, or one by hotkey with a disk cache)
 - Dendrite broadcast helper
 """
 
+import json
+import time
 from pathlib import Path
-from typing import List
+from typing import Callable, List, Optional
 
 import bittensor as bt
 
 EPHEMERAL_WALLET_DIR = Path.home() / '.allways' / 'ephemeral_wallet'
 EPHEMERAL_WALLET_NAME = 'allways_ephemeral'
 EPHEMERAL_HOTKEY_NAME = 'default'
+
+AXON_CACHE_FILE = Path.home() / '.allways' / 'axon_cache.json'
+AXON_CACHE_TTL_SECS = 3600
 
 
 def get_ephemeral_wallet() -> bt.Wallet:
@@ -56,6 +61,78 @@ def discover_validators(
         axons.append(axon)
 
     return axons
+
+
+def find_validator_axon(
+    subtensor_factory: Callable[[], bt.Subtensor],
+    netuid: int,
+    hotkey: str,
+    fresh: bool = False,
+) -> Optional[bt.AxonInfo]:
+    """The axon of one specific validator hotkey, with a disk cache so the routed
+    happy path skips the multi-second metagraph sync entirely.
+
+    ``subtensor_factory`` defers the chain connection to the cache-miss path.
+    ``fresh=True`` bypasses the cache (used after a dendrite failure to a cached
+    axon — validators move IPs). Returns None if the hotkey isn't a serving
+    validator on the subnet."""
+    if not fresh:
+        cached = _read_axon_cache(netuid, hotkey)
+        if cached is not None:
+            return cached
+    metagraph = subtensor_factory().metagraph(netuid=netuid)
+    for uid in range(metagraph.n):
+        if metagraph.hotkeys[uid] != hotkey:
+            continue
+        axon = metagraph.axons[uid]
+        if metagraph.validator_permit[uid] and axon.is_serving:
+            _write_axon_cache(netuid, hotkey, axon)
+            return axon
+        return None
+    return None
+
+
+def invalidate_axon_cache() -> None:
+    AXON_CACHE_FILE.unlink(missing_ok=True)
+
+
+def _read_axon_cache(netuid: int, hotkey: str) -> Optional[bt.AxonInfo]:
+    try:
+        entry = json.loads(AXON_CACHE_FILE.read_text())
+        fresh_enough = time.time() - float(entry['cached_at']) < AXON_CACHE_TTL_SECS
+        if entry['netuid'] == netuid and entry['hotkey'] == hotkey and fresh_enough:
+            return bt.AxonInfo(
+                version=entry.get('version', 0),
+                ip=entry['ip'],
+                port=entry['port'],
+                ip_type=entry.get('ip_type', 4),
+                hotkey=hotkey,
+                coldkey=entry.get('coldkey', ''),
+            )
+    except (OSError, ValueError, KeyError, TypeError):
+        pass  # unreadable/stale cache is a miss, never an error
+    return None
+
+
+def _write_axon_cache(netuid: int, hotkey: str, axon: bt.AxonInfo) -> None:
+    try:
+        AXON_CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        AXON_CACHE_FILE.write_text(
+            json.dumps(
+                {
+                    'netuid': netuid,
+                    'hotkey': hotkey,
+                    'ip': axon.ip,
+                    'port': axon.port,
+                    'ip_type': getattr(axon, 'ip_type', 4),
+                    'version': getattr(axon, 'version', 0),
+                    'coldkey': getattr(axon, 'coldkey', ''),
+                    'cached_at': time.time(),
+                }
+            )
+        )
+    except OSError:
+        pass  # best-effort cache
 
 
 def broadcast_synapse(

--- a/allways/cli/main.py
+++ b/allways/cli/main.py
@@ -158,6 +158,7 @@ VALID_CONFIG_KEYS = (
     'solana-network',
     'solana-keypair',
     'btc-network',
+    'router',
     'env',
 )
 
@@ -172,7 +173,7 @@ def config_set(key: str, value: str):
     """Set a configuration value.
 
     [dim]Valid keys:
-        env                 One-liner bundle: sets network + solana-network + btc-network + netuid
+        env                 One-liner bundle: sets network + solana-network + btc-network + netuid + router
         wallet              Bittensor wallet name
         hotkey              Bittensor hotkey name
         network             Bittensor network name (test/finney/local) or ws:// endpoint
@@ -181,6 +182,7 @@ def config_set(key: str, value: str):
         solana-rpc          Custom Solana RPC URL (escape hatch; SOLANA_RPC_URL env wins)
         solana-keypair      Path to the Solana keypair that signs miner/admin ops (SOLANA_KEYPAIR_PATH env wins)
         btc-network         Bitcoin network name (mainnet/testnet4/testnet/signet)
+        router              Validator hotkey (ss58) to route reservations through; "" = self-represent
         program-id          Solana program ID (miner/admin commands)[/dim]
 
     [dim]Networks per chain:

--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -36,10 +36,24 @@ SOLANA_NETWORKS = {
 }
 # Names the BTC provider (BTC_NETWORK env) accepts; endpoints default to public esplora per network.
 BTC_NETWORKS = ('mainnet', 'testnet', 'testnet4', 'signet')
-# One-liner env bundle: `alw config set env testnet|mainnet` sets all three chains' networks + netuid.
+# One-liner env bundle: `alw config set env testnet|mainnet` sets all three chains' networks + netuid
+# + the recommended router (the Ventura Labs validator per network) so reservations are
+# validator-routed out of the box. `alw config set router ""` or --no-router opts out.
 ENV_BUNDLES = {
-    'testnet': {'network': 'test', 'solana-network': 'devnet', 'btc-network': 'testnet4', 'netuid': '19'},
-    'mainnet': {'network': 'finney', 'solana-network': 'mainnet', 'btc-network': 'mainnet', 'netuid': '7'},
+    'testnet': {
+        'network': 'test',
+        'solana-network': 'devnet',
+        'btc-network': 'testnet4',
+        'netuid': '19',
+        'router': '5HicmHG7fjbxrtx8FZNdv4xxS5jSN84KGpMnTHsKtKv9peao',
+    },
+    'mainnet': {
+        'network': 'finney',
+        'solana-network': 'mainnet',
+        'btc-network': 'mainnet',
+        'netuid': '7',
+        'router': '5DtUJ9ytbeCMjovFieNwaxxqRP3DzT6iQPnZTyKmi3n6iXey',
+    },
 }
 
 

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -3,9 +3,10 @@
 Origination is on-chain on Solana, two-phase: the taker BIDS into a per-miner reservation pool
 (`open_or_request`, pair only), a permissionless stake-weighted draw (`resolve_pool`) seats a winner,
 then the seat winner FILLS the reservation (`finalize_reservation`, naming the taker + amounts). `swap
-now` is the unrouted-taker path — the taker is its own router: bid → self-crank the draw → finalize
-against the pinned rate → then send source funds + `swap post-tx`. Self-cranking the draw means an
-unrouted taker never waits on validator liveness."""
+now` runs either self-represented (the taker is its own router: bid → self-crank the draw → finalize
+against the pinned rate) or validator-routed (a `SwapReserveSynapse` asks the configured router
+validator to enter the pool with its stake weight and finalize the won seat with the taker pinned).
+Either way the tail is the same: send source funds + `swap post-tx`."""
 
 import json
 import time
@@ -14,13 +15,22 @@ from typing import NamedTuple, Optional
 import click
 
 from allways.chains import SUPPORTED_CHAINS, get_chain
+from allways.cli.dendrite_lite import (
+    broadcast_synapse,
+    find_validator_axon,
+    get_ephemeral_wallet,
+    invalidate_axon_cache,
+    resolve_dendrite_timeout,
+)
 from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
     FINITE_FLOAT,
     PENDING_SWAP_FILE,
     console,
     fail,
+    get_cli_context,
     get_solana_cli_context,
+    hotkey_bytes_to_ss58,
     live_unclaimed,
 )
 from allways.cli.swap_commands.swap_intake import (
@@ -30,8 +40,10 @@ from allways.cli.swap_commands.swap_intake import (
     select_best_miner,
     to_smallest_units,
 )
-from allways.constants import FEE_DIVISOR, NUMERAIRE_CHAIN
+from allways.cli.validator_rejections import render_and_aggregate
+from allways.constants import FEE_DIVISOR, NETUID_FINNEY, NUMERAIRE_CHAIN
 from allways.solana.rpc import TransientRpcError
+from allways.synapses import SwapReserveSynapse
 from allways.utils.rate import apply_fee_deduction, directional_rate
 
 
@@ -49,6 +61,9 @@ class PoolContention(NamedTuple):
     bidders: int  # distinct bids already in the round (before you join)
     closes_in: int  # seconds until the window closes
     weighted_rivals: int  # existing bidders that are weighted validators (0 => the draw is uniform)
+    from_chain: str = ''  # the open round's pair + PINNED rate — every fill this round settles at it,
+    to_chain: str = ''  # so a preview must quote it, not the (possibly drifted) live quote
+    rate: int = 0
 
 
 def _pool_contention(client, miner, cfg) -> PoolContention:
@@ -62,7 +77,15 @@ def _pool_contention(client, miner, cfg) -> PoolContention:
         reqs = list(getattr(pool, 'requests', []))
         weighted = {bytes(v.key) for v in getattr(cfg, 'validators', []) if int(getattr(v, 'weight', 0)) > 0}
         weighted_rivals = sum(1 for r in reqs if bytes(r.router) in weighted)
-        return PoolContention(True, len(reqs), max(0, int(pool.closes_at) - now), weighted_rivals)
+        return PoolContention(
+            True,
+            len(reqs),
+            max(0, int(pool.closes_at) - now),
+            weighted_rivals,
+            str(getattr(pool, 'from_chain', '') or ''),
+            str(getattr(pool, 'to_chain', '') or ''),
+            int(getattr(pool, 'rate', 0) or 0),
+        )
     except Exception:  # noqa: BLE001 - visibility only; a bad read must not stop the swap
         return PoolContention(False, 0, 0, 0)
 
@@ -151,6 +174,85 @@ def _poll_reservation(client, miner, timeout_secs: int):
     return None
 
 
+class _RoutedUnavailable(Exception):
+    """A routed attempt failed BEFORE any pool was entered on our behalf (no axon, rejected, or the
+    dendrite went unanswered) — safe to offer the self-represented path instead."""
+
+
+_ROUTED_SLACK_SECS = 30
+
+
+def _send_reserve_synapse(axon, synapse) -> tuple:
+    """One dendrite round-trip to the router. Returns (accepted, reason, pool_closes_at)."""
+    responses = broadcast_synapse(get_ephemeral_wallet(), [axon], synapse, resolve_dendrite_timeout(60.0))
+    info = render_and_aggregate(console, responses, label='router')
+    resp = responses[0] if responses else None
+    accepted = bool(getattr(resp, 'accepted', False))
+    reason = getattr(resp, 'rejection_reason', None) or info.headline or 'no response from the router'
+    return accepted, reason, int(getattr(resp, 'pool_closes_at', 0) or 0)
+
+
+def _reserve_routed(client, miner, user, router_hotkey, netuid, synapse, pool_window, finalize_window):
+    """Validator-routed reservation: ask ``router_hotkey`` to enter the pool for us, then wait for the
+    seat to go live with OUR pubkey pinned — no self-crank, no finalize (the router does both, #558).
+    Raises ``_RoutedUnavailable`` for any failure before a pool was entered; terminal post-entry
+    outcomes (lost, unresolved) ``fail`` with re-run guidance. The subtensor connection is lazy —
+    a fresh axon-cache hit sends the synapse without ever syncing the chain."""
+    memo = {}
+
+    def _subtensor():
+        if 'st' not in memo:
+            _cfg, _wallet, memo['st'], _ = get_cli_context(need_wallet=False)
+        return memo['st']
+
+    axon = find_validator_axon(_subtensor, netuid, router_hotkey)
+    if axon is None:
+        raise _RoutedUnavailable(f'router {router_hotkey[:8]}… is not a serving validator on netuid {netuid}')
+
+    accepted, reason, pool_closes_at = _send_reserve_synapse(axon, synapse)
+    if not accepted:
+        # A cached axon may be stale (validators move IPs): refresh once, then retry the send.
+        fresh_axon = find_validator_axon(_subtensor, netuid, router_hotkey, fresh=True)
+        if fresh_axon is not None and (fresh_axon.ip, fresh_axon.port) != (axon.ip, axon.port):
+            accepted, reason, pool_closes_at = _send_reserve_synapse(fresh_axon, synapse)
+        if not accepted:
+            invalidate_axon_cache()
+            raise _RoutedUnavailable(f'router declined/unreachable: {reason}')
+
+    console.print(
+        f'[green]  Routed[/green] — {router_hotkey[:8]}… entered the pool for you (it pays the entry fee) '
+        'and will finalize if it wins.\n'
+        '  [yellow]Do NOT send any funds yet[/yellow] — wait for the reservation to go live below; '
+        'early deposits are rejected by freshness checks and are not recoverable.'
+    )
+    now = int(time.time())
+    wait = max(pool_closes_at - now, pool_window) + finalize_window + _ROUTED_SLACK_SECS
+    resv = _poll_routed_reservation(client, miner, user, timeout_secs=wait)
+    if resv is None:
+        fail(
+            '  The routed reservation did not resolve in time. No funds moved — do NOT send anything. '
+            'Re-run to try again (resume-safe), or use --no-router to self-represent.'
+        )
+    if str(resv.user) != str(user):
+        fail(
+            '  You lost this round — the seat went to another user. The router paid the entry fee; no funds '
+            'of yours moved. Rates may have moved too — re-running re-quotes fresh for the next round.'
+        )
+    return resv
+
+
+def _poll_routed_reservation(client, miner, user, timeout_secs: int):
+    """Poll until the router's win goes LIVE (finalized). Returns the live reservation as soon as one
+    exists — the caller checks whether it pins OUR pubkey (won) or another user's (lost the pick)."""
+    deadline = time.time() + timeout_secs
+    while time.time() < deadline:
+        resv = client.get_reservation(miner)
+        if live_unclaimed(resv):
+            return resv
+        time.sleep(3)
+    return None
+
+
 @swap_group.command('now', show_disclaimer=True)
 @click.option('--from', 'from_chain_opt', default=None, help='Source chain (e.g. btc, tao)')
 @click.option('--to', 'to_chain_opt', default=None, help='Destination chain (e.g. btc, tao)')
@@ -159,6 +261,8 @@ def _poll_reservation(client, miner, timeout_secs: int):
 @click.option('--from-address', 'from_address_opt', default=None, help='Source address on source chain')
 @click.option('--from-tx-hash', 'from_tx_hash_opt', default=None, help='Source tx hash (skip fund sending)')
 @click.option('--yes', 'skip_confirm', is_flag=True, help='Skip confirmation prompts')
+@click.option('--router', 'router_opt', default=None, help='Validator hotkey to route through (overrides config)')
+@click.option('--no-router', 'no_router', is_flag=True, help='Self-represent even when a router is configured')
 @click.option(
     '--btc-fee-rate',
     'btc_fee_rate_opt',
@@ -179,11 +283,17 @@ def swap_now_command(
     from_address_opt: Optional[str],
     from_tx_hash_opt: Optional[str],
     skip_confirm: bool,
+    router_opt: Optional[str],
+    no_router: bool,
     btc_fee_rate_opt: Optional[int],
 ):
     """Originate a swap: reserve a miner on-chain, then send source funds.
 
-    [dim]Flag-driven form (interactive prompts + auto fund-sending land next):
+    [dim]Routed by default when a router is configured (`alw config set router <validator-hotkey>`):
+    the validator enters the pool with its stake weight and finalizes for you. --no-router
+    self-represents (you bid, crank, and finalize yourself, paying the entry fee).
+
+    Flag-driven form (interactive prompts + auto fund-sending land next):
         alw swap now --from sol --to btc --amount 1.0 --receive-address <btc-addr> --yes[/dim]
     """
     from_chain = (from_chain_opt or '').lower()
@@ -197,8 +307,11 @@ def swap_now_command(
     if not receive_address_opt:
         fail('--receive-address (destination chain) is required.')
 
-    _config, client = get_solana_cli_context(need_keypair=True)
+    config, client = get_solana_cli_context(need_keypair=True)
+    config = config or {}
     user = client.keypair.pubkey()
+    router_hotkey = (router_opt or config.get('router') or '').strip()
+    routed = bool(router_hotkey) and not no_router
     user_from_addr = str(user) if from_chain == NUMERAIRE_CHAIN else (from_address_opt or '')
     if not user_from_addr:
         fail(f'--from-address (your source-chain address) is required for a non-{NUMERAIRE_CHAIN.upper()} source.')
@@ -207,6 +320,7 @@ def swap_now_command(
     min_swap = int(getattr(cfg, 'min_swap_amount', 0)) if cfg else 0
     max_swap = int(getattr(cfg, 'max_swap_amount', 0)) if cfg else 0
     pool_window = int(getattr(cfg, 'pool_window_secs', 60)) if cfg else 60
+    finalize_window = int(getattr(cfg, 'finalize_window_secs', 150)) if cfg else 150
 
     from_amount = to_smallest_units(amount_opt, from_chain)
     candidates = candidate_miners(client, from_chain, to_chain)
@@ -216,15 +330,6 @@ def swap_now_command(
     if best is None:
         fail('No miner can fund an executable swap for that amount within bounds.')
     cand, amts = best
-    # Quote the NET dest leg — the miner delivers `to_amount` less the protocol fee, same as
-    # `alw swap quote`. The gross `to_amount` is what gets pinned on-chain, not what you receive.
-    recv = apply_fee_deduction(amts.to_amount, FEE_DIVISOR) / 10 ** get_chain(to_chain).decimals
-
-    rate_disp = directional_rate(from_chain, to_chain, cand.rate_display)
-    console.print(
-        f'\n  Swap [cyan]{amount_opt} {from_chain.upper()}[/cyan] -> ~[cyan]{recv:.8g} {to_chain.upper()}[/cyan]'
-        f'  (miner [dim]{str(cand.miner)[:8]}…[/dim], rate {rate_disp} {to_chain.upper()}/{from_chain.upper()})\n'
-    )
 
     # Resume a seat this taker already holds rather than paying for a second bid: a prior run may have
     # bid + drawn (or even finalized) but crashed on a transient RPC before instructing the send. The
@@ -234,70 +339,113 @@ def swap_now_command(
     resume_drawn = not resume_live and _drawn_unfilled(existing) and str(getattr(existing, 'router', '')) == str(user)
     resuming = resume_live or resume_drawn
 
-    # Pool contention — surface it BEFORE the fee-charging bid so the taker isn't bidding blind into an
-    # already-open, contested round (skipped when resuming, since no new bid is placed).
+    # Pool contention — surface it BEFORE the fee-charging entry so the taker isn't entering blind into
+    # an already-open, contested round (skipped when resuming, since no new entry is placed).
     contention = _pool_contention(client, cand.miner, cfg)
+
+    # Every fill in an open round settles at the round's PINNED rate — preview that, not the live
+    # quote (which can drift after the pool opened and would show a receive the fill won't honor).
+    pinned = contention.is_open and (contention.from_chain, contention.to_chain) == (from_chain, to_chain)
+    if pinned and contention.rate > 0:
+        amts = compute_intake_amounts(from_chain, to_chain, from_amount, rate_display_from_fixed(contention.rate))
+    # Quote the NET dest leg — the miner delivers `to_amount` less the protocol fee, same as
+    # `alw swap quote`. The gross `to_amount` is what gets pinned on-chain, not what you receive.
+    recv = apply_fee_deduction(amts.to_amount, FEE_DIVISOR) / 10 ** get_chain(to_chain).decimals
+
+    rate_display = rate_display_from_fixed(contention.rate) if pinned and contention.rate > 0 else cand.rate_display
+    rate_disp = directional_rate(from_chain, to_chain, rate_display)
+    pinned_note = ' (pinned pool rate)' if pinned and contention.rate > 0 else ''
+    console.print(
+        f'\n  Swap [cyan]{amount_opt} {from_chain.upper()}[/cyan] -> ~[cyan]{recv:.8g} {to_chain.upper()}[/cyan]'
+        f'  (miner [dim]{str(cand.miner)[:8]}…[/dim], rate {rate_disp} '
+        f'{to_chain.upper()}/{from_chain.upper()}{pinned_note})\n'
+    )
     if contention.is_open and not resuming:
         fee_sol = int(getattr(cfg, 'reservation_fee_lamports', 0)) / 10 ** get_chain(NUMERAIRE_CHAIN).decimals
         if contention.weighted_rivals > 0:
+            hopeless = '' if routed else ', so a self-represented taker is very unlikely to win this draw'
             console.print(
-                f'  [yellow]This miner already has an open bid pool[/yellow]: {contention.bidders} bidder(s), '
-                f'closes in {contention.closes_in}s — and a weighted validator is bidding, so an unrouted '
-                f'taker is very unlikely to win this draw.'
+                f'  [yellow]This miner already has an open pool[/yellow]: {contention.bidders} entrant(s), '
+                f'closes in {contention.closes_in}s — a weighted validator is competing{hopeless}.'
             )
         else:
             odds = 100.0 / (contention.bidders + 1)
             console.print(
-                f'  [yellow]This miner already has an open bid pool[/yellow]: {contention.bidders} taker(s) '
-                f'bidding, closes in {contention.closes_in}s. Joining makes {contention.bidders + 1}; the draw '
+                f'  [yellow]This miner already has an open pool[/yellow]: {contention.bidders} entrant(s), '
+                f'closes in {contention.closes_in}s. Joining makes {contention.bidders + 1}; the draw '
                 f'is uniform, so ~[cyan]{odds:.0f}%[/cyan] odds to win the seat.'
             )
-        console.print(f'  [dim]A losing bid still spends the {fee_sol:g} SOL reservation fee.[/dim]')
+        fee_note = (
+            'Your router pays the entry fee, win or lose.'
+            if routed
+            else f'A losing entry still spends the {fee_sol:g} SOL reservation fee.'
+        )
+        console.print(f'  [dim]{fee_note}[/dim]')
 
-    if not resuming and not skip_confirm and not click.confirm('  Bid on this miner on-chain?', default=False):
-        return
+    if not resuming and not skip_confirm:
+        prompt = (
+            f'  Ask {router_hotkey[:8]}… to reserve this miner for you? (the validator pays the entry fee)'
+            if routed
+            else '  Bid on this miner on-chain?'
+        )
+        if not click.confirm(prompt, default=False):
+            return
 
-    # Phases 1-3 — obtain a live reservation held by us: resume an existing seat if we have one,
-    # otherwise bid, self-crank the draw, and finalize against the PINNED rate.
+    # Obtain a live reservation held by us: resume an existing seat, route through the validator,
+    # or self-represent (bid, self-crank the draw, finalize against the PINNED rate).
     if resume_live:
         console.print('[green]  Resuming the reservation you already hold[/green] (skipping bid + finalize).')
         resv = existing
+    elif routed and not resume_drawn:
+        try:
+            binding = client.get_binding(cand.miner)
+            if binding is None:
+                raise _RoutedUnavailable('miner has no hotkey binding to route by')
+            console.print(f'  Routing via [cyan]{router_hotkey[:8]}…[/cyan] — the validator enters the pool for you.')
+            synapse = SwapReserveSynapse(
+                miner_hotkey=hotkey_bytes_to_ss58(bytes(binding.hotkey)),
+                from_chain=from_chain,
+                to_chain=to_chain,
+                user_pubkey=str(user),
+                user_from_addr=user_from_addr,
+                user_to_addr=receive_address_opt,
+                from_amount=from_amount,
+            )
+            netuid = int(config.get('netuid') or NETUID_FINNEY)
+            resv = _reserve_routed(
+                client, cand.miner, user, router_hotkey, netuid, synapse, pool_window, finalize_window
+            )
+        except _RoutedUnavailable as e:
+            console.print(f'  [yellow]Routing failed[/yellow]: {e}')
+            if not skip_confirm and not click.confirm(
+                '  Enter the pool self-represented instead? You pay the reservation fee yourself.', default=False
+            ):
+                fail('  Aborted — no funds moved. Re-run to retry routing, or use --no-router.')
+            resv = _reserve_self_represented(
+                client,
+                cand.miner,
+                user,
+                user_from_addr,
+                receive_address_opt,
+                from_chain,
+                to_chain,
+                from_amount,
+                pool_window,
+                drawn=None,
+            )
     else:
-        if resume_drawn:
-            console.print('[green]  Resuming the seat you already drew[/green] (skipping bid); finalizing…')
-            drawn = existing
-        else:
-            # Phase 1 — BID (pair only; no taker, no amounts).
-            sig = client.open_or_request(cand.miner, from_chain, to_chain)
-            console.print(f'[green]  Bid placed[/green] (tx {sig[:16]}…). Cranking the draw…')
-
-            # Phase 2 — self-crank the draw until we're seated (unfilled reservation, router == us).
-            drawn = _poll_drawn(client, cand.miner, user, timeout_secs=pool_window + 120)
-            if drawn is None:
-                winner = _lost_seat_to(client, cand.miner, user)
-                if winner:
-                    fail(
-                        f'  You lost the draw — the seat went to [dim]{winner[:8]}…[/dim]. Your reservation fee is '
-                        'spent (non-refundable); do NOT send funds. Re-run to bid on the next round.'
-                    )
-                fail(
-                    '  The draw did not resolve in the bid window (no seat drawn yet). Do NOT send funds; re-run to try again.'
-                )
-
-        # Phase 3 — FINALIZE against the PINNED rate (not the live quote, which can drift after the bid).
-        fill = compute_intake_amounts(from_chain, to_chain, from_amount, rate_display_from_fixed(drawn.rate))
-        client.finalize_reservation(
+        resv = _reserve_self_represented(
+            client,
             cand.miner,
             user,
             user_from_addr,
             receive_address_opt,
-            fill.collateral_amount,
-            fill.from_amount,
-            fill.to_amount,
+            from_chain,
+            to_chain,
+            from_amount,
+            pool_window,
+            drawn=existing if resume_drawn else None,
         )
-        resv = _poll_reservation(client, cand.miner, timeout_secs=30)
-        if resv is None or str(resv.user) != str(user):
-            fail('  Finalize did not produce a live reservation for you. Do NOT send funds; re-run.')
     recv = apply_fee_deduction(int(resv.to_amount), FEE_DIVISOR) / 10 ** get_chain(to_chain).decimals
     console.print(f'[green]  Seat filled[/green] — receiving ~[cyan]{recv:.8g} {to_chain.upper()}[/cyan].')
     # Never instruct a send the reservation can't outlive: a deposit that lands after reserved_until
@@ -316,6 +464,50 @@ def swap_now_command(
         f'[green]  Reserved.[/green] Send [cyan]{amount_opt} {from_chain.upper()}[/cyan] to '
         f'[cyan]{resv.miner_from_addr}[/cyan], then run [bold]alw swap post-tx[/bold] with the tx hash.'
     )
+
+
+def _reserve_self_represented(
+    client, miner, user, user_from_addr, user_to_addr, from_chain, to_chain, from_amount, pool_window, drawn=None
+):
+    """Self-represented phases 1-3: bid (unless resuming a ``drawn`` seat), self-crank the draw, and
+    finalize against the PINNED rate. Returns the live reservation or ``fail``s with send-safety
+    guidance — a taker must never send funds without a live reservation pinning them."""
+    if drawn is not None:
+        console.print('[green]  Resuming the seat you already drew[/green] (skipping bid); finalizing…')
+    else:
+        # Phase 1 — BID (pair only; no taker, no amounts).
+        sig = client.open_or_request(miner, from_chain, to_chain)
+        console.print(f'[green]  Bid placed[/green] (tx {sig[:16]}…). Cranking the draw…')
+
+        # Phase 2 — self-crank the draw until we're seated (unfilled reservation, router == us).
+        drawn = _poll_drawn(client, miner, user, timeout_secs=pool_window + 120)
+        if drawn is None:
+            winner = _lost_seat_to(client, miner, user)
+            if winner:
+                fail(
+                    f'  You lost the draw — the seat went to [dim]{winner[:8]}…[/dim]. Your reservation fee is '
+                    'spent (non-refundable); do NOT send funds. Rates may have moved — re-running re-quotes '
+                    'fresh for the next round.'
+                )
+            fail(
+                '  The draw did not resolve in the bid window (no seat drawn yet). Do NOT send funds; re-run to try again.'
+            )
+
+    # Phase 3 — FINALIZE against the PINNED rate (not the live quote, which can drift after the bid).
+    fill = compute_intake_amounts(from_chain, to_chain, from_amount, rate_display_from_fixed(drawn.rate))
+    client.finalize_reservation(
+        miner,
+        user,
+        user_from_addr,
+        user_to_addr,
+        fill.collateral_amount,
+        fill.from_amount,
+        fill.to_amount,
+    )
+    resv = _poll_reservation(client, miner, timeout_secs=30)
+    if resv is None or str(resv.user) != str(user):
+        fail('  Finalize did not produce a live reservation for you. Do NOT send funds; re-run.')
+    return resv
 
 
 def _save_pending(miner, from_chain: str, to_chain: str) -> None:

--- a/tests/test_finalize_sweep.py
+++ b/tests/test_finalize_sweep.py
@@ -17,7 +17,7 @@ NOW = 1_000_000
 MINER = str(SolKeypair().pubkey())
 USER_A = str(SolKeypair().pubkey())
 USER_B = str(SolKeypair().pubkey())
-RATE_FIXED = int(0.0021 * RATE_PRECISION)  # sol->btc: 0.0021 BTC per 1 SOL
+RATE_FIXED = 21 * RATE_PRECISION // 10_000  # sol->btc: 0.0021 BTC per 1 SOL, exact fixed-point
 
 
 class SweepClient:

--- a/tests/test_network_config.py
+++ b/tests/test_network_config.py
@@ -81,7 +81,7 @@ def test_api_key_composes_onto_network_name(monkeypatch):
 def test_env_bundles_cover_all_three_chains():
     for name in ('testnet', 'mainnet'):
         b = ENV_BUNDLES[name]
-        assert set(b) == {'network', 'solana-network', 'btc-network', 'netuid'}
+        assert set(b) == {'network', 'solana-network', 'btc-network', 'netuid', 'router'}
         assert b['solana-network'] in SOLANA_NETWORKS
         assert b['btc-network'] in BTC_NETWORKS
 

--- a/tests/test_swap_routed.py
+++ b/tests/test_swap_routed.py
@@ -1,0 +1,296 @@
+"""`alw swap now` validator-routed mode: dendrite reserve → wait for the router's finalize.
+
+Drives the command with a stubbed chain/client (same harness as test_swap_now_reservation) and a
+patched dendrite layer. Covers mode selection, the routed happy path, lost/unresolved outcomes,
+the confirm-or-abort native fallback, send-safety messaging, and the axon disk cache.
+"""
+
+import time
+import types
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from allways.cli.swap_commands.swap import swap_now_command
+
+USER = '68ToGUYjjYpqi7Atx7QyhbybR2RCfo2tkmgcoNR3DxYF'
+ROUTER = '5DtUJ9ytbeCMjovFieNwaxxqRP3DzT6iQPnZTyKmi3n6iXey'
+EMPTY = bytes(32)
+
+
+def _live_resv(user=USER):
+    return types.SimpleNamespace(
+        reserved_until=int(time.time()) + 400,
+        claimed_swap_key=EMPTY,
+        user=user,
+        miner_from_addr='miner-addr',
+        to_amount=10**9,
+    )
+
+
+def _client(reservations):
+    client = MagicMock()
+    client.keypair.pubkey.return_value = USER
+    client.get_config.return_value = types.SimpleNamespace(
+        min_swap_amount=1, max_swap_amount=10**18, pool_window_secs=60, finalize_window_secs=150
+    )
+    client.get_reservation.side_effect = reservations
+    client.get_binding.return_value = types.SimpleNamespace(hotkey=b'\x11' * 32)
+    return client
+
+
+def _accepted(pool_closes_at=None):
+    return types.SimpleNamespace(
+        accepted=True, rejection_reason=None, pool_closes_at=pool_closes_at or int(time.time()) + 5
+    )
+
+
+def _flat(result) -> str:
+    return ' '.join(result.output.split())
+
+
+AXON = types.SimpleNamespace(ip='1.2.3.4', port=8091, ip_type=4, version=0, coldkey='', is_serving=True)
+
+
+def _run(client, *, argv_extra=(), responses=None, axon=AXON, config=None, confirm_input=None):
+    amts = types.SimpleNamespace(collateral_amount=10**9, from_amount=5000, to_amount=10**9)
+    cand = types.SimpleNamespace(miner='miner-pk', rate_display='0.0021', collateral=10**10)
+    argv = ['--from', 'btc', '--to', 'sol', '--amount', '0.00005', '--from-address', 'tb1qsource']
+    argv += ['--receive-address', USER, *argv_extra]
+    info = types.SimpleNamespace(headline='router unreachable', accepted=0)
+    with (
+        patch('allways.cli.swap_commands.swap.get_solana_cli_context', return_value=(config, client)),
+        patch('allways.cli.swap_commands.swap.candidate_miners', return_value=[cand]),
+        patch('allways.cli.swap_commands.swap.select_best_miner', return_value=(cand, amts)),
+        patch('allways.cli.swap_commands.swap.find_validator_axon', return_value=axon) as find_axon,
+        patch('allways.cli.swap_commands.swap.get_ephemeral_wallet'),
+        patch('allways.cli.swap_commands.swap.broadcast_synapse', return_value=responses or []) as broadcast,
+        patch('allways.cli.swap_commands.swap.render_and_aggregate', return_value=info),
+        patch(
+            'allways.cli.swap_commands.swap.get_cli_context', return_value=({'netuid': '7'}, None, MagicMock(), None)
+        ),
+        patch('allways.cli.swap_commands.swap._save_pending') as save_pending,
+        patch('allways.cli.swap_commands.swap.time.sleep'),
+    ):
+        result = CliRunner().invoke(swap_now_command, argv, input=confirm_input)
+    return result, broadcast, save_pending, find_axon
+
+
+def test_routed_happy_path_waits_for_router_finalize():
+    client = _client([None, _live_resv()])  # no resume seat, then the router's finalize goes live
+    r, broadcast, save_pending, _ = _run(client, argv_extra=['--router', ROUTER, '--yes'], responses=[_accepted()])
+    assert r.exit_code == 0, r.output
+    synapse = broadcast.call_args.args[2]
+    assert (synapse.user_pubkey, synapse.from_chain, synapse.to_chain) == (USER, 'btc', 'sol')
+    assert 'Do NOT send any funds yet' in _flat(r)
+    assert save_pending.called
+    # never self-cranks or finalizes in routed mode
+    assert not client.open_or_request.called and not client.finalize_reservation.called
+
+
+def test_routed_never_prints_deposit_address_before_live():
+    """Send-safety: the waiting stage must not reveal where to send."""
+    client = _client([None, _live_resv()])
+    r, *_ = _run(client, argv_extra=['--router', ROUTER, '--yes'], responses=[_accepted()])
+    out = _flat(r)
+    warn_at = out.index('Do NOT send any funds yet')
+    addr_at = out.index('miner-addr')
+    assert warn_at < addr_at
+
+
+def test_routed_lost_to_other_user_fails_with_rerun_hint():
+    client = _client([None, _live_resv(user='SomeoneElse')])
+    r, _, save_pending, _ = _run(client, argv_extra=['--router', ROUTER, '--yes'], responses=[_accepted()])
+    assert r.exit_code != 0
+    out = _flat(r)
+    assert 'lost this round' in out and 're-quotes fresh' in out
+    assert not save_pending.called
+
+
+def test_routed_unresolved_deadline_fails_safely():
+    client = _client(lambda *_a: None)  # reservation never appears
+    client.get_reservation.side_effect = None
+    client.get_reservation.return_value = None
+    # Advance a fake clock 30s per read so the ~240s poll deadline elapses in a few iterations
+    # (a real clock would spin the no-op-sleep loop for minutes and bloat mock call history).
+    base = time.time()
+    ticks = iter(range(0, 100_000, 30))
+    with patch('allways.cli.swap_commands.swap.time.time', side_effect=lambda: base + next(ticks)):
+        r, _, save_pending, _ = _run(
+            client, argv_extra=['--router', ROUTER, '--yes'], responses=[_accepted(pool_closes_at=int(base) + 5)]
+        )
+    assert r.exit_code != 0
+    assert 'No funds moved' in _flat(r) and not save_pending.called
+
+
+def test_routed_failure_fallback_declined_aborts():
+    client = _client([None])
+    r, _, save_pending, _ = _run(
+        client, argv_extra=['--router', ROUTER], axon=None, confirm_input='y\nn\n'
+    )  # confirm the ask prompt, decline the fallback
+    assert r.exit_code != 0
+    assert 'Routing failed' in _flat(r) and 'no funds moved' in _flat(r)
+    assert not client.open_or_request.called and not save_pending.called
+
+
+def test_routed_failure_with_yes_falls_back_to_self_represented():
+    drawn = types.SimpleNamespace(
+        router=USER, reserved_until=0, finalize_by=int(time.time()) + 60, rate=int(0.0021 * 10**18)
+    )
+    client = _client([None])
+    with (
+        patch('allways.cli.swap_commands.swap._poll_drawn', return_value=drawn),
+        patch('allways.cli.swap_commands.swap._poll_reservation', return_value=_live_resv()),
+    ):
+        r, _, save_pending, _ = _run(client, argv_extra=['--router', ROUTER, '--yes'], axon=None)
+    assert r.exit_code == 0, r.output
+    assert 'Routing failed' in _flat(r)
+    assert client.open_or_request.called and client.finalize_reservation.called  # native path ran
+    assert save_pending.called
+
+
+def test_no_router_forces_self_represented_despite_config():
+    drawn = types.SimpleNamespace(
+        router=USER, reserved_until=0, finalize_by=int(time.time()) + 60, rate=int(0.0021 * 10**18)
+    )
+    client = _client([None])
+    with (
+        patch('allways.cli.swap_commands.swap._poll_drawn', return_value=drawn),
+        patch('allways.cli.swap_commands.swap._poll_reservation', return_value=_live_resv()),
+    ):
+        r, broadcast, _, find_axon = _run(client, argv_extra=['--no-router', '--yes'], config={'router': ROUTER})
+    assert r.exit_code == 0, r.output
+    assert not broadcast.called and not find_axon.called
+    assert client.open_or_request.called
+
+
+def test_router_flag_overrides_config():
+    client = _client([None, _live_resv()])
+    other = '5HicmHG7fjbxrtx8FZNdv4xxS5jSN84KGpMnTHsKtKv9peao'
+    r, _, _, find_axon = _run(
+        client, argv_extra=['--router', other, '--yes'], responses=[_accepted()], config={'router': ROUTER}
+    )
+    assert r.exit_code == 0, r.output
+    assert find_axon.call_args.args[2] == other
+
+
+def test_rejection_reason_surfaces():
+    client = _client([None])
+    rejected = types.SimpleNamespace(accepted=False, rejection_reason='miner is not active', pool_closes_at=0)
+    r, *_ = _run(client, argv_extra=['--router', ROUTER, '--yes'], responses=[rejected], confirm_input=None)
+    # --yes falls back; native path unpatched -> open_or_request MagicMock succeeds then draw fails,
+    # but the routed failure reason must have been shown first.
+    assert 'miner is not active' in _flat(r)
+
+
+def test_env_bundles_carry_routers_and_config_key_registered():
+    from allways.cli.main import VALID_CONFIG_KEYS
+    from allways.cli.swap_commands.helpers import ENV_BUNDLES
+
+    assert 'router' in VALID_CONFIG_KEYS
+    assert ENV_BUNDLES['mainnet']['router'] == ROUTER
+    assert ENV_BUNDLES['testnet']['router'] == '5HicmHG7fjbxrtx8FZNdv4xxS5jSN84KGpMnTHsKtKv9peao'
+
+
+def test_pinned_pool_rate_drives_preview():
+    """An open pool for the same pair previews the PINNED rate, not the drifted live quote."""
+    pool = types.SimpleNamespace(
+        opened_at=1,
+        closes_at=int(time.time()) + 30,
+        requests=[],
+        from_chain='btc',
+        to_chain='sol',
+        rate=int(500.0 * 10**18),  # pinned; live quote says 0.0021
+    )
+    client = _client([None, _live_resv()])
+    client.get_pool.return_value = pool
+    r, *_ = _run(client, argv_extra=['--router', ROUTER, '--yes'], responses=[_accepted()])
+    assert 'pinned pool rate' in _flat(r)
+
+
+# ─── axon disk cache ─────────────────────────────────────────────────────────
+
+
+def test_axon_cache_hit_skips_metagraph(tmp_path):
+    from allways.cli import dendrite_lite as dl
+
+    with patch.object(dl, 'AXON_CACHE_FILE', tmp_path / 'axon_cache.json'):
+        axon = types.SimpleNamespace(ip='1.2.3.4', port=8091, ip_type=4, version=0, coldkey='', is_serving=True)
+        dl._write_axon_cache(7, ROUTER, axon)
+        factory = MagicMock(side_effect=AssertionError('metagraph must not be read on a cache hit'))
+        got = dl.find_validator_axon(factory, 7, ROUTER)
+        assert (got.ip, got.port) == ('1.2.3.4', 8091)
+        assert not factory.called
+
+
+def test_axon_cache_miss_reads_metagraph_and_writes_cache(tmp_path):
+    from allways.cli import dendrite_lite as dl
+
+    with patch.object(dl, 'AXON_CACHE_FILE', tmp_path / 'axon_cache.json'):
+        axon = types.SimpleNamespace(ip='5.6.7.8', port=1234, ip_type=4, version=0, coldkey='', is_serving=True)
+        metagraph = types.SimpleNamespace(n=1, hotkeys=[ROUTER], axons=[axon], validator_permit=[True])
+        subtensor = MagicMock()
+        subtensor.metagraph.return_value = metagraph
+        got = dl.find_validator_axon(lambda: subtensor, 7, ROUTER)
+        assert got is axon
+        assert dl._read_axon_cache(7, ROUTER) is not None  # cached for next time
+
+
+def test_rerun_requotes_fresh_candidates():
+    """Rate freshness: every invocation re-selects from live quotes — nothing is cached between runs."""
+    for _ in range(2):
+        client = _client([None, _live_resv()])
+        r, _, _, find_axon = _run(client, argv_extra=['--router', ROUTER, '--yes'], responses=[_accepted()])
+        assert r.exit_code == 0, r.output
+        assert find_axon.called  # each run resolved candidates + axon afresh (patched per-run)
+
+
+def test_stale_cached_axon_refreshes_once_then_succeeds():
+    """A dead cached axon triggers ONE fresh lookup + resend before any fallback."""
+    stale = types.SimpleNamespace(ip='9.9.9.9', port=1, ip_type=4, version=0, coldkey='', is_serving=True)
+    fresh = AXON
+    rejected = types.SimpleNamespace(accepted=False, rejection_reason=None, pool_closes_at=0)
+    client = _client([None, _live_resv()])
+    amts = types.SimpleNamespace(collateral_amount=10**9, from_amount=5000, to_amount=10**9)
+    cand = types.SimpleNamespace(miner='miner-pk', rate_display='0.0021', collateral=10**10)
+    argv = ['--from', 'btc', '--to', 'sol', '--amount', '0.00005', '--from-address', 'tb1qsource']
+    argv += ['--receive-address', USER, '--router', ROUTER, '--yes']
+    info = types.SimpleNamespace(headline='no response', accepted=0)
+    with (
+        patch('allways.cli.swap_commands.swap.get_solana_cli_context', return_value=(None, client)),
+        patch('allways.cli.swap_commands.swap.candidate_miners', return_value=[cand]),
+        patch('allways.cli.swap_commands.swap.select_best_miner', return_value=(cand, amts)),
+        patch('allways.cli.swap_commands.swap.find_validator_axon', side_effect=[stale, fresh]) as find_axon,
+        patch('allways.cli.swap_commands.swap.get_ephemeral_wallet'),
+        patch('allways.cli.swap_commands.swap.broadcast_synapse', side_effect=[[rejected], [_accepted()]]) as bc,
+        patch('allways.cli.swap_commands.swap.render_and_aggregate', return_value=info),
+        patch(
+            'allways.cli.swap_commands.swap.get_cli_context', return_value=({'netuid': '7'}, None, MagicMock(), None)
+        ),
+        patch('allways.cli.swap_commands.swap._save_pending') as save_pending,
+        patch('allways.cli.swap_commands.swap.time.sleep'),
+    ):
+        r = CliRunner().invoke(swap_now_command, argv)
+    assert r.exit_code == 0, r.output
+    assert bc.call_count == 2  # stale send, then fresh-axon resend
+    assert find_axon.call_args_list[1].kwargs.get('fresh') is True  # second lookup bypassed the cache
+    assert save_pending.called
+
+
+def test_axon_cache_rejects_wrong_key_and_non_validator(tmp_path):
+    from allways.cli import dendrite_lite as dl
+
+    with patch.object(dl, 'AXON_CACHE_FILE', tmp_path / 'axon_cache.json'):
+        metagraph = types.SimpleNamespace(
+            n=1,
+            hotkeys=[ROUTER],
+            axons=[types.SimpleNamespace(ip='9.9.9.9', port=1, ip_type=4, version=0, coldkey='', is_serving=True)],
+            validator_permit=[False],  # not a validator
+        )
+        subtensor = MagicMock()
+        subtensor.metagraph.return_value = metagraph
+        assert dl.find_validator_axon(lambda: subtensor, 7, ROUTER) is None
+        assert dl.find_validator_axon(lambda: subtensor, 7, 'unknown-hotkey') is None
+        metagraph.validator_permit = [True]
+        metagraph.axons[0].is_serving = False  # validator but axon down
+        assert dl.find_validator_axon(lambda: subtensor, 7, ROUTER) is None


### PR DESCRIPTION
`alw swap now` gains a validator-routed mode: with a `router` configured, the CLI asks that validator to enter the miner's pool (stake-weighted, validator pays the entry fee) via SwapReserveSynapse, then just polls until the reservation goes live with the user pinned — the #558 sweep finalizes server-side. No self-crank, no finalize, no TAO wallet needed (ephemeral transport identity).

- `alw config set router <hotkey>`; `--router`/`--no-router` per swap; `env testnet|mainnet` bundles set the Ventura Labs router per network
- Axon lookup via a disk cache (~/.allways/axon_cache.json, 1h TTL) — the routed happy path never syncs a metagraph; a stale cached axon is invalidated and refreshed once before any fallback
- Routed failure before a pool is entered → confirm-or-abort fallback to self-represented (--yes auto-continues); lost draw/pick → message + re-run hint (re-runs re-quote fresh)
- Send-safety: the deposit address is never rendered pre-live, and the waiting stage warns explicitly — early deposits fail is_tx_fresh and are unrecoverable
- Open-pool previews quote the PINNED pool rate, not the drifted live quote
- Native phases extracted to _reserve_self_represented, byte-identical (all pre-existing swap tests pass)

Also fixes a latent test failure on merged test (#558's sweep test built its pinned rate from an inexact float; #559's 5-sig display exposed it) — test-only, exact fixed-point now.

Tests: full suite 728 passed. Docs: allways-docs-ui #65 → #67 (stacked).