### PR TITLE
Show effective consensus votes in view config

### DIFF
--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -421,6 +421,17 @@ def _sol_or(amount: int, zero_label: str) -> str:
     return f'{from_lamports(amount):.4f} SOL' + (f' ({zero_label})' if amount == 0 else '')
 
 
+def _votes_needed(cfg) -> int:
+    """Votes required for consensus — mirrors the program's headcount check
+    (consensus.rs: votes*100 >= threshold*total), i.e. ceil(threshold*total/100)."""
+    total = len(cfg.validators)
+    return -(-cfg.consensus_threshold_percent * total // 100)
+
+
+def _threshold_line(cfg) -> str:
+    return f'{cfg.consensus_threshold_percent}% ({_votes_needed(cfg)} of {len(cfg.validators)} validator votes)'
+
+
 @view_group.command('config')
 @click.option('--json', 'as_json', is_flag=True, help='Emit machine-readable JSON instead of text.')
 def view_config(as_json):
@@ -440,6 +451,7 @@ def view_config(as_json):
                 'version': cfg.version,
                 'halted': bool(cfg.halted),
                 'consensus_threshold_percent': cfg.consensus_threshold_percent,
+                'votes_needed': _votes_needed(cfg),
                 'reservation_fee_sol': from_lamports(cfg.reservation_fee_lamports),
                 'min_collateral_sol': from_lamports(cfg.min_collateral),
                 'max_collateral_sol': from_lamports(cfg.max_collateral),
@@ -458,7 +470,7 @@ def view_config(as_json):
     console.print(f'  Admin:                {cfg.admin}')
     console.print(f'  Version:              {cfg.version}')
     console.print(f'  Halted:               {"yes" if cfg.halted else "no"}')
-    console.print(f'  Consensus threshold:  {cfg.consensus_threshold_percent}%')
+    console.print(f'  Consensus threshold:  {_threshold_line(cfg)}')
     console.print(f'  Reservation fee:      {from_lamports(cfg.reservation_fee_lamports):.6f} SOL')
     console.print(f'  Min collateral:       {from_lamports(cfg.min_collateral):.4f} SOL')
     console.print(f'  Max collateral:       {_sol_or(cfg.max_collateral, "unlimited")}')
@@ -487,10 +499,16 @@ def view_validators(as_json):
         return
     validators = [{'pubkey': str(Pubkey.from_bytes(bytes(v.key))), 'weight': v.weight} for v in cfg.validators]
     if as_json:
-        print_json({'consensus_threshold_percent': cfg.consensus_threshold_percent, 'validators': validators})
+        print_json(
+            {
+                'consensus_threshold_percent': cfg.consensus_threshold_percent,
+                'votes_needed': _votes_needed(cfg),
+                'validators': validators,
+            }
+        )
         return
     console.print('\n[bold]Validators[/bold]\n')
-    console.print(f'  Consensus threshold: {cfg.consensus_threshold_percent}%\n')
+    console.print(f'  Consensus threshold: {_threshold_line(cfg)}\n')
     if not validators:
         console.print('  [yellow]No validators registered.[/yellow]\n')
         return

--- a/tests/test_cli_view_solana.py
+++ b/tests/test_cli_view_solana.py
@@ -51,6 +51,28 @@ def test_view_config_renders_every_field(monkeypatch):
     assert 'alw config' in result.output  # cross-link to the local CLI settings
 
 
+def test_votes_needed_mirrors_contract_headcount_math():
+    """consensus.rs: votes*100 >= threshold*total. Note 67% of 3 needs ALL 3 (2/3 = 66.7% < 67%)."""
+    one = types.SimpleNamespace(key=b'', weight=1)
+    assert view._votes_needed(_config(consensus_threshold_percent=67, validators=[one])) == 1
+    assert view._votes_needed(_config(consensus_threshold_percent=67, validators=[one] * 3)) == 3
+    assert view._votes_needed(_config(consensus_threshold_percent=66, validators=[one] * 3)) == 2
+    assert view._votes_needed(_config(consensus_threshold_percent=51, validators=[one] * 4)) == 3
+
+
+def test_view_config_shows_effective_votes(monkeypatch):
+    client = MagicMock()
+    client.get_config.return_value = _config(
+        consensus_threshold_percent=67, validators=[types.SimpleNamespace(key=b'', weight=1)]
+    )
+    _patch_client(monkeypatch, client)
+
+    result = CliRunner().invoke(view.view_group, ['config'])
+
+    assert result.exit_code == 0, result.output
+    assert '67% (1 of 1 validator votes)' in ' '.join(result.output.split())
+
+
 def test_view_config_reports_uninitialized(monkeypatch):
     client = MagicMock()
     client.get_config.return_value = None


### PR DESCRIPTION
QA item 2 finding: `Consensus threshold: 67%` with 1 registered validator reads nonsensical — what it means in practice is 1 of 1 votes.

`alw view config` and `alw view validators` now render `67% (1 of 1 validator votes)`, computed exactly as the program tallies (consensus.rs headcount: votes*100 >= threshold*total). `--json` gains `votes_needed`.

Worth a design glance while here (display-only PR, no behavior change): the strict >= means 67% of 3 validators requires ALL 3 (2/3 = 66.7% < 67%) — if 2-of-3 is the intent, the threshold should be <=66 once a third validator registers.

Tests: 777 passed (docker py3.12).