### PR TITLE
Include unpaid crown holders in scoring trace

### DIFF
--- a/allways/validator/scoring_trace.py
+++ b/allways/validator/scoring_trace.py
@@ -88,14 +88,13 @@ def log_scoring_trace(
         )
         lines.append(f'  [{from_c}→{to_c}] pool={trace.pool:g} holders={{{holders}}} unfilled={trace.unfilled_time}s')
 
-    def _in_story(u: int) -> bool:
-        # A miner belongs in the round's story if it was PAID or if it HELD crown time —
-        # an ineligible crown holder earning 0 is exactly the case the log must explain
-        # (otherwise "why did uid N get nothing?" needs a database query to answer).
-        hk = hotkeys[u]
-        return float(rewards[u]) > 0 or any(t.crown_time.get(hk, 0.0) > 0 for t in direction_traces.values())
+    # The round's story covers every miner that was PAID or HELD crown time — an ineligible
+    # crown holder earning 0 must appear (eligible=False, reward=0.000), or "why did uid N
+    # get nothing?" needs a database query to answer.
+    crown_holders = {hk for t in direction_traces.values() for hk, secs in t.crown_time.items() if secs > 0}
+    story_uids = [u for u in range(len(rewards)) if rewards[u] > 0 or hotkeys[u] in crown_holders]
 
-    for uid in sorted((u for u in range(len(rewards)) if _in_story(u)), key=lambda u: -float(rewards[u])):
+    for uid in sorted(story_uids, key=lambda u: -float(rewards[u])):
         hk = hotkeys[uid]
         crown_secs = sum(t.crown_time.get(hk, 0.0) for t in direction_traces.values())
         if uid == recycle_uid and crown_secs == 0:

--- a/allways/validator/scoring_trace.py
+++ b/allways/validator/scoring_trace.py
@@ -88,7 +88,14 @@ def log_scoring_trace(
         )
         lines.append(f'  [{from_c}→{to_c}] pool={trace.pool:g} holders={{{holders}}} unfilled={trace.unfilled_time}s')
 
-    for uid in sorted((u for u in range(len(rewards)) if rewards[u] > 0), key=lambda u: -float(rewards[u])):
+    def _in_story(u: int) -> bool:
+        # A miner belongs in the round's story if it was PAID or if it HELD crown time —
+        # an ineligible crown holder earning 0 is exactly the case the log must explain
+        # (otherwise "why did uid N get nothing?" needs a database query to answer).
+        hk = hotkeys[u]
+        return float(rewards[u]) > 0 or any(t.crown_time.get(hk, 0.0) > 0 for t in direction_traces.values())
+
+    for uid in sorted((u for u in range(len(rewards)) if _in_story(u)), key=lambda u: -float(rewards[u])):
         hk = hotkeys[uid]
         crown_secs = sum(t.crown_time.get(hk, 0.0) for t in direction_traces.values())
         if uid == recycle_uid and crown_secs == 0:

--- a/allways/validator/scoring_trace.py
+++ b/allways/validator/scoring_trace.py
@@ -88,13 +88,11 @@ def log_scoring_trace(
         )
         lines.append(f'  [{from_c}→{to_c}] pool={trace.pool:g} holders={{{holders}}} unfilled={trace.unfilled_time}s')
 
-    # The round's story covers every miner that was PAID or HELD crown time — an ineligible
-    # crown holder earning 0 must appear (eligible=False, reward=0.000), or "why did uid N
-    # get nothing?" needs a database query to answer.
+    # Log everyone paid OR holding crown — an ineligible crown holder earning 0 must appear.
     crown_holders = {hk for t in direction_traces.values() for hk, secs in t.crown_time.items() if secs > 0}
-    story_uids = [u for u in range(len(rewards)) if rewards[u] > 0 or hotkeys[u] in crown_holders]
+    shown = [u for u in range(len(rewards)) if rewards[u] > 0 or hotkeys[u] in crown_holders]
 
-    for uid in sorted(story_uids, key=lambda u: -float(rewards[u])):
+    for uid in sorted(shown, key=lambda u: -float(rewards[u])):
         hk = hotkeys[uid]
         crown_secs = sum(t.crown_time.get(hk, 0.0) for t in direction_traces.values())
         if uid == recycle_uid and crown_secs == 0:
@@ -171,8 +169,7 @@ def non_earner_lines(
 
     out: List[str] = []
     for uid, hk in enumerate(self.metagraph.hotkeys):
-        # `covered` = zero-reward crown holders — already narrated with full factors in the
-        # story loop (their crown_s is nonzero, so this section's crown_s=0 line would be wrong).
+        # crown holders already got a full factor line above
         if uid == recycle_uid or rewards[uid] > 0 or hk in covered:
             continue
         latest_rates = rates_by_hotkey.get(hk, {})

--- a/allways/validator/scoring_trace.py
+++ b/allways/validator/scoring_trace.py
@@ -130,6 +130,7 @@ def log_scoring_trace(
             collaterals,
             min_swap_lamports,
             max_swap_lamports,
+            covered=crown_holders,
         )
     )
 
@@ -154,8 +155,10 @@ def non_earner_lines(
     collaterals: Optional[Dict[str, int]] = None,
     min_swap_lamports: int = 0,
     max_swap_lamports: int = 0,
+    covered: Optional[Set[str]] = None,
 ) -> List[str]:
     collaterals = collaterals or {}
+    covered = covered or set()
     ever_active = set(self.event_index.get_active_miners_at(window_start))
     for e in self.event_index.get_active_events_in_range(window_start, window_end):
         if e['active']:
@@ -168,7 +171,9 @@ def non_earner_lines(
 
     out: List[str] = []
     for uid, hk in enumerate(self.metagraph.hotkeys):
-        if uid == recycle_uid or rewards[uid] > 0:
+        # `covered` = zero-reward crown holders — already narrated with full factors in the
+        # story loop (their crown_s is nonzero, so this section's crown_s=0 line would be wrong).
+        if uid == recycle_uid or rewards[uid] > 0 or hk in covered:
             continue
         latest_rates = rates_by_hotkey.get(hk, {})
         if not latest_rates and hk not in ever_active:


### PR DESCRIPTION
QA finding V1 (weights-proof review): the round trace only printed per-miner factor lines for rewards > 0, so an INELIGIBLE crown holder (e.g. a miner below the 2-success gate holding tao→sol crown all round) was absent from the log — 'why did uid N get nothing' needed a das/db query. Miners now appear whenever they were paid OR held crown time: uid line shows eligible=False, factors, reward=0.000 — the log tells the whole payment story by itself. Tests: 153 scoring tests pass; full suite green.