### PR TITLE
Exit nonzero on post-tx failure paths, reject bad swap keys

### DIFF
--- a/allways/cli/swap_commands/post_tx.py
+++ b/allways/cli/swap_commands/post_tx.py
@@ -26,6 +26,7 @@ from allways.cli.help import StyledCommand
 from allways.cli.swap_commands.helpers import (
     clear_pending_swap,
     console,
+    fail,
     get_cli_context,
     get_solana_cli_context,
     hotkey_bytes_to_ss58,
@@ -126,8 +127,7 @@ def post_tx_command(tx_hash: str, tx_block: int, miner_hint: str):
     else:
         tx_hash = tx_hash.strip()
     if not tx_hash:
-        console.print('[red]A source transaction hash is required.[/red]')
-        return
+        fail('A source transaction hash is required.')
 
     _config, client = get_solana_cli_context(need_keypair=True)
     user = client.keypair.pubkey()
@@ -144,27 +144,25 @@ def post_tx_command(tx_hash: str, tx_block: int, miner_hint: str):
             matches = _find_reservations(client, user, None, require_user=True)
 
     if not matches:
-        console.print(
-            '[yellow]No live, unclaimed reservation found for your address.[/yellow]\n'
-            '[dim]Reserve one with `alw swap now` first, and confirm before it expires. '
-            'Check status with `alw view reservation`.[/dim]'
+        # fail (exit 1), not a friendly return — a scripted relay must see this as failure.
+        fail(
+            'No live, unclaimed reservation found for your address. Reserve one with '
+            '`alw swap now` first, and confirm before it expires. Check status with `alw view reservation`.'
         )
-        return
     if len(matches) > 1:
         console.print('[yellow]You hold multiple live reservations — pick one with --miner <pubkey>:[/yellow]')
         for mpk, _hotkey, resv in matches:
             console.print(
                 f'  [cyan]{mpk}[/cyan]  {resv.from_chain}->{resv.to_chain}  send to [dim]{resv.miner_from_addr}[/dim]'
             )
-        return
+        fail('Ambiguous reservation — nothing was relayed.')
 
     miner_pk, miner_hotkey, resv = matches[0]
     if not miner_hotkey:
-        console.print(
-            f'[red]Miner {miner_pk} has no verifiable hotkey binding — validators cannot resolve the '
-            'reservation. The miner must `alw miner bind-hotkey` before this swap can be confirmed.[/red]'
+        fail(
+            f'Miner {miner_pk} has no verifiable hotkey binding — validators cannot resolve the '
+            'reservation. The miner must `alw miner bind-hotkey` before this swap can be confirmed.'
         )
-        return
 
     # Resolve the source-tx slot as a verification hint (validators can scan without it, but a slot
     # makes it O(1)). Best-effort: fall back to 0 (server-side lookup) or the --block override.

--- a/allways/cli/swap_commands/post_tx.py
+++ b/allways/cli/swap_commands/post_tx.py
@@ -221,8 +221,8 @@ def post_tx_command(tx_hash: str, tx_block: int, miner_hint: str):
             '[dim]Track it with `alw view swap`.[/dim]'
         )
     else:
-        console.print(
-            '\n[yellow]No validator accepted the confirm yet.[/yellow]\n'
-            '[dim]Re-run `alw swap post-tx` with the same hash in a moment. If it keeps failing, '
-            'check the reservation is still active with `alw view reservation`.[/dim]'
+        # exit 1: a scripted relay must see "not accepted" as failure and re-run (idempotent).
+        fail(
+            'No validator accepted the confirm yet. Re-run `alw swap post-tx` with the same hash '
+            'in a moment. If it keeps failing, check the reservation is still active with `alw view reservation`.'
         )

--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -384,6 +384,9 @@ def view_swap(swap_key_hex: str, watch: bool, as_json: bool):
         key = bytes.fromhex(swap_key_hex)
     except ValueError:
         fail(f'Invalid swap_key {swap_key_hex!r}: expected hex (the 32-byte swap_key, not an integer id).')
+    if len(key) != 32:
+        # A truncated paste must not read as "swap finished" — it never existed under that key.
+        fail(f'Invalid swap_key: expected 32 bytes (64 hex chars), got {len(key)}.')
 
     _, client = get_solana_cli_context(need_keypair=False)
 

--- a/tests/test_cli_view_solana.py
+++ b/tests/test_cli_view_solana.py
@@ -123,3 +123,14 @@ def test_view_swap_closed_is_informative_not_error(monkeypatch):
     js = CliRunner().invoke(view.view_group, ['swap', key, '--json'])
     assert js.exit_code == 0, js.output
     assert '"found": false' in js.output
+
+
+def test_view_swap_rejects_wrong_length_key(monkeypatch):
+    client = MagicMock()
+    _patch_client(monkeypatch, client)
+
+    result = CliRunner().invoke(view.view_group, ['swap', '1234'])
+
+    assert result.exit_code == 1, result.output
+    assert '32 bytes' in result.output
+    client.get_swap.assert_not_called()


### PR DESCRIPTION
QA #9 negative-input matrix findings (everything else graded clean — messages, safety, --json shapes):

- E1: `alw swap post-tx` exited 0 on its failure paths (no live reservation / ambiguous reservations / unbound miner / empty hash) — a scripted agent reads that as success. All four now route through fail() (exit 1), messages unchanged.
- E2: `alw view swap <key>` accepted any-length hex; a truncated paste read as "finished or never existed" (exit 0). Non-32-byte keys now fail with the expected length.

Full suite 790 green.