### PR TITLE
Opt in to CLI arg parsing under bittensor 10.5

### DIFF
--- a/allways/utils/config.py
+++ b/allways/utils/config.py
@@ -137,6 +137,9 @@ def add_validator_args(cls, parser):
 
 def config(cls):
     """Returns the configuration object specific to this miner or validator after adding relevant arguments."""
+    # bittensor >= 10.5 skips CLI/parser parsing unless this env opts in (BT_NO_PARSE_CLI_ARGS
+    # defaults to true) — without it every custom arg (--netuid, --neuron.*) comes back None.
+    os.environ.setdefault('BT_NO_PARSE_CLI_ARGS', 'false')
     parser = argparse.ArgumentParser()
     bt.Wallet.add_args(parser)
     bt.Subtensor.add_args(parser)

--- a/tests/test_neuron_config_parsing.py
+++ b/tests/test_neuron_config_parsing.py
@@ -1,0 +1,31 @@
+"""Canary: entrypoint CLI flags must reach the neuron config. bittensor >= 10.5 silently drops
+argv unless BT_NO_PARSE_CLI_ARGS=false — if an SDK bump ever breaks parsing again, this fails
+the suite instead of crash-looping every deployed neuron."""
+
+import sys
+
+from allways.utils import config as cfgmod
+
+
+class _MinerLike:
+    @classmethod
+    def add_args(cls, parser):
+        cfgmod.add_args(cls, parser)
+        cfgmod.add_miner_args(cls, parser)
+
+
+def test_cli_flags_reach_neuron_config(monkeypatch):
+    monkeypatch.delenv('BT_NO_PARSE_CLI_ARGS', raising=False)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['miner.py', '--netuid', '19', '--wallet.name', 'w', '--wallet.hotkey', 'h', '--axon.port', '8091'],
+    )
+
+    cfg = cfgmod.config(_MinerLike)
+
+    assert cfg.netuid == 19
+    assert cfg.neuron.name == 'miner'
+    assert cfg.wallet.name == 'w'
+    assert cfg.wallet.hotkey == 'h'
+    assert cfg.axon.port == 8091


### PR DESCRIPTION
Follow-up to #567: bittensor 10.5.0 skips all CLI/parser parsing unless BT_NO_PARSE_CLI_ARGS=false (new upstream default is true), so every entrypoint flag (--netuid, --wallet.name, --neuron.*) came back None and both neurons crash at check_config with `'NoneType' object has no attribute 'name'`. Found live: the freshly built test image crash-loops on temp-dev-box; the testnet validator only survives because it still runs the pinned pre-#567 contract-v2 image — it would crash on its next redeploy.

Fix: `allways.utils.config.config()` (the single bt.Config construction site) sets `os.environ.setdefault('BT_NO_PARSE_CLI_ARGS', 'false')` — a real env override still wins.

Verified in the py3.12 deps image: full miner arg path resolves (netuid 19, neuron.name miner, axon.port 8091). 775 unit tests pass.