### PR TITLE
Show effective config and clean unreachable RPC errors

### DIFF
--- a/allways/cli/main.py
+++ b/allways/cli/main.py
@@ -38,6 +38,7 @@ if os.environ.get('_ALW_COMPLETE'):
             _sys.modules[_pkg + _suffix] = _mock
 
 import json  # noqa: E402
+import re  # noqa: E402
 from pathlib import Path  # noqa: E402
 
 import click  # noqa: E402
@@ -62,6 +63,7 @@ from allways.cli.swap_commands.helpers import (  # noqa: E402
     fail,
     get_effective_config,
 )
+from allways.constants import NETUID_FINNEY  # noqa: E402
 
 # Feed a configured btc-network into the BTC provider (which reads BTC_NETWORK from env; a real env wins).
 apply_btc_network_env(get_effective_config())
@@ -93,39 +95,86 @@ def config_group(ctx):
 
 
 def show_config():
-    """Show current CLI configuration"""
-    console.print('\n[bold]Allways CLI Configuration[/bold]\n')
+    """Show the local CLI configuration: every settable key with its effective value and source."""
+    console.print('\n[bold]Local CLI Configuration[/bold]\n')
 
     if not CONFIG_FILE.exists():
-        console.print('[yellow]No config file found at ~/.allways/config.json[/yellow]')
-        console.print('[dim]Run `alw config set <key> <value>` to create config[/dim]')
-        return
+        console.print(
+            '[yellow]No config file yet — run `alw config set env testnet` (or `mainnet`) to create one.[/yellow]'
+        )
+    else:
+        try:
+            json.loads(CONFIG_FILE.read_text())
+        except (json.JSONDecodeError, OSError):
+            console.print('[red]Warning: could not parse the config file — showing defaults.[/red]')
+    config = get_effective_config()
 
+    table = Table(show_header=True)
+    table.add_column('Setting', style='cyan')
+    table.add_column('Effective value', style='green')
+    table.add_column('Source', style='dim')
+    for key, value, source in _effective_settings(config):
+        table.add_row(key, value, source)
+    console.print(table)
+
+    # Show which key will actually sign (env > solana-keypair config > ~/.solana/id.json),
+    # so a wrong signer is visible here instead of as a cryptic on-chain failure.
+    signer = _resolved_signer_line(config)
+    if signer:
+        console.print(f'\n[dim]Solana signer:[/dim] {signer}')
+    console.print(f'\n[dim]Config file: {CONFIG_FILE}[/dim]')
+    console.print('[dim]On-chain program parameters: `alw view config`[/dim]\n')
+
+
+def _effective_settings(config: dict) -> list:
+    """One (key, effective value, source) row per settable key, mirroring each key's real
+    resolution order (env escape hatch > config > default) — `alw config` shows what a command
+    would actually use, not just what the file contains."""
+    from allways.cli.swap_commands.helpers import resolve_solana_keypair_path, resolve_solana_rpc
+    from allways.solana.program import CONFIG_KEYS as PROGRAM_CONFIG_KEYS
+    from allways.solana.program import ENV_VAR as PROGRAM_ID_ENV
+    from allways.solana.program import resolve_program_id
+
+    def row(key, default=None):
+        if key in config:
+            return key, str(config[key]), 'config'
+        return (key, str(default), 'default') if default is not None else (key, '(not set)', '—')
+
+    def source(env_var: str, config_hit: bool, derived: str = '') -> str:
+        if os.environ.get(env_var):
+            return 'env'
+        if config_hit:
+            return 'config'
+        return derived or 'default'
+
+    rpc_url = re.sub(r'(api-key=)[^&]+', r'\1***', resolve_solana_rpc(config))
+    rpc_src = source(
+        'SOLANA_RPC_URL', bool(config.get('solana-rpc')), 'solana-network' if config.get('solana-network') else ''
+    )
+    keypair_src = source('SOLANA_KEYPAIR_PATH', bool(config.get('solana-keypair')))
+    program_src = source(PROGRAM_ID_ENV, any(config.get(k) for k in PROGRAM_CONFIG_KEYS))
     try:
-        config = json.loads(CONFIG_FILE.read_text())
+        program_id = str(resolve_program_id(config))
+    except ValueError as e:
+        program_id = f'invalid: {e}'
 
-        table = Table(show_header=True)
-        table.add_column('Setting', style='cyan')
-        table.add_column('Value', style='green')
-
-        for key, value in config.items():
-            if key in HIDDEN_CONFIG_KEYS:
-                continue  # legacy substrate key, dead on Solana — hidden but tolerated in the file
-            table.add_row(key, str(value))
-
-        console.print(table)
-
-        # Show which key will actually sign (env > solana-keypair config > ~/.solana/id.json),
-        # so a wrong signer is visible here instead of as a cryptic on-chain failure.
-        signer = _resolved_signer_line(config)
-        if signer:
-            console.print(f'\n[dim]Solana signer:[/dim] {signer}')
-        console.print(f'\n[dim]Config file: {CONFIG_FILE}[/dim]\n')
-
-    except json.JSONDecodeError:
-        console.print('[red]Error: Invalid JSON in config file[/red]')
-    except Exception as e:
-        console.print(f'[red]Error reading config: {e}[/red]')
+    btc_env = os.environ.get('BTC_NETWORK')
+    return [
+        row('network', default='finney'),
+        row('netuid', default=NETUID_FINNEY),
+        row('wallet'),
+        row('hotkey'),
+        row('solana-network'),
+        ('solana-rpc', rpc_url, rpc_src),
+        ('solana-keypair', resolve_solana_keypair_path(config), keypair_src),
+        (
+            'btc-network',
+            config.get('btc-network') or btc_env or 'mainnet',
+            'config' if config.get('btc-network') else 'env' if btc_env else 'default',
+        ),
+        row('router'),
+        ('program-id', program_id, program_src),
+    ]
 
 
 def _resolved_signer_line(config: dict) -> str | None:
@@ -161,9 +210,6 @@ VALID_CONFIG_KEYS = (
     'router',
     'env',
 )
-
-# Legacy keys still tolerated in an existing config file but never shown or settable (dead on Solana).
-HIDDEN_CONFIG_KEYS = ('contract-address', 'contract')
 
 
 @config_group.command('set')

--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -17,7 +17,7 @@ from rich.text import Text
 from allways.classes import SwapStatus
 from allways.constants import NETUID_FINNEY, TAO_TO_RAO
 from allways.solana.client import SolanaClientError
-from allways.solana.rpc import SolanaRpcError, resolve_rpc_url
+from allways.solana.rpc import SolanaRpcError, SolanaRpcUnreachable, resolve_rpc_url
 
 ALLWAYS_DIR = Path.home() / '.allways'
 CONFIG_FILE = ALLWAYS_DIR / 'config.json'
@@ -251,6 +251,13 @@ def safe_read(fn: Callable, what: str = 'read from Solana'):
     never a stacktrace."""
     try:
         return fn()
+    except SolanaRpcUnreachable as e:
+        hint = (
+            ''
+            if CONFIG_FILE.exists()
+            else ' No config file found — run `alw config set env testnet` (or `mainnet`) first.'
+        )
+        fail(f'Could not reach the Solana RPC at {e.url} to {what}.{hint}')
     except (SolanaClientError, SolanaRpcError) as e:
         fail(f'Failed to {what}: {e}')
     except requests.RequestException:

--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -454,7 +454,7 @@ def view_config(as_json):
             }
         )
         return
-    console.print('\n[bold]Program Config[/bold]\n')
+    console.print('\n[bold]On-chain Program Config[/bold] [dim](read-only — set by the program admin)[/dim]\n')
     console.print(f'  Admin:                {cfg.admin}')
     console.print(f'  Version:              {cfg.version}')
     console.print(f'  Halted:               {"yes" if cfg.halted else "no"}')
@@ -470,6 +470,7 @@ def view_config(as_json):
     console.print(f'  Weights interval:     {secs_str(cfg.weights_update_min_interval_secs)}')
     console.print(f'  Max total extension:  {secs_str(cfg.max_total_extension_secs)}')
     console.print(f'  Validators:           {len(cfg.validators)}\n')
+    console.print('[dim]Local CLI settings: `alw config`[/dim]\n')
 
 
 @view_group.command('validators')

--- a/allways/solana/rpc.py
+++ b/allways/solana/rpc.py
@@ -39,6 +39,15 @@ class TransientRpcError(SolanaRpcError):
     handlers keep working."""
 
 
+class SolanaRpcUnreachable(TransientRpcError):
+    """The endpoint could not be reached at all (connection refused / DNS failure) — carries the
+    resolved URL so callers can tell the user which RPC they were actually pointed at."""
+
+    def __init__(self, message: str, url: str):
+        super().__init__(message)
+        self.url = url
+
+
 # JSON-RPC error codes that mean "try again", not "your request was malformed / the tx failed".
 _TRANSIENT_RPC_CODES = frozenset({-32603, -32005, -32004, -32014, -32016})
 # HTTP statuses that are the provider hiccuping, not a client-side error.
@@ -88,8 +97,12 @@ class SolanaRpc:
                         raise TransientRpcError(f'{method}: {err}')
                     raise SolanaRpcError(f'{method}: {err}')
                 return body['result']
-            except (requests.Timeout, requests.ConnectionError) as e:
-                transient: TransientRpcError = TransientRpcError(f'{method}: {type(e).__name__}: {e}')
+            except requests.ConnectionError:
+                transient: TransientRpcError = SolanaRpcUnreachable(
+                    f'{method}: could not connect to {self.url}', url=self.url
+                )
+            except requests.Timeout as e:
+                transient = TransientRpcError(f'{method}: {type(e).__name__}: {e}')
             except TransientRpcError as e:
                 transient = e
             # Retry side-effect-free reads with exponential backoff; surface everything else at once.

--- a/tests/test_cli_config_show.py
+++ b/tests/test_cli_config_show.py
@@ -1,0 +1,112 @@
+"""`alw config` shows every settable key's EFFECTIVE value + source (works with no config file),
+and an unreachable RPC fails with the resolved URL + a first-run hint instead of a raw traceback."""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+from click.testing import CliRunner
+
+from allways.cli import main
+from allways.cli.swap_commands import helpers
+from allways.solana.rpc import SolanaRpc, SolanaRpcUnreachable
+
+
+@pytest.fixture
+def config_file(tmp_path, monkeypatch):
+    path = tmp_path / 'config.json'
+    monkeypatch.setattr(main, 'CONFIG_FILE', path)
+    monkeypatch.setattr(helpers, 'CONFIG_FILE', path)
+    monkeypatch.setattr(helpers, '_CLI_OVERRIDES', {})
+    for var in ('SOLANA_RPC_URL', 'SOLANA_RPC_API_KEY', 'SOLANA_KEYPAIR_PATH', 'BTC_NETWORK', 'ALLWAYS_PROGRAM_ID'):
+        monkeypatch.delenv(var, raising=False)
+    return path
+
+
+def _show():
+    return CliRunner().invoke(main.config_group, [])
+
+
+def test_show_config_without_file_renders_defaults(config_file):
+    result = _show()
+
+    assert result.exit_code == 0, result.output
+    assert 'No config file yet' in result.output
+    assert 'finney' in result.output  # network default
+    assert '(not set)' in result.output  # wallet/hotkey/router
+    assert '127.0.0.1:8899' in result.output  # solana-rpc localnet default
+    assert 'alw view config' in result.output
+
+
+def test_show_config_reports_sources_and_derived_rpc(config_file):
+    config_file.write_text(json.dumps(helpers.ENV_BUNDLES['testnet'] | {'wallet': 'alice'}))
+
+    result = _show()
+
+    assert result.exit_code == 0, result.output
+    assert 'alice' in result.output
+    assert 'devnet' in result.output
+    assert 'api.devnet.solana' in result.output  # rpc derived from the network name
+    assert 'solana-network' in result.output  # ...and labeled as such
+    assert 'config' in result.output
+
+
+def test_show_config_redacts_rpc_api_key(config_file, monkeypatch):
+    config_file.write_text(json.dumps({'solana-rpc': 'https://x.y/rpc'}))
+    monkeypatch.setenv('SOLANA_RPC_API_KEY', 'sekrit')
+
+    result = _show()
+
+    assert result.exit_code == 0, result.output
+    assert 'sekrit' not in result.output
+    assert '***' in result.output
+
+
+def test_show_config_survives_invalid_json(config_file):
+    config_file.write_text('{not json')
+
+    result = _show()
+
+    assert result.exit_code == 0, result.output
+    assert 'could not parse' in result.output
+    assert 'finney' in result.output  # still renders the defaults table
+
+
+def test_safe_read_unreachable_names_url_and_hints_first_run(config_file, capsys):
+    def boom():
+        raise SolanaRpcUnreachable('getAccountInfo: could not connect', url='http://127.0.0.1:8899')
+
+    with pytest.raises(SystemExit):
+        helpers.safe_read(boom, what='read config')
+    out = capsys.readouterr().out
+    assert 'http://127.0.0.1:8899' in out
+    assert 'alw config set env testnet' in out  # no config file → first-run hint
+
+
+def test_safe_read_unreachable_skips_hint_when_configured(config_file, capsys):
+    config_file.write_text('{}')
+
+    def boom():
+        raise SolanaRpcUnreachable('getAccountInfo: could not connect', url='https://x.y/rpc')
+
+    with pytest.raises(SystemExit):
+        helpers.safe_read(boom, what='read config')
+    out = capsys.readouterr().out
+    assert 'https://x.y/rpc' in out
+    assert 'config set env' not in out
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    monkeypatch.setattr('allways.solana.rpc.time.sleep', lambda *_: None)
+
+
+def test_rpc_connection_error_raises_unreachable_with_url():
+    rpc = SolanaRpc('http://127.0.0.1:8899')
+    rpc._session = MagicMock()
+    rpc._session.post.side_effect = requests.ConnectionError('refused')
+
+    with pytest.raises(SolanaRpcUnreachable) as exc:
+        rpc.get_account_info('11111111111111111111111111111111')
+    assert exc.value.url == 'http://127.0.0.1:8899'

--- a/tests/test_cli_view_solana.py
+++ b/tests/test_cli_view_solana.py
@@ -47,6 +47,8 @@ def test_view_config_renders_every_field(monkeypatch):
         assert label in result.output
     assert '51%' in result.output
     assert '0.001000 SOL' in result.output  # reservation fee in SOL
+    assert 'On-chain Program Config' in result.output
+    assert 'alw config' in result.output  # cross-link to the local CLI settings
 
 
 def test_view_config_reports_uninitialized(monkeypatch):


### PR DESCRIPTION
QA item 1 findings (fresh-install walkthrough), items 7-8.

- `alw config` now renders every settable key with its effective value and source (env / config / default), mirroring each key's real resolution order — including the resolved Solana RPC (api-key redacted) and program id. Works without a config file (shows defaults plus a first-run hint) instead of returning early.
- Headers distinguish the two config surfaces: "Local CLI Configuration" vs "On-chain Program Config (read-only — set by the program admin)"; each output cross-links the other command.
- Connection failures to the Solana RPC now raise `SolanaRpcUnreachable` (carrying the resolved URL) and `safe_read` prints one clean line with that URL; when no config file exists it appends "run `alw config set env testnet` (or `mainnet`)" — the exact fresh-user trap of defaulting to localnet.
- Dropped the now-unused `HIDDEN_CONFIG_KEYS`.

Tests: 767 passed (docker py3.12), incl. new tests/test_cli_config_show.py; live-smoked fresh-user and configured-testnet flows against devnet.