### PR TITLE
Ignore stale reservation residue in routed sweep

### DIFF
--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -161,7 +161,7 @@ async def handle_swap_reserve(
     miner = synapse.miner_hotkey
     label = miner_label(validator, miner)
     direction = f'{(synapse.from_chain or "?").upper()}->{(synapse.to_chain or "?").upper()}'
-    ctx = f'[{label}] SwapReserve {direction}'
+    ctx = f'[miner {label}] SwapReserve {direction}'
     try:
         result = reserve_on_behalf(
             validator,

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -187,12 +187,22 @@ def finalize_won_seats(validator, now: int) -> list:
     me = str(client.keypair.pubkey())
     finalized: list = []
     for miner, from_chain, to_chain in store.distinct_routed_pools():
+        queue = store.pending_routed_requests(miner, from_chain, to_chain)
+        if not queue:
+            continue
+        entered_at = queue[0]['created_at']
         try:
             resv = client.get_reservation(Pubkey.from_string(miner))
         except Exception as e:
             bt.logging.warning(f'routed sweep {miner[:8]}: reservation read failed, retrying next step: {e}')
             continue
-        drawn_unfilled = resv is not None and int(resv.reserved_until) == 0 and int(resv.finalize_by) != 0
+        # The Reservation PDA is reused across rounds: state older than our oldest queued request
+        # is residue from a PREVIOUS round — our pool simply hasn't been drawn yet, so wait (the
+        # TTL backstop clears a queue whose draw never comes). Treating residue as terminal
+        # deleted every queue on the first sweep step and permanently dead-ended routed mode for
+        # any miner-direction carrying an old lapsed seat.
+        fresh = resv is not None and max(int(resv.reserved_until), int(resv.finalize_by)) >= entered_at
+        drawn_unfilled = fresh and int(resv.reserved_until) == 0 and int(resv.finalize_by) != 0
         won = (
             drawn_unfilled
             and now <= int(resv.finalize_by)
@@ -201,14 +211,16 @@ def finalize_won_seats(validator, now: int) -> list:
             and resv.to_chain == to_chain
         )
         if not won:
-            # No seat we can fill: not drawn yet (pool still open/uncranked) → wait; anything
-            # terminal (lost, filled, lapsed) → drop. The TTL backstop clears the never-drawn.
+            # No seat we can fill: not drawn yet (open pool / residue) → wait; a fresh terminal
+            # outcome (lost to another router, filled, lapsed) → drop.
             if drawn_unfilled and now <= int(resv.finalize_by):
-                store.delete_routed_requests(miner, from_chain, to_chain)  # another router's seat
-            elif resv is not None and (int(resv.reserved_until) != 0 or int(resv.finalize_by) != 0):
-                store.delete_routed_requests(miner, from_chain, to_chain)  # filled or lapsed
+                bt.logging.info(f'routed sweep {miner[:8]}: seat won by another router, dropping queue')
+                store.delete_routed_requests(miner, from_chain, to_chain)
+            elif fresh:
+                bt.logging.info(f'routed sweep {miner[:8]}: reservation filled or window lapsed, dropping queue')
+                store.delete_routed_requests(miner, from_chain, to_chain)
             continue
-        req = draw_pool_winner(store.pending_routed_requests(miner, from_chain, to_chain))
+        req = draw_pool_winner(queue)
         if read_only:
             bt.logging.info(f'routed sweep {miner[:8]}: WOULD finalize for {req["user_pubkey"][:8]} (read-only)')
             continue

--- a/tests/test_finalize_sweep.py
+++ b/tests/test_finalize_sweep.py
@@ -116,6 +116,43 @@ def test_already_filled_reservation_drops_queue(tmp_path):
     v.state_store.close()
 
 
+def test_stale_lapsed_residue_from_previous_round_waits(tmp_path):
+    # The PDA still carries a LAPSED seat drawn before our request existed — that's residue from
+    # an earlier round, not our outcome. Deleting here dead-ended routed mode forever on this
+    # miner-direction (each attempt's lapsed seat killed the next attempt's queue).
+    client = SweepClient(None)
+    client._reservation = _drawn_seat(client, finalize_by=NOW - 500)
+    v = _validator(tmp_path, client)
+    _queue(v.state_store, USER_A, created_at=NOW - 10)
+    assert finalize_won_seats(v, NOW) == []
+    assert not client.finalized
+    assert v.state_store.distinct_routed_pools() == [(MINER, 'sol', 'btc')]  # kept — our draw is pending
+    v.state_store.close()
+
+
+def test_stale_expired_reservation_residue_waits(tmp_path):
+    client = SweepClient(None)
+    client._reservation = _drawn_seat(client, reserved_until=NOW - 500, finalize_by=0)
+    v = _validator(tmp_path, client)
+    _queue(v.state_store, USER_A, created_at=NOW - 10)
+    assert finalize_won_seats(v, NOW) == []
+    assert v.state_store.distinct_routed_pools() == [(MINER, 'sol', 'btc')]
+    v.state_store.close()
+
+
+def test_residue_then_fresh_draw_finalizes(tmp_path):
+    # Recovery path: sweep waits through residue, then our round's draw lands → finalize.
+    client = SweepClient(None)
+    client._reservation = _drawn_seat(client, finalize_by=NOW - 500)
+    v = _validator(tmp_path, client)
+    _queue(v.state_store, USER_A, created_at=NOW - 10)
+    assert finalize_won_seats(v, NOW) == []
+    client._reservation = _drawn_seat(client, finalize_by=NOW + 100)
+    assert finalize_won_seats(v, NOW) == [MINER]
+    assert len(client.finalized) == 1
+    v.state_store.close()
+
+
 def test_undrawn_pool_keeps_queue_for_next_step(tmp_path):
     # No reservation yet (pool still open / crank pending) → wait, don't drop.
     client = SweepClient(None)


### PR DESCRIPTION
Live QA finding: routed swaps are dead on testnet. Reproduced end to end with a real routed sol->tao swap:

1. Router queues the request + enters the pool.
2. Next sweep step (12s) reads the miner's Reservation PDA, sees a LAPSED seat from a previous round (reserved_until=0, finalize_by in the past), takes the silent "filled or lapsed" branch, deletes the queue.
3. Pool closes, router wins the draw — queue is gone, nothing finalizes, the seat lapses.
4. That lapsed seat is the residue that kills the next attempt. Self-perpetuating: one lapsed seat permanently dead-ends routed mode for that miner-direction. On-chain evidence: ER9Jt5… Reservation with finalize_by 6 min in the past, router = the validator itself.

Fix: the sweep anchors on the queue's oldest created_at — Reservation state older than that (max(reserved_until, finalize_by) < entered_at) is residue from a previous round, so WAIT for our draw instead of dropping (TTL backstop still clears queues whose draw never comes). Fresh terminal outcomes (lost / filled / lapsed THIS round) still drop, and both drop branches now log — previously they were silent, which is why the validator told no story at all.

Tests: 784 passed; new cases — lapsed residue waits, expired-reservation residue waits, residue-then-fresh-draw finalizes.