### PR TITLE
Quote UX: exclude inactive miners, headline receive, chain-option prompts

### DIFF
--- a/allways/cli/swap_commands/quote.py
+++ b/allways/cli/swap_commands/quote.py
@@ -61,8 +61,9 @@ def quote_command(from_chain: str, to_chain: str, amount: float, as_json: bool):
         alw swap quote --from btc --to sol --amount 0.001
     """
     set_json_output(as_json)
-    from_chain = _prompt_or_fail(from_chain, 'Source chain', '--from')
-    to_chain = _prompt_or_fail(to_chain, 'Destination chain', '--to')
+    chains = ', '.join(SUPPORTED_CHAINS)
+    from_chain = _prompt_or_fail(from_chain, f'Source chain ({chains})', '--from')
+    to_chain = _prompt_or_fail(to_chain, f'Destination chain ({chains})', '--to')
     amount = _prompt_or_fail(amount, 'Amount (source units)', '--amount', cast=float)
 
     from_chain = from_chain.lower()
@@ -85,6 +86,9 @@ def quote_command(from_chain: str, to_chain: str, amount: float, as_json: bool):
     book = load_miner_book(client, with_reservation=False)
     candidates = []
     for e in book:
+        # Inactive miners can't be reserved (the contract rejects it) — never offer one as a quote.
+        if e.state is None or not e.state.active:
+            continue
         for q in e.quotes:
             if q.from_chain == from_chain and q.to_chain == to_chain:
                 candidates.append(
@@ -144,6 +148,15 @@ def quote_command(from_chain: str, to_chain: str, amount: float, as_json: bool):
         fail(f'No quote available: {why} right now.')
 
     viable.sort(key=lambda x: x[1], reverse=True)
+
+    # Lead with the headline number — what you'd actually receive at the best offer — then the breakdown.
+    best_recv = viable[0][1] / 10**to_dec
+    console.print(
+        f'\n[bold green]≈ {best_recv:.8g} {to_chain.upper()}[/bold green]'
+        f'  [dim]for[/dim]  {amount:g} {from_chain.upper()}'
+        f'  [dim](best of {len(viable)} offer{"s" if len(viable) != 1 else ""}, after {100 / FEE_DIVISOR:g}% fee)[/dim]'
+    )
+
     table = Table(
         title=f'Quote: {amount:g} {from_chain.upper()} → {to_chain.upper()}  (after {100 / FEE_DIVISOR:g}% fee)',
         show_header=True,

--- a/allways/cli/swap_commands/swap_intake.py
+++ b/allways/cli/swap_commands/swap_intake.py
@@ -43,15 +43,24 @@ def rate_display_from_fixed(rate_fixed: int) -> str:
 
 
 def candidate_miners(client, from_chain: str, to_chain: str) -> List[MinerCandidate]:
-    """All miners with a posted quote for this exact direction, collateral attached.
+    """Active miners with a posted quote for this exact direction, collateral attached.
     Shared by the CLI taker path and the validator reserve engine so "who is
-    quotable" can never diverge between what a taker sees and what reserves."""
+    quotable" can never diverge between what a taker sees and what reserves.
+
+    Inactive miners are excluded: the contract rejects a reserve against them
+    (reserve_on_behalf / finalize_reservation), so a taker must never see one as
+    a candidate. One MinerState read per quoted miner gives both the active gate
+    and the tracked collateral in a single fetch."""
     out: List[MinerCandidate] = []
     for _pk, q in client.get_all('MinerQuote'):
         if q.from_chain != from_chain or q.to_chain != to_chain:
             continue
-        collateral = client.get_collateral_lamports(q.miner) or 0
-        out.append(MinerCandidate(miner=q.miner, rate_display=rate_display_from_fixed(q.rate), collateral=collateral))
+        ms = client.get_miner_state(q.miner)
+        if ms is None or not ms.active:
+            continue
+        out.append(
+            MinerCandidate(miner=q.miner, rate_display=rate_display_from_fixed(q.rate), collateral=int(ms.collateral))
+        )
     return out
 
 

--- a/tests/test_swap_intake.py
+++ b/tests/test_swap_intake.py
@@ -112,3 +112,38 @@ def test_select_best_miner_skips_underfunded():
 def test_select_best_miner_none_when_all_unviable():
     cands = [MinerCandidate(miner='m', rate_display='0.6', collateral=1)]
     assert select_best_miner(cands, 'sol', 'btc', SOL, MIN, MAX) is None
+
+
+# ---- candidate_miners: active gate + tracked collateral ----
+class _FakeCandClient:
+    """Minimal client for candidate_miners: get_all('MinerQuote') + get_miner_state."""
+
+    def __init__(self, quotes, states):
+        self._quotes = quotes  # list of SimpleNamespace(miner, from_chain, to_chain, rate)
+        self._states = states  # {miner: SimpleNamespace(active, collateral)}
+
+    def get_all(self, name):
+        assert name == 'MinerQuote'
+        return [(f'pda{i}', q) for i, q in enumerate(self._quotes)]
+
+    def get_miner_state(self, miner):
+        return self._states.get(miner)
+
+
+def test_candidate_miners_excludes_inactive():
+    from types import SimpleNamespace
+
+    from allways.cli.swap_commands.swap_intake import candidate_miners
+
+    q = lambda m: SimpleNamespace(miner=m, from_chain='tao', to_chain='sol', rate=15 * 10**17)
+    client = _FakeCandClient(
+        quotes=[q('active-m'), q('inactive-m'), q('no-state-m')],
+        states={
+            'active-m': SimpleNamespace(active=True, collateral=976_466_670),
+            'inactive-m': SimpleNamespace(active=False, collateral=5 * SOL),
+            # 'no-state-m' absent → get_miner_state returns None
+        },
+    )
+    out = candidate_miners(client, 'tao', 'sol')
+    assert [c.miner for c in out] == ['active-m']
+    assert out[0].collateral == 976_466_670  # tracked field, not vault lamports

--- a/tests/test_swap_intake.py
+++ b/tests/test_swap_intake.py
@@ -135,7 +135,9 @@ def test_candidate_miners_excludes_inactive():
 
     from allways.cli.swap_commands.swap_intake import candidate_miners
 
-    q = lambda m: SimpleNamespace(miner=m, from_chain='tao', to_chain='sol', rate=15 * 10**17)
+    def q(m):
+        return SimpleNamespace(miner=m, from_chain='tao', to_chain='sol', rate=15 * 10**17)
+
     client = _FakeCandClient(
         quotes=[q('active-m'), q('inactive-m'), q('no-state-m')],
         states={


### PR DESCRIPTION
Three QA findings from the manual quote walkthrough, all in the swap-quote path:

- Inactive miners were quoted: `alw swap quote` (and `candidate_miners`, shared with the validator reserve engine) offered a miner whose on-chain `active` flag was false — the contract rejects a reserve against it, so a taker would reserve and fail. Both the quote command's own loop and `candidate_miners` now filter on `MinerState.active`. Verified live: an inactive miner is excluded; an active one below min_swap correctly reports "no miner can fund" instead of showing a bogus offer.
- Blind interactive prompts: "Source chain:" now shows "Source chain (sol, btc, tao)".
- Lead with the number: a bold headline — `≈ 0.1782 TAO  for  0.15 SOL  (best of N offers, after 1% fee)` — prints above the breakdown table.

Tests: full suite green; +1 candidate_miners active-filter unit test.