### PR TITLE
Treat closed swap as informative result in view swap

### DIFF
--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -393,7 +393,17 @@ def view_swap(swap_key_hex: str, watch: bool, as_json: bool):
 
     s = _load()
     if s is None:
-        fail(f'No swap found for swap_key {swap_key_hex}.')
+        # Not an error: Swap accounts close at resolution, so a missing account usually MEANS
+        # "finished". Say so in both modes instead of failing a normal terminal probe.
+        note = (
+            'No swap account on-chain for this swap_key — swaps close when resolved '
+            '(Completed or TimedOut), so this swap either finished or never existed.'
+        )
+        if as_json:
+            print_json({'found': False, 'note': note})
+        else:
+            console.print(f'[yellow]{note}[/yellow]')
+        return
 
     if as_json:
         print_json(_swap_json(s))

--- a/tests/test_cli_view_solana.py
+++ b/tests/test_cli_view_solana.py
@@ -108,3 +108,18 @@ def test_view_validators_handles_empty_set(monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert 'No validators registered' in result.output
+
+
+def test_view_swap_closed_is_informative_not_error(monkeypatch):
+    client = MagicMock()
+    client.get_swap.return_value = None
+    _patch_client(monkeypatch, client)
+    key = 'ab' * 32
+
+    text = CliRunner().invoke(view.view_group, ['swap', key])
+    assert text.exit_code == 0, text.output
+    assert 'finished or never existed' in text.output
+
+    js = CliRunner().invoke(view.view_group, ['swap', key, '--json'])
+    assert js.exit_code == 0, js.output
+    assert '"found": false' in js.output


### PR DESCRIPTION
QA finding C4: `alw view swap --json` on a closed swap returned a bare error while text --watch mode explained the closure. Swap accounts close at resolution, so a missing account usually means finished — both modes now say so (JSON: {found: false, note}, exit 0) instead of failing a normal terminal probe. Tests +1.