### PR TITLE
Drop browser swap pointers, add TAO identity to status

### DIFF
--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -120,11 +120,6 @@ def quote_update_fee_lamports(elapsed_secs: int) -> int:
 
 console = Console()
 
-# The taker fund-relay path (post-tx / claim / resume) verifies deposits against a chain provider before it
-# can advance a swap; that verification isn't wired into the CLI yet. Until it is, those commands point at the
-# working browser flow. Keep this URL in one place so every pointer agrees.
-BROWSER_SWAP_URL = 'http://localhost:9090'
-
 
 class CliError(Exception):
     """Local CLI/Solana error type — replaces the deleted ink! contract error."""
@@ -177,15 +172,14 @@ def fail(message: str, code: int = 1) -> None:
 
 
 def not_implemented(what: str, code: int = NOT_IMPLEMENTED_EXIT) -> None:
-    """Honest exit for the fund-moving relays (post-tx / claim / resume) that need chain-provider verification.
+    """Honest exit for deferred CLI paths that need chain-provider deposit verification.
 
-    Points at the working browser flow and exits with EX_UNAVAILABLE (69, not Click's usage-error 2) so
-    scripts can tell a deferred path apart from bad args. The read views are all live on Solana now."""
+    Exits with EX_UNAVAILABLE (69, not Click's usage-error 2) so scripts can tell a deferred path
+    apart from bad args."""
     console.print(
         f'[yellow]{what} is not available from the CLI yet.[/yellow]\n'
-        f'[dim]This step verifies your deposit against the source chain, which the CLI taker path does not do '
-        f'yet. Use the browser swap flow at {BROWSER_SWAP_URL} to complete a swap end-to-end; '
-        f'`alw swap now` originates a reservation on-chain.[/dim]'
+        f'[dim]Inspect the reservation with `alw view reservation --miner <pubkey>`; if you already sent the '
+        f'deposit, relay it with `alw swap post-tx`.[/dim]'
     )
     raise SystemExit(code)
 

--- a/allways/cli/swap_commands/resume.py
+++ b/allways/cli/swap_commands/resume.py
@@ -1,7 +1,7 @@
 """alw swap resume-reservation - Recover an interrupted pre-initiate reservation flow.
 
 Deferred: resuming a reservation submits + verifies the source deposit against the source chain (a
-chain-provider check the CLI taker path does not do yet). Exits non-zero; use the browser flow."""
+chain-provider check the CLI taker path does not do yet). Exits non-zero."""
 
 import click
 
@@ -13,7 +13,7 @@ def resume_reservation_command():
     """Resume an interrupted pre-initiate reservation (not yet available from the CLI).
 
     Advancing a reservation submits + verifies the source deposit against the source chain, which the
-    CLI taker path does not do yet. Use the browser swap flow to resume; inspect a reservation's state
-    with `alw view reservation --miner <pubkey>`.
+    CLI taker path does not do yet. If you already sent the deposit, `alw swap post-tx` relays it;
+    inspect a reservation's state with `alw view reservation --miner <pubkey>`.
     """
     not_implemented('Swap resume-reservation (CLI fund relay)')

--- a/allways/cli/swap_commands/status.py
+++ b/allways/cli/swap_commands/status.py
@@ -1,7 +1,8 @@
-"""alw status - Quick dashboard: network, Solana RPC/program health, your balance, and miner/taker state.
+"""alw status - Quick dashboard: network, Solana RPC/program health, your balances, and miner/taker state.
 
 Reads the live Solana program. If your keypair is a registered miner it summarizes miner state; otherwise it
-shows the taker view (any live reservation for --miner / the saved swap) and points at the browser swap UI."""
+shows the taker view (any live reservation for --miner / the saved swap). Identities shown are the Solana
+keypair (always — fees + on-chain identity) plus the configured bittensor wallet's coldkey + TAO balance."""
 
 import time
 
@@ -9,7 +10,6 @@ import click
 
 from allways.cli.help import StyledCommand
 from allways.cli.swap_commands.helpers import (
-    BROWSER_SWAP_URL,
     ZERO_SWAP_KEY,
     console,
     fail,
@@ -21,6 +21,26 @@ from allways.cli.swap_commands.helpers import (
     safe_read,
     set_json_output,
 )
+
+
+def _tao_identity(config):
+    """(coldkey ss58, TAO balance | None) for the configured bittensor wallet, or None when no
+    wallet is configured or its files are missing. Reads only the public coldkey file — no
+    password; an unreachable subtensor degrades to an unknown balance, never an error."""
+    name = config.get('wallet')
+    if not name:
+        return None
+    import bittensor as bt
+
+    try:
+        ss58 = bt.Wallet(name=name).coldkeypub.ss58_address
+    except Exception:
+        return None
+    try:
+        balance = float(bt.Subtensor(network=config.get('network', 'finney')).get_balance(ss58))
+    except Exception:
+        balance = None
+    return ss58, balance
 
 
 def _load_caller(config):
@@ -52,6 +72,7 @@ def status_command(miner_pk, as_json):
     halted = bool(cfg and cfg.halted)
 
     caller = _load_caller(config)
+    tao = _tao_identity(config)
     balance = None
     miner_state = None
     if caller is not None:
@@ -83,6 +104,10 @@ def status_command(miner_pk, as_json):
             'balance_sol': from_lamports(balance) if balance is not None else None,
             'is_miner': is_miner,
         }
+        if tao is not None:
+            out['wallet'] = config['wallet']
+            out['coldkey'] = tao[0]
+            out['tao_balance'] = tao[1]
         if is_miner:
             out['miner'] = {
                 'collateral_sol': from_lamports(miner_state.collateral),
@@ -117,6 +142,11 @@ def status_command(miner_pk, as_json):
         console.print(
             '  Keypair:      [dim]none loaded (`alw config set solana-keypair <path>` or SOLANA_KEYPAIR_PATH)[/dim]'
         )
+    if tao is not None:
+        ss58, tao_balance = tao
+        tao_s = f'{tao_balance:.4f} τ' if tao_balance is not None else '[dim]unknown[/dim]'
+        console.print(f'  Wallet:       {config["wallet"]} ({ss58})')
+        console.print(f'  TAO balance:  {tao_s}')
 
     if is_miner:
         console.print('\n[bold]Miner[/bold]\n')
@@ -138,7 +168,7 @@ def status_command(miner_pk, as_json):
         console.print(f'  [dim]No active reservation on {resv_miner}.[/dim]')
     else:
         console.print('  [dim]No pending swap. Preview with `alw swap quote`, originate with `alw swap now`.[/dim]')
-    console.print(f'\n[dim]Or swap in the browser: {BROWSER_SWAP_URL}[/dim]\n')
+    console.print()
 
 
 def _saved_miner():

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -1,0 +1,62 @@
+"""`alw status` shows the configured bittensor identity (coldkey + TAO balance) alongside the
+Solana keypair, and no longer points at a browser swap flow (unsupported)."""
+
+import types
+from unittest.mock import MagicMock
+
+from click.testing import CliRunner
+from solders.keypair import Keypair
+
+from allways.cli.swap_commands import status
+
+
+def _client():
+    client = MagicMock()
+    client.rpc.url = 'https://api.devnet.solana.com'
+    client.get_config.return_value = types.SimpleNamespace(halted=False)
+    client.rpc.get_account_lamports.return_value = 5_000_000_000
+    client.get_miner_state.return_value = None
+    return client
+
+
+def _patch(monkeypatch, config, tao):
+    monkeypatch.setattr(status, 'get_effective_config', lambda: config)
+    monkeypatch.setattr(status, 'get_solana_cli_context', lambda need_keypair=True: ({}, _client()))
+    monkeypatch.setattr(status, '_load_caller', lambda _: Keypair().pubkey())
+    monkeypatch.setattr(status, '_tao_identity', lambda _: tao)
+    monkeypatch.setattr(status, '_saved_miner', lambda: None)
+
+
+def test_status_shows_tao_identity_when_wallet_configured(monkeypatch):
+    _patch(monkeypatch, {'wallet': 'ck', 'network': 'test'}, ('5FabcColdkey', 10.5))
+
+    result = CliRunner().invoke(status.status_command, [])
+
+    assert result.exit_code == 0, result.output
+    assert 'ck (5FabcColdkey)' in result.output
+    assert '10.5000 τ' in result.output
+    assert 'browser' not in result.output.lower()
+
+
+def test_status_omits_tao_lines_without_wallet(monkeypatch):
+    _patch(monkeypatch, {'network': 'test'}, None)
+
+    result = CliRunner().invoke(status.status_command, [])
+
+    assert result.exit_code == 0, result.output
+    assert 'TAO balance' not in result.output
+    assert 'browser' not in result.output.lower()
+
+
+def test_status_json_includes_tao_fields(monkeypatch):
+    _patch(monkeypatch, {'wallet': 'ck', 'network': 'test'}, ('5FabcColdkey', None))
+
+    result = CliRunner().invoke(status.status_command, ['--json'])
+
+    assert result.exit_code == 0, result.output
+    assert '"coldkey": "5FabcColdkey"' in result.output
+    assert '"tao_balance": null' in result.output
+
+
+def test_tao_identity_none_without_wallet():
+    assert status._tao_identity({}) is None


### PR DESCRIPTION
QA item 2 findings.

- Browser swap flow is unsupported — removed every CLI pointer to it: the `alw status` footer, `not_implemented()` messaging (now points at `alw view reservation` / `alw swap post-tx`), and `resume-reservation` help. `BROWSER_SWAP_URL` deleted.
- `alw status` now shows the configured bittensor identity next to the Solana keypair: wallet name, coldkey ss58, and TAO balance (public coldkey file only; unreachable subtensor degrades to "unknown"). Absent when no wallet is configured — status shows the hub identity always, configured identities when present, never per-chain sprawl. `--json` gains `wallet` / `coldkey` / `tao_balance`.

Tests: 771 passed (docker py3.12), incl. new tests/test_cli_status.py.