### PR TITLE
docs: add X (@allways_io) badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Trustless native transactions across independent assets — Bittensor Subnet 7 (SN7).
 
+[![Twitter](https://img.shields.io/twitter/follow/allways_io?style=social)](https://x.com/allways_io)
+
 ## Overview
 
 Allways creates a verification layer above independent systems. Assets move natively. Miners complete transactions, validators independently verify the results, and a smart contract enforces outcomes through collateral and slashing.


### PR DESCRIPTION
Adds the Allways X account badge to the top of the README, matching the style Gittensor uses in its README.

- Badge: shields.io Twitter follow badge for @allways_io
- Links to https://x.com/allways_io