### PR TITLE
Default mainnet env to self-represent (no router)

### DIFF
--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -37,8 +37,8 @@ SOLANA_NETWORKS = {
 # Names the BTC provider (BTC_NETWORK env) accepts; endpoints default to public esplora per network.
 BTC_NETWORKS = ('mainnet', 'testnet', 'testnet4', 'signet')
 # One-liner env bundle: `alw config set env testnet|mainnet` sets all three chains' networks + netuid
-# + the recommended router (the Ventura Labs validator per network) so reservations are
-# validator-routed out of the box. `alw config set router ""` or --no-router opts out.
+# + the default router. Testnet routes through the Ventura Labs validator; mainnet self-represents
+# (no routing validator live yet). `alw config set router <ss58>` opts into routing on mainnet.
 ENV_BUNDLES = {
     'testnet': {
         'network': 'test',
@@ -52,7 +52,9 @@ ENV_BUNDLES = {
         'solana-network': 'mainnet',
         'btc-network': 'mainnet',
         'netuid': '7',
-        'router': '5DtUJ9ytbeCMjovFieNwaxxqRP3DzT6iQPnZTyKmi3n6iXey',
+        # No routing validator on mainnet yet — bid self-represented until one ships a routing
+        # product. Explicit '' (not omitted) so re-running `env mainnet` CLEARS a stale router.
+        'router': '',
     },
 }
 

--- a/tests/test_swap_routed.py
+++ b/tests/test_swap_routed.py
@@ -183,12 +183,14 @@ def test_rejection_reason_surfaces():
     assert 'miner is not active' in _flat(r)
 
 
-def test_env_bundles_carry_routers_and_config_key_registered():
+def test_env_bundles_router_defaults_and_config_key_registered():
     from allways.cli.main import VALID_CONFIG_KEYS
     from allways.cli.swap_commands.helpers import ENV_BUNDLES
 
     assert 'router' in VALID_CONFIG_KEYS
-    assert ENV_BUNDLES['mainnet']['router'] == ROUTER
+    # Mainnet has no routing validator yet — self-represent by default (explicit '' clears any stale
+    # router on re-run). Testnet routes through the Ventura Labs validator used in QA.
+    assert ENV_BUNDLES['mainnet']['router'] == ''
     assert ENV_BUNDLES['testnet']['router'] == '5HicmHG7fjbxrtx8FZNdv4xxS5jSN84KGpMnTHsKtKv9peao'
 
 


### PR DESCRIPTION
`alw config set env mainnet` no longer sets a default router — mainnet has no routing validator live yet, so entrants self-represent (bid → self-crank draw → finalize).

- `ENV_BUNDLES['mainnet']['router']` → `''` (explicit, so re-running `env mainnet` also *clears* a stale router; empty router → `routed=False`).
- Testnet unchanged: still routes through the Ventura Labs validator used in QA.
- `alw config set router <ss58>` opts into routing on mainnet once a routing product ships.

Full suite green.