### PR TITLE
Share benign-race classifier; match landed code-only form

### DIFF
--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -44,7 +44,7 @@ from allways.cli.swap_commands.swap_intake import (
 )
 from allways.cli.validator_rejections import render_and_aggregate
 from allways.constants import FEE_DIVISOR, NETUID_FINNEY, NUMERAIRE_CHAIN
-from allways.solana.client import contract_reject_reason
+from allways.solana.client import benign_marker, contract_reject_reason
 from allways.solana.rpc import TransientRpcError
 from allways.synapses import SwapReserveSynapse
 from allways.utils.rate import apply_fee_deduction, directional_rate
@@ -101,15 +101,10 @@ _SEND_MARGIN_SECS = 180
 
 
 # Benign crank races — `resolve_pool` lost to another cranker (the validator, or a peer taker) or ran
-# before the draw was possible. Each surfaces in TWO string forms depending on where it was caught:
-#   • Anchor error NAME — when the tx is rejected in pre-flight simulation (e.g. "PoolNotClosed").
-#   • numeric CODE only — when the tx is submitted and *lands* in a failed state; the confirm path
-#     stringifies `status["err"]` as `{'InstructionError': [0, {'Custom': 6044}]}`, with no name.
-# Matching names alone (the old behavior) missed the code-only form, so a benign race that reached the
-# chain re-raised and aborted `swap now` — abandoning the taker's already-paid, since-drawn seat until
-# it expired (fee forfeited, miner locked busy_until). Match both forms. Codes are ErrorCode indices.
+# before the draw was possible. A miss must not abort `swap now` — that abandons the taker's already-paid,
+# since-drawn seat until it expires (fee forfeited, miner locked busy_until) — so benign_marker matches
+# both string forms (pre-flight name, landed code-only).
 _BENIGN_CRANK_NAMES = ('SeedSlotNotYetProduced', 'PoolNotClosed', 'NoRequests', 'AlreadyFilled')
-_BENIGN_CRANK_CODES = (6045, 6042, 6044, 6046)  # same order as the names above
 
 
 def _self_crank_resolve(client, miner) -> None:
@@ -122,9 +117,7 @@ def _self_crank_resolve(client, miner) -> None:
         return  # RPC hiccup while nudging the pool — the poll loop re-cranks and re-reads the real
         # outcome (the reservation). If this resolve_pool actually landed, the next pass sees the seat.
     except Exception as e:  # noqa: BLE001
-        msg = str(e)
-        benign = any(n in msg for n in _BENIGN_CRANK_NAMES) or any(f"'Custom': {c}" in msg for c in _BENIGN_CRANK_CODES)
-        if not benign:
+        if not benign_marker(e, _BENIGN_CRANK_NAMES):
             raise
 
 

--- a/allways/solana/client.py
+++ b/allways/solana/client.py
@@ -147,6 +147,34 @@ def contract_reject_reason(err: Exception) -> Optional[str]:
     return 'miner is not available for reservation right now'
 
 
+# Contract ErrorCode names → Anchor codes (6000 + enum index). A landed failed tx stringifies as
+# {'Custom': N} with no name (see contract_reject_reason), so benign classification matches both forms.
+_ERROR_CODES = {
+    'NotValidator': 6007,
+    'AlreadyVoted': 6012,
+    'NotPending': 6031,
+    'ClaimNotExpired': 6033,
+    'ExtensionNotLater': 6034,
+    'ExtensionExceedsCeiling': 6035,
+    'PoolNotClosed': 6042,
+    'NoRequests': 6044,
+    'SeedSlotNotYetProduced': 6045,
+    'AlreadyFilled': 6046,
+    'WeightsUpdateTooSoon': 6050,
+}
+
+
+def benign_marker(err: Exception, names: Tuple[str, ...]) -> Optional[str]:
+    """The matched benign error NAME (for terse logs), or None for a real failure. Names without a
+    code entry (framework/RPC messages) match on name alone."""
+    s = str(err)
+    for name in names:
+        code = _ERROR_CODES.get(name)
+        if name in s or (code is not None and f"'Custom': {code}" in s):
+            return name
+    return None
+
+
 class AllwaysSolanaClient:
     def __init__(
         self,

--- a/allways/validator/solana_swap_loop.py
+++ b/allways/validator/solana_swap_loop.py
@@ -21,7 +21,7 @@ from allways.chain_providers.base import ProviderUnreachableError
 from allways.chains import compute_extension_target_secs, get_chain
 from allways.constants import EXTENSION_PADDING_SECONDS
 from allways.solana import pdas
-from allways.solana.client import swap_from_solana, swap_key_from_tx_hash
+from allways.solana.client import benign_marker, swap_from_solana, swap_key_from_tx_hash
 from allways.utils.rate import apply_fee_deduction, expected_swap_amounts
 
 
@@ -89,21 +89,6 @@ def _confs(chain_id: str, info: Any) -> str:
 
 def _swap_key_hex(key: Any) -> str:
     return key.hex() if isinstance(key, (bytes, bytearray)) else str(key)
-
-
-def _is_benign_extension(e: Exception) -> bool:
-    """A contract ceiling hit or a lost extension race — expected, not an error."""
-    return any(m in str(e) for m in _BENIGN_EXTEND_MARKERS)
-
-
-def _is_benign_resolve(e: Exception) -> bool:
-    """A lost resolve_pool race — a peer already resolved it, or the clock hasn't crossed closes_at."""
-    return any(m in str(e) for m in _BENIGN_RESOLVE_MARKERS)
-
-
-def _is_benign_close(e: Exception) -> bool:
-    """A lost close_stale_claim race — a peer already reaped it, or the reservation isn't expired yet."""
-    return any(m in str(e) for m in _BENIGN_CLOSE_MARKERS)
 
 
 def is_tx_fresh(info: Any, floor_unix: int, grace: int = 0) -> bool:
@@ -389,11 +374,13 @@ class SolanaSwapLoop:
             else:
                 return False  # REJECT / non-actionable: cast nothing
         except Exception as e:
-            if decision in (SwapDecision.EXTEND_RESERVATION, SwapDecision.EXTEND_TIMEOUT) and _is_benign_extension(e):
-                bt.logging.debug(f'{label}: {decision.value} no-op ({e})')
+            if decision in (SwapDecision.EXTEND_RESERVATION, SwapDecision.EXTEND_TIMEOUT) and (
+                m := benign_marker(e, _BENIGN_EXTEND_MARKERS)
+            ):
+                bt.logging.debug(f'{label}: {decision.value} no-op ({m})')
                 return False
-            if decision == SwapDecision.CANCEL and _is_benign_close(e):
-                bt.logging.debug(f'{label}: {decision.value} no-op ({e})')
+            if decision == SwapDecision.CANCEL and (m := benign_marker(e, _BENIGN_CLOSE_MARKERS)):
+                bt.logging.debug(f'{label}: {decision.value} no-op ({m})')
                 return False
             bt.logging.error(f'{label}: {decision.value} failed: {e}')
             return False
@@ -447,8 +434,8 @@ class SolanaSwapLoop:
             try:
                 self.client.resolve_pool(miner)
             except Exception as e:  # one bad pool must not break the pass
-                if _is_benign_resolve(e):
-                    bt.logging.debug(f'pool {miner}: resolve_pool no-op (peer won the race): {e}')
+                if m := benign_marker(e, _BENIGN_RESOLVE_MARKERS):
+                    bt.logging.debug(f'pool {miner}: resolve_pool no-op ({m})')
                     continue
                 bt.logging.error(f'pool {miner}: resolve_pool failed: {e}')
                 continue

--- a/allways/validator/weights_vote.py
+++ b/allways/validator/weights_vote.py
@@ -24,6 +24,7 @@ from allways.constants import (
     WEIGHTS_VOTE_INTERVAL_BLOCKS,
     WEIGHTS_VOTE_RETRY_SECS,
 )
+from allways.solana.client import benign_marker
 from allways.validator.binding import build_attribution
 
 if TYPE_CHECKING:
@@ -93,8 +94,8 @@ def _step(self: Validator, now: int) -> None:
     try:
         sig = self.solana_client.vote_set_weights(vector, [bytes(v.key) for v in config.validators])
     except Exception as e:
-        if any(m in str(e) for m in _BENIGN_WEIGHTS_MARKERS):
-            bt.logging.debug(f'weights vote: no-op ({e})')
+        if m := benign_marker(e, _BENIGN_WEIGHTS_MARKERS):
+            bt.logging.debug(f'weights vote: no-op ({m})')
             return
         raise
     bt.logging.success(f'weights vote: {vector} submitted (sig {sig[:16]}…)')

--- a/tests/test_solana_swap_loop.py
+++ b/tests/test_solana_swap_loop.py
@@ -8,8 +8,13 @@ Mocks the solana client (get_swaps / get_reservation) + chain providers; no chai
 from types import SimpleNamespace
 
 from allways.chain_providers.base import ProviderUnreachableError
-from allways.solana.client import swap_key_from_tx_hash
-from allways.validator.solana_swap_loop import SolanaSwapLoop, SwapAction, SwapDecision, _is_benign_resolve
+from allways.solana.client import benign_marker, swap_key_from_tx_hash
+from allways.validator.solana_swap_loop import (
+    _BENIGN_RESOLVE_MARKERS,
+    SolanaSwapLoop,
+    SwapAction,
+    SwapDecision,
+)
 
 INITIATED_AT = 1000  # dest-freshness floor
 RESV_CREATED_AT = 1200  # source-freshness floor
@@ -580,10 +585,14 @@ def test_resolve_pools_one_failure_does_not_break_sweep():
     assert loop.resolve_pools_once(now=500) == ['good']
 
 
-def test_is_benign_resolve_classifies_lost_race():
-    assert _is_benign_resolve(RuntimeError('custom program error: NoRequests'))
-    assert _is_benign_resolve(RuntimeError('PoolNotClosed'))
-    assert not _is_benign_resolve(RuntimeError('rpc down'))
+def test_benign_marker_classifies_lost_race():
+    assert benign_marker(RuntimeError('custom program error: NoRequests'), _BENIGN_RESOLVE_MARKERS) == 'NoRequests'
+    assert benign_marker(RuntimeError('PoolNotClosed'), _BENIGN_RESOLVE_MARKERS) == 'PoolNotClosed'
+    assert (
+        benign_marker(RuntimeError("{'InstructionError': [0, {'Custom': 6042}]}"), _BENIGN_RESOLVE_MARKERS)
+        == 'PoolNotClosed'
+    )
+    assert benign_marker(RuntimeError('rpc down'), _BENIGN_RESOLVE_MARKERS) is None
 
 
 def test_resolve_pools_lost_race_is_not_counted_and_sweep_continues():


### PR DESCRIPTION
Log-hygiene sweep of the benign-race handling around permissionless cranks. No behavior change to flow control; one log-level fix.

- **One classifier.** `benign_marker` in `solana/client.py` replaces five copies of the `any(m in str(e))` predicate (swap loop x3, weights vote, CLI crank). Returns the matched error NAME.
- **Close the code-only gap.** A benign race that lands on-chain stringifies as `{'Custom': N}` with no name. CLI already matched both forms; the validator matched names only, so a landed benign race logged a false-alarm ERROR. All sites now match both via a single name->code map.
- **Terse benign logs.** Benign no-ops log the marker name (e.g. `no-op (PoolNotClosed)`) instead of the full ~1KB RPC simulation blob.
- **Accurate label.** `resolve_pool no-op (peer won the race)` dropped - `PoolNotClosed`/`SeedSlotNotYetProduced` mean the validator was early, not that a peer won.

Tests: classifier test covers name form, landed code-only form, and non-benign passthrough. Full suite passes (795).