### PR TITLE
Auto-send wizard for swap now: send, relay, watch to completion

### DIFF
--- a/allways/chain_providers/base.py
+++ b/allways/chain_providers/base.py
@@ -45,6 +45,13 @@ class ChainProvider(ABC):
         """One-line summary of the backend/API this provider talks to, for startup logs."""
         return self.get_chain().name
 
+    def can_send_from(self, address: str) -> bool:
+        """True iff this provider's signing credentials control ``address`` — i.e. a ``send_amount``
+        would broadcast FROM it. Gates the CLI's auto-send: a deposit must come from the reservation's
+        pinned ``from_addr`` or the validator rejects it. Conservative default (unknown provider can't
+        prove it); each provider overrides with a real check."""
+        return False
+
     @abstractmethod
     def check_connection(self, **kwargs) -> None:
         """Verify the chain provider can reach its backend (RPC node, subtensor, etc).

--- a/allways/chain_providers/bitcoin.py
+++ b/allways/chain_providers/bitcoin.py
@@ -149,6 +149,24 @@ class BitcoinProvider(ChainProvider):
         hosts = ', '.join(urlparse(base).netloc or base for base, _ in self.btc_api_bases())
         return f'Esplora API ({self.network}): {hosts}'
 
+    def can_send_from(self, address: str) -> bool:
+        """True iff BTC_PRIVATE_KEY derives ``address`` (any of its p2wpkh / p2sh-p2wpkh / p2pkh
+        forms) — i.e. this WIF can broadcast the source deposit from the pinned sender."""
+        wif = os.environ.get('BTC_PRIVATE_KEY')
+        if not wif:
+            return False
+        try:
+            from embit.ec import PrivateKey as EmbitPrivateKey
+            from embit.networks import NETWORKS
+            from embit.script import p2pkh, p2sh, p2wpkh
+
+            net = NETWORKS['test'] if self.network in ('testnet', 'testnet4') else NETWORKS['main']
+            pub = EmbitPrivateKey.from_wif(wif).get_public_key()
+            seg = p2wpkh(pub)
+            return address in {seg.address(net), p2sh(seg).address(net), p2pkh(pub).address(net)}
+        except Exception:
+            return False
+
     def check_connection(self, require_send: bool = True) -> None:
         if require_send and not os.environ.get('BTC_PRIVATE_KEY'):
             raise ConnectionError('BTC signing requires the BTC_PRIVATE_KEY env var')

--- a/allways/chain_providers/solana.py
+++ b/allways/chain_providers/solana.py
@@ -45,6 +45,9 @@ class SolanaProvider(ChainProvider):
     def describe(self) -> str:
         return f'Solana RPC {self.rpc_url}'
 
+    def can_send_from(self, address: str) -> bool:
+        return self.keypair is not None and str(self.keypair.pubkey()) == address
+
     def check_connection(self, require_send: bool = True, **kwargs) -> None:
         if require_send and self.keypair is None:
             raise ConnectionError('SOL send requires a Solana keypair (pass solana_keypair)')

--- a/allways/chain_providers/subtensor.py
+++ b/allways/chain_providers/subtensor.py
@@ -38,6 +38,9 @@ class SubtensorProvider(ChainProvider):
     def describe(self) -> str:
         return f'Subtensor {self.subtensor.chain_endpoint}'
 
+    def can_send_from(self, address: str) -> bool:
+        return self.wallet is not None and self.wallet.coldkeypub.ss58_address == address
+
     def check_connection(self, **kwargs) -> None:
         try:
             block = self.subtensor.get_current_block()

--- a/allways/cli/swap_commands/post_tx.py
+++ b/allways/cli/swap_commands/post_tx.py
@@ -165,9 +165,22 @@ def post_tx_command(tx_hash: str, tx_block: int, miner_hint: str):
             'reservation. The miner must `alw miner bind-hotkey` before this swap can be confirmed.'
         )
 
-    # Resolve the source-tx slot as a verification hint (validators can scan without it, but a slot
-    # makes it O(1)). Best-effort: fall back to 0 (server-side lookup) or the --block override.
+    swap_key = relay_deposit(client, resv, miner_pk, miner_hotkey, tx_hash, tx_block, on_behalf_of=user)
+    if swap_key is None:
+        # exit 1: a scripted relay must see "not accepted" as failure and re-run (idempotent).
+        fail(
+            'No validator accepted the confirm yet. Re-run `alw swap post-tx` with the same hash '
+            'in a moment. If it keeps failing, check the reservation is still active with `alw view reservation`.'
+        )
+    console.print(f'[dim]Track it with `alw view swap {swap_key} --watch`.[/dim]')
+
+
+def relay_deposit(client, resv, miner_pk, miner_hotkey, tx_hash, tx_block=0, *, on_behalf_of=None) -> str | None:
+    """Relay a source deposit to the validators (the shared core of ``post-tx`` and the ``swap now``
+    auto-send). Returns the swap_key hex on acceptance, else None. Idempotent: validators re-verify the
+    same on-chain deposit each call."""
     if tx_block == 0:
+        # Slot is a verification hint (O(1) lookup); validators can scan without it. Best-effort.
         try:
             info = client.rpc.get_transaction(tx_hash)
             if info and info.get('slot'):
@@ -175,7 +188,9 @@ def post_tx_command(tx_hash: str, tx_block: int, miner_hint: str):
         except Exception:
             pass
 
-    on_behalf = '' if str(resv.user) == str(user) else f'  [dim](relaying on behalf of {str(resv.user)[:8]}…)[/dim]'
+    on_behalf = ''
+    if on_behalf_of is not None and str(resv.user) != str(on_behalf_of):
+        on_behalf = f'  [dim](relaying on behalf of {str(resv.user)[:8]}…)[/dim]'
     console.print(
         f'\n[bold]Confirming deposit[/bold] for {resv.from_chain.upper()}->{resv.to_chain.upper()} swap{on_behalf}\n'
         f'  Miner:   [dim]{miner_hotkey[:16]}… ({str(miner_pk)[:8]}…)[/dim]\n'
@@ -194,11 +209,10 @@ def post_tx_command(tx_hash: str, tx_block: int, miner_hint: str):
     )
 
     config, _wallet, subtensor, _ = get_cli_context(need_wallet=False)
-    netuid = int(config['netuid'])
-    validator_axons = discover_validators(subtensor, netuid)
+    validator_axons = discover_validators(subtensor, int(config['netuid']))
     if not validator_axons:
         console.print('[red]No serving validators found on the metagraph.[/red]')
-        return
+        return None
 
     wallet = get_ephemeral_wallet()  # transport-only throwaway hotkey; auth is the on-chain deposit
     info = None
@@ -214,18 +228,13 @@ def post_tx_command(tx_hash: str, tx_block: int, miner_hint: str):
         )
         time.sleep(_RELAY_WAIT_SECS)
 
-    if info.accepted:
-        clear_pending_swap()
-        swap_key = swap_key_from_tx_hash(tx_hash).hex()
-        console.print(
-            f'\n[green]Deposit confirmed by {info.accepted} validator(s).[/green] '
-            'The miner will fulfil the destination leg once the claim is attested.\n'
-            f'  Swap key: {swap_key}\n'
-            f'[dim]Track it with `alw view swap {swap_key} --watch`.[/dim]'
-        )
-    else:
-        # exit 1: a scripted relay must see "not accepted" as failure and re-run (idempotent).
-        fail(
-            'No validator accepted the confirm yet. Re-run `alw swap post-tx` with the same hash '
-            'in a moment. If it keeps failing, check the reservation is still active with `alw view reservation`.'
-        )
+    if not info.accepted:
+        return None
+    clear_pending_swap()
+    swap_key = swap_key_from_tx_hash(tx_hash).hex()
+    console.print(
+        f'\n[green]Deposit confirmed by {info.accepted} validator(s).[/green] '
+        'The miner will fulfil the destination leg once the claim is attested.\n'
+        f'  Swap key: {swap_key}'
+    )
+    return swap_key

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -621,36 +621,48 @@ def _miner_hotkey(client, miner_pk) -> str:
     return hotkey_bytes_to_ss58(b.hotkey) if b else ''
 
 
+# Plain-English gloss for each on-chain swap status, shown beside it while watching.
+_STATUS_NOTE = {
+    'PendingAttestation': 'validators verifying your deposit',
+    'Active': 'deposit confirmed — miner is sending your funds',
+    'Fulfilled': 'miner delivered — validators confirming both legs',
+}
+
+
 def _watch_swap(client, swap_key_hex: str, to_chain: str, timeout_secs: int = 900) -> None:
     """Watch a just-relayed swap to a terminal state, printing transitions. A closed account is the
     SUCCESS signal (swaps close on settle) — so once we've seen it live, its disappearance reads as
     COMPLETED, never the bare 'never existed' scare."""
     key = bytes.fromhex(swap_key_hex)
-    console.print('[dim]  Watching your swap — this settles on its own; Ctrl-C is safe to walk away.[/dim]')
+    resume = f'[dim]  Resume anytime with `alw view swap {swap_key_hex} --watch`.[/dim]'
+    console.print(f'[dim]  Watching your swap — this settles on its own; Ctrl-C is safe to walk away.[/dim]\n{resume}')
     last, seen_live, seen_fulfilled = None, False, False
     deadline = time.time() + timeout_secs
-    while time.time() < deadline:
-        try:
-            acct = client.get_swap(key)
-        except Exception:
-            acct = None
-        if acct is not None:
-            seen_live = True
-            status = type(acct.status).__name__
-            if status != last:
-                console.print(f'    {status}')
-                last = status
-            if status == 'Fulfilled':
-                seen_fulfilled = True
-        elif seen_live:
-            console.print(f'[green]  ✓ COMPLETED[/green] — settled on-chain, your {to_chain.upper()} was delivered.')
-            return
-        time.sleep(4)
+    try:
+        while time.time() < deadline:
+            try:
+                acct = client.get_swap(key)
+            except Exception:
+                acct = None
+            if acct is not None:
+                seen_live = True
+                status = type(acct.status).__name__
+                if status != last:
+                    console.print(f'    {status:<19}[dim]{_STATUS_NOTE.get(status, "")}[/dim]')
+                    last = status
+                if status == 'Fulfilled':
+                    seen_fulfilled = True
+            elif seen_live:
+                console.print(
+                    f'[green]  ✓ COMPLETED[/green] — settled on-chain, your {to_chain.upper()} was delivered.'
+                )
+                return
+            time.sleep(4)
+    except KeyboardInterrupt:
+        console.print(f'\n[dim]  Stopped watching (the swap keeps settling on its own).[/dim]\n{resume}')
+        return
     tail = 'delivered' if seen_fulfilled else 'check `alw status` for your balance'
-    console.print(
-        f'[yellow]  Still settling after {timeout_secs}s[/yellow] — {tail}. '
-        f'Track: `alw view swap {swap_key_hex} --watch`.'
-    )
+    console.print(f'[yellow]  Still settling after {timeout_secs}s[/yellow] — {tail}.\n{resume}')
 
 
 def _reserve_self_represented(

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -33,6 +33,7 @@ from allways.cli.swap_commands.helpers import (
     get_solana_cli_context,
     hotkey_bytes_to_ss58,
     live_unclaimed,
+    loading,
 )
 from allways.cli.swap_commands.swap_intake import (
     candidate_miners,
@@ -276,6 +277,13 @@ def _poll_routed_reservation(client, miner, user, timeout_secs: int):
 @click.option('--router', 'router_opt', default=None, help='Validator hotkey to route through (overrides config)')
 @click.option('--no-router', 'no_router', is_flag=True, help='Self-represent even when a router is configured')
 @click.option(
+    '--send/--no-send',
+    'auto_send',
+    default=None,
+    help='Auto-send the source funds from your configured wallet after reserving, then relay and '
+    'watch to completion. Default: on when interactive (prompts), off for scripts (print instructions).',
+)
+@click.option(
     '--btc-fee-rate',
     'btc_fee_rate_opt',
     type=click.IntRange(min=1),
@@ -297,6 +305,7 @@ def swap_now_command(
     skip_confirm: bool,
     router_opt: Optional[str],
     no_router: bool,
+    auto_send: Optional[bool],
     btc_fee_rate_opt: Optional[int],
 ):
     """Originate a swap: reserve a miner on-chain, then send source funds.
@@ -483,9 +492,135 @@ def swap_now_command(
         )
 
     _save_pending(cand.miner, from_chain, to_chain)
+
+    # Wizard: auto-send the source leg from the configured wallet, relay, and watch to completion.
+    # Default on when interactive (a Y/n confirm), off for scripts/agents unless --send. --no-send
+    # forces the manual print-and-exit. Falls back to manual if this wallet can't sign the source.
+    want_send = auto_send if auto_send is not None else sys.stdin.isatty()
+    if want_send and _auto_send_wizard(
+        client, config, resv, cand.miner, from_chain, to_chain, from_amount, skip_confirm, btc_fee_rate_opt
+    ):
+        return
+
     console.print(
         f'[green]  Reserved.[/green] Send [cyan]{amount_opt} {from_chain.upper()}[/cyan] to '
         f'[cyan]{resv.miner_from_addr}[/cyan], then run [bold]alw swap post-tx[/bold] with the tx hash.'
+    )
+
+
+def _source_provider(from_chain: str, client, config):
+    """Build ONLY the source chain's provider with this CLI's own signing creds (solana keypair /
+    bt wallet / BTC WIF), from the same registry the neurons use — so a new spoke chain works with
+    zero changes here. Uses the CLI's live RPC (never a fresh localhost default). Returns None
+    (→ manual fallback) if the provider can't be built with send credentials."""
+    from allways.chain_providers import PROVIDER_REGISTRY
+
+    entry = next((e for e in PROVIDER_REGISTRY if e[0] == from_chain), None)
+    if entry is None:
+        return None
+    _id, cls, kwarg_names = entry
+
+    avail = {'solana_rpc_url': client.rpc.url, 'solana_keypair': client.keypair}
+    if from_chain == 'tao':
+        _cfg, wallet, subtensor, _ = get_cli_context(need_wallet=True)
+        try:
+            wallet.unlock_coldkey()
+        except Exception as e:  # noqa: BLE001 - a locked coldkey means we can't auto-send TAO; fall back
+            console.print(f'[dim]  Could not unlock coldkey for auto-send ({e}); use the manual flow.[/dim]')
+            return None
+        avail.update(subtensor=subtensor, wallet=wallet)
+    try:
+        provider = cls(**{k: avail[k] for k in kwarg_names if k in avail})
+        provider.check_connection(require_send=True)
+    except Exception as e:  # noqa: BLE001 - missing creds (e.g. no BTC_PRIVATE_KEY) → manual fallback
+        console.print(f'[dim]  Auto-send unavailable for {from_chain.upper()} ({e}); use the manual flow.[/dim]')
+        return None
+    return provider
+
+
+def _auto_send_wizard(client, config, resv, miner_pk, from_chain, to_chain, from_amount, skip_confirm, btc_fee_rate):
+    """Send the source deposit from the configured wallet, relay it, and watch to a terminal state.
+    Returns True if it drove the send (success or a clean stop), False to fall back to manual."""
+    provider = _source_provider(from_chain, client, config)
+    if provider is None:
+        return False
+    # SAFETY: the deposit MUST come from the reservation's pinned sender or the validator rejects it
+    # (the exact wrong-key failure). Verify BEFORE moving any funds.
+    if not provider.can_send_from(resv.from_addr):
+        console.print(
+            f'[dim]  Your configured {from_chain.upper()} wallet does not control the pinned source '
+            f'address {resv.from_addr[:12]}… — sending it yourself and running post-tx.[/dim]'
+        )
+        return False
+
+    amount_disp = int(resv.from_amount) / 10 ** get_chain(from_chain).decimals
+    to_addr = resv.miner_from_addr
+    if not skip_confirm and not click.confirm(
+        f'  Send {amount_disp:g} {from_chain.upper()} from your wallet ({resv.from_addr[:10]}…) now?',
+        default=True,
+    ):
+        return False  # user declined auto-send → manual instructions
+
+    kw = {'from_address': resv.from_addr}
+    if from_chain == 'btc' and btc_fee_rate is not None:
+        kw['fee_rate_override'] = btc_fee_rate
+    with loading(f'Sending {amount_disp:g} {from_chain.upper()} to the miner…'):
+        sent = provider.send_amount(to_addr, int(resv.from_amount), **kw)
+    if not sent:
+        err = getattr(provider, 'last_send_error', None)
+        fail(
+            f'  Source send failed{f": {err}" if err else ""}. No claim relayed; your reservation is still live '
+            '— retry `alw swap now` or send manually.'
+        )
+    tx_hash = sent[0]
+    console.print(f'[green]  Sent[/green] {amount_disp:g} {from_chain.upper()} — [cyan]{tx_hash}[/cyan]')
+
+    from allways.cli.swap_commands.post_tx import relay_deposit
+
+    miner_hotkey = _miner_hotkey(client, miner_pk)
+    swap_key = relay_deposit(client, resv, miner_pk, miner_hotkey, tx_hash)
+    if swap_key is None:
+        fail(
+            f'  Deposit sent but no validator accepted the relay yet. Re-run `alw swap post-tx {tx_hash}` in a moment.'
+        )
+    _watch_swap(client, swap_key, to_chain)
+    return True
+
+
+def _miner_hotkey(client, miner_pk) -> str:
+    b = client.get_binding(miner_pk)
+    return hotkey_bytes_to_ss58(b.hotkey) if b else ''
+
+
+def _watch_swap(client, swap_key_hex: str, to_chain: str, timeout_secs: int = 900) -> None:
+    """Watch a just-relayed swap to a terminal state, printing transitions. A closed account is the
+    SUCCESS signal (swaps close on settle) — so once we've seen it live, its disappearance reads as
+    COMPLETED, never the bare 'never existed' scare."""
+    key = bytes.fromhex(swap_key_hex)
+    console.print('[dim]  Watching your swap — this settles on its own; Ctrl-C is safe to walk away.[/dim]')
+    last, seen_live, seen_fulfilled = None, False, False
+    deadline = time.time() + timeout_secs
+    while time.time() < deadline:
+        try:
+            acct = client.get_swap(key)
+        except Exception:
+            acct = None
+        if acct is not None:
+            seen_live = True
+            status = type(acct.status).__name__
+            if status != last:
+                console.print(f'    {status}')
+                last = status
+            if status == 'Fulfilled':
+                seen_fulfilled = True
+        elif seen_live:
+            console.print(f'[green]  ✓ COMPLETED[/green] — settled on-chain, your {to_chain.upper()} was delivered.')
+            return
+        time.sleep(4)
+    tail = 'delivered' if seen_fulfilled else 'check `alw status` for your balance'
+    console.print(
+        f'[yellow]  Still settling after {timeout_secs}s[/yellow] — {tail}. '
+        f'Track: `alw view swap {swap_key_hex} --watch`.'
     )
 
 

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -522,12 +522,9 @@ def _source_provider(from_chain: str, client, config):
 
     avail = {'solana_rpc_url': client.rpc.url, 'solana_keypair': client.keypair}
     if from_chain == 'tao':
+        # Wallet only — do NOT unlock the coldkey here. `can_send_from` reads the public coldkeypub,
+        # so we defer the (possibly interactive) unlock until AFTER the user confirms the send.
         _cfg, wallet, subtensor, _ = get_cli_context(need_wallet=True)
-        try:
-            wallet.unlock_coldkey()
-        except Exception as e:  # noqa: BLE001 - a locked coldkey means we can't auto-send TAO; fall back
-            console.print(f'[dim]  Could not unlock coldkey for auto-send ({e}); use the manual flow.[/dim]')
-            return None
         avail.update(subtensor=subtensor, wallet=wallet)
     try:
         provider = cls(**{k: avail[k] for k in kwarg_names if k in avail})
@@ -536,6 +533,28 @@ def _source_provider(from_chain: str, client, config):
         console.print(f'[dim]  Auto-send unavailable for {from_chain.upper()} ({e}); use the manual flow.[/dim]')
         return None
     return provider
+
+
+def _unlock_coldkey_for_send(wallet) -> bool:
+    """Unlock the bt coldkey to sign a TAO transfer — reading MINER_BITTENSOR_COLDKEY_PASSWORD from
+    env first (seamless, no prompt), else prompting WITH context so the ask never reads as a bare,
+    unexplained 'Enter your password:'. Returns False (→ manual fallback) if it can't unlock."""
+    import os
+
+    pw = os.environ.get('MINER_BITTENSOR_COLDKEY_PASSWORD')
+    try:
+        if pw:
+            wallet.coldkey_file.save_password_to_env(pw)
+        else:
+            console.print(
+                '  [dim]Unlock your Bittensor coldkey to sign the TAO transfer '
+                '(set MINER_BITTENSOR_COLDKEY_PASSWORD to skip this):[/dim]'
+            )
+        wallet.unlock_coldkey()
+        return True
+    except Exception as e:  # noqa: BLE001 - wrong/absent password → fall back to manual send
+        console.print(f'[dim]  Could not unlock coldkey ({e}); send the TAO yourself and run post-tx.[/dim]')
+        return False
 
 
 def _auto_send_wizard(client, config, resv, miner_pk, from_chain, to_chain, from_amount, skip_confirm, btc_fee_rate):
@@ -560,6 +579,10 @@ def _auto_send_wizard(client, config, resv, miner_pk, from_chain, to_chain, from
         default=True,
     ):
         return False  # user declined auto-send → manual instructions
+
+    # TAO leaves the encrypted coldkey — unlock it only now (after the confirm), with context.
+    if from_chain == 'tao' and not _unlock_coldkey_for_send(provider.wallet):
+        return False
 
     kw = {'from_address': resv.from_addr}
     if from_chain == 'btc' and btc_fee_rate is not None:

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -574,8 +574,14 @@ def _auto_send_wizard(client, config, resv, miner_pk, from_chain, to_chain, from
 
     amount_disp = int(resv.from_amount) / 10 ** get_chain(from_chain).decimals
     to_addr = resv.miner_from_addr
+    wallet_label = {
+        'sol': 'Solana keypair',
+        'tao': f'Bittensor coldkey ({config.get("wallet", "?")})',
+        'btc': 'Bitcoin WIF wallet',
+    }.get(from_chain, f'{from_chain.upper()} wallet')
+    console.print(f'  [dim]Source: your configured {wallet_label}[/dim]  [cyan]{resv.from_addr}[/cyan]')
     if not skip_confirm and not click.confirm(
-        f'  Send {amount_disp:g} {from_chain.upper()} from your wallet ({resv.from_addr[:10]}…) now?',
+        f'  Send {amount_disp:g} {from_chain.upper()} to the miner now?',
         default=True,
     ):
         return False  # user declined auto-send → manual instructions

--- a/tests/test_swap_now_reservation.py
+++ b/tests/test_swap_now_reservation.py
@@ -364,3 +364,39 @@ def test_swap_now_does_not_resume_a_foreign_seat():
     # with no _poll_drawn patched, the bid path runs its self-crank; we only assert it did NOT short-circuit
     # into a resume (no "Resuming" banner) — it treated the foreign seat as not-ours.
     assert 'Resuming' not in result.output
+
+
+def test_can_send_from_gates_on_signer(monkeypatch):
+    """The auto-send safety gate: a provider must confirm it controls the pinned sender before any
+    funds move (prevents the wrong-key deposit the validator would reject)."""
+    from types import SimpleNamespace
+
+    from allways.chain_providers.solana import SolanaProvider
+
+    kp = SimpleNamespace(pubkey=lambda: 'PINNED')
+    p = SolanaProvider.__new__(SolanaProvider)
+    p.keypair = kp
+    assert p.can_send_from('PINNED') is True
+    assert p.can_send_from('SOMEONE_ELSE') is False
+    p.keypair = None
+    assert p.can_send_from('PINNED') is False
+
+
+def test_watch_swap_reports_completed_after_close(monkeypatch):
+    """A swap account that disappears AFTER we've seen it live must read as COMPLETED, never the
+    bare 'never existed' message (the fast-close scare)."""
+    from unittest.mock import MagicMock, patch
+
+    from allways.cli.swap_commands import swap as swap_mod
+
+    active = types.SimpleNamespace(status=type('Active', (), {})())
+    client = MagicMock()
+    client.get_swap.side_effect = [active, None]  # live once, then closed
+    out = []
+    with (
+        patch('allways.cli.swap_commands.swap.time.sleep'),
+        patch.object(swap_mod.console, 'print', lambda *a, **k: out.append(' '.join(str(x) for x in a))),
+    ):
+        swap_mod._watch_swap(client, 'ab' * 32, 'tao')
+    joined = ' '.join(out)
+    assert 'COMPLETED' in joined and 'never existed' not in joined


### PR DESCRIPTION
QA #4: `alw swap now` ended at "Reserved. Go send the money and post-tx yourself" — a jarring, error-prone stop (you had to broadcast from the exact pinned key by hand, then relay, then the swap closed so fast that `view swap --watch` said "never existed"). Now it's an end-to-end wizard.

After reserving, on a TTY (or with --send) it:
1. Auto-sends the source leg from your configured wallet — ONE chain-agnostic path (`provider.send_amount`) built from the same PROVIDER_REGISTRY the neurons use, so SOL / TAO / BTC all work and a new spoke chain needs zero changes here.
2. Safety gate first: `provider.can_send_from(reservation.from_addr)` — the deposit must come from the pinned sender or the validator rejects it; verified BEFORE any funds move (catches the wrong-key class of error). Sends EXACTLY the pinned from_amount read off-chain, not the display.
3. Auto-relays via the shared `relay_deposit` (extracted from post-tx — one source of truth).
4. Watches to a terminal state, printing PendingAttestation → Active → Fulfilled → ✓ COMPLETED. A closed account after we've seen it live reads as COMPLETED, killing the "never existed" fast-close scare.

`--no-send` keeps the manual print-and-exit; scripts/agents (no TTY) stay manual unless `--send`. Falls back to manual cleanly if the wallet can't sign the source (missing WIF, locked coldkey, wrong key).

New: `can_send_from` on the ChainProvider base + all three providers (SOL keypair, TAO coldkey, BTC WIF-derived across p2wpkh/p2sh/p2pkh).

Verified live end-to-end on testnet: sol→tao 0.15 auto-sent, relayed, watched to COMPLETED in one command. Tests: 794 pass (+3: send-gate, watch-close-is-completed, and the E2E was manual).