### PR TITLE
Reward depth in crown scoring: collateral tie-break + convex capacity

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -70,6 +70,11 @@ DIRECTION_POOLS: dict[tuple[str, str], float] = {
 }
 # Idle-crown penalty: 0 = none, 1 = pure volume share; a zero-fill holder floors at 1-α (0.25).
 VOLUME_WEIGHT_ALPHA: float = 0.75
+# Capacity curve exponent (>1 = convex): capacity = min(1, (collateral / required)^k). Convex so
+# thin-parked collateral is penalised harder than linear (a miner backing the best rate on a sliver
+# earns a smaller slice than the ratio alone), pushing miners to deepen. Still capped at 1.0 — depth
+# past required earns nothing extra, so it never becomes pay-to-win.
+CAPACITY_CURVE_EXPONENT: float = 2.0
 # Flat eligibility gate (B3.3): read off the on-chain MinerState counters,
 # replacing the success_rate³ × credibility ramp. A miner is crown-eligible iff
 # it has at least MIN_SUCCESSFUL_SWAPS successes and at most MAX_FAILED_SWAPS

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -24,6 +24,7 @@ from allways import dev_signal
 from allways.chains import canonical_pair
 from allways.classes import ActivityTransition, MinerActivity, next_activity
 from allways.constants import (
+    CAPACITY_CURVE_EXPONENT,
     DIRECTION_POOLS,
     MAX_FAILED_SWAPS,
     MAX_SCORING_BACKFILL_SECS,
@@ -547,14 +548,18 @@ def snapshot_current_miner_scores(self: Validator, at_time: Optional[int] = None
 
 
 def capacity_factor(collateral_rao: int, max_swap_amount_rao: int) -> float:
-    """min(1, collateral / required_collateral(max_swap)) — full credit means holding enough
-    to actually accept a max_swap fill at the contract's 1.10× gate. Fail-safe to 1.0 when
-    bounds unset."""
+    """min(1, (collateral / required_collateral(max_swap))^k) — full credit means holding enough
+    to accept a max_swap fill at the contract's 1.10× gate. The exponent k (CAPACITY_CURVE_EXPONENT,
+    >1) makes the ramp convex: backing a rate on a sliver of the band earns less than the raw ratio,
+    so thin-parked collateral is penalised harder and depth is worth posting. Still capped at 1.0 —
+    collateral past the requirement earns nothing extra, so it never becomes pay-to-win. Fail-safe to
+    1.0 when bounds unset."""
     if max_swap_amount_rao <= 0:
         return 1.0
     if collateral_rao <= 0:
         return 0.0
-    return min(1.0, collateral_rao / required_collateral(max_swap_amount_rao))
+    ratio = collateral_rao / required_collateral(max_swap_amount_rao)
+    return min(1.0, ratio**CAPACITY_CURVE_EXPONENT)
 
 
 def fill_ratio(
@@ -762,7 +767,8 @@ def replay_crown_time_window(
     max_swap_lamports: int = 0,
 ) -> Dict[str, float]:
     """Walk the merged event stream, return ``{hotkey: crown_seconds_float}``.
-    Ties at the same rate split credit evenly. A miner qualifies for crown
+    Among miners tied on the best rate the crown goes to the deepest collateral;
+    only a dead-heat on both rate and collateral splits evenly. A miner qualifies for crown
     at an instant iff they are on the current metagraph, were active at
     that instant, in a rewardable activity state (∈ REWARD_MINER_STATES — a
     reserved/fulfilling miner forfeits), had a positive rate posted, and their
@@ -826,10 +832,16 @@ def replay_crown_time_window(
         winner_rate = rates_for_instant.get(holders[0], 0.0)
         if trace is not None and winner_rate > 0:
             trace.best_rate = winner_rate
+        # Among holders tied on the best rate, the crown goes to the deepest collateral:
+        # matching the leader's rate only earns if you also back it with the most depth,
+        # so posting a sharp quote on a sliver no longer wins a free share. A genuine
+        # dead-heat — same rate AND same collateral — still splits evenly.
+        max_coll = max(collaterals.get(hk, 0) for hk in holders)
+        winners = [hk for hk in holders if collaterals.get(hk, 0) == max_coll]
         if intervals_out is not None:
-            intervals_out.append((interval_start, interval_end, list(holders), winner_rate))
-        split = duration / len(holders)
-        for hk in holders:
+            intervals_out.append((interval_start, interval_end, list(winners), winner_rate))
+        split = duration / len(winners)
+        for hk in winners:
             crown_time[hk] = crown_time.get(hk, 0.0) + split
             # Unknown collateral counts as zero, matching can_fund's fail-closed
             # (the reconcile seeds a baseline for every bound active miner);
@@ -939,9 +951,14 @@ def snapshot_current_crown_holders(
             can_fund_at_rate=can_fund if bounds_set else None,
         )
         if holders:
-            share = 1.0 / len(holders)
-            rate = rates.get(holders[0], 0.0)
-            rows_by_direction[(from_chain, to_chain)] = [(from_chain, to_chain, hk, share, rate, ts) for hk in holders]
+            # Same rate tie-break as the scoring replay: the deepest collateral among
+            # tied-rate holders takes the crown, so the live table agrees with what the
+            # round scorer will credit. A dead-heat on both rate and collateral still splits.
+            max_coll = max(collaterals.get(hk, 0) for hk in holders)
+            winners = [hk for hk in holders if collaterals.get(hk, 0) == max_coll]
+            share = 1.0 / len(winners)
+            rate = rates.get(winners[0], 0.0)
+            rows_by_direction[(from_chain, to_chain)] = [(from_chain, to_chain, hk, share, rate, ts) for hk in winners]
         else:
             rows_by_direction[(from_chain, to_chain)] = []
     return rows_by_direction

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -1663,7 +1663,9 @@ class TestHaltShortCircuit:
 
 class TestCapacityFactorHelper:
     """Direct unit tests for the capacity_factor pure function. Full credit requires
-    backing a max_swap fill at the contract's 1.10× gate: denominator = 1.1 × max_swap."""
+    backing a max_swap fill at the contract's 1.10× gate: denominator = 1.1 × max_swap.
+    The ramp below full is convex (ratio ** CAPACITY_CURVE_EXPONENT, k=2), so partial
+    depth earns less than the raw ratio."""
 
     def test_at_required_collateral_is_full(self):
         from allways.validator.scoring import capacity_factor
@@ -1674,17 +1676,19 @@ class TestCapacityFactorHelper:
         """Collateral == max_swap can't actually accept a max_swap fill (needs 1.1×)."""
         from allways.validator.scoring import capacity_factor
 
-        assert capacity_factor(500_000_000, 500_000_000) == 500_000_000 / 550_000_000
+        assert capacity_factor(500_000_000, 500_000_000) == (500_000_000 / 550_000_000) ** 2
 
-    def test_half_required_is_half(self):
+    def test_half_required_is_quarter(self):
+        """Convex ramp (k=2): half the required collateral earns a quarter, not a half."""
         from allways.validator.scoring import capacity_factor
 
-        assert capacity_factor(275_000_000, 500_000_000) == 0.5
+        assert capacity_factor(275_000_000, 500_000_000) == 0.25
 
-    def test_quarter_required_is_quarter(self):
+    def test_quarter_required_is_sixteenth(self):
+        """Convex ramp (k=2): a quarter of required earns (1/4)^2 = 1/16."""
         from allways.validator.scoring import capacity_factor
 
-        assert capacity_factor(137_500_000, 500_000_000) == 0.25
+        assert capacity_factor(137_500_000, 500_000_000) == 0.0625
 
     def test_above_required_caps_at_one(self):
         from allways.validator.scoring import capacity_factor
@@ -1801,8 +1805,9 @@ class TestCapacityWeighting:
         np.testing.assert_allclose(rewards[0], POOL_BTC_SOL, atol=1e-6)
         v.state_store.close()
 
-    def test_quarter_capacity_pays_quarter(self, tmp_path: Path):
-        """Collateral at 1/4 of required (1.1 x max_swap) → 1/4 reward, 3/4 recycles."""
+    def test_quarter_collateral_pays_sixteenth(self, tmp_path: Path):
+        """Collateral at 1/4 of required (1.1 x max_swap) → convex capacity (1/4)^2 =
+        1/16 reward, the rest recycles."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
         v = make_validator(
             tmp_path,
@@ -1812,11 +1817,11 @@ class TestCapacityWeighting:
         )
         self.seed_sol_btc_crown(v, 'hk_a')
         rewards, _ = calculate_miner_rewards(v, v.block)
-        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 0.25, atol=1e-6)
-        # Pool conservation: hk_a got POOL_BTC_SOL*0.25; the rest of both buckets
+        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 0.0625, atol=1e-6)
+        # Pool conservation: hk_a got POOL_BTC_SOL*0.0625; the rest of both buckets
         # and the unallocated pool all recycle, so recycle = 1 - that share.
         recycle_uid = RECYCLE_UID if RECYCLE_UID < len(rewards) else 0
-        np.testing.assert_allclose(rewards[recycle_uid], 1.0 - POOL_BTC_SOL * 0.25, atol=1e-6)
+        np.testing.assert_allclose(rewards[recycle_uid], 1.0 - POOL_BTC_SOL * 0.0625, atol=1e-6)
         np.testing.assert_allclose(rewards.sum(), 1.0, atol=1e-6)
         v.state_store.close()
 
@@ -1849,8 +1854,10 @@ class TestCapacityWeighting:
         np.testing.assert_allclose(rewards[recycle_uid], 1.0, atol=1e-6)
         v.state_store.close()
 
-    def test_unequal_collateral_proportional_rewards(self, tmp_path: Path):
-        """Two miners tie crown, unequal collateral → rewards scale linearly."""
+    def test_rate_tie_broken_by_collateral(self, tmp_path: Path):
+        """Two miners tie on the best rate with unequal collateral → the crown does NOT
+        split; the deeper miner takes the whole interval (tie-break #2). hk_a (deeper,
+        full capacity) earns the entire pool; hk_b earns nothing."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a', 'hk_b'])
         v = make_validator(
             tmp_path,
@@ -1866,10 +1873,31 @@ class TestCapacityWeighting:
             )
         conn.commit()
         rewards, _ = calculate_miner_rewards(v, v.block)
-        # Both split crown 50/50. A's capacity = 1.0, B's = 0.2.
-        # A earns pool * 0.5 * 1.0; B earns pool * 0.5 * 0.2.
-        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 0.5 * 1.0, atol=1e-6)
-        np.testing.assert_allclose(rewards[1], POOL_BTC_SOL * 0.5 * 0.2, atol=1e-6)
+        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL, atol=1e-6)
+        np.testing.assert_allclose(rewards[1], 0.0, atol=1e-6)
+        v.state_store.close()
+
+    def test_rate_and_collateral_dead_heat_splits_evenly(self, tmp_path: Path):
+        """Same best rate AND same collateral → genuine dead-heat still splits the crown
+        evenly. Collateral only breaks the tie when it differs."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a', 'hk_b'])
+        v = make_validator(
+            tmp_path,
+            hotkeys,
+            max_swap_amount=500_000_000,
+            collaterals={'hk_a': 550_000_000, 'hk_b': 550_000_000},
+        )
+        conn = v.state_store.require_connection()
+        for hk in ('hk_a', 'hk_b'):
+            conn.execute(
+                'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+                (hk, 'btc', 'sol', 0.00020, 0),
+            )
+        conn.commit()
+        rewards, _ = calculate_miner_rewards(v, v.block)
+        # 50/50 crown split, both at full capacity → each earns half the pool.
+        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 0.5, atol=1e-6)
+        np.testing.assert_allclose(rewards[1], POOL_BTC_SOL * 0.5, atol=1e-6)
         v.state_store.close()
 
     def test_cold_start_max_swap_zero_is_fail_safe(self, tmp_path: Path):
@@ -2232,7 +2260,8 @@ class TestCapacityVolumeInteraction:
     """Capacity + volume are independent multipliers — verify they compose."""
 
     def test_both_factors_compose_multiplicatively(self, tmp_path: Path):
-        """Single miner, capacity 0.5, idle on volume → reward = pool * 0.5 * (1-α)."""
+        """Single miner, half required collateral → convex capacity (0.5)^2 = 0.25, idle
+        on volume → reward = pool * 0.25 * (1-α)."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a', 'hk_b'])
         v = make_validator(
             tmp_path,
@@ -2249,8 +2278,8 @@ class TestCapacityVolumeInteraction:
         # B serves the market's (floor-clearing) volume so A's vol_share = 0.
         v.state_store.insert_clearing_rate(9_900, 'hk_b', 'btc', 'sol', 1_000_000_000, 1_000_000_000, 'sk12')
         rewards, _ = calculate_miner_rewards(v, v.block)
-        # A: pool × crown 1.0 × eligible 1 × capacity 0.5 × fill_ratio 1-α (B serves the volume).
-        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 1.0 * 0.5 * (1 - VOLUME_WEIGHT_ALPHA), atol=1e-6)
+        # A: pool × crown 1.0 × eligible 1 × capacity 0.25 × fill_ratio 1-α (B serves the volume).
+        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 1.0 * 0.25 * (1 - VOLUME_WEIGHT_ALPHA), atol=1e-6)
         v.state_store.close()
 
     def test_full_pool_conservation_with_all_factors(self, tmp_path: Path):
@@ -2380,15 +2409,16 @@ class TestHistoricalCollateralReplay:
             {'miner': 'hk_a', 'amount': 440_000_000, 'total': 550_000_000},
         )
         rewards, _ = calculate_miner_rewards(v, v.block)
-        # capacity_factor = 110M / (1.1 × 500M) = 0.2; pool 0.5 → reward 0.1.
-        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 0.2, atol=1e-6)
+        # capacity_factor = (110M / (1.1 × 500M))^2 = 0.2^2 = 0.04; pool 0.5 → reward 0.02.
+        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 0.04, atol=1e-6)
         v.state_store.close()
 
     def test_mid_window_topup_blends_capacity(self, tmp_path: Path):
         """A miner posts more collateral midway through the window. Capacity
-        is integrated per-block: half the window at 1/4 cap, half at full cap
-        → time-weighted average 0.625. Validates that the multiplier reflects
-        collateral *during* the interval, not at the end of it."""
+        is integrated per-block: half the window at convex 1/4-collateral cap
+        ((1/4)^2 = 0.0625), half at full cap (1.0) → time-weighted average
+        0.53125. Validates that the multiplier reflects collateral *during*
+        the interval, not at the end of it."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
         v = make_validator(
             tmp_path,
@@ -2406,8 +2436,8 @@ class TestHistoricalCollateralReplay:
             {'miner': 'hk_a', 'amount': 412_500_000, 'total': 550_000_000},
         )
         rewards, _ = calculate_miner_rewards(v, v.block)
-        # First 150 blocks at cap 0.25, next 150 at cap 1.0 → mean cap 0.625.
-        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 0.625, atol=1e-6)
+        # First 150 blocks at cap 0.0625 ((1/4)^2), next 150 at cap 1.0 → mean cap 0.53125.
+        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 0.53125, atol=1e-6)
         v.state_store.close()
 
 


### PR DESCRIPTION
## Why

A live ranking of allways miners (`/allways-rates`) surfaced two structural gaps in the crown incentive:

- **No depth.** The best-rate miners hold the crown on thin collateral (0.15–0.34 SOL against a 1 SOL max swap). Capacity is a multiplier that caps at `1.0` once you hold `1.1 × max_swap`, so there was no pull toward posting real depth behind a sharp quote.
- **Matching the leader is free.** Rates quantize to 5 sig figs and exact ties split the crown evenly, so N miners can post the identical best rate and each take `1/N` of the pool without competing on anything. Observed live: a 6-way exact tie plus a 15-deep cluster inside a 0.06% band.

(Context: in a 50-swap window every taker was a registered miner — there is currently ~zero external demand, so these are the two levers that don't depend on demand data.)

## What

Two changes, both pool-conserving and bounded (deliberately **not** pay-to-win):

1. **Rate-tie broken by collateral.** Among miners tied on the best rate, the crown goes to the deepest collateral instead of splitting evenly. A genuine dead-heat (same rate **and** same collateral) still splits. This converts "match the leader for a free share" into a depth race. Applied to **both** the round scorer (`replay_crown_time_window`) and the live-crown snapshot (`snapshot_current_miner_scores`) so the two never disagree.
2. **Convex capacity.** `capacity = min(1, (collateral / required)^2)` instead of linear. Thin-parked collateral is penalised harder (0.34 SOL: 0.31 → 0.10), pushing miners to deepen — but still capped at `1.0`, so a whale can't capture more than the pool share. New constant `CAPACITY_CURVE_EXPONENT = 2.0`.

## Tests

Updated the scoring tests to the new contract (convex values, tie-break), added `test_rate_tie_broken_by_collateral` and `test_rate_and_collateral_dead_heat_splits_evenly`. Full suite green (795 passed).

## Not in this PR (discussed, deferred)

- Raising `max_swap` (on-chain config) to widen the useful depth range the convex curve rewards.
- α → 1.0 on `fill_ratio` (would zero the pool in the current no-demand regime — kept the 0.25 bootstrap floor).
- External price anchor (rejected: relies on incentivising best relative rates instead).

Docs updated in a parallel PR on allways-docs-ui.