### PR TITLE
fix(solana): register FulfillmentGraceApplied in the event decoder

### DIFF
--- a/allways/solana/layouts.py
+++ b/allways/solana/layouts.py
@@ -203,6 +203,7 @@ ACCOUNT_PUBKEY_FIELDS = {
 EVENT_DISCRIMINATORS = {
     'CollateralPosted': bytes([133, 193, 58, 199, 229, 183, 154, 206]),
     'CollateralWithdrawn': bytes([51, 224, 133, 106, 74, 173, 72, 82]),
+    'FulfillmentGraceApplied': bytes([201, 98, 85, 62, 191, 162, 4, 22]),
     'HaltSet': bytes([72, 72, 136, 23, 166, 26, 205, 223]),
     'HotkeyBound': bytes([168, 26, 136, 137, 160, 137, 120, 133]),
     'MinerActivated': bytes([203, 75, 131, 151, 24, 167, 159, 19]),
@@ -230,6 +231,7 @@ EVENT_DISCRIMINATORS = {
 EVENT_LAYOUTS = {
     'CollateralPosted': CStruct('miner' / Pubkey32, 'amount' / U64, 'total' / U64),
     'CollateralWithdrawn': CStruct('miner' / Pubkey32, 'amount' / U64, 'total' / U64),
+    'FulfillmentGraceApplied': CStruct('swap_key' / Hash32, 'miner' / Pubkey32, 'timeout_at' / I64),
     'HaltSet': CStruct('halted' / Bool),
     'HotkeyBound': CStruct('miner' / Pubkey32, 'hotkey' / Hash32, 'bound_at' / I64),
     'MinerActivated': CStruct('miner' / Pubkey32, 'at' / I64),
@@ -307,6 +309,7 @@ EVENT_LAYOUTS = {
 EVENT_PUBKEY_FIELDS = {
     'CollateralPosted': ['miner'],
     'CollateralWithdrawn': ['miner'],
+    'FulfillmentGraceApplied': ['miner'],
     'HaltSet': [],
     'HotkeyBound': ['miner'],
     'MinerActivated': ['miner'],

--- a/tests/test_solana_events.py
+++ b/tests/test_solana_events.py
@@ -6,6 +6,8 @@ by a fake client.
 """
 
 import hashlib
+import re
+from pathlib import Path
 
 from solders.keypair import Keypair
 
@@ -81,9 +83,34 @@ def test_decode_miner_activated_and_collateral():
     assert name == 'CollateralPosted' and f.total == 9
 
 
+def test_decode_fulfillment_grace_applied_roundtrip():
+    miner = Keypair().pubkey()
+    raw = _encode(
+        'FulfillmentGraceApplied',
+        {'swap_key': bytes(range(32)), 'miner': bytes(miner), 'timeout_at': 1_700_000_222},
+    )
+    name, f = decode_event(raw)
+    assert name == 'FulfillmentGraceApplied'
+    assert f.miner == miner
+    assert bytes(f.swap_key) == bytes(range(32))  # stays raw bytes
+    assert f.timeout_at == 1_700_000_222
+
+
 def test_decode_unknown_discriminator_returns_none():
     assert decode_event(b'\x00' * 8 + b'junk') is None
     assert decode_event(b'\x01\x02') is None  # too short
+
+
+def test_every_contract_event_is_registered():
+    # Every #[event] struct in the program source must decode, or the indexer/validator
+    # silently drop it (decode_event returns None for unknown discriminators).
+    events_rs = (
+        Path(__file__).resolve().parents[1] / 'smart-contracts/solana/programs/allways_swap_manager/src/events.rs'
+    )
+    declared = set(re.findall(r'#\[event\]\s*pub struct (\w+)', events_rs.read_text()))
+    assert declared, 'no #[event] structs parsed from events.rs — pattern drifted?'
+    missing = declared - set(events.EVENT_DISCRIMINATORS)
+    assert not missing, f'contract events missing from the Python decoder registry: {sorted(missing)}'
 
 
 # ---- ingest cursor ----


### PR DESCRIPTION
## What

PR #560 added the new `FulfillmentGraceApplied` event to the contract (`mark_fulfilled` sliding `timeout_at` forward) and the IDL, but never registered it in the Python decoder (`allways/solana/layouts.py`). `decode_event` returns `None` for unknown discriminators, so both consumers silently dropped the event:

- the validator's event index (`allways/validator/event_index.py`)
- the external indexer, which imports `decode_event` from this package

No crash — the event was just invisible, which loses the deadline-change record that swap forensics rely on.

## Changes

- Register `FulfillmentGraceApplied` in `EVENT_DISCRIMINATORS` / `EVENT_LAYOUTS` / `EVENT_PUBKEY_FIELDS` (discriminator matches both the IDL and Anchor's `sha256("event:<Name>")[:8]` formula, verified by the existing test).
- Add a borsh round-trip test for the new event.
- Add `test_every_contract_event_is_registered`: parses `#[event]` structs out of `events.rs` and fails if any is missing from the decoder registry — so the next contract event can't ship without its decoder entry (exactly how this one slipped through #560).

Note `MinerDeactivated` needs nothing: #560 only added a new emit site for an already-registered event.

## Deploy note

Indexer deployments import this package and need a pull + restart after merge. Worth landing before the #560 program upgrade goes on-chain: `mark_fulfilled` emits `SwapFulfilled` + `FulfillmentGraceApplied` in the same tx, and once the indexer ingests the `SwapFulfilled` its cursor moves past the signature, so grace events emitted before the decoder fix deploys are skipped permanently absent a backfill rescan.

## Testing

`tests/test_solana_events.py`: 9 passed (both new tests fail on `test` without the layouts fix — verified via stash).