### PR TITLE
Fail clean on contract rejections in native reserve

### DIFF
--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -42,6 +42,7 @@ from allways.cli.swap_commands.swap_intake import (
 )
 from allways.cli.validator_rejections import render_and_aggregate
 from allways.constants import FEE_DIVISOR, NETUID_FINNEY, NUMERAIRE_CHAIN
+from allways.solana.client import contract_reject_reason
 from allways.solana.rpc import TransientRpcError
 from allways.synapses import SwapReserveSynapse
 from allways.utils.rate import apply_fee_deduction, directional_rate
@@ -475,8 +476,15 @@ def _reserve_self_represented(
     if drawn is not None:
         console.print('[green]  Resuming the seat you already drew[/green] (skipping bid); finalizing…')
     else:
-        # Phase 1 — BID (pair only; no taker, no amounts).
-        sig = client.open_or_request(miner, from_chain, to_chain)
+        # Phase 1 — BID (pair only; no taker, no amounts). A contract rejection (miner busy,
+        # already reserved, …) is a normal outcome — fail with its message, never a traceback.
+        try:
+            sig = client.open_or_request(miner, from_chain, to_chain)
+        except Exception as e:
+            reason = contract_reject_reason(e)
+            if reason is None:
+                raise
+            fail(f'  Reservation rejected: {reason}. No funds moved; re-run shortly.')
         console.print(f'[green]  Bid placed[/green] (tx {sig[:16]}…). Cranking the draw…')
 
         # Phase 2 — self-crank the draw until we're seated (unfilled reservation, router == us).
@@ -495,15 +503,21 @@ def _reserve_self_represented(
 
     # Phase 3 — FINALIZE against the PINNED rate (not the live quote, which can drift after the bid).
     fill = compute_intake_amounts(from_chain, to_chain, from_amount, rate_display_from_fixed(drawn.rate))
-    client.finalize_reservation(
-        miner,
-        user,
-        user_from_addr,
-        user_to_addr,
-        fill.collateral_amount,
-        fill.from_amount,
-        fill.to_amount,
-    )
+    try:
+        client.finalize_reservation(
+            miner,
+            user,
+            user_from_addr,
+            user_to_addr,
+            fill.collateral_amount,
+            fill.from_amount,
+            fill.to_amount,
+        )
+    except Exception as e:
+        reason = contract_reject_reason(e)
+        if reason is None:
+            raise
+        fail(f'  Finalize rejected: {reason}. Do NOT send funds; re-run shortly.')
     resv = _poll_reservation(client, miner, timeout_secs=30)
     if resv is None or str(resv.user) != str(user):
         fail('  Finalize did not produce a live reservation for you. Do NOT send funds; re-run.')

--- a/allways/solana/client.py
+++ b/allways/solana/client.py
@@ -7,6 +7,7 @@ builders land in B1/B2 as the loop needs them.
 """
 
 import base64
+import re
 import time
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
@@ -122,6 +123,28 @@ def _as_pubkey(p) -> Pubkey:
 
 class SolanaClientError(Exception):
     pass
+
+
+def contract_reject_reason(err: Exception) -> Optional[str]:
+    """A deliberate on-chain program rejection is a normal domain rejection — e.g. the miner got
+    reserved between a pre-check and this tx (a race the contract, as final arbiter, closes).
+    Returns a clean human reason, or None for a genuine transport/RPC fault which must still
+    surface as an error.
+
+    A program rejection surfaces two ways: a PRE-FLIGHT simulation reject carries the Anchor name /
+    'custom program error' text; a tx that is submitted and LANDS failed surfaces through the confirm
+    path as `{'InstructionError': [0, {'Custom': N}]}` — a numeric code with neither phrase."""
+    s = str(err)
+    sl = s.lower()
+    if not ('custom program error' in sl or 'anchorerror' in sl or 'instructionerror' in sl or "'custom':" in sl):
+        return None
+    m = re.search(r'Error Message: ([^.\"\']+)', s)
+    if m:
+        return m.group(1).strip()
+    code = re.search(r"'Custom':\s*(\d+)", s)  # landed-tx form has no human message — surface the code
+    if code:
+        return f'miner is not available for reservation right now (contract error {code.group(1)})'
+    return 'miner is not available for reservation right now'
 
 
 class AllwaysSolanaClient:

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -5,7 +5,6 @@ One source of truth for reserve / confirm / rate / status, shared by the axon sy
 invariants before it signs — the caller (offering or CLI) is never trusted.
 """
 
-import re
 import time
 from dataclasses import dataclass, field
 from typing import Optional
@@ -22,33 +21,10 @@ from allways.cli.swap_commands.swap_intake import (
     select_best_miner,
     swap_viable,
 )
-from allways.solana.client import swap_key_from_tx_hash
+from allways.solana.client import contract_reject_reason, swap_key_from_tx_hash
 from allways.validator.binding import hotkey_ss58, verify_binding
 
 EMPTY_SWAP_KEY = b'\x00' * 32
-
-
-def _contract_reject_reason(err: Exception) -> Optional[str]:
-    """A deliberate on-chain program rejection is a normal domain rejection — e.g. the miner got
-    reserved between our pre-check and this tx (a race the contract, as final arbiter, closes). Return a
-    clean human reason so the seam answers 422, not a 500. Returns None for a genuine transport/RPC
-    fault, which must still surface as an error.
-
-    A program rejection surfaces two ways: a PRE-FLIGHT simulation reject carries the Anchor name /
-    'custom program error' text; a tx that is submitted and LANDS failed surfaces through the confirm
-    path as `{'InstructionError': [0, {'Custom': N}]}` — a numeric code with neither phrase. Both are
-    contract domain rejections (a transport fault has no Custom program code), so 422 for both."""
-    s = str(err)
-    sl = s.lower()
-    if not ('custom program error' in sl or 'anchorerror' in sl or 'instructionerror' in sl or "'custom':" in sl):
-        return None
-    m = re.search(r'Error Message: ([^.\"\']+)', s)
-    if m:
-        return m.group(1).strip()
-    code = re.search(r"'Custom':\s*(\d+)", s)  # landed-tx form has no human message — surface the code
-    if code:
-        return f'miner is not available for reservation right now (contract error {code.group(1)})'
-    return 'miner is not available for reservation right now'
 
 
 def resolve_miner_pubkey(validator, miner_hotkey: str) -> Optional[Pubkey]:
@@ -147,7 +123,7 @@ def reserve_on_behalf(
     try:
         sig = client.open_or_request(miner_pk, from_chain, to_chain)
     except Exception as e:
-        reason = _contract_reject_reason(e)
+        reason = contract_reject_reason(e)
         if reason is None:
             raise
         return ReserveResult(False, reason)
@@ -236,7 +212,7 @@ def finalize_won_seats(validator, now: int) -> list:
                 fill.to_amount,
             )
         except Exception as e:
-            reason = _contract_reject_reason(e) or (str(e) if isinstance(e, ValueError) else None)
+            reason = contract_reject_reason(e) or (str(e) if isinstance(e, ValueError) else None)
             if reason is None:
                 bt.logging.warning(f'routed sweep {miner[:8]}: finalize transport fault, retrying next step: {e}')
                 continue

--- a/tests/test_swap_routed.py
+++ b/tests/test_swap_routed.py
@@ -294,3 +294,23 @@ def test_axon_cache_rejects_wrong_key_and_non_validator(tmp_path):
         metagraph.validator_permit = [True]
         metagraph.axons[0].is_serving = False  # validator but axon down
         assert dl.find_validator_axon(lambda: subtensor, 7, ROUTER) is None
+
+
+def test_native_bid_contract_rejection_fails_clean(monkeypatch):
+    """A program rejection on the native bid (miner busy mid-race) must fail() with the contract's
+    message, never a raw traceback (QA finding C5)."""
+    from unittest.mock import MagicMock
+
+    import pytest
+
+    from allways.cli.swap_commands import swap as swap_mod
+
+    client = MagicMock()
+    client.open_or_request.side_effect = RuntimeError(
+        "sendTransaction: {'code': -32002, 'message': 'Transaction simulation failed: custom program error: "
+        "0x1774', 'data': {'logs': ['Program log: AnchorError thrown. Error Code: MinerHasActiveSwap. "
+        "Error Number: 6004. Error Message: Miner has an in-flight swap; cannot proceed.']}}"
+    )
+    with pytest.raises(SystemExit):
+        swap_mod._reserve_self_represented(client, 'miner', 'user', 'src', 'dst', 'tao', 'sol', 100, 30)
+    client.open_or_request.assert_called_once()


### PR DESCRIPTION
QA finding C5 (contested-pool run): retrying a swap against a busy miner dumped a raw AnchorError traceback (MinerHasActiveSwap 6004) — the contract supplies the human message and the CLI threw it away. The reject-reason decoder moves from the validator kernel to allways.solana.client (shared one source of truth); the CLI's native bid and finalize now fail() with the contract's message ('Reservation rejected: Miner has an in-flight swap; cannot proceed. No funds moved; re-run shortly.'). Validator seam behavior unchanged. Tests +1; full suite green.