### PR TITLE
Add copy-me header and role labels to env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,18 @@
-# ─── Network ───────────────────────────────────────────────
+# Copy me first: `cp .env.example .env` — docker compose reads `.env` directly (env_file +
+# ${PORT}/${WALLET_PATH} interpolation) and won't start without it. The neurons and `alw` load it too.
+#
+# Who needs what: Identity & network + Solana → every role. Bitcoin → BTC-pair miners
+# (+ optional CLI signing). Miner-only / Validator-only → their sections below.
+
+# ─── Identity & network (all roles) ────────────────────────
+# 7 = mainnet (finney) | 19 = testnet
 NETUID=7
+# Your local btcli wallet/hotkey names (as shown by `btcli w list`).
 WALLET_NAME=default
 HOTKEY_NAME=default
 WALLET_PATH=~/.bittensor/wallets
 
-# local (ws://127.0.0.1:9944) | finney | ws://host:9944
+# finney | test | local (ws://127.0.0.1:9944) | ws://host:9944
 # Validators should point at a local lite node for cheap commitment polling.
 SUBTENSOR_NETWORK=finney
 
@@ -20,7 +28,7 @@ LOG_LEVEL=info
 # read as absent rather than erroring. Wins over `alw config set program-id`.
 # ALLWAYS_PROGRAM_ID=
 
-# ─── Chain: Solana ─────────────────────────────────────────
+# ─── Chain: Solana (all roles) ─────────────────────────────
 # Read by the miner, validator, and `alw`. Unset uses http://127.0.0.1:8899.
 SOLANA_RPC_URL=
 
@@ -33,7 +41,7 @@ SOLANA_RPC_URL=
 # then the solana-CLI default ~/.solana/id.json.
 # SOLANA_KEYPAIR_PATH=
 
-# ─── Chain: Bitcoin ────────────────────────────────────────
+# ─── Chain: Bitcoin (BTC pairs) ────────────────────────────
 # mainnet | testnet | testnet4
 BTC_NETWORK=mainnet
 
@@ -54,7 +62,7 @@ BTC_PRIVATE_KEY=
 # "password invalid". Unset prompts interactively at launch.
 MINER_BITTENSOR_COLDKEY_PASSWORD=
 
-# ─── Validator ─────────────────────────────────────────────
+# ─── Validator-only ────────────────────────────────────────
 # Authority ladder — each level strictly more binding than the last:
 #   watch — observe-only: verifies swaps and computes scores, but submits no Solana
 #           votes (logs "WOULD …") and sets no Bittensor weights. Stage a new

--- a/.env.example
+++ b/.env.example
@@ -1,82 +1,49 @@
-# Copy me first: `cp .env.example .env` — docker compose reads `.env` directly (env_file +
-# ${PORT}/${WALLET_PATH} interpolation) and won't start without it. The neurons and `alw` load it too.
-#
-# Who needs what: Identity & network + Solana → every role. Bitcoin → BTC-pair miners
-# (+ optional CLI signing). Miner-only / Validator-only → their sections below.
+# cp .env.example .env — docker compose won't start without .env; the neurons and `alw` read it too.
+# Identity & network + Solana = all roles · Bitcoin = BTC-pair miners · then role-specific sections.
+# Quote a value only if it contains spaces or '#'.
 
 # ─── Identity & network (all roles) ────────────────────────
-# 7 = mainnet (finney) | 19 = testnet
-NETUID=7
-# Your local btcli wallet/hotkey names (as shown by `btcli w list`).
-WALLET_NAME=default
+NETUID=7                            # 7 mainnet | 19 testnet
+WALLET_NAME=default                 # your btcli names (`btcli w list`)
 HOTKEY_NAME=default
 WALLET_PATH=~/.bittensor/wallets
-
-# finney | test | local (ws://127.0.0.1:9944) | ws://host:9944
-# Validators should point at a local lite node for cheap commitment polling.
-SUBTENSOR_NETWORK=finney
-
+SUBTENSOR_NETWORK=finney            # finney | test | local | ws://host:9944 (validators: local lite node)
 PORT=8091
 LOG_LEVEL=info
-
-# Bind the axon loopback-only behind a reverse proxy. Unset publishes to the raw internet.
+# OPTIONAL loopback-bind axon behind a reverse proxy; unset = public
 # AXON_PUBLISH=127.0.0.1:9000
 
 # ─── Contract ──────────────────────────────────────────────
-# allways_swap_manager program address. Unset uses the committed devnet default.
-# Must match the deployed program: a mismatch derives different PDAs, so accounts
-# read as absent rather than erroring. Wins over `alw config set program-id`.
+# OPTIONAL dev override; must match the deployed program (mismatch = accounts read absent)
 # ALLWAYS_PROGRAM_ID=
 
 # ─── Chain: Solana (all roles) ─────────────────────────────
-# Read by the miner, validator, and `alw`. Unset uses http://127.0.0.1:8899.
+# keyed/paid recommended; unset = http://127.0.0.1:8899
 SOLANA_RPC_URL=
-
-# Optional keyed-provider API key (e.g. Helius) — composed onto SOLANA_RPC_URL as
-# the api-key query param, so the URL stays a plain endpoint.
+# OPTIONAL keyed-provider key, composed onto the URL (api-key param)
 # SOLANA_RPC_API_KEY=
-
-# Solana signer for miner/admin commands (collateral, quotes, config are keyed by this
-# pubkey — not the bt wallet). Unset falls back to `alw config set solana-keypair`,
-# then the solana-CLI default ~/.solana/id.json.
+# OPTIONAL miner/admin signer; unset = `alw config` value, then ~/.solana/id.json
 # SOLANA_KEYPAIR_PATH=
 
 # ─── Chain: Bitcoin (BTC pairs) ────────────────────────────
-# mainnet | testnet | testnet4
-BTC_NETWORK=mainnet
-
-# Esplora endpoints, tried in order. Unset uses public blockstream.info then mempool.space.
-# Each entry is URL or URL|API_KEY. A keyed entry sends the key via the header named below;
-# the default Authorization header adds a "Bearer " prefix, any other name sends the raw key.
+BTC_NETWORK=mainnet                 # mainnet | testnet | testnet4
+# OPTIONAL ordered esplora endpoints, URL or URL|API_KEY; unset = public (blockstream, mempool.space)
+# keyed entries send the key via the header below; "Authorization" adds a Bearer prefix
 # BTC_ESPLORA_API_KEY_HEADER=api-key
-# BTC_ESPLORA_URLS=https://xbt-mainnet.gomaestro-api.org/v0/esplora|your_maestro_key,https://mempool.space/api
-
-# ─── Bitcoin signing (users + miners) ──────────────────────
-# WIF private key. Required for miners. Optional for `alw swap`: when set the CLI signs and
-# broadcasts BTC sends locally; when unset you sign and broadcast via your own wallet.
+# BTC_ESPLORA_URLS=https://host/esplora|your_key,https://mempool.space/api
+# WIF — required for miners; optional local signing for `alw swap`
 BTC_PRIVATE_KEY=
 
-# ─── Miner-only ───────────────────────────────────────────
-# Coldkey password for headless miners. Unlocked once at startup so per-swap TAO transfers
-# don't re-prompt — detached from a TTY the prompt fails and every fulfillment errors with
-# "password invalid". Unset prompts interactively at launch.
+# ─── Miner-only ────────────────────────────────────────────
+# headless miners: unlocks the coldkey at startup for TAO sends; unset = prompt at launch
 MINER_BITTENSOR_COLDKEY_PASSWORD=
 
 # ─── Validator-only ────────────────────────────────────────
-# Authority ladder — each level strictly more binding than the last:
-#   watch — observe-only: verifies swaps and computes scores, but submits no Solana
-#           votes (logs "WOULD …") and sets no Bittensor weights. Stage a new
-#           validator before it can affect consensus or emissions.
-#   vote  — casts Solana consensus votes but sets NO Bittensor weights. Burn a
-#           validator in against a live contract without touching emissions.
-#   full  — votes and sets weights. Production. (default when unset)
-# Unknown values refuse to start. Legacy VALIDATOR_DEV_MODE=1 still means 'watch'.
+# watch (observe-only) | vote (no weights) | full (votes + weights, default)
 # VALIDATOR_MODE=full
 
 # ─── Validator: Weights & Biases ───────────────────────────
-# The validator opens a wandb run at startup that captures its console output.
-# Set WANDB_API_KEY to log online; unset runs offline (./wandb/), or pass
-# --neuron.wandb_off to disable entirely.
+# unset = offline (./wandb/); --neuron.wandb_off disables
 WANDB_API_KEY=
 WANDB_ENTITY=entrius-gittensor
 WANDB_PROJECT=allways-validators


### PR DESCRIPTION
QA item 2 finding: nothing told a fresh miner to `cp .env.example .env` (docker compose fails without it), and the sections didn't say who needs what. Header now states the copy step + how the file is consumed; sections labeled by role (all roles / BTC pairs / miner-only / validator-only); NETUID annotated 7 mainnet / 19 testnet; wallet names pointed at `btcli w list`; SUBTENSOR_NETWORK values reordered finney-first. Comments only — no value changes. Pairs with the docs-ui miner-guide PR adding the cp step.