### PR TITLE
Reject malformed reserve synapses at INFO, not ERROR

### DIFF
--- a/allways/validator/axon_handlers.py
+++ b/allways/validator/axon_handlers.py
@@ -179,6 +179,10 @@ async def handle_swap_reserve(
         synapse.accepted = True
         synapse.pool_closes_at = result.pool_closes_at
         bt.logging.info(f'{ctx}: entered pool on-behalf (closes_at={result.pool_closes_at}, tx={result.sig[:16]}…)')
+    except ValueError as e:
+        # Malformed caller input (bad ss58/pubkey) is a client error, not a validator fault —
+        # reject at INFO like every other rejection, don't spam ERROR on garbage synapses.
+        reject_synapse(synapse, str(e), ctx)
     except Exception as e:
         bt.logging.error(f'{ctx} failed: {e}')
         reject_synapse(synapse, str(e))

--- a/tests/test_axon_solana_handlers.py
+++ b/tests/test_axon_solana_handlers.py
@@ -224,3 +224,30 @@ def test_confirm_success_relays_claim():
     assert client.calls == [
         ('submit_swap_claim', MINER_PK, swap_key_from_tx_hash('srctx'), 'srctx', 800_000),
     ]
+
+
+# ---- handle_swap_reserve: malformed caller input ----
+def test_reserve_bad_hotkey_rejects_at_info_not_error(monkeypatch):
+    from allways.synapses import SwapReserveSynapse
+
+    def _raise(*_a, **_k):
+        raise ValueError('Invalid SS58 address: Base 58 requirement is violated')
+
+    monkeypatch.setattr(axon_handlers, 'reserve_on_behalf', _raise)
+    errors = []
+    monkeypatch.setattr(axon_handlers.bt.logging, 'error', lambda msg, *a, **k: errors.append(msg))
+
+    syn = SwapReserveSynapse(
+        miner_hotkey='not-an-ss58',
+        from_chain='tao',
+        to_chain='sol',
+        user_pubkey='u',
+        user_from_addr='x',
+        user_to_addr='y',
+        from_amount=1,
+    )
+    out = run(axon_handlers.handle_swap_reserve(make_validator(FakeSolanaClient()), syn))
+
+    assert out.accepted is False
+    assert 'Invalid SS58' in out.rejection_reason
+    assert errors == []  # a garbage caller must not land on the validator's ERROR log


### PR DESCRIPTION
QA #10 robustness finding: a malformed SwapReserve (bad ss58 miner hotkey) logged at ERROR with a raw exception string, while every other rejection is a clean INFO reason — a garbage caller could spam a validator's ERROR log. The handler now catches ValueError (client-input errors) and rejects at INFO via reject_synapse; genuine faults still ERROR. Validator was already crash-proof (verified live: SS58/pubkey/chain/amount garbage all handled, no traceback, kept cranking). Test asserts no ERROR line. Full suite green.