### PR TITLE
Remove the volume component from crown scoring

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -68,8 +68,6 @@ DIRECTION_POOLS: dict[tuple[str, str], float] = {
     for spoke in LAUNCH_SPOKES
     for pair in ((NUMERAIRE_CHAIN, spoke), (spoke, NUMERAIRE_CHAIN))
 }
-# Idle-crown penalty: 0 = none, 1 = pure volume share; a zero-fill holder floors at 1-α (0.25).
-VOLUME_WEIGHT_ALPHA: float = 0.75
 # Capacity curve exponent (>1 = convex): capacity = min(1, (collateral / required)^k). Convex so
 # thin-parked collateral is penalised harder than linear (a miner backing the best rate on a sliver
 # earns a smaller slice than the ratio alone), pushing miners to deepen. Still capped at 1.0 — depth

--- a/allways/validator/event_index.py
+++ b/allways/validator/event_index.py
@@ -6,8 +6,8 @@ collateral, quoted rate) through a small read interface. B1/B2 fed that interfac
 this index persists them into the ``state_store`` event tables, attributing each on-chain Solana pubkey to
 its bound Bittensor hotkey at write time (B3.2). The crown math is unchanged — it consumes the same
 ``get_*_at`` / ``get_*_in_range`` shapes ``ContractEventWatcher`` exposed. ``SwapCompleted`` additionally
-persists its realized legs into ``clearing_rates``, the per-swap history the windowed volume read
-(``fill_ratio``'s input) sums over. ``SwapCompleted``/``SwapTimedOut`` also record the swap's terminal outcome into
+persists its realized legs into ``clearing_rates``, the per-swap realized-volume history the dashboard and
+treasury reporting read. ``SwapCompleted``/``SwapTimedOut`` also record the swap's terminal outcome into
 ``swap_outcomes``, the seam's post-close completed-vs-slashed truth (terminal swap PDAs are closed on-chain).
 
 The axis is unix ``blockTime`` seconds (the ``block_num``/``block`` columns are repurposed), not substrate

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -1,11 +1,8 @@
 """Crown-time scoring pipeline.
 
-Reward per miner is ``eligible × pool × crown_share × capacity × fill_ratio``,
-where ``eligible`` is a flat 0/1 gate read off the on-chain ``MinerState``
-counters (B3.3) — it replaces the old ``sr³ × credibility ramp``. ``fill_ratio``
-scales crown credit by served volume, summed over the scored window from the
-ingested ``clearing_rates`` ledger (the ``SwapCompleted`` history — volume is
-what cleared this round, not a lifetime account total). Penalty shortfall is
+Reward per miner is ``eligible × pool × crown_share × capacity``, where
+``eligible`` is a flat 0/1 gate read off the on-chain ``MinerState`` counters
+(B3.3) — it replaces the old ``sr³ × credibility ramp``. Penalty shortfall is
 not burned: ``set_weights`` L1-normalizes, stretching distributed rewards to
 100% of emissions. Entry is ``score_and_reward_miners``.
 """
@@ -34,7 +31,6 @@ from allways.constants import (
     SCORING_WINDOW_BLOCKS,
     SCORING_WINDOW_SECS,
     SWAP_OUTCOME_RETENTION_SECS,
-    VOLUME_WEIGHT_ALPHA,
     required_collateral,
 )
 from allways.utils.rate import is_executable_rate, min_executable_sol_leg
@@ -192,22 +188,6 @@ def build_eligibility(solana_client, metagraph, attribution: Optional[Dict[str, 
     return {hk: is_eligible(ms) for hk, ms in live_miner_states(solana_client, metagraph, attribution).items()}
 
 
-def windowed_direction_volumes(
-    clearing_volumes: Dict[Tuple[str, str], Dict[str, Tuple[int, int]]],
-    from_chain: str,
-    to_chain: str,
-    rewardable_hotkeys: Set[str],
-) -> Tuple[Dict[str, int], int]:
-    """One direction's scored volume: metagraph-filter the windowed leg sums and
-    return ``({hotkey: from_leg}, total)`` — within a direction, vol_share stays
-    in from-asset units."""
-    leg_sums = {
-        hk: legs for hk, legs in clearing_volumes.get((from_chain, to_chain), {}).items() if hk in rewardable_hotkeys
-    }
-    volumes_dir = {hk: legs[0] for hk, legs in leg_sums.items()}
-    return volumes_dir, sum(volumes_dir.values())
-
-
 @dataclass
 class ScoreRow:
     """One (hotkey, direction) scoring snapshot: the factors the reward math
@@ -222,8 +202,6 @@ class ScoreRow:
     eligible: bool
     crown_share: float
     capacity: float
-    fill_ratio: float
-    vol_share: float
     reward: float
 
 
@@ -233,17 +211,13 @@ def build_direction_score_rows(
     pool: float,
     crown_time: Dict[str, float],
     cap_weighted_time: Dict[str, float],
-    volumes_dir: Dict[str, int],
-    total_volume_dir: int,
     eligibility: Dict[str, bool],
 ) -> List[ScoreRow]:
     """Per-holder factors + reward for one direction — the single place the
     reward multiplication lives, shared by the round scorer
     (``calculate_miner_rewards``) and the live tip
     (``snapshot_current_miner_scores``) so the two can never disagree.
-    One row per crown holder — only crown holders earn. ``vol_share`` is
-    persisted as an informational factor (it explains ``fill_ratio``) but is
-    not itself a reward term."""
+    One row per crown holder — only crown holders earn."""
     total_crown_dir = sum(crown_time.values())
     rows: List[ScoreRow] = []
     if total_crown_dir <= 0:
@@ -257,9 +231,6 @@ def build_direction_score_rows(
         cap = (cap_secs / secs) if secs > 0 else 0.0
         eligible = eligibility.get(hotkey, False)
         crown_share_dir = secs / total_crown_dir
-        vol_dir = volumes_dir.get(hotkey, 0)
-        vol_share_dir = (vol_dir / total_volume_dir) if total_volume_dir > 0 else 0.0
-        fill = fill_ratio(vol_dir, total_volume_dir, crown_share_dir)
         rows.append(
             ScoreRow(
                 hotkey=hotkey,
@@ -268,9 +239,7 @@ def build_direction_score_rows(
                 eligible=eligible,
                 crown_share=crown_share_dir,
                 capacity=cap,
-                fill_ratio=fill,
-                vol_share=vol_share_dir,
-                reward=(1.0 if eligible else 0.0) * pool * crown_share_dir * cap * fill,
+                reward=(1.0 if eligible else 0.0) * pool * crown_share_dir * cap,
             )
         )
     return rows
@@ -278,14 +247,9 @@ def build_direction_score_rows(
 
 def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndarray, Set[int]]:
     """Replay the crown-time event stream, derive per-miner rewards
-    (eligible × pool × crown_share × capacity × fill_ratio); the shortfall is
-    not burned — weight normalization stretches distributed rewards to 100%.
-    ``current_time`` is the unix-seconds window_end (the crown axis).
-
-    Volume weighting is *per direction*: a miner earning crown on btc→tao is
-    compared only to btc→tao volume on the network, not to the total of both
-    directions. Otherwise heavy tao→btc flow from other miners would dilute
-    a btc→tao earner's vol_share even though they own that direction."""
+    (eligible × pool × crown_share × capacity); the shortfall is not burned —
+    weight normalization stretches distributed rewards to 100%.
+    ``current_time`` is the unix-seconds window_end (the crown axis)."""
     n_uids = self.metagraph.n.item()
     if n_uids == 0:
         return np.array([], dtype=np.float32), set()
@@ -302,7 +266,6 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
     hotkey_to_uid: Dict[str, int] = {self.metagraph.hotkeys[uid]: uid for uid in range(n_uids)}
 
     rewards = np.zeros(n_uids, dtype=np.float32)
-    unweighted_rewards = np.zeros(n_uids, dtype=np.float32)
     # One live MinerState snapshot serves two jobs: the flat eligibility gate off the
     # on-chain counters (B3.3, pubkey→hotkey via the sr25519 binding; absent hotkey → not
     # eligible), and the reconcile backstop that corrects event-derived active/collateral
@@ -310,11 +273,6 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
     live_states = live_miner_states(self.solana_client, self.metagraph)
     self.event_index.reconcile_live_state(live_states, now=current_time)
     eligibility = {hk: is_eligible(ms) for hk, ms in live_states.items()}
-    # Per-direction realized volume summed over this round's window from the
-    # ingested clearing_rates ledger — volume is what cleared this hour, not a
-    # lifetime account total. Hotkeys were attributed at ingest (event_index),
-    # so no binding read is needed. Built once, sliced per direction below.
-    clearing_volumes = self.state_store.get_clearing_volumes(window_start, window_end)
 
     direction_traces: Dict[Tuple[str, str], DirectionTrace] = {}
     weighting_traces: Dict[str, WeightingTrace] = {}
@@ -336,10 +294,6 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
     except Exception as e:
         bt.logging.warning(f'min_swap_amount read failed: {e}')
         min_swap_amount = 0
-    miner_volume_total: Dict[str, int] = {}
-    miner_crown_total: Dict[str, float] = {}
-    network_volume_total: int = 0
-    network_crown_total: float = 0.0
 
     for (from_chain, to_chain), pool in DIRECTION_POOLS.items():
         trace = DirectionTrace(pool=pool)
@@ -362,20 +316,8 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
             max_swap_lamports=max_swap_amount,
         )
         total_crown_dir = sum(crown_time.values())
-        volumes_dir, total_volume_dir = windowed_direction_volumes(
-            clearing_volumes, from_chain, to_chain, rewardable_hotkeys
-        )
-        for hk, v in volumes_dir.items():
-            miner_volume_total[hk] = miner_volume_total.get(hk, 0) + int(v)
-        network_volume_total += int(total_volume_dir)
-        for hk, secs in crown_time.items():
-            miner_crown_total[hk] = miner_crown_total.get(hk, 0.0) + secs
-        network_crown_total += total_crown_dir
 
-        bt.logging.debug(
-            f'V1 scoring [{from_chain}→{to_chain}]: '
-            f'total_crown={total_crown_dir:.1f}s, total_volume_rao={total_volume_dir}'
-        )
+        bt.logging.debug(f'V1 scoring [{from_chain}→{to_chain}]: total_crown={total_crown_dir:.1f}s')
 
         if total_crown_dir == 0:
             continue  # empty bucket — its pool spreads to earners via normalization
@@ -386,40 +328,17 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
             pool,
             crown_time=crown_time,
             cap_weighted_time=trace.cap_weighted_time,
-            volumes_dir=volumes_dir,
-            total_volume_dir=total_volume_dir,
             eligibility=eligibility,
         )
         for row in rows:
             uid = hotkey_to_uid.get(row.hotkey)
             if uid is None:
                 continue  # dereg'd mid-window; credit forfeited
-            eligible = 1.0 if row.eligible else 0.0
             wt = weighting_traces.setdefault(row.hotkey, WeightingTrace())
             wt.record_capacity(factor=row.capacity)
             wt.record_eligibility(eligible=row.eligible)
-            # Trace baseline is the pre-volume crown reward (dashboard attributes
-            # the volume penalty off the gap to the final reward).
-            unweighted_rewards[uid] += eligible * pool * row.crown_share * row.capacity
             rewards[uid] += row.reward
             score_rows.append(row)
-            if row.fill_ratio < 1.0:
-                bt.logging.debug(
-                    f'V1 scoring [{from_chain}→{to_chain}] {row.hotkey[:8]}: '
-                    f'crown_share={row.crown_share:.3f} vol_share={row.vol_share:.3f} '
-                    f'fill_ratio={row.fill_ratio:.3f}'
-                )
-
-    record_volume_traces(
-        weighting_traces=weighting_traces,
-        hotkey_to_uid=hotkey_to_uid,
-        rewards=rewards,
-        unweighted_rewards=unweighted_rewards,
-        miner_volume_total=miner_volume_total,
-        miner_crown_total=miner_crown_total,
-        network_volume_total=network_volume_total,
-        network_crown_total=network_crown_total,
-    )
 
     # Penalty shortfall is deliberately NOT routed to a burn/recycle UID:
     # set_weights L1-normalizes scores, so the distributed mass stretches to
@@ -477,8 +396,6 @@ def miner_score_tuples(score_rows: List[ScoreRow], ts: int) -> List[Tuple]:
             r.eligible,
             r.crown_share,
             r.capacity,
-            r.fill_ratio,
-            r.vol_share,
             r.reward,
         )
         for r in score_rows
@@ -500,7 +417,6 @@ def snapshot_current_miner_scores(self: Validator, at_time: Optional[int] = None
     window_start, window_end = scoring_window_bounds(ts, self.last_scored_time)
     rewardable_hotkeys: Set[str] = set(self.metagraph.hotkeys)
     eligibility = build_eligibility(self.solana_client, self.metagraph)
-    clearing_volumes = self.state_store.get_clearing_volumes(window_start, window_end)
     try:
         min_swap_amount = int(self.solana_config_cache.min_swap_amount())
         max_swap_amount = int(self.solana_config_cache.max_swap_amount())
@@ -524,17 +440,12 @@ def snapshot_current_miner_scores(self: Validator, at_time: Optional[int] = None
         )
         if not crown_time:
             continue
-        volumes_dir, total_volume_dir = windowed_direction_volumes(
-            clearing_volumes, from_chain, to_chain, rewardable_hotkeys
-        )
         dir_rows = build_direction_score_rows(
             from_chain,
             to_chain,
             pool,
             crown_time=crown_time,
             cap_weighted_time=trace.cap_weighted_time,
-            volumes_dir=volumes_dir,
-            total_volume_dir=total_volume_dir,
             eligibility=eligibility,
         )
         rows.extend(dir_rows)
@@ -554,52 +465,6 @@ def capacity_factor(collateral_rao: int, max_swap_amount_rao: int) -> float:
         return 0.0
     ratio = collateral_rao / required_collateral(max_swap_amount_rao)
     return min(1.0, ratio**CAPACITY_CURVE_EXPONENT)
-
-
-def fill_ratio(
-    vol_rao: int,
-    total_volume_rao: int,
-    crown_share: float,
-    alpha: float = VOLUME_WEIGHT_ALPHA,
-) -> float:
-    """(1-α) + α·min(1, vol_share/crown_share). Idle network or no crown → 1.0
-    (no penalty); cap kills any over-serve bonus."""
-    if total_volume_rao <= 0 or crown_share <= 0:
-        return 1.0
-    participation = min(1.0, (vol_rao / total_volume_rao) / crown_share)
-    return (1.0 - alpha) + alpha * participation
-
-
-def record_volume_traces(
-    *,
-    weighting_traces: Dict[str, WeightingTrace],
-    hotkey_to_uid: Dict[str, int],
-    rewards: np.ndarray,
-    unweighted_rewards: np.ndarray,
-    miner_volume_total: Dict[str, int],
-    miner_crown_total: Dict[str, float],
-    network_volume_total: int,
-    network_crown_total: float,
-) -> None:
-    """Populate the per-miner volume rows of the scoring log. Volume gating is
-    already applied inline in ``calculate_miner_rewards``; this only records
-    aggregate counters and the effective per-miner multiplier
-    (weighted / unweighted) for human-readable diagnosis."""
-    for hotkey, wt in weighting_traces.items():
-        uid = hotkey_to_uid.get(hotkey)
-        if uid is None:
-            continue
-        unweighted = float(unweighted_rewards[uid])
-        weighted = float(rewards[uid])
-        effective = (weighted / unweighted) if unweighted > 0 else 1.0
-        crown = miner_crown_total.get(hotkey, 0.0)
-        crown_share = (crown / network_crown_total) if network_crown_total > 0 else 0.0
-        wt.record_volume(
-            vol_rao=miner_volume_total.get(hotkey, 0),
-            total_volume_rao=network_volume_total,
-            crown_share=crown_share,
-            factor=effective,
-        )
 
 
 # ─── Crown-time replay ───────────────────────────────────────────────────

--- a/allways/validator/scoring_trace.py
+++ b/allways/validator/scoring_trace.py
@@ -24,7 +24,7 @@ NON_EARNER_LINE_CAP = 30
 
 @dataclass
 class WeightingTrace:
-    """Per-hotkey capacity + volume + eligibility factors for the scoring log.
+    """Per-hotkey capacity + eligibility factors for the scoring log.
 
     ``capacity_factor`` is the time-weighted average of
     ``min(1, collateral / (1.1 × max_swap))`` over the miner's crown intervals — the
@@ -33,22 +33,10 @@ class WeightingTrace:
     crown gate read off the on-chain MinerState counters (B3.3)."""
 
     capacity_factor: float = 1.0
-    volume_rao: int = 0
-    crown_share: float = 0.0
-    volume_share: float = 0.0
-    participation: float = 1.0
-    fill_ratio: float = 1.0
     eligible: bool = False
 
     def record_capacity(self, factor: float) -> None:
         self.capacity_factor = factor
-
-    def record_volume(self, vol_rao: int, total_volume_rao: int, crown_share: float, factor: float) -> None:
-        self.volume_rao = vol_rao
-        self.crown_share = crown_share
-        self.volume_share = (vol_rao / total_volume_rao) if total_volume_rao > 0 else 0.0
-        self.participation = min(1.0, self.volume_share / crown_share) if crown_share > 0 else 1.0
-        self.fill_ratio = factor
 
     def record_eligibility(self, eligible: bool) -> None:
         self.eligible = eligible
@@ -97,11 +85,7 @@ def log_scoring_trace(
         wt = weighting_traces.get(hk)
         extras = ''
         if wt is not None:
-            extras = (
-                f' cap={wt.capacity_factor:.2f}'
-                f' vol={wt.volume_rao / TAO_TO_RAO:g}t vol_share={wt.volume_share:.2f}'
-                f' crown_share={wt.crown_share:.2f} fill={wt.fill_ratio:.2f}'
-            )
+            extras = f' cap={wt.capacity_factor:.2f}'
         lines.append(
             f'  uid={uid} hotkey={hk[:8]}.. crown_s={crown_secs:.0f} eligible={eligible}{extras} reward={crown_reward:.3f}'
         )

--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -313,9 +313,10 @@ class ValidatorStateStore:
 
     def get_clearing_volumes(self, start_time: int, end_time: int) -> Dict[Tuple[str, str], Dict[str, Tuple[int, int]]]:
         """``{(from_chain, to_chain): {hotkey: (from_amount_sum, to_amount_sum)}}``
-        over ``(start_time, end_time]`` — the windowed realized-volume read the
-        reward weighting consumes. Summed in Python: the legs are stored as TEXT
-        (u128-safe) and SQL SUM would coerce them to float."""
+        over ``(start_time, end_time]`` — the windowed realized-volume read.
+        Scoring no longer consumes it; the dashboard and treasury reporting do.
+        Summed in Python: the legs are stored as TEXT (u128-safe) and SQL SUM
+        would coerce them to float."""
         rows = self._fetchall(
             """
             SELECT from_chain, to_chain, hotkey, from_amount, to_amount FROM clearing_rates
@@ -649,7 +650,7 @@ class ValidatorStateStore:
                     ON collateral_events(hotkey);
 
                 -- Per-swap realized legs from SwapCompleted. One row per completed
-                -- swap; the windowed volume read (fill_ratio's input) sums these.
+                -- swap; the windowed volume read sums these for reporting.
                 -- from_amount/to_amount are TEXT because the on-chain legs are
                 -- u128 and overflow SQLite's signed-64 INTEGER.
                 CREATE TABLE IF NOT EXISTS clearing_rates (

--- a/allways/validator/storage/queries.py
+++ b/allways/validator/storage/queries.py
@@ -55,14 +55,12 @@ DO UPDATE SET credit = EXCLUDED.credit,
 # the crown ledger. Idempotent on retry of the same round.
 BULK_UPSERT_MINER_SCORES = """
 INSERT INTO miner_scores (round_ts, hotkey, from_chain, to_chain, eligible,
-                          crown_share, capacity, fill_ratio, vol_share, reward)
-VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                          crown_share, capacity, reward)
+VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
 ON CONFLICT (round_ts, hotkey, from_chain, to_chain)
 DO UPDATE SET eligible    = EXCLUDED.eligible,
               crown_share = EXCLUDED.crown_share,
               capacity    = EXCLUDED.capacity,
-              fill_ratio  = EXCLUDED.fill_ratio,
-              vol_share   = EXCLUDED.vol_share,
               reward      = EXCLUDED.reward
 """
 
@@ -75,6 +73,6 @@ DELETE FROM current_miner_scores
 
 BULK_INSERT_CURRENT_MINER_SCORES = """
 INSERT INTO current_miner_scores (ts, hotkey, from_chain, to_chain, eligible,
-                                  crown_share, capacity, fill_ratio, vol_share, reward, updated_at)
-VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())
+                                  crown_share, capacity, reward, updated_at)
+VALUES (%s, %s, %s, %s, %s, %s, %s, %s, NOW())
 """

--- a/allways/validator/storage/repository.py
+++ b/allways/validator/storage/repository.py
@@ -100,7 +100,7 @@ class Repository(BaseRepository):
         commit: bool = True,
     ) -> int:
         """Upsert per-round score snapshots. Rows: (round_ts, hotkey, from_chain,
-        to_chain, eligible, crown_share, capacity, fill_ratio, vol_share, reward)."""
+        to_chain, eligible, crown_share, capacity, reward)."""
         if not rows:
             return 0
         try:
@@ -121,8 +121,8 @@ class Repository(BaseRepository):
         commit: bool = True,
     ) -> int:
         """Wipe + rewrite the live score tip. Rows: (ts, hotkey, from_chain,
-        to_chain, eligible, crown_share, capacity, fill_ratio, vol_share,
-        reward). The table only holds the in-progress round, so
+        to_chain, eligible, crown_share, capacity, reward).
+        The table only holds the in-progress round, so
         the delete is unconditional; one transaction so readers never see a
         partial tip. An empty row list clears it (halt, or no crown holder)."""
         try:

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -16,7 +16,6 @@ from allways.constants import (
     MIN_SUCCESSFUL_SWAPS,
     RECYCLE_UID,
     SCORING_WINDOW_BLOCKS,
-    VOLUME_WEIGHT_ALPHA,
     required_collateral,
 )
 from allways.utils.rate import is_executable_rate, min_executable_sol_leg
@@ -28,7 +27,6 @@ from allways.validator.scoring import (
     crown_can_fund,
     crown_holders_at_instant,
     due_for_scoring,
-    fill_ratio,
     is_eligible,
     make_crown_predicates,
     replay_crown_time_window,
@@ -300,8 +298,8 @@ class TestBuildEligibility:
 
 class TestGetClearingVolumes:
     """``get_clearing_volumes`` sums the windowed clearing-rate legs per
-    (direction, hotkey) — the realized-volume read ``fill_ratio`` consumes.
-    Window semantics are ``(start, end]``."""
+    (direction, hotkey) — the realized-volume read the dashboard and treasury
+    reporting consume. Window semantics are ``(start, end]``."""
 
     def _store(self, tmp_path: Path) -> ValidatorStateStore:
         return ValidatorStateStore(db_path=tmp_path / 'state.db')
@@ -1714,66 +1712,6 @@ class TestCapacityFactorHelper:
         assert capacity_factor(100_000_000, -1) == 1.0
 
 
-class TestFillRatioHelper:
-    """Direct unit tests for the fill_ratio pure function.
-
-    Signature: fill_ratio(vol_rao, total_volume_rao, crown_share, alpha).
-    """
-
-    def test_idle_crown_loses_alpha(self):
-        """vol=0 of total=1 → vol_share=0, participation=0 → factor = (1-α)."""
-        from allways.validator.scoring import fill_ratio
-
-        assert fill_ratio(0, 1_000, crown_share=1.0, alpha=0.5) == 0.5
-
-    def test_matching_volume_keeps_full_reward(self):
-        from allways.validator.scoring import fill_ratio
-
-        # 500/1000 = 0.5 vol_share, crown_share 0.5 → participation 1.0.
-        assert fill_ratio(500, 1_000, crown_share=0.5, alpha=0.5) == 1.0
-
-    def test_over_serving_capped_at_one(self):
-        """Anti-wash-trade: high volume / low crown stays at 1.0."""
-        from allways.validator.scoring import fill_ratio
-
-        assert fill_ratio(900, 1_000, crown_share=0.1, alpha=0.5) == 1.0
-
-    def test_partial_mismatch_interpolates(self):
-        """vol_share/crown_share = 0.5 → factor = 0.5 + 0.5*0.5 = 0.75."""
-        from allways.validator.scoring import fill_ratio
-
-        assert fill_ratio(250, 1_000, crown_share=0.5, alpha=0.5) == 0.75
-
-    def test_zero_crown_share_is_moot(self):
-        from allways.validator.scoring import fill_ratio
-
-        assert fill_ratio(500, 1_000, crown_share=0.0, alpha=0.5) == 1.0
-
-    def test_idle_network_short_circuits_to_one(self):
-        """total_volume == 0 → factor = 1.0 (no penalty for a quiet window)."""
-        from allways.validator.scoring import fill_ratio
-
-        assert fill_ratio(0, 0, crown_share=1.0, alpha=0.5) == 1.0
-
-    def test_alpha_zero_disables_volume_weighting(self):
-        from allways.validator.scoring import fill_ratio
-
-        for vol in (0, 250, 500, 750, 1_000):
-            assert fill_ratio(vol, 1_000, crown_share=1.0, alpha=0.0) == 1.0
-
-    def test_alpha_one_is_pure_volume_share(self):
-        from allways.validator.scoring import fill_ratio
-
-        assert fill_ratio(0, 1_000, crown_share=1.0, alpha=1.0) == 0.0
-        assert fill_ratio(250, 1_000, crown_share=0.5, alpha=1.0) == 0.5
-
-    def test_alpha_03_softer_penalty(self):
-        from allways.validator.scoring import fill_ratio
-
-        assert fill_ratio(0, 1_000, crown_share=1.0, alpha=0.3) == 0.7
-        np.testing.assert_allclose(fill_ratio(500, 1_000, crown_share=1.0, alpha=0.3), 0.85, atol=1e-6)
-
-
 class TestCapacityWeighting:
     """End-to-end capacity weighting via calculate_miner_rewards."""
 
@@ -1957,9 +1895,9 @@ class TestCapacityWeighting:
 
 
 class TestWeightingTraceRecorders:
-    """The three record_* methods on WeightingTrace own their own math —
-    direct unit coverage so changes there don't have to be inferred from
-    integration tests."""
+    """The record_* methods on WeightingTrace own their own math — direct unit
+    coverage so changes there don't have to be inferred from integration
+    tests."""
 
     def test_record_capacity_sets_factor(self):
         from allways.validator.scoring_trace import WeightingTrace
@@ -1967,37 +1905,6 @@ class TestWeightingTraceRecorders:
         wt = WeightingTrace()
         wt.record_capacity(factor=0.5)
         assert wt.capacity_factor == 0.5
-
-    def test_record_volume_computes_share_and_participation(self):
-        from allways.validator.scoring_trace import WeightingTrace
-
-        wt = WeightingTrace()
-        # vol 250 of total 1000 = 25% share; crown_share 50% → participation 50%.
-        wt.record_volume(vol_rao=250, total_volume_rao=1_000, crown_share=0.5, factor=0.75)
-        assert wt.volume_rao == 250
-        assert wt.volume_share == 0.25
-        assert wt.crown_share == 0.5
-        assert wt.participation == 0.5
-        assert wt.fill_ratio == 0.75
-
-    def test_record_volume_idle_network_zeros_share(self):
-        """total_volume == 0 → volume_share = 0, participation defaults to 1.0
-        only when crown_share also 0; otherwise participation = 0."""
-        from allways.validator.scoring_trace import WeightingTrace
-
-        wt = WeightingTrace()
-        wt.record_volume(vol_rao=0, total_volume_rao=0, crown_share=1.0, factor=1.0)
-        assert wt.volume_share == 0.0
-        assert wt.participation == 0.0  # vol_share / crown_share = 0/1 = 0
-        assert wt.fill_ratio == 1.0  # set by caller (idle-network short-circuit)
-
-    def test_record_volume_caps_participation_at_one(self):
-        """Over-serving: vol_share/crown_share > 1 → participation capped."""
-        from allways.validator.scoring_trace import WeightingTrace
-
-        wt = WeightingTrace()
-        wt.record_volume(vol_rao=900, total_volume_rao=1_000, crown_share=0.1, factor=1.0)
-        assert wt.participation == 1.0  # min(1.0, 0.9/0.1)
 
     def test_record_eligibility_sets_flag(self):
         from allways.validator.scoring_trace import WeightingTrace
@@ -2010,8 +1917,9 @@ class TestWeightingTraceRecorders:
         assert wt.eligible is False
 
 
-class TestVolumeWeighting:
-    """End-to-end volume weighting via calculate_miner_rewards."""
+class TestVolumeIsNotARewardTerm:
+    """Realized volume no longer enters the reward. These pin that: the ledger
+    can say anything and the payout is still pool x crown_share x capacity."""
 
     def seed_sol_btc_crown(self, v: SimpleNamespace, hotkey: str, rate: float = 0.00020) -> None:
         conn = v.state_store.require_connection()
@@ -2027,234 +1935,64 @@ class TestVolumeWeighting:
         miner_hotkey: str,
         from_amount: int,
         block: int = 9_900,  # inside the (9_700, 10_000] window these tests score
-        completed: bool = True,
         from_chain: str = 'btc',
         to_chain: str = 'sol',
-        to_amount: int | None = None,
     ) -> None:
-        """Seed one completed swap's realized legs on the ``clearing_rates``
-        ledger — the windowed volume read the reward weighting consumes.
-        ``from_amount`` is the from-leg the ``fill_ratio`` compares within a
-        direction. A non-completed swap never lands a ``SwapCompleted`` event,
-        so it writes nothing — timed-out swaps contribute no volume."""
-        if not completed:
-            return
         v.state_store.insert_clearing_rate(
-            block,
-            miner_hotkey,
-            from_chain,
-            to_chain,
-            from_amount,
-            from_amount if to_amount is None else to_amount,
-            uuid4().hex,
+            block, miner_hotkey, from_chain, to_chain, from_amount, from_amount, uuid4().hex
         )
 
-    def test_idle_network_no_penalty(self, tmp_path: Path):
-        """Total network volume = 0 → factor 1.0 for all crown earners."""
-        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
-        v = make_validator(tmp_path, hotkeys)
-        self.seed_sol_btc_crown(v, 'hk_a')
-        rewards, _ = calculate_miner_rewards(v, v.block)
-        # No swaps → factor = 1.0 → full crown reward.
-        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL, atol=1e-6)
-        v.state_store.close()
-
-    def test_idle_crown_holder_loses_alpha(self, tmp_path: Path):
-        """A holds 100% crown, B serves 100% volume → A factor = (1 - α)."""
+    def test_zero_volume_crown_holder_earns_full_reward(self, tmp_path: Path):
+        """Regression: a crown holder that served nothing used to keep only
+        1-alpha (0.25) of its crown reward. It now earns the full pool."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a', 'hk_b'])
         v = make_validator(tmp_path, hotkeys)
         self.seed_sol_btc_crown(v, 'hk_a')
-        # B doesn't post a rate → never holds crown.
+        # B posts no rate, so it never holds crown — it only serves the volume.
         self.insert_volume(v, 'hk_b', from_amount=1_000_000_000)
         rewards, _ = calculate_miner_rewards(v, v.block)
-        # A's vol_share = 0, crown_share = 1.0 → participation = 0 → fill_ratio = 1-α (0.25).
-        # A = pool·(1-α). B has crown_share = 0 → no crown reward to multiply.
-        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * (1 - VOLUME_WEIGHT_ALPHA), atol=1e-6)
+        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL, atol=1e-6)
         assert rewards[1] == 0.0
         v.state_store.close()
 
-    def test_matched_crown_and_volume_full_reward(self, tmp_path: Path):
-        """Equal crown + equal volume → factor 1.0 for both."""
-        from allways.constants import VOLUME_WEIGHT_ALPHA  # noqa: F401 — keep imports tidy
-
-        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a', 'hk_b'])
-        v = make_validator(tmp_path, hotkeys)
-        conn = v.state_store.require_connection()
-        for hk in ('hk_a', 'hk_b'):
-            conn.execute(
-                'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
-                (hk, 'btc', 'sol', 0.00020, 0),
-            )
-        conn.commit()
-        self.insert_volume(v, 'hk_a', from_amount=500_000_000)
-        self.insert_volume(v, 'hk_b', from_amount=500_000_000)
-        rewards, _ = calculate_miner_rewards(v, v.block)
-        # Both 50/50 on crown and volume → participation 1.0 → factor 1.0 each.
-        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 0.5, atol=1e-6)
-        np.testing.assert_allclose(rewards[1], POOL_BTC_SOL * 0.5, atol=1e-6)
-        v.state_store.close()
-
-    def test_over_serving_capped_no_bonus(self, tmp_path: Path):
-        """A holds 100% crown but B serves 9× more volume → A's factor still > 0,
-        B gets nothing (no crown). Verifies cap is one-sided: high volume can't
-        amplify a low crown holder."""
-        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a', 'hk_b'])
-        v = make_validator(tmp_path, hotkeys)
-        # btc→tao: higher rate wins (canonical direction). A wins, B loses.
-        conn = v.state_store.require_connection()
-        conn.execute(
-            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
-            ('hk_a', 'sol', 'btc', 200.0, 0),
-        )
-        conn.execute(
-            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
-            ('hk_b', 'sol', 'btc', 100.0, 0),
-        )
-        conn.commit()
-        self.insert_volume(v, 'hk_a', from_amount=100_000_000, from_chain='sol', to_chain='btc')
-        self.insert_volume(v, 'hk_b', from_amount=900_000_000, from_chain='sol', to_chain='btc')
-        rewards, _ = calculate_miner_rewards(v, v.block)
-        # A: crown_share = 1.0, vol_share = 0.1, participation = 0.1 → fill_ratio = (1-α) + α·0.1.
-        np.testing.assert_allclose(
-            rewards[0], POOL_SOL_BTC * ((1 - VOLUME_WEIGHT_ALPHA) + VOLUME_WEIGHT_ALPHA * 0.1), atol=1e-6
-        )
-        # B: crown_share = 0 → factor moot, no reward to multiply.
-        assert rewards[1] == 0.0
-        v.state_store.close()
-
-    def test_partial_mismatch_interpolates(self, tmp_path: Path):
-        """A holds 80% crown / 20% volume, B holds 20% crown / 80% volume.
-        Uses btc→tao (higher rate wins) so the rate-direction mapping is
-        self-evident in the test."""
-        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a', 'hk_b'])
-        v = make_validator(tmp_path, hotkeys)
-        conn = v.state_store.require_connection()
-        conn.execute(
-            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
-            ('hk_a', 'sol', 'btc', 200.0, 0),
-        )
-        conn.execute(
-            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
-            ('hk_b', 'sol', 'btc', 150.0, 0),
-        )
-        conn.commit()
-        # Window is (9700, 10000]. A is reserved 9_800..9_860 (60 blocks within
-        # the window) so B holds crown 20% of window. A bare PoolResolved (no
-        # swap) with a 60s TTL forfeits the crown for exactly the reserved span,
-        # then RESERVE_EXPIRE returns A to AVAILABLE.
-        v.event_watcher.apply_event(9_800, 'PoolResolved', {'miner': 'hk_a', 'ttl': 60})
-        self.insert_volume(v, 'hk_a', from_amount=200_000_000, from_chain='sol', to_chain='btc')
-        self.insert_volume(v, 'hk_b', from_amount=800_000_000, from_chain='sol', to_chain='btc')
-        rewards, _ = calculate_miner_rewards(v, v.block)
-        # Crown: A=240/300=0.8, B=60/300=0.2. Volume: A=0.2, B=0.8.
-        # A participation = 0.2/0.8 = 0.25 → fill_ratio = (1-α) + α·0.25; B → fill_ratio 1.0.
-        fill_a = (1 - VOLUME_WEIGHT_ALPHA) + VOLUME_WEIGHT_ALPHA * 0.25
-        np.testing.assert_allclose(rewards[0], POOL_SOL_BTC * 0.8 * fill_a, atol=1e-6)
-        np.testing.assert_allclose(rewards[1], POOL_SOL_BTC * 0.2, atol=1e-6)
-        v.state_store.close()
-
-    def test_timed_out_swaps_dont_count_as_volume(self, tmp_path: Path):
-        """A timed-out swap contributes no volume — only completed swaps do."""
+    def test_idle_network_pays_the_same_as_a_busy_one(self, tmp_path: Path):
+        """The old term made a direction that traded pay less than one that sat
+        idle. Same crown, same capacity -> same reward either way."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
-        v = make_validator(tmp_path, hotkeys)
-        self.seed_sol_btc_crown(v, 'hk_a')
-        self.insert_volume(
-            v,
-            'hk_a',
-            from_amount=1_000_000_000,
-            completed=False,
-        )
-        # A timed-out swap never lands SwapCompleted, so no clearing row exists.
-        assert v.state_store.get_clearing_volumes(9_700, 10_000) == {}
-        rewards, _ = calculate_miner_rewards(v, v.block)
-        # Eligible solo crown holder, zero counted volume → idle-network
-        # short-circuit → factor 1.0 → full tao→btc pool.
-        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL, atol=1e-6)
-        v.state_store.close()
+        v_idle = make_validator(tmp_path / 'idle', hotkeys)
+        self.seed_sol_btc_crown(v_idle, 'hk_a')
+        idle_rewards, _ = calculate_miner_rewards(v_idle, v_idle.block)
+        v_idle.state_store.close()
 
-    def test_volume_split_per_direction(self, tmp_path: Path):
-        """Per-direction volume isolates each market. A miner with volume in both
-        directions is keyed by direction in ``get_clearing_volumes``, so each
-        direction's ``from_amount`` is summed independently."""
-        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
-        v = make_validator(tmp_path, hotkeys)
-        self.seed_sol_btc_crown(v, 'hk_a')
-        self.insert_volume(v, 'hk_a', from_amount=300_000_000, from_chain='btc', to_chain='sol')
-        self.insert_volume(v, 'hk_a', from_amount=200_000_000, from_chain='sol', to_chain='btc')
-        vols = v.state_store.get_clearing_volumes(9_700, 10_000)
-        assert vols[('btc', 'sol')]['hk_a'] == (300_000_000, 300_000_000)
-        assert vols[('sol', 'btc')]['hk_a'] == (200_000_000, 200_000_000)
-        v.state_store.close()
+        v_busy = make_validator(tmp_path / 'busy', hotkeys)
+        self.seed_sol_btc_crown(v_busy, 'hk_a')
+        self.insert_volume(v_busy, 'hk_a', from_amount=1_000_000_000)
+        busy_rewards, _ = calculate_miner_rewards(v_busy, v_busy.block)
+        v_busy.state_store.close()
 
-    def test_per_direction_volume_isolates_markets(self, tmp_path: Path):
-        """A holds 100% of btc→tao crown and 100% of btc→tao volume. B has
-        no crown but serves heavy tao→btc volume. A's reward must not be
-        penalized for sitting out the tao→btc market — its denominator is
-        btc→tao only."""
-        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a', 'hk_b'])
-        v = make_validator(tmp_path, hotkeys)
-        conn = v.state_store.require_connection()
-        conn.execute(
-            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
-            ('hk_a', 'sol', 'btc', 200.0, 0),
-        )
-        conn.commit()
-        # A serves all of btc→tao. B floods tao→btc but earns no crown there.
-        self.insert_volume(v, 'hk_a', from_amount=1_000_000_000, from_chain='sol', to_chain='btc')
-        self.insert_volume(v, 'hk_b', from_amount=9_000_000_000, from_chain='btc', to_chain='sol')
-        rewards, _ = calculate_miner_rewards(v, v.block)
-        # Old direction-blind logic: A's vol_share would be diluted by B's flood,
-        # dragging the factor below 1. Per-direction logic: A is the sole server
-        # in its own market, factor = 1.0.
-        np.testing.assert_allclose(rewards[0], POOL_SOL_BTC, atol=1e-6)
-        assert rewards[1] == 0.0
-        v.state_store.close()
+        np.testing.assert_allclose(idle_rewards[0], busy_rewards[0], atol=1e-9)
+        np.testing.assert_allclose(idle_rewards[0], POOL_BTC_SOL, atol=1e-6)
 
-    def test_dust_volume_counts_toward_shares(self, tmp_path: Path):
-        """Any cleared volume counts — there is no direction volume floor. A dust
-        swap served by a non-holder costs the idle crown holder alpha, exactly
-        like larger volume."""
+    def test_crown_split_ignores_who_served(self, tmp_path: Path):
+        """Two holders splitting crown evenly split the pool evenly, even when
+        one of them served every swap."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a', 'hk_b'])
         v = make_validator(tmp_path, hotkeys)
         self.seed_sol_btc_crown(v, 'hk_a')
-        # B clears dust in A's market: A holds all crown, serves none of the
-        # volume → pool·(1-α).
-        self.insert_volume(v, 'hk_b', from_amount=100, to_amount=999_999_999)
+        self.seed_sol_btc_crown(v, 'hk_b')
+        self.insert_volume(v, 'hk_a', from_amount=5_000_000_000)
         rewards, _ = calculate_miner_rewards(v, v.block)
-        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * (1 - VOLUME_WEIGHT_ALPHA), atol=1e-6)
-        v.state_store.close()
-
-    def test_volume_outside_window_ignored(self, tmp_path: Path):
-        """Clearing rows outside the scored window contribute no volume — the
-        weighting reads this round's flow, not history."""
-        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a', 'hk_b'])
-        v = make_validator(tmp_path, hotkeys)
-        self.seed_sol_btc_crown(v, 'hk_a')
-        # B's heavy volume landed before the window opened (block 9_600 ≤ 9_700).
-        self.insert_volume(v, 'hk_b', from_amount=9_000_000_000, block=9_600)
-        rewards, _ = calculate_miner_rewards(v, v.block)
-        # No in-window volume → idle-network fallback → full pool for the holder.
-        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL, atol=1e-6)
-        v.state_store.close()
-
-    def test_zero_amount_clearing_row_tolerated(self, tmp_path: Path):
-        """A clearing row with zero legs is tolerated — it contributes no volume,
-        never a crash."""
-        hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
-        v = make_validator(tmp_path, hotkeys)
-        self.seed_sol_btc_crown(v, 'hk_a')
-        self.insert_volume(v, 'hk_a', from_amount=0, to_amount=0)
-        rewards, _ = calculate_miner_rewards(v, v.block)
-        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL, atol=1e-6)
+        np.testing.assert_allclose(rewards[0], rewards[1], atol=1e-9)
         v.state_store.close()
 
 
 class TestCapacityVolumeInteraction:
-    """Capacity + volume are independent multipliers — verify they compose."""
+    """Capacity is the only multiplier left beside crown share — verify a
+    served-volume ledger doesn't perturb it."""
 
     def test_both_factors_compose_multiplicatively(self, tmp_path: Path):
-        """Single miner, half required collateral → convex capacity (0.5)^2 = 0.25, idle
-        on volume → reward = pool * 0.25 * (1-α)."""
+        """Single miner, half required collateral → convex capacity (0.5)^2 = 0.25,
+        and another miner serving the volume → reward = pool * 0.25."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a', 'hk_b'])
         v = make_validator(
             tmp_path,
@@ -2268,11 +2006,11 @@ class TestCapacityVolumeInteraction:
             ('hk_a', 'btc', 'sol', 0.00020, 0),
         )
         conn.commit()
-        # B serves the market's (floor-clearing) volume so A's vol_share = 0.
+        # B serves all the volume; A still holds the crown and is paid on it.
         v.state_store.insert_clearing_rate(9_900, 'hk_b', 'btc', 'sol', 1_000_000_000, 1_000_000_000, 'sk12')
         rewards, _ = calculate_miner_rewards(v, v.block)
-        # A: pool × crown 1.0 × eligible 1 × capacity 0.25 × fill_ratio 1-α (B serves the volume).
-        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 1.0 * 0.25 * (1 - VOLUME_WEIGHT_ALPHA), atol=1e-6)
+        # A: pool × crown 1.0 × eligible 1 × capacity 0.25.
+        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 1.0 * 0.25, atol=1e-6)
         v.state_store.close()
 
     def test_full_pool_conservation_with_all_factors(self, tmp_path: Path):
@@ -2643,14 +2381,14 @@ class TestScoreSnapshots:
         kwargs = v.database_storage.flush_scoring_window.call_args.kwargs
         rows = kwargs['miner_score_rows']
         assert len(rows) == 1
-        (round_ts, hotkey, from_c, to_c, eligible, crown_share, capacity, fill_ratio, vol_share, reward) = rows[0]
+        (round_ts, hotkey, from_c, to_c, eligible, crown_share, capacity, reward) = rows[0]
         assert round_ts == v.block  # round keyed by window_end
         assert (hotkey, from_c, to_c) == ('hk_a', 'btc', 'sol')
         assert eligible is True
-        np.testing.assert_allclose((crown_share, capacity, fill_ratio, vol_share), (1.0,) * 4)
+        np.testing.assert_allclose((crown_share, capacity), (1.0, 1.0))
         # The persisted factors reproduce the persisted reward, and the
         # persisted reward is what the weights actually paid.
-        expected = POOL_BTC_SOL * crown_share * capacity * fill_ratio
+        expected = POOL_BTC_SOL * crown_share * capacity
         np.testing.assert_allclose(reward, expected, atol=1e-9)
         np.testing.assert_allclose(reward, rewards[0], atol=1e-6)
 
@@ -2672,7 +2410,7 @@ class TestScoreSnapshots:
         row = rows[0]
         assert row[4] is False  # eligible
         np.testing.assert_allclose(row[5], 1.0)  # crown_share still recorded
-        assert row[9] == 0.0  # reward
+        assert row[7] == 0.0  # reward
         assert rewards[0] == 0.0
         v.state_store.close()
 
@@ -2703,28 +2441,6 @@ class TestScoreSnapshots:
         assert v.database_storage.flush_halt_window.called
         assert not v.database_storage.flush_scoring_window.called
         v.state_store.close()
-
-
-class TestFillRatio:
-    """fill_ratio = (1-α) + α·min(1, vol_share/crown_share), α = VOLUME_WEIGHT_ALPHA (0.75):
-    a zero-fill holder in an active direction floors at 0.25; an idle direction
-    (0 total volume) pays full — 0/0 is full earnings by design."""
-
-    def test_zero_fill_in_active_direction_floors_at_quarter(self):
-        assert fill_ratio(0, 1_000, 0.5) == pytest.approx(1.0 - VOLUME_WEIGHT_ALPHA) == pytest.approx(0.25)
-
-    def test_idle_direction_pays_full(self):
-        assert fill_ratio(0, 0, 1.0) == 1.0
-
-    def test_matching_share_pays_full(self):
-        assert fill_ratio(500, 1_000, 0.5) == 1.0
-
-    def test_over_serve_capped_at_full(self):
-        assert fill_ratio(1_000, 1_000, 0.5) == 1.0
-
-    def test_partial_fill_lands_between_floor_and_full(self):
-        # vol_share 0.25 vs crown_share 0.5 → participation 0.5 → 0.25 + 0.75·0.5
-        assert fill_ratio(250, 1_000, 0.5) == pytest.approx(0.25 + 0.75 * 0.5)
 
 
 class TestCrownCanFund:


### PR DESCRIPTION
The reward becomes `eligible × pool × crown_share × capacity`. `fill_ratio` and its input `vol_share` are deleted from the reward math. Crown replay, the collateral tie-break, the convex capacity curve, the flat eligibility gate, and L1 weight normalization are all unchanged.

## Why

`fill_ratio(vol, total_vol, crown_share) = (1-α) + α·min(1, vol_share/crown_share)` with α = 0.75. It reads as a modifier, but algebraically the reward was `min(crown_share, 0.25·crown_share + 0.75·vol_share)` — for any miner below their crown share on volume it was predominantly a volume-share mechanism.

Measured over 240 hourly rounds (~10 days, 7,810 `miner_scores` rows, 36 miners):

- **81.4%** of (round, direction) buckets had zero network volume, short-circuiting the term to 1.0 for everyone. Inert 4 rounds in 5.
- Of the 179 buckets that traded, **77.2% of rows sat exactly at the 0.25 floor**, 20.4% at 1.0, 2.5% in between — bimodal with an empty middle.
- Cause is arrival counts, not miner behaviour: ~10 crown holders per bucket, and in 89 of 179 buckets **exactly one miner had any volume at all**. It graded whether the hour's single swap landed on you.

And the sign was backwards. Average crown mass paid by a bucket that traded vs one that sat idle:

| direction | traded | idle | ratio |
|---|---|---|---|
| BTC-SOL | 0.0430 | 0.1456 | 0.30× |
| SOL-BTC | 0.0571 | 0.1515 | 0.38× |
| SOL-TAO | 0.0758 | 0.1319 | 0.57× |
| TAO-SOL | 0.0431 | 0.1512 | 0.28× |

A direction paid its miners 28–57% of what it paid when nothing traded. The term penalised trading.

It was also a sophistication tax: the only on-chain self-deal guard is the literal `user != miner` check in `finalize_reservation.rs`, whose own comment concedes a second wallet is out of reach and "the scorer's volume exclusion owns that half" — which was never built. Washing to hold `fill_ratio` at 1.0 cost far less than forfeiting 75% of emissions.

**Impact:** reconstructing all 240 rounds with the term stripped and re-normalising moves **1.19% of total emission share**. Largest single mover is one miner at −0.31pp (1.72% → 1.41%); everyone else is within ±0.1pp.

## What's deliberately kept

- **`clearing_rates` ingest.** `event_index._apply` still writes `SwapCompleted` legs and `get_clearing_volumes` still works — the dashboard and treasury reporting read it. Only scoring's *consumption* goes away. This also removes a SQLite aggregation from the ~12s forward loop, since the live-tip path called it every step.
- **`REWARD_MINER_STATES`** — busy-forfeits-crown is deliberate and stays.
- **The contract.** Validator-only, no Solana program changes.

## Schema

Depends on allways-db#44, which made `fill_ratio`/`vol_share` nullable. The validator simply stops naming the columns, so historical rows are untouched and new rows record `NULL` — "term not applied", distinguishable from a genuine `fill_ratio` of 1.0. The columns get dropped in a follow-up once the whole fleet is on this build.

Pairs with das-allways#72 and allways-ui#154, which stop reading the fields.

## Rollout

Every validator must run the same scoring version — divergent scoring means divergent `set_weights`, which yuma penalises. Coordinate the upgrade rather than rolling one neuron at a time. `aw-indexer` bakes the `allways` package, so it needs an image rebuild + container recreate, not a pull-and-restart.

Worth a heads-up in the subnet Discord: the term was inert 81% of rounds and a coin flip the rest, so this is a correctness fix, not a policy shift.

## Known trade-off, accepted

Post-removal nothing in the mechanism references an external price — emissions track rate *rank*, not rate *quality*. A tacit cartel quoting wide splits the pot the same as a competitive field. That hole exists today and `fill_ratio` did not defend it (a cartel attracts no takers → zero volume → fill 1.0 for everyone). Mitigation is monitoring, not mechanism.

## Tests

Full suite: **781 passed**, 6 deselected (integration). `ruff check` + `ruff format --check` clean.

- Deleted `TestFillRatioHelper`, `TestFillRatio`, `TestVolumeWeighting`, and the three `record_volume` trace unit tests
- Added `TestVolumeIsNotARewardTerm`: a zero-volume crown holder now earns the full `pool × crown_share × capacity` (previously `× 0.25`); an idle direction pays the same as a busy one; two holders splitting crown split the pool evenly even when one served every swap
- `TestCapacityVolumeInteraction` reworked to assert a served-volume ledger doesn't perturb the capacity multiplier
- Persisted-row test asserts the 8-tuple shape

