### PR TITLE
Report tracked collateral, not rent-inclusive vault lamports

### DIFF
--- a/allways/cli/swap_commands/pair.py
+++ b/allways/cli/swap_commands/pair.py
@@ -97,7 +97,7 @@ def post_pair(
     yes: bool,
     dry_run: bool,
 ):
-    """Post a trading pair to chain via commitment.
+    """Post a trading pair as an on-chain quote on the Solana program.
 
     [dim]All arguments are optional — if omitted, you'll be prompted interactively.[/dim]
 

--- a/allways/solana/client.py
+++ b/allways/solana/client.py
@@ -205,8 +205,12 @@ class AllwaysSolanaClient:
         return self._get('MinerDirectionStats', pdas.stats_pda(miner, from_chain, to_chain, self.program_id))
 
     def get_collateral_lamports(self, miner) -> Optional[int]:
-        """Collateral balance = vault lamports (the SOL the miner posted; rent is included)."""
-        return self.rpc.get_account_lamports(pdas.collateral_vault_pda(miner, self.program_id))
+        """Slashable/gating collateral = the tracked ``MinerState.collateral`` — the exact field the
+        contract checks in finalize_reservation / vote_initiate. NOT the vault's raw lamports, which
+        include the account's rent-exempt reserve (~0.00089 SOL) and would over-credit capacity and
+        viability everywhere this is read. None if the miner never posted collateral."""
+        ms = self.get_miner_state(miner)
+        return int(ms.collateral) if ms is not None else None
 
     def get_vote_round(self, req_type: int, target=None):
         return self._get('VoteRound', pdas.vote_round_pda(req_type, target, self.program_id))

--- a/tests/test_solana_client_integration.py
+++ b/tests/test_solana_client_integration.py
@@ -105,13 +105,14 @@ def test_b0_round_trip(client):
     assert cfg.halted is False
     assert list(cfg.validators) == []
 
-    # post_collateral -> MinerState + vault lamports
+    # post_collateral -> MinerState.collateral (the tracked, slashable, gating field)
     client.post_collateral(5_000_000)
     ms = client.get_miner_state(me)
     assert ms.miner == me
     assert ms.collateral == 5_000_000
     assert ms.active is False and ms.successful_swaps == 0 and ms.failed_swaps == 0
-    assert client.get_collateral_lamports(me) >= 5_000_000
+    # get_collateral_lamports returns exactly the tracked field — not vault lamports (rent-inclusive).
+    assert client.get_collateral_lamports(me) == 5_000_000
 
     # set_quote -> MinerQuote (u128 fixed-point rate)
     rate = 15 * 10**17  # 1.5 * RATE_PRECISION


### PR DESCRIPTION
QA finding: `alw status` (0.9765 SOL) and `alw miner status` (0.9774) disagreed on collateral with no swap between — a 0.00089 SOL gap = the collateral vault's rent-exempt reserve.

Root cause: `get_collateral_lamports` read the vault's raw lamports (rent included), while `alw status` reads the tracked `MinerState.collateral`. The contract gates every swap on `MinerState.collateral` (finalize_reservation.rs:111, vote_initiate.rs:81) — so the vault reading over-credited collateral everywhere it's used: capacity math (swap_intake), the validator's swap-viability pre-check (reserve_engine), `view miners`, and deposit/withdraw displays. At the margin the CLI/validator would call a swap viable that the contract rejects.

Fix: `get_collateral_lamports` returns `MinerState.collateral` — the exact field the contract checks. One source of truth; CLI/validator now agree with the contract byte-for-byte. Also fixed a stale `alw miner post` help string ("via commitment" → "on-chain quote on the Solana program" — it's a MinerQuote PDA, not a bittensor commitment).

Tests: 791 pass; integration assertion tightened to `==`.