### PR TITLE
Show on-chain bound hotkey in status

### DIFF
--- a/allways/cli/swap_commands/status.py
+++ b/allways/cli/swap_commands/status.py
@@ -16,6 +16,7 @@ from allways.cli.swap_commands.helpers import (
     from_lamports,
     get_effective_config,
     get_solana_cli_context,
+    hotkey_bytes_to_ss58,
     print_json,
     resolve_solana_keypair_path,
     safe_read,
@@ -41,6 +42,19 @@ def _tao_identity(config):
     except Exception:
         balance = None
     return ss58, balance
+
+
+def _configured_hotkey_ss58(config):
+    """ss58 of the configured hotkey, or None when unset/unreadable — used only to annotate
+    whether the on-chain binding matches the local config, never to fail status."""
+    if not config.get('wallet') or not config.get('hotkey'):
+        return None
+    import bittensor as bt
+
+    try:
+        return bt.Wallet(name=config['wallet'], hotkey=config['hotkey']).hotkey.ss58_address
+    except Exception:
+        return None
 
 
 def _load_caller(config):
@@ -75,9 +89,12 @@ def status_command(miner_pk, as_json):
     tao = _tao_identity(config)
     balance = None
     miner_state = None
+    binding = None
     if caller is not None:
         balance = safe_read(lambda: client.rpc.get_account_lamports(caller), what='read balance')
         miner_state = safe_read(lambda: client.get_miner_state(caller), what='read miner state')
+        binding = safe_read(lambda: client.get_binding(caller), what='read hotkey binding')
+    bound_ss58 = hotkey_bytes_to_ss58(bytes(binding.hotkey)) if binding is not None else None
 
     is_miner = miner_state is not None
     now = int(time.time())
@@ -102,6 +119,7 @@ def status_command(miner_pk, as_json):
             'halted': halted,
             'caller': str(caller) if caller else None,
             'balance_sol': from_lamports(balance) if balance is not None else None,
+            'bound_hotkey': bound_ss58,
             'is_miner': is_miner,
         }
         if tao is not None:
@@ -138,6 +156,18 @@ def status_command(miner_pk, as_json):
         bal = f'{from_lamports(balance):.4f} SOL' if balance is not None else '[dim]unknown[/dim]'
         console.print(f'  Keypair:      {caller}')
         console.print(f'  Balance:      {bal}')
+        if bound_ss58:
+            local = _configured_hotkey_ss58(config)
+            note = ''
+            if local:
+                note = (
+                    '  [green](matches your configured hotkey)[/green]'
+                    if local == bound_ss58
+                    else '  [red](configured hotkey differs!)[/red]'
+                )
+            console.print(f'  Bound hotkey: {bound_ss58}{note}')
+        else:
+            console.print('  Bound hotkey: [dim]none — miners/validators bind with `alw bind-hotkey`[/dim]')
     else:
         console.print(
             '  Keypair:      [dim]none loaded (`alw config set solana-keypair <path>` or SOLANA_KEYPAIR_PATH)[/dim]'

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -10,20 +10,22 @@ from solders.keypair import Keypair
 from allways.cli.swap_commands import status
 
 
-def _client():
+def _client(binding=None):
     client = MagicMock()
     client.rpc.url = 'https://api.devnet.solana.com'
     client.get_config.return_value = types.SimpleNamespace(halted=False)
     client.rpc.get_account_lamports.return_value = 5_000_000_000
     client.get_miner_state.return_value = None
+    client.get_binding.return_value = binding
     return client
 
 
-def _patch(monkeypatch, config, tao):
+def _patch(monkeypatch, config, tao, binding=None, local_hotkey=None):
     monkeypatch.setattr(status, 'get_effective_config', lambda: config)
-    monkeypatch.setattr(status, 'get_solana_cli_context', lambda need_keypair=True: ({}, _client()))
+    monkeypatch.setattr(status, 'get_solana_cli_context', lambda need_keypair=True: ({}, _client(binding)))
     monkeypatch.setattr(status, '_load_caller', lambda _: Keypair().pubkey())
     monkeypatch.setattr(status, '_tao_identity', lambda _: tao)
+    monkeypatch.setattr(status, '_configured_hotkey_ss58', lambda _: local_hotkey)
     monkeypatch.setattr(status, '_saved_miner', lambda: None)
 
 
@@ -60,3 +62,50 @@ def test_status_json_includes_tao_fields(monkeypatch):
 
 def test_tao_identity_none_without_wallet():
     assert status._tao_identity({}) is None
+
+
+def _binding(hotkey: bytes):
+    return types.SimpleNamespace(hotkey=hotkey, miner=None)
+
+
+def test_status_shows_bound_hotkey_with_match_note(monkeypatch):
+    hk = b'\x01' * 32
+    ss58 = status.hotkey_bytes_to_ss58(hk)
+    _patch(monkeypatch, {'network': 'test'}, None, binding=_binding(hk), local_hotkey=ss58)
+
+    result = CliRunner().invoke(status.status_command, [])
+
+    assert result.exit_code == 0, result.output
+    flat = ' '.join(result.output.split())
+    assert f'Bound hotkey: {ss58}' in flat
+    assert 'matches your configured hotkey' in flat
+
+
+def test_status_flags_binding_config_mismatch(monkeypatch):
+    hk = b'\x01' * 32
+    _patch(monkeypatch, {'network': 'test'}, None, binding=_binding(hk), local_hotkey='5SomethingElse')
+
+    result = CliRunner().invoke(status.status_command, [])
+
+    assert result.exit_code == 0, result.output
+    assert 'configured hotkey differs' in ' '.join(result.output.split())
+
+
+def test_status_unbound_points_at_bind_command(monkeypatch):
+    _patch(monkeypatch, {'network': 'test'}, None)
+
+    result = CliRunner().invoke(status.status_command, [])
+
+    assert result.exit_code == 0, result.output
+    assert 'alw bind-hotkey' in result.output
+
+
+def test_status_json_includes_bound_hotkey(monkeypatch):
+    hk = b'\x02' * 32
+    ss58 = status.hotkey_bytes_to_ss58(hk)
+    _patch(monkeypatch, {'network': 'test'}, None, binding=_binding(hk))
+
+    result = CliRunner().invoke(status.status_command, ['--json'])
+
+    assert result.exit_code == 0, result.output
+    assert f'"bound_hotkey": "{ss58}"' in result.output


### PR DESCRIPTION
QA item 2 finding: there was no way to inspect an existing hotkey↔pubkey binding (bind-hotkey only reports "already bound"; view miners requires being a registered miner).

`alw status` now shows the chain-stored binding for the loaded keypair:

- Bound hotkey: <ss58>, annotated green "matches your configured hotkey" or red "configured hotkey differs!" when the local wallet/hotkey resolve (annotation never fails status)
- Unbound: dim pointer at `alw bind-hotkey`
- `--json` gains `bound_hotkey`

Tests: 775 passed (docker py3.12).