### PR TITLE
Floor whitelisted draw weight at 1

### DIFF
--- a/allways/validator/weights_vote.py
+++ b/allways/validator/weights_vote.py
@@ -37,13 +37,16 @@ _BENIGN_WEIGHTS_MARKERS = ('AlreadyVoted', 'WeightsUpdateTooSoon', 'NotValidator
 
 def derive_weight_vector(validators, attribution: Dict[str, str], metagraph) -> List[int]:
     """Draw weight per whitelisted validator, index-aligned to ``Config.validators``:
-    floor(alpha_stake / bucket); no binding or not on the metagraph → 0."""
+    max(1, floor(alpha_stake / bucket)); no binding or not on the metagraph → 0.
+
+    The floor of 1 keeps a bound, sub-bucket validator ahead of native (weight-0) bidders —
+    all-zero weights make resolve_pool's draw uniform and break routed win odds."""
     uid_of = {hk: uid for uid, hk in enumerate(metagraph.hotkeys)}
     weights = []
     for v in validators:
         uid = uid_of.get(attribution.get(str(Pubkey.from_bytes(bytes(v.key)))))
         alpha = float(metagraph.alpha_stake[uid]) if uid is not None else 0.0
-        weights.append(int(alpha // WEIGHTS_STAKE_BUCKET_ALPHA))
+        weights.append(max(1, int(alpha // WEIGHTS_STAKE_BUCKET_ALPHA)) if uid is not None else 0)
     return weights
 
 

--- a/tests/test_weights_vote.py
+++ b/tests/test_weights_vote.py
@@ -74,7 +74,9 @@ def test_derive_buckets_floor_and_alignment():
     validators = [_vali(k) for k in keys]
     attribution = {str(keys[0]): 'hkA', str(keys[1]): 'hkB', str(keys[2]): 'hkC'}  # keys[3] unbound
     mg = _metagraph(['hkA', 'hkB', 'hkC'], [178_000.0, 49_999.0, 50_000.0])
-    assert derive_weight_vector(validators, attribution, mg) == [3, 0, 1, 0]
+    # Sub-bucket but bound (hkB) floors to 1, not 0 — an all-zero vector makes the contract's
+    # draw uniform and native bidders beat routed takers (QA finding P1). Unbound stays 0.
+    assert derive_weight_vector(validators, attribution, mg) == [3, 1, 1, 0]
 
 
 def test_derive_hotkey_off_metagraph_is_zero():


### PR DESCRIPTION
QA finding P1, observed live: the testnet vali's alpha stake is under the 50k bucket, so floor(alpha/50k) posted weight 0 — resolve_pool's all-zero fallback made contested draws uniform, and a native (weight-0) bidder beat the Ventura router in a real 2-contender draw. Bound whitelisted validators now post max(1, floor(alpha/50k)); unbound stays 0. Contract unchanged (natives already draw 0 tickets when any weight is nonzero), so this fully restores routed win odds. Deploy: takes effect at the next weights vote (~3600 blocks); all validators must run the same formula to quorum. Tests updated; 788 pass.