### PR TITLE
Close scoring event-loss and unfunded-crown gaps

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -68,14 +68,18 @@ DIRECTION_POOLS: dict[tuple[str, str], float] = {
     for spoke in LAUNCH_SPOKES
     for pair in ((NUMERAIRE_CHAIN, spoke), (spoke, NUMERAIRE_CHAIN))
 }
-# Idle-crown penalty: 0 = none, 1 = pure volume share, 0.5 = half-credit floor.
-VOLUME_WEIGHT_ALPHA: float = 0.5
+# Idle-crown penalty: 0 = none, 1 = pure volume share; a zero-fill holder floors at 1-α (0.25).
+VOLUME_WEIGHT_ALPHA: float = 0.75
 # Flat eligibility gate (B3.3): read off the on-chain MinerState counters,
 # replacing the success_rate³ × credibility ramp. A miner is crown-eligible iff
 # it has at least MIN_SUCCESSFUL_SWAPS successes and at most MAX_FAILED_SWAPS
 # failures — a binary 0/1 multiplier, no ramp.
 MIN_SUCCESSFUL_SWAPS: int = 2
 MAX_FAILED_SWAPS: int = 2
+# Live-state reconcile (scoring-round backstop for lost events): a miner's event-derived
+# active/collateral state is only corrected against the live chain read after its event
+# stream has been quiet this long, so a stale RPC read never fights an in-flight event.
+RECONCILE_QUIET_SECS = 600
 
 # ─── Validator stake weights (reservation-lottery draw) ──
 # Each validator derives the same vector — floor(alpha_stake / bucket) per whitelisted

--- a/allways/solana/events.py
+++ b/allways/solana/events.py
@@ -20,6 +20,10 @@ _BY_DISC = {disc: name for name, disc in EVENT_DISCRIMINATORS.items()}
 
 PROGRAM_DATA_PREFIX = 'Program data: '
 
+# Slot age at which poll() stops holding the cursor for an unstamped tx (~2 min): past this the
+# RPC is never going to backfill its blockTime, and holding would wedge ingest forever.
+UNSTAMPED_GIVE_UP_SLOTS = 300
+
 
 def decode_event(raw: bytes) -> Optional[Tuple[str, Any]]:
     """Decode one `Program data:` payload → (event_name, parsed). None for unknown/foreign discriminators
@@ -88,10 +92,19 @@ class SolanaEventIngest:
 
     def poll(self, until_sig: Optional[str]) -> Tuple[List[EventRecord], Optional[str]]:
         """Fetch + decode all events newer than until_sig. Returns (records oldest-first, new_cursor_sig).
-        The cursor is the newest signature seen this pass (unchanged if nothing new)."""
+        The cursor advances only through stamped entries and holds at the first not-yet-stamped
+        (blockTime-less) tip tx, so its events are re-read once stamped instead of skipped forever.
+        An unstamped tx older than UNSTAMPED_GIVE_UP_SLOTS is abandoned (this RPC won't stamp it;
+        holding would wedge the cursor) — the live-state reconcile backstops the loss."""
         entries = self._fetch_new_signatures(until_sig)
+        newest_slot = entries[-1]['slot'] if entries else 0
         records: List[EventRecord] = []
+        new_cursor = until_sig
         for entry in entries:
-            records.extend(self._decode_signature(entry))
-        new_cursor = entries[-1]['signature'] if entries else until_sig
+            unstamped = entry.get('blockTime') is None and entry.get('err') is None
+            if unstamped and newest_slot - entry['slot'] < UNSTAMPED_GIVE_UP_SLOTS:
+                break
+            if not unstamped:
+                records.extend(self._decode_signature(entry))
+            new_cursor = entry['signature']
         return records, new_cursor

--- a/allways/validator/event_index.py
+++ b/allways/validator/event_index.py
@@ -24,7 +24,7 @@ import bittensor as bt
 
 from allways import dev_signal
 from allways.classes import ActivityTransition, MinerActivity
-from allways.constants import RATE_PRECISION
+from allways.constants import RATE_PRECISION, RECONCILE_QUIET_SECS
 from allways.solana.events import EventRecord
 from allways.utils.rate import quantize_rate_fixed
 from allways.validator.state_store import ValidatorStateStore
@@ -63,8 +63,9 @@ class SolanaEventIndex:
     def ingest(self, records: List[EventRecord], attribution: Dict[str, str]) -> int:
         """Persist ``records`` (oldest-first) into the event tables, mapping each event's miner Solana
         pubkey → bound hotkey via ``attribution`` (B3.2 ``build_attribution``). Events from an unbound
-        pubkey, or carrying no ``blockTime`` yet (an unstamped tip tx), are skipped — the cursor stays
-        behind them so a later pass re-ingests once they stamp. Returns the count written."""
+        pubkey are dropped (no UID to credit); ``reconcile_live_state`` later heals any state they carried.
+        Records with no ``blockTime`` are skipped defensively — poll() already holds the cursor before
+        unstamped txs, so none should reach here. Returns the count written."""
         written = 0
         for rec in records:
             block_time = rec.block_time
@@ -164,6 +165,30 @@ class SolanaEventIndex:
             bt.logging.warning(f'SolanaEventIndex: reservation_ttl read failed: {e}')
             return None
         return ttl if ttl > 0 else None
+
+    def reconcile_live_state(self, live_states: Dict[str, object], now: int) -> None:
+        """Scoring-round backstop for lost events (unbound-at-ingest drops, abandoned unstamped
+        txs, RPC gaps): diff each bound miner's live chain state against the event-derived view
+        and write corrective events stamped ``now``. Corrections apply from now on — crown
+        already credited over a divergent stretch stands, bounding the error at one round.
+        A miner is corrected only while its event stream has been quiet for
+        ``RECONCILE_QUIET_SECS``, so a stale live read never fights an in-flight real event."""
+        derived_active = self.state_store.get_active_state_at(now)
+        derived_collateral = self.state_store.get_collaterals_at(now)
+        quiet_start = now - RECONCILE_QUIET_SECS
+        recent_active = {e['hotkey'] for e in self.state_store.get_active_events_in_range(quiet_start, now)}
+        recent_collateral = {e['hotkey'] for e in self.state_store.get_collateral_events_in_range(quiet_start, now)}
+        for hotkey, ms in live_states.items():
+            live_active = bool(ms.active)
+            if hotkey not in recent_active and live_active != (hotkey in derived_active):
+                self.state_store.insert_active_event(now, hotkey, live_active)
+                bt.logging.warning(f'reconcile {hotkey[:8]}: event-derived active ≠ chain, corrected to {live_active}')
+            live_collateral = int(ms.collateral)
+            if hotkey not in recent_collateral and derived_collateral.get(hotkey) != live_collateral:
+                self.state_store.insert_collateral_event(now, hotkey, live_collateral)
+                bt.logging.warning(
+                    f'reconcile {hotkey[:8]}: event-derived collateral ≠ chain, corrected to {live_collateral}'
+                )
 
     @staticmethod
     def _miner_str(rec: EventRecord) -> Optional[str]:

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -175,22 +175,28 @@ def is_eligible(miner_state) -> bool:
     )
 
 
-def build_eligibility(solana_client, metagraph, attribution: Optional[Dict[str, str]] = None) -> Dict[str, bool]:
-    """``{hotkey: eligible_bool}`` for on-metagraph miners, from the on-chain
-    ``MinerState`` counters. Each pubkey-keyed ``MinerState`` is attributed to a
-    Bittensor hotkey via the sr25519 binding (B3.2 ``build_attribution``);
+def live_miner_states(solana_client, metagraph, attribution: Optional[Dict[str, str]] = None) -> Dict[str, object]:
+    """``{hotkey: MinerState}`` for bound, on-metagraph miners — one chain read shared by
+    the eligibility gate and the live-state reconcile. Each pubkey-keyed ``MinerState`` is
+    attributed to a Bittensor hotkey via the sr25519 binding (B3.2 ``build_attribution``);
     unbound or off-metagraph miners are dropped (they have no UID to credit).
     Pass ``attribution`` to reuse one per-round binding snapshot."""
     if attribution is None:
         attribution = build_attribution(solana_client)
     metagraph_hotkeys = set(metagraph.hotkeys)
-    eligibility: Dict[str, bool] = {}
+    states: Dict[str, object] = {}
     for _pubkey, ms in solana_client.get_all('MinerState'):
         hotkey = attribution.get(str(ms.miner))
         if hotkey is None or hotkey not in metagraph_hotkeys:
             continue
-        eligibility[hotkey] = is_eligible(ms)
-    return eligibility
+        states[hotkey] = ms
+    return states
+
+
+def build_eligibility(solana_client, metagraph, attribution: Optional[Dict[str, str]] = None) -> Dict[str, bool]:
+    """``{hotkey: eligible_bool}`` for on-metagraph miners — ``is_eligible`` over the
+    on-chain ``MinerState`` counters (see ``live_miner_states``)."""
+    return {hk: is_eligible(ms) for hk, ms in live_miner_states(solana_client, metagraph, attribution).items()}
 
 
 def windowed_direction_volumes(
@@ -303,10 +309,13 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
 
     rewards = np.zeros(n_uids, dtype=np.float32)
     unweighted_rewards = np.zeros(n_uids, dtype=np.float32)
-    # Flat eligibility gate off the on-chain MinerState counters (B3.3),
-    # attributed pubkey→hotkey via the sr25519 binding. Absent hotkey → not
-    # eligible (no on-chain counters ⇒ no proven successful swaps).
-    eligibility = build_eligibility(self.solana_client, self.metagraph)
+    # One live MinerState snapshot serves two jobs: the flat eligibility gate off the
+    # on-chain counters (B3.3, pubkey→hotkey via the sr25519 binding; absent hotkey → not
+    # eligible), and the reconcile backstop that corrects event-derived active/collateral
+    # state the ingest lost — before the replay below reads those tables.
+    live_states = live_miner_states(self.solana_client, self.metagraph)
+    self.event_index.reconcile_live_state(live_states, now=current_time)
+    eligibility = {hk: is_eligible(ms) for hk, ms in live_states.items()}
     # Per-direction realized volume summed over this round's window from the
     # ingested clearing_rates ledger — volume is what cleared this hour, not a
     # lifetime account total. Hotkeys were attributed at ingest (event_index),
@@ -707,14 +716,13 @@ def merge_replay_events(
 
 
 def crown_can_fund(hotkey, rate, from_chain, to_chain, min_swap_lamports, max_swap_lamports, collaterals):
-    """Boundary-squat gate: a miner whose own rate forces a SOL leg larger than
-    their collateral earns no crown (collateral and the bounded leg are both SOL).
-    Fail open on unknown collateral (absent != zero) so a missing baseline doesn't
-    silently drop them."""
-    if hotkey not in collaterals:
-        return True
+    """Boundary-squat gate: a miner who cannot fund their own rate's smallest SOL leg
+    at the contract's 1.10× reserve requirement (mirroring routing's ``swap_viable``)
+    is unreservable at any size and earns no crown. Unknown collateral counts as zero
+    (fail closed) — the live-state reconcile seeds a baseline for every bound active
+    miner, so absent means the chain doesn't know this miner either."""
     min_leg = min_executable_sol_leg(rate, from_chain, to_chain, min_swap_lamports, max_swap_lamports)
-    return min_leg == 0 or collaterals[hotkey] >= min_leg
+    return min_leg == 0 or collaterals.get(hotkey, 0) >= required_collateral(min_leg)
 
 
 def make_crown_predicates(from_chain, to_chain, min_swap_lamports, max_swap_lamports, collaterals):
@@ -823,9 +831,10 @@ def replay_crown_time_window(
         split = duration / len(holders)
         for hk in holders:
             crown_time[hk] = crown_time.get(hk, 0.0) + split
-            # Unknown collateral (no event recorded) → capacity 1.0, matching
-            # can_fund's fail-open. Only a known value scales capacity down.
-            cap = capacity_factor(collaterals[hk], max_swap_lamports) if hk in collaterals else 1.0
+            # Unknown collateral counts as zero, matching can_fund's fail-closed
+            # (the reconcile seeds a baseline for every bound active miner);
+            # capacity_factor keeps its bounds-unset fail-safe of 1.0.
+            cap = capacity_factor(collaterals.get(hk, 0), max_swap_lamports)
             cap_weighted_time[hk] = cap_weighted_time.get(hk, 0.0) + split * cap
 
     def apply_event(event: ReplayEvent) -> None:

--- a/tests/test_event_index.py
+++ b/tests/test_event_index.py
@@ -535,3 +535,66 @@ class TestIngestEndToEndCrown:
         # A: (100,400] + (800,1100] = 600. B: (400,800] = 400.
         assert crown == {'hk_a': 600.0, 'hk_b': 400.0}
         store.close()
+
+
+class TestReconcileLiveState:
+    """Scoring-round backstop: divergence between live MinerState and the
+    event-derived view is corrected with events stamped ``now`` — but only for
+    miners whose event stream has been quiet for RECONCILE_QUIET_SECS."""
+
+    NOW = 100_000
+
+    @staticmethod
+    def _ms(active: bool = True, collateral: int = 0):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(active=active, collateral=collateral)
+
+    def test_corrects_missed_deactivation(self, tmp_path: Path):
+        store = make_store(tmp_path)
+        idx = SolanaEventIndex(store)
+        store.insert_active_event(100, 'hk_a', True)  # activation seen, deactivation lost
+        idx.reconcile_live_state({'hk_a': self._ms(active=False)}, now=self.NOW)
+        assert idx.get_active_miners_at(self.NOW) == set()
+        store.close()
+
+    def test_corrects_pre_binding_activation_drop(self, tmp_path: Path):
+        # Chain says active with collateral, but the events landed before the
+        # miner bound its hotkey and were dropped — reconcile makes them earnable.
+        store = make_store(tmp_path)
+        idx = SolanaEventIndex(store)
+        idx.reconcile_live_state({'hk_a': self._ms(active=True, collateral=550)}, now=self.NOW)
+        assert idx.get_active_miners_at(self.NOW) == {'hk_a'}
+        assert idx.get_miner_collaterals_at(self.NOW) == {'hk_a': 550}
+        store.close()
+
+    def test_seeds_missing_collateral_baseline(self, tmp_path: Path):
+        store = make_store(tmp_path)
+        idx = SolanaEventIndex(store)
+        store.insert_active_event(100, 'hk_a', True)  # active agrees; collateral unknown
+        idx.reconcile_live_state({'hk_a': self._ms(active=True, collateral=42)}, now=self.NOW)
+        assert idx.get_miner_collaterals_at(self.NOW) == {'hk_a': 42}
+        assert idx.get_active_miners_at(self.NOW) == {'hk_a'}  # no spurious active row
+        store.close()
+
+    def test_quiet_guard_defers_to_recent_event(self, tmp_path: Path):
+        # A real active event landed seconds ago; a stale live read disagreeing
+        # with it must NOT be written over the fresher event truth.
+        store = make_store(tmp_path)
+        idx = SolanaEventIndex(store)
+        store.insert_active_event(self.NOW - 60, 'hk_a', True)
+        store.insert_collateral_event(self.NOW - 60, 'hk_a', 999)
+        idx.reconcile_live_state({'hk_a': self._ms(active=False, collateral=1)}, now=self.NOW)
+        assert idx.get_active_miners_at(self.NOW) == {'hk_a'}
+        assert idx.get_miner_collaterals_at(self.NOW) == {'hk_a': 999}
+        store.close()
+
+    def test_noop_when_consistent(self, tmp_path: Path):
+        store = make_store(tmp_path)
+        idx = SolanaEventIndex(store)
+        store.insert_active_event(100, 'hk_a', True)
+        store.insert_collateral_event(100, 'hk_a', 550)
+        idx.reconcile_live_state({'hk_a': self._ms(active=True, collateral=550)}, now=self.NOW)
+        assert len(store.load_all_active_events()) == 1
+        assert len(store.load_all_collateral_events()) == 1
+        store.close()

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -16,6 +16,8 @@ from allways.constants import (
     MIN_SUCCESSFUL_SWAPS,
     RECYCLE_UID,
     SCORING_WINDOW_BLOCKS,
+    VOLUME_WEIGHT_ALPHA,
+    required_collateral,
 )
 from allways.utils.rate import is_executable_rate, min_executable_sol_leg
 from allways.validator import scoring as scoring_mod
@@ -23,8 +25,10 @@ from allways.validator.event_index import SolanaEventIndex
 from allways.validator.scoring import (
     build_eligibility,
     calculate_miner_rewards,
+    crown_can_fund,
     crown_holders_at_instant,
     due_for_scoring,
+    fill_ratio,
     is_eligible,
     make_crown_predicates,
     replay_crown_time_window,
@@ -55,13 +59,29 @@ class FakeSolanaClient:
     state keys by the same opaque strings the crown tables use. End-to-end
     sr25519 attribution is covered in ``tests/test_eligibility.py``."""
 
-    def __init__(self, miner_counters: dict[str, tuple[int, int]]):
+    def __init__(
+        self,
+        miner_counters: dict[str, tuple[int, int]],
+        collaterals: dict[str, int] | None = None,
+        inactive: set[str] | None = None,
+    ):
         self._counters = miner_counters
+        self._collaterals = collaterals or {}
+        self._inactive = inactive or set()
 
     def get_all(self, name: str):
         if name == 'MinerState':
             return [
-                (f'pda_{hk}', SimpleNamespace(miner=hk, successful_swaps=s, failed_swaps=f))
+                (
+                    f'pda_{hk}',
+                    SimpleNamespace(
+                        miner=hk,
+                        successful_swaps=s,
+                        failed_swaps=f,
+                        active=hk not in self._inactive,
+                        collateral=self._collaterals.get(hk, 0),
+                    ),
+                )
                 for hk, (s, f) in self._counters.items()
             ]
         return []
@@ -209,7 +229,9 @@ def make_validator(
         event_index=SolanaEventIndex(store),
         solana_config_cache=solana_config_cache,
         database_storage=database_storage,
-        solana_client=FakeSolanaClient(miner_counters),
+        # Live collateral mirrors the seeded event tables so the scoring-round
+        # reconcile is a no-op unless a test diverges them deliberately.
+        solana_client=FakeSolanaClient(miner_counters, collaterals=collaterals),
     )
 
 
@@ -590,8 +612,8 @@ class TestReplayCrownTime:
         store = ValidatorStateStore(db_path=tmp_path / 'state.db')
         watcher = make_watcher(store, active={'hk_squat'})
         seed_collateral(watcher, 'hk_squat', 150_000_000, block=0)
-        # Top-up mid-window — collateral becomes enough to fund the 0.5 TAO leg.
-        watcher.apply_event(600, 'CollateralPosted', {'miner': 'hk_squat', 'amount': 350_000_000, 'total': 500_000_000})
+        # Top-up mid-window — collateral clears the 1.10× requirement on the 0.5 TAO leg.
+        watcher.apply_event(600, 'CollateralPosted', {'miner': 'hk_squat', 'amount': 400_000_000, 'total': 550_000_000})
         conn = store.require_connection()
         conn.execute(
             'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
@@ -1861,18 +1883,17 @@ class TestCapacityWeighting:
         np.testing.assert_allclose(rewards[0], POOL_BTC_SOL, atol=1e-6)
         v.state_store.close()
 
-    def test_unknown_collateral_fails_open(self, tmp_path: Path):
-        """A miner with NO collateral event in the watcher's series (unknown,
-        not zero) must fail OPEN: capacity 1.0 and can_fund passes, so it earns
-        the full pool. The contract auto-deactivates anyone below
-        min_collateral, so an active miner always holds enough — treating a
-        missing baseline as zero would silently drop honest miners from crown
-        (the collateral-baseline bug). Absent != zero."""
+    def test_unknown_collateral_fails_closed(self, tmp_path: Path):
+        """A miner with no collateral baseline anywhere (event tables empty and
+        the live chain reads zero) earns nothing while capacity weighting is
+        active. The scoring-round reconcile seeds a real baseline for every
+        live funded miner, so a persistent absence means unfunded — failing
+        open here was the L4b hole (full capacity for an unknown miner)."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
         v = make_validator(tmp_path, hotkeys, max_swap_amount=500_000_000)  # no collaterals dict → absent
         self.seed_sol_btc_crown(v, 'hk_a')
         rewards, _ = calculate_miner_rewards(v, v.block)
-        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL, atol=1e-6)
+        assert rewards[0] == 0.0
         v.state_store.close()
 
     def test_scoring_does_not_call_contract_for_collateral(self, tmp_path: Path):
@@ -2025,9 +2046,9 @@ class TestVolumeWeighting:
         # B doesn't post a rate → never holds crown.
         self.insert_volume(v, 'hk_b', from_amount=1_000_000_000)
         rewards, _ = calculate_miner_rewards(v, v.block)
-        # A's vol_share = 0, crown_share = 1.0 → participation = 0 → fill_ratio = 0.5.
-        # A = pool·0.5. B has crown_share = 0 → no crown reward to multiply.
-        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 0.5, atol=1e-6)
+        # A's vol_share = 0, crown_share = 1.0 → participation = 0 → fill_ratio = 1-α (0.25).
+        # A = pool·(1-α). B has crown_share = 0 → no crown reward to multiply.
+        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * (1 - VOLUME_WEIGHT_ALPHA), atol=1e-6)
         assert rewards[1] == 0.0
         v.state_store.close()
 
@@ -2072,8 +2093,10 @@ class TestVolumeWeighting:
         self.insert_volume(v, 'hk_a', from_amount=100_000_000, from_chain='sol', to_chain='btc')
         self.insert_volume(v, 'hk_b', from_amount=900_000_000, from_chain='sol', to_chain='btc')
         rewards, _ = calculate_miner_rewards(v, v.block)
-        # A: crown_share = 1.0, vol_share = 0.1, participation = 0.1 → fill_ratio = 0.55.
-        np.testing.assert_allclose(rewards[0], POOL_SOL_BTC * 0.55, atol=1e-6)
+        # A: crown_share = 1.0, vol_share = 0.1, participation = 0.1 → fill_ratio = (1-α) + α·0.1.
+        np.testing.assert_allclose(
+            rewards[0], POOL_SOL_BTC * ((1 - VOLUME_WEIGHT_ALPHA) + VOLUME_WEIGHT_ALPHA * 0.1), atol=1e-6
+        )
         # B: crown_share = 0 → factor moot, no reward to multiply.
         assert rewards[1] == 0.0
         v.state_store.close()
@@ -2103,9 +2126,9 @@ class TestVolumeWeighting:
         self.insert_volume(v, 'hk_b', from_amount=800_000_000, from_chain='sol', to_chain='btc')
         rewards, _ = calculate_miner_rewards(v, v.block)
         # Crown: A=240/300=0.8, B=60/300=0.2. Volume: A=0.2, B=0.8.
-        # A participation = 0.2/0.8 = 0.25 → fill_ratio 0.625; B → fill_ratio 1.0.
-        # A = 0.8·0.625 = 0.5·pool. B = 0.2·1.0 = 0.2·pool.
-        np.testing.assert_allclose(rewards[0], POOL_SOL_BTC * 0.5, atol=1e-6)
+        # A participation = 0.2/0.8 = 0.25 → fill_ratio = (1-α) + α·0.25; B → fill_ratio 1.0.
+        fill_a = (1 - VOLUME_WEIGHT_ALPHA) + VOLUME_WEIGHT_ALPHA * 0.25
+        np.testing.assert_allclose(rewards[0], POOL_SOL_BTC * 0.8 * fill_a, atol=1e-6)
         np.testing.assert_allclose(rewards[1], POOL_SOL_BTC * 0.2, atol=1e-6)
         v.state_store.close()
 
@@ -2174,10 +2197,10 @@ class TestVolumeWeighting:
         v = make_validator(tmp_path, hotkeys)
         self.seed_sol_btc_crown(v, 'hk_a')
         # B clears dust in A's market: A holds all crown, serves none of the
-        # volume → pool·fill_ratio(0.5).
+        # volume → pool·(1-α).
         self.insert_volume(v, 'hk_b', from_amount=100, to_amount=999_999_999)
         rewards, _ = calculate_miner_rewards(v, v.block)
-        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 0.5, atol=1e-6)
+        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * (1 - VOLUME_WEIGHT_ALPHA), atol=1e-6)
         v.state_store.close()
 
     def test_volume_outside_window_ignored(self, tmp_path: Path):
@@ -2209,7 +2232,7 @@ class TestCapacityVolumeInteraction:
     """Capacity + volume are independent multipliers — verify they compose."""
 
     def test_both_factors_compose_multiplicatively(self, tmp_path: Path):
-        """Single miner, capacity 0.5, idle on volume → reward = pool * 0.5 * 0.5."""
+        """Single miner, capacity 0.5, idle on volume → reward = pool * 0.5 * (1-α)."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a', 'hk_b'])
         v = make_validator(
             tmp_path,
@@ -2226,8 +2249,8 @@ class TestCapacityVolumeInteraction:
         # B serves the market's (floor-clearing) volume so A's vol_share = 0.
         v.state_store.insert_clearing_rate(9_900, 'hk_b', 'btc', 'sol', 1_000_000_000, 1_000_000_000, 'sk12')
         rewards, _ = calculate_miner_rewards(v, v.block)
-        # A: pool × crown 1.0 × eligible 1 × capacity 0.5 × fill_ratio 0.5 (B serves the volume).
-        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 1.0 * 0.5 * 0.5, atol=1e-6)
+        # A: pool × crown 1.0 × eligible 1 × capacity 0.5 × fill_ratio 1-α (B serves the volume).
+        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 1.0 * 0.5 * (1 - VOLUME_WEIGHT_ALPHA), atol=1e-6)
         v.state_store.close()
 
     def test_full_pool_conservation_with_all_factors(self, tmp_path: Path):
@@ -2530,10 +2553,8 @@ class TestCrownPredicateParity:
             return is_executable_rate(rate, from_chain, to_chain, min_rao, max_rao)
 
         def fund_ref(hotkey, rate):
-            if hotkey not in collaterals:
-                return True
             min_leg = min_executable_sol_leg(rate, from_chain, to_chain, min_rao, max_rao)
-            return min_leg == 0 or collaterals[hotkey] >= min_leg
+            return min_leg == 0 or collaterals.get(hotkey, 0) >= required_collateral(min_leg)
 
         return exec_ref, fund_ref
 
@@ -2554,10 +2575,11 @@ class TestCrownPredicateParity:
                             f'bounds=({min_rao},{max_rao}) hk={hk} rate={rate}'
                         )
 
-    def test_fail_open_on_absent_collateral(self):
-        # absent != zero — a miner with no recorded baseline must not be dropped.
+    def test_fail_closed_on_absent_collateral(self):
+        # Absent counts as zero — the scoring-round reconcile seeds a baseline for
+        # every live funded miner, so a missing one means the chain agrees: unfunded.
         _, can_fund = make_crown_predicates('sol', 'btc', 100_000_000, 500_000_000, {})
-        assert can_fund('hk_unknown', 345.0) is True
+        assert can_fund('hk_unknown', 345.0) is False
 
     def test_drops_holder_whose_collateral_cannot_fund_min_leg(self):
         # 1-rao collateral can't cover any real in-band leg → boundary-squat drop;
@@ -2657,3 +2679,63 @@ class TestScoreSnapshots:
         assert v.database_storage.flush_halt_window.called
         assert not v.database_storage.flush_scoring_window.called
         v.state_store.close()
+
+
+class TestFillRatio:
+    """fill_ratio = (1-α) + α·min(1, vol_share/crown_share), α = VOLUME_WEIGHT_ALPHA (0.75):
+    a zero-fill holder in an active direction floors at 0.25; an idle direction
+    (0 total volume) pays full — 0/0 is full earnings by design."""
+
+    def test_zero_fill_in_active_direction_floors_at_quarter(self):
+        assert fill_ratio(0, 1_000, 0.5) == pytest.approx(1.0 - VOLUME_WEIGHT_ALPHA) == pytest.approx(0.25)
+
+    def test_idle_direction_pays_full(self):
+        assert fill_ratio(0, 0, 1.0) == 1.0
+
+    def test_matching_share_pays_full(self):
+        assert fill_ratio(500, 1_000, 0.5) == 1.0
+
+    def test_over_serve_capped_at_full(self):
+        assert fill_ratio(1_000, 1_000, 0.5) == 1.0
+
+    def test_partial_fill_lands_between_floor_and_full(self):
+        # vol_share 0.25 vs crown_share 0.5 → participation 0.5 → 0.25 + 0.75·0.5
+        assert fill_ratio(250, 1_000, 0.5) == pytest.approx(0.25 + 0.75 * 0.5)
+
+
+class TestCrownCanFund:
+    """The crown funding gate mirrors routing's swap_viable / the contract's
+    1.10× reserve requirement — a miner below required_collateral(min_leg) is
+    unreservable at any size and must earn no crown."""
+
+    BOUNDS = dict(from_chain='sol', to_chain='btc', min_swap_lamports=100_000_000, max_swap_lamports=500_000_000)
+    RATE = 326.0
+
+    def min_leg(self) -> int:
+        return min_executable_sol_leg(self.RATE, **self.BOUNDS)
+
+    def test_collateral_at_raw_leg_is_rejected(self):
+        # Regression: the pre-1.1× gate passed exactly-min_leg collateral, paying
+        # crown to a miner the contract would refuse to reserve at any size.
+        leg = self.min_leg()
+        assert leg > 0
+        assert not crown_can_fund('hk', self.RATE, collaterals={'hk': leg}, **self.BOUNDS)
+
+    def test_collateral_at_required_collateral_passes(self):
+        assert crown_can_fund('hk', self.RATE, collaterals={'hk': required_collateral(self.min_leg())}, **self.BOUNDS)
+
+    def test_unknown_collateral_fails_closed(self):
+        assert not crown_can_fund('hk', self.RATE, collaterals={}, **self.BOUNDS)
+
+    def test_unexecutable_rate_is_unconstrained(self):
+        # min_leg 0 = "no in-band fundable swap" — executability is policed by
+        # is_executable_rate, not this gate (the #392 sentinel rate, btc→sol).
+        assert crown_can_fund(
+            'hk',
+            1e10,
+            from_chain='btc',
+            to_chain='sol',
+            min_swap_lamports=100_000_000,
+            max_swap_lamports=500_000_000,
+            collaterals={},
+        )

--- a/tests/test_solana_events.py
+++ b/tests/test_solana_events.py
@@ -172,3 +172,48 @@ def test_ingest_skips_failed_tx_and_empty_is_noop():
     empty = FakeClient([], {})
     recs, cur = SolanaEventIngest(empty).poll(until_sig='good')
     assert recs == [] and cur == 'good'
+
+
+def test_poll_holds_cursor_at_unstamped_tip():
+    miner = Keypair().pubkey()
+    ev = _encode('MinerActivated', {'miner': bytes(miner), 'at': 1})
+    # Newest-first: stamped tip, unstamped middle (fresh), stamped oldest.
+    pages = [
+        {'signature': 'sigC', 'slot': 21, 'blockTime': 1_700_000_021, 'err': None},
+        {'signature': 'sigB', 'slot': 20, 'blockTime': None, 'err': None},
+        {'signature': 'sigA', 'slot': 10, 'blockTime': 1_700_000_010, 'err': None},
+    ]
+    client = FakeClient(pages, {s: [ev] for s in ('sigA', 'sigB', 'sigC')})
+    records, cursor = SolanaEventIngest(client).poll(until_sig=None)
+    # The cursor holds before sigB so its events are re-read once stamped; sigC
+    # (newer than the hold point) is deliberately not consumed either.
+    assert [r.signature for r in records] == ['sigA']
+    assert cursor == 'sigA'
+
+
+def test_poll_reingests_previously_unstamped_once_stamped():
+    miner = Keypair().pubkey()
+    ev = _encode('MinerActivated', {'miner': bytes(miner), 'at': 1})
+    pages = [
+        {'signature': 'sigC', 'slot': 21, 'blockTime': 1_700_000_021, 'err': None},
+        {'signature': 'sigB', 'slot': 20, 'blockTime': 1_700_000_020, 'err': None},
+    ]
+    client = FakeClient(pages, {'sigB': [ev], 'sigC': [ev]})
+    records, cursor = SolanaEventIngest(client).poll(until_sig='sigA')
+    assert [r.signature for r in records] == ['sigB', 'sigC']
+    assert cursor == 'sigC'
+
+
+def test_poll_abandons_ancient_unstamped_entry():
+    miner = Keypair().pubkey()
+    ev = _encode('MinerActivated', {'miner': bytes(miner), 'at': 1})
+    # sigOld is unstamped and > UNSTAMPED_GIVE_UP_SLOTS behind the tip: this RPC
+    # will never stamp it — the cursor moves past (its events are written off).
+    pages = [
+        {'signature': 'sigTip', 'slot': 500, 'blockTime': 1_700_000_500, 'err': None},
+        {'signature': 'sigOld', 'slot': 100, 'blockTime': None, 'err': None},
+    ]
+    client = FakeClient(pages, {'sigTip': [ev], 'sigOld': [ev]})
+    records, cursor = SolanaEventIngest(client).poll(until_sig=None)
+    assert [r.signature for r in records] == ['sigTip']
+    assert cursor == 'sigTip'


### PR DESCRIPTION
Security batch A (scoring/validator only, no redeploy). Re-vetted against the audit backlog; items H2/M5 closed as working-as-designed, the rest land here.

- fill_ratio floor 0.5 -> 0.25 (`VOLUME_WEIGHT_ALPHA` 0.75): a zero-fill crown holder in an active direction earns a quarter; an idle direction (0/0) still pays full.
- `crown_can_fund` now requires `required_collateral(min_leg)` (the contract/routing 1.10x gate) instead of the raw leg — closes the crowned-but-unreservable band — and fails closed on unknown collateral.
- Event cursor fix: `poll()` no longer advances past a not-yet-stamped tx (its events were permanently lost); ancient unstamped entries are abandoned after `UNSTAMPED_GIVE_UP_SLOTS`.
- New `reconcile_live_state`: each scoring round diffs live `MinerState` (active, collateral) against the event-derived view and writes corrective events, guarded by a 600s quiet window. Heals unbound-at-ingest drops (miner activates before binding), lost events, and seeds collateral baselines so the fail-closed flips are safe. Reuses the eligibility fetch — no new RPC.
- Replay capacity treats unknown collateral as zero (bounds-unset fail-safe preserved).

Tests: 760 passed (new coverage for the floor, the 1.1x boundary, fail-closed, cursor hold/abandon, reconcile correct/seed/quiet/no-op).