### PR TITLE
Require providers only for chains the miner quotes

### DIFF
--- a/allways/chain_providers/__init__.py
+++ b/allways/chain_providers/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict, Tuple, Type
+from typing import Dict, Optional, Set, Tuple, Type
 
 import bittensor as bt
 
@@ -24,7 +24,12 @@ PROVIDER_REGISTRY: Tuple[Tuple[str, Type[ChainProvider], Tuple[str, ...]], ...] 
 )
 
 
-def create_chain_providers(check: bool = False, require_send: bool = True, **kwargs) -> Dict[str, ChainProvider]:
+def create_chain_providers(
+    check: bool = False,
+    require_send: bool = True,
+    required_chains: Optional[Set[str]] = None,
+    **kwargs,
+) -> Dict[str, ChainProvider]:
     """Initialize all available chain providers.
 
     Args:
@@ -33,6 +38,10 @@ def create_chain_providers(check: bool = False, require_send: bool = True, **kwa
         require_send: If False, skip validation of send credentials (e.g.
                       BTC_PRIVATE_KEY) during check. Validators only need
                       read/verify access so they pass require_send=False.
+        required_chains: Chains whose provider MUST pass the check — others
+                         degrade to a warning and are left out (a tao<->sol
+                         miner must not need BTC credentials). None = all
+                         chains required (validators verify every chain).
 
     Keyword arguments are forwarded to providers that need them.
     e.g. create_chain_providers(subtensor=subtensor)
@@ -40,6 +49,7 @@ def create_chain_providers(check: bool = False, require_send: bool = True, **kwa
     providers: Dict[str, ChainProvider] = {}
 
     for chain_id, cls, kwarg_names in PROVIDER_REGISTRY:
+        required = required_chains is None or chain_id in required_chains
         try:
             provider_kwargs = {k: kwargs[k] for k in kwarg_names if k in kwargs}
             provider = cls(**provider_kwargs)
@@ -47,9 +57,12 @@ def create_chain_providers(check: bool = False, require_send: bool = True, **kwa
                 provider.check_connection(require_send=require_send)
             providers[chain_id] = provider
         except Exception as e:
-            if check:
+            if check and required:
                 raise RuntimeError(f'{cls.__name__} failed startup check: {e}') from e
-            bt.logging.warning(f'{cls.__name__} not available: {e}')
+            bt.logging.warning(
+                f'{cls.__name__} disabled: {e}'
+                + (f' — {chain_id}-pair swaps cannot be fulfilled until this is fixed' if check else '')
+            )
 
     if check and providers:
         bt.logging.info('Chain providers ready:')

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -21,7 +21,7 @@ import bittensor as bt  # noqa: E402
 from bittensor import Keypair as BtKeypair  # noqa: E402
 
 from allways.chain_providers import create_chain_providers  # noqa: E402
-from allways.constants import FORWARD_STALL_THRESHOLD_SECONDS  # noqa: E402
+from allways.constants import FORWARD_STALL_THRESHOLD_SECONDS, NUMERAIRE_CHAIN  # noqa: E402
 from allways.miner.fulfillment import SwapFulfiller  # noqa: E402
 from allways.miner.swap_poller import SwapPoller  # noqa: E402
 from allways.solana import keys  # noqa: E402
@@ -49,8 +49,22 @@ class Miner(BaseMinerNeuron):
         self.solana_pubkey = self.solana_client.keypair.pubkey()
         # SOL swap-leg provider signs the dest leg with the same Solana keypair (peer-to-peer
         # user↔miner transfer; separate from the program client that never custodies swap assets).
+        # Only chains this miner actually quotes (plus the hub) must pass the startup check —
+        # a tao<->sol miner starts without BTC credentials; a btc-quoting miner still fails hard.
+        try:
+            quoted = {
+                chain
+                for _pda, q in self.solana_client.get_all('MinerQuote')
+                if bytes(q.miner) == bytes(self.solana_pubkey)
+                for chain in (q.from_chain, q.to_chain)
+            }
+            required_chains = quoted | {NUMERAIRE_CHAIN}
+        except Exception as e:
+            bt.logging.warning(f'Could not read own quotes at startup ({e}); requiring all chain providers.')
+            required_chains = None
         self.chain_providers = create_chain_providers(
             check=True,
+            required_chains=required_chains,
             subtensor=self.subtensor,
             wallet=self.wallet,
             solana_rpc_url=solana_rpc_url,

--- a/tests/test_chain_providers_optional.py
+++ b/tests/test_chain_providers_optional.py
@@ -1,0 +1,40 @@
+"""Provider startup checks: chains the miner doesn't quote degrade to a warning; quoted (required)
+chains still fail hard — a tao<->sol miner must start without BTC creds, a btc miner must not."""
+
+import pytest
+
+from allways import chain_providers as cp
+
+
+class _Boom:
+    def __init__(self):
+        raise RuntimeError('no creds')
+
+
+class _Ok:
+    def check_connection(self, require_send=True):
+        pass
+
+    def describe(self):
+        return 'ok'
+
+
+@pytest.fixture
+def registry(monkeypatch):
+    monkeypatch.setattr(cp, 'PROVIDER_REGISTRY', (('btc', _Boom, ()), ('sol', _Ok, ())))
+
+
+def test_unrequired_failure_degrades_to_warning(registry):
+    providers = cp.create_chain_providers(check=True, required_chains={'sol'})
+    assert 'sol' in providers
+    assert 'btc' not in providers
+
+
+def test_required_failure_still_raises(registry):
+    with pytest.raises(RuntimeError, match='failed startup check'):
+        cp.create_chain_providers(check=True, required_chains={'btc', 'sol'})
+
+
+def test_none_means_all_required(registry):
+    with pytest.raises(RuntimeError, match='failed startup check'):
+        cp.create_chain_providers(check=True)


### PR DESCRIPTION
QA item 2 finding: the miner builds every chain provider with a hard startup check, so a tao<->sol miner dies with `BTC signing requires the BTC_PRIVATE_KEY env var` for a chain it never quotes.

- `create_chain_providers` gains `required_chains`: failures outside it degrade to one clear warning ("BitcoinProvider disabled: ... — btc-pair swaps cannot be fulfilled until this is fixed"); required chains still raise. None = all required (validator behavior unchanged).
- The miner derives `required_chains` from its own on-chain quotes + the hub, so a btc-quoting miner with broken creds still fails hard (silent no-BTC mining = timeout slash). Quote read failure falls back to requiring everything.
- Runtime was already safe: the fulfiller `.get()`s providers and error-logs per swap.

Tests: 778 passed (docker py3.12), incl. new tests/test_chain_providers_optional.py.