### PR TITLE
Restore the dynamic miner burn

### DIFF
--- a/allways/__init__.py
+++ b/allways/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '2.0.1'
+__version__ = '2.0.2'
 version_split = __version__.split('.')
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -112,11 +112,8 @@ def required_collateral(collateral_amount: int) -> int:
     return collateral_amount * COLLATERAL_REQUIREMENT_BPS // 10_000
 
 
-# ─── Emissions ─────────────────────────────────────────────
-# Subnet owner UID. No longer paid the penalty shortfall: set_weights
-# L1-normalizes scores so distributed rewards stretch to 100% of emissions
-# (burning would shrink subnet emission via 1 - miner_burn).
-RECYCLE_UID = 53
+# ─── Emission Recycling ────────────────────────────────────
+RECYCLE_UID = 53  # Subnet owner UID
 
 # ─── Optimistic Extensions ───────────────────────────────
 # Tunables for the propose/challenge/finalize extension flow. Per-chain timing

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -2,9 +2,10 @@
 
 Reward per miner is ``eligible × pool × crown_share × capacity``, where
 ``eligible`` is a flat 0/1 gate read off the on-chain ``MinerState`` counters
-(B3.3) — it replaces the old ``sr³ × credibility ramp``. Penalty shortfall is
-not burned: ``set_weights`` L1-normalizes, stretching distributed rewards to
-100% of emissions. Entry is ``score_and_reward_miners``.
+(B3.3) — it replaces the old ``sr³ × credibility ramp``. Any shortfall recycles
+to ``RECYCLE_UID`` — the burn is dynamic (whatever the pool did not earn) and
+deliberate: it keeps a penalty absolute rather than something weight
+normalization stretches back to 100%. Entry is ``score_and_reward_miners``.
 """
 
 from __future__ import annotations
@@ -27,6 +28,7 @@ from allways.constants import (
     MAX_FAILED_SWAPS,
     MAX_SCORING_BACKFILL_SECS,
     MIN_SUCCESSFUL_SWAPS,
+    RECYCLE_UID,
     REWARD_MINER_STATES,
     SCORING_WINDOW_BLOCKS,
     SCORING_WINDOW_SECS,
@@ -77,16 +79,12 @@ def score_and_reward_miners(self: Validator) -> None:
         now = int(time.time())
         halted = contract_is_halted(self)
         if halted:
-            # No crown accrues during a halt, and burning the pool would shrink
-            # subnet emissions (price × (1 - miner_burn)). Freeze scores so the
-            # pre-halt weights persist until scoring resumes.
-            bt.logging.info('V1 scoring: halted, scores frozen')
+            rewards, miner_uids = build_halted_rewards(self)
             _flush_halt_window(self, now)
-            dev_signal.emit('scoring_rewards', halted=True, rewards={})
         else:
             rewards, miner_uids = calculate_miner_rewards(self, now)
-            self.update_scores(rewards, miner_uids)
-            dev_signal.emit('scoring_rewards', halted=False, rewards={i: float(r) for i, r in enumerate(rewards) if r})
+        self.update_scores(rewards, miner_uids)
+        dev_signal.emit('scoring_rewards', halted=halted, rewards={i: float(r) for i, r in enumerate(rewards) if r})
         prune_crown_events(self, now)
         # Advance both cursors only after a round completes, so a mid-round
         # failure retries the same window next forward. last_scored_block gates
@@ -102,7 +100,7 @@ def _flush_halt_window(self: Validator, current_time: int) -> None:
     sync_cursor watermarks, and clear the live current_crown_holders
     table. Mirrors the daemon's halt-tick semantics so the dashboard
     doesn't keep showing pre-halt holders while the validator has
-    frozen scoring. Live-table clear lives here (not in the
+    recycled the pool. Live-table clear lives here (not in the
     per-forward snapshot) so we don't pay an RPC every step just to
     check halt — halt is rare; one clear per round is enough."""
     if not self.database_storage.is_enabled():
@@ -135,6 +133,18 @@ def contract_is_halted(self: Validator) -> bool:
     except Exception as e:
         bt.logging.warning(f'halt RPC check failed, proceeding as not-halted: {e}')
         return False
+
+
+def build_halted_rewards(self: Validator) -> Tuple[np.ndarray, Set[int]]:
+    """During a halt, no miner earns crown; the full pool recycles."""
+    n_uids = self.metagraph.n.item()
+    rewards = np.zeros(n_uids, dtype=np.float32)
+    if n_uids == 0:
+        return rewards, set()
+    recycle_uid = RECYCLE_UID if RECYCLE_UID < n_uids else 0
+    rewards[recycle_uid] = 1.0
+    bt.logging.info('V1 scoring: halted, recycled full pool')
+    return rewards, set(range(n_uids))
 
 
 def prune_crown_events(self: Validator, current_time: int) -> None:
@@ -247,8 +257,7 @@ def build_direction_score_rows(
 
 def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndarray, Set[int]]:
     """Replay the crown-time event stream, derive per-miner rewards
-    (eligible × pool × crown_share × capacity); the shortfall is not burned —
-    weight normalization stretches distributed rewards to 100%.
+    (eligible × pool × crown_share × capacity), recycle the rest.
     ``current_time`` is the unix-seconds window_end (the crown axis)."""
     n_uids = self.metagraph.n.item()
     if n_uids == 0:
@@ -320,7 +329,7 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
         bt.logging.debug(f'V1 scoring [{from_chain}→{to_chain}]: total_crown={total_crown_dir:.1f}s')
 
         if total_crown_dir == 0:
-            continue  # empty bucket — its pool spreads to earners via normalization
+            continue  # empty bucket — pool recycles via the remainder below
 
         rows = build_direction_score_rows(
             from_chain,
@@ -340,11 +349,13 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
             rewards[uid] += row.reward
             score_rows.append(row)
 
-    # Penalty shortfall is deliberately NOT routed to a burn/recycle UID:
-    # set_weights L1-normalizes scores, so the distributed mass stretches to
-    # 100% of emissions (subnet emission scales with 1 - miner_burn).
+    # The shortfall is burned to RECYCLE_UID rather than left for weight
+    # normalization to stretch back over the earners. Normalization preserves
+    # every ratio, so an undistributed pool would cost a shallow field nothing.
+    recycle_uid = RECYCLE_UID if RECYCLE_UID < n_uids else 0
     distributed = float(rewards.sum())
-    undistributed = max(0.0, 1.0 - distributed)
+    recycled = max(0.0, 1.0 - distributed)
+    rewards[recycle_uid] += recycled
 
     log_scoring_trace(
         self,
@@ -354,7 +365,7 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
         rewards=rewards,
         eligibility=eligibility,
         distributed=distributed,
-        undistributed=undistributed,
+        recycled=recycled,
         weighting_traces=weighting_traces,
         min_swap_lamports=min_swap_amount,
         max_swap_lamports=max_swap_amount,
@@ -406,7 +417,7 @@ def snapshot_current_miner_scores(self: Validator, at_time: Optional[int] = None
     """Mid-round live tip: the factors each crown holder would be paid on if
     the in-progress round [last_scored_time, now] flushed right now — the same
     replay + ``build_direction_score_rows`` math ``calculate_miner_rewards``
-    runs, minus weights/traces. Returns ``current_miner_scores``-shaped
+    runs, minus weights/traces/recycle. Returns ``current_miner_scores``-shaped
     tuples for the per-forward-step wipe+insert (``miner_scores``' live
     counterpart, same pattern as ``current_crown_holders``).
 
@@ -762,7 +773,7 @@ def snapshot_current_crown_holders(
     scoring round when a halt is detected. Worst case the live table
     shows the actual best-rate holder during halt for ~1h, while the
     HaltBanner + top-right indicator (both fed by /halt off
-    contract_events) signal the halt state to users."""
+    contract_events) signal the recycle state to users."""
     # The live crown reads per-instant state at "now" on the unix-time
     # (blockTime) axis the event tables use. Tests pass an explicit instant.
     ts = int(time.time()) if at_time is None else at_time

--- a/allways/validator/scoring_trace.py
+++ b/allways/validator/scoring_trace.py
@@ -1,6 +1,6 @@
 """Per-round scoring log block: how the pool was distributed, who held
-crown, why each non-earner earned nothing, how much of the raw pool went
-undistributed before normalization. Pure presentation — never mutates state."""
+crown, why each non-earner earned nothing, why pool recycled. Pure
+presentation — never mutates state."""
 
 from __future__ import annotations
 
@@ -11,7 +11,10 @@ import bittensor as bt
 import numpy as np
 
 from allways.chains import canonical_pair
-from allways.constants import TAO_TO_RAO
+from allways.constants import (
+    RECYCLE_UID,
+    TAO_TO_RAO,
+)
 from allways.utils.rate import min_executable_sol_leg
 
 if TYPE_CHECKING:
@@ -51,18 +54,18 @@ def log_scoring_trace(
     rewards: np.ndarray,
     eligibility: Dict[str, bool],
     distributed: float,
-    undistributed: float,
+    recycled: float,
     weighting_traces: Optional[Dict[str, 'WeightingTrace']] = None,
     min_swap_lamports: int = 0,
     max_swap_lamports: int = 0,
 ) -> None:
     hotkeys = self.metagraph.hotkeys
+    recycle_uid = RECYCLE_UID if RECYCLE_UID < len(rewards) else 0
     hotkey_to_uid = {hk: uid for uid, hk in enumerate(hotkeys)}
     weighting_traces = weighting_traces or {}
 
     lines = [
-        f'V1 scoring: window=[{window_start}, {window_end}], '
-        f'distributed={distributed:.6f}, undistributed={undistributed:.6f}'
+        f'V1 scoring: window=[{window_start}, {window_end}], distributed={distributed:.6f}, recycled={recycled:.6f}'
     ]
 
     for (from_c, to_c), trace in direction_traces.items():
@@ -80,7 +83,9 @@ def log_scoring_trace(
     for uid in sorted(shown, key=lambda u: -float(rewards[u])):
         hk = hotkeys[uid]
         crown_secs = sum(t.crown_time.get(hk, 0.0) for t in direction_traces.values())
-        crown_reward = float(rewards[uid])
+        if uid == recycle_uid and crown_secs == 0:
+            continue
+        crown_reward = float(rewards[uid]) - (recycled if uid == recycle_uid else 0.0)
         eligible = eligibility.get(hk, False)
         wt = weighting_traces.get(hk)
         extras = ''
@@ -103,6 +108,7 @@ def log_scoring_trace(
             rewards,
             eligibility,
             direction_traces,
+            recycle_uid,
             collaterals,
             min_swap_lamports,
             max_swap_lamports,
@@ -110,14 +116,12 @@ def log_scoring_trace(
         )
     )
 
-    if undistributed > 0:
+    if recycled > 0:
         parts = [
             f'{t.unfilled_time}s unfilled in {f}→{to}' for (f, to), t in direction_traces.items() if t.unfilled_time > 0
         ]
         cause = '; '.join(parts) or 'no crown winners'
-        lines.append(
-            f'  undistributed={undistributed:.3f} (stretched across earners by weight normalization) cause={cause}'
-        )
+        lines.append(f'  recycled={recycled:.3f} → UID{recycle_uid} (subnet owner) cause={cause}')
 
     bt.logging.info('\n'.join(lines))
 
@@ -129,6 +133,7 @@ def non_earner_lines(
     rewards: np.ndarray,
     eligibility: Dict[str, bool],
     direction_traces: Dict[Tuple[str, str], DirectionTrace],
+    recycle_uid: int,
     collaterals: Optional[Dict[str, int]] = None,
     min_swap_lamports: int = 0,
     max_swap_lamports: int = 0,
@@ -149,7 +154,7 @@ def non_earner_lines(
     out: List[str] = []
     for uid, hk in enumerate(self.metagraph.hotkeys):
         # crown holders already got a full factor line above
-        if rewards[uid] > 0 or hk in covered:
+        if uid == recycle_uid or rewards[uid] > 0 or hk in covered:
             continue
         latest_rates = rates_by_hotkey.get(hk, {})
         if not latest_rates and hk not in ever_active:

--- a/allways/validator/storage/storage.py
+++ b/allways/validator/storage/storage.py
@@ -182,8 +182,8 @@ class DatabaseStorage:
     ) -> StorageResult:
         """Halt-aware counterpart to flush_scoring_window.
 
-        During a halt, no miner earns crown and scoring is frozen
-        (see ``score_and_reward_miners``). Mirror that on the dashboard by
+        During a halt, no miner earns crown and the pool recycles
+        (see ``build_halted_rewards``). Mirror that on the dashboard by
         deleting any pre-existing crown_holders rows in the halted
         window, clearing the live score tip (nothing is being paid),
         and advancing the cursor — leaves no stale "current holder"

--- a/neurons/base/validator.py
+++ b/neurons/base/validator.py
@@ -9,7 +9,7 @@ from typing import List, Set, Union
 import bittensor as bt
 import numpy as np
 
-from allways.constants import VALIDATOR_POLL_INTERVAL_SECONDS
+from allways.constants import RECYCLE_UID, VALIDATOR_POLL_INTERVAL_SECONDS
 from allways.utils.config import add_validator_args
 from neurons.base.neuron import BaseNeuron
 from neurons.base.utils.weight_utils import (
@@ -184,12 +184,16 @@ class BaseValidatorNeuron(BaseNeuron):
 
         if np.any(norm == 0) or np.isnan(norm).any():
             # Empty/NaN scores (cold start, RPC failure, all miners deregistered).
-            # Skip the round so the chain keeps the previous weights — burning to
-            # a recycle UID would shrink subnet emissions (1 - miner_burn), and
-            # bittensor's fallback would otherwise split uniform 1/n.
-            bt.logging.warning('set_weights: scores empty, skipping weight set this round')
-            return
-        raw_weights = self.scores / norm
+            # Hand the full pool to RECYCLE_UID — without this, bittensor's
+            # process_weights_for_netuid falls back to uniform 1/n across every
+            # UID and emissions split evenly instead of fully recycling.
+            n_uids = self.metagraph.n.item()
+            recycle_uid = RECYCLE_UID if RECYCLE_UID < n_uids else 0
+            raw_weights = np.zeros_like(self.scores)
+            raw_weights[recycle_uid] = 1.0
+            bt.logging.warning(f'set_weights: scores empty, routing full pool to recycle UID {recycle_uid}')
+        else:
+            raw_weights = self.scores / norm
 
         bt.logging.debug('raw_weights', raw_weights)
         bt.logging.debug('raw_weight_uids', str(self.metagraph.uids.tolist()))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "allways"
-version = "2.0.1"
+version = "2.0.2"
 description = "Allways - Universal Transaction Layer: Trustless cross-chain swaps on Bittensor Subnet 7"
 license = "MIT"
 requires-python = ">=3.10,<3.15"

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -1119,16 +1119,16 @@ class TestLedgerSnapshotAgreement:
 
 
 class TestCalculateMinerRewards:
-    def test_empty_direction_distributes_nothing(self, tmp_path: Path):
+    def test_empty_direction_recycles_full_pool(self, tmp_path: Path):
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
         v = make_validator(tmp_path, hotkeys=hotkeys)
 
         rewards, uids = calculate_miner_rewards(v, v.block)
 
         assert set(uids) == set(range(len(hotkeys)))
-        assert rewards[RECYCLE_UID] == 0.0
+        assert rewards[RECYCLE_UID] == 1.0
         assert rewards[0] == 0.0
-        np.testing.assert_allclose(rewards.sum(), 0.0, atol=1e-6)
+        np.testing.assert_allclose(rewards.sum(), 1.0, atol=1e-6)
         v.state_store.close()
 
     def test_single_eligible_miner_earns_full_pool(self, tmp_path: Path):
@@ -1147,12 +1147,12 @@ class TestCalculateMinerRewards:
         rewards, _ = calculate_miner_rewards(v, v.block)
 
         np.testing.assert_allclose(rewards[0], POOL_BTC_SOL + POOL_SOL_BTC, atol=1e-6)
-        np.testing.assert_allclose(rewards.sum(), POOL_BTC_SOL + POOL_SOL_BTC, atol=1e-6)
+        np.testing.assert_allclose(rewards.sum(), 1.0, atol=1e-6)
         v.state_store.close()
 
     def test_ineligible_miner_earns_nothing(self, tmp_path: Path):
         """A crown-holding miner below the success floor gates to weight 0 and
-        nothing is distributed — the flat gate is a hard 0/1 multiplier."""
+        the whole pool recycles — the flat gate is a hard 0/1 multiplier."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
         # hk_a holds the crown but has only 1 successful swap (< MIN=2).
         v = make_validator(tmp_path, hotkeys=hotkeys, miner_counters={'hk_a': (1, 0)})
@@ -1166,7 +1166,7 @@ class TestCalculateMinerRewards:
         rewards, _ = calculate_miner_rewards(v, v.block)
 
         assert rewards[0] == 0.0
-        np.testing.assert_allclose(rewards.sum(), 0.0, atol=1e-6)
+        np.testing.assert_allclose(rewards[RECYCLE_UID], 1.0, atol=1e-6)
         v.state_store.close()
 
     def test_eligible_high_fail_miner_excluded(self, tmp_path: Path):
@@ -1184,7 +1184,7 @@ class TestCalculateMinerRewards:
         rewards, _ = calculate_miner_rewards(v, v.block)
 
         assert rewards[0] == 0.0
-        np.testing.assert_allclose(rewards.sum(), 0.0, atol=1e-6)
+        np.testing.assert_allclose(rewards[RECYCLE_UID], 1.0, atol=1e-6)
         v.state_store.close()
 
     def test_unbound_miner_without_counters_ineligible(self, tmp_path: Path):
@@ -1202,7 +1202,7 @@ class TestCalculateMinerRewards:
         rewards, _ = calculate_miner_rewards(v, v.block)
 
         assert rewards[0] == 0.0
-        np.testing.assert_allclose(rewards.sum(), 0.0, atol=1e-6)
+        np.testing.assert_allclose(rewards[RECYCLE_UID], 1.0, atol=1e-6)
         v.state_store.close()
 
     def test_dereg_mid_window_forfeits_credit(self, tmp_path: Path):
@@ -1226,13 +1226,13 @@ class TestCalculateMinerRewards:
         np.testing.assert_allclose(rewards[0], POOL_SOL_BTC, atol=1e-6)
         v.state_store.close()
 
-    def test_small_metagraph_empty_window_distributes_nothing(self, tmp_path: Path):
+    def test_recycle_uid_out_of_bounds_falls_back_to_zero(self, tmp_path: Path):
         hotkeys = ['hk_a', 'hk_b']
         v = make_validator(tmp_path, hotkeys=hotkeys)
 
         rewards, _ = calculate_miner_rewards(v, v.block)
 
-        assert float(rewards.sum()) == 0.0
+        assert rewards[0] == 1.0
         assert len(rewards) == 2
         v.state_store.close()
 
@@ -1263,7 +1263,7 @@ class TestCalculateMinerRewards:
         rewards, _ = calculate_miner_rewards(v, v.block)
 
         assert rewards[0] == 0.0
-        assert float(rewards.sum()) == 0.0
+        assert rewards[RECYCLE_UID] == 1.0
         v.state_store.close()
 
 
@@ -1356,7 +1356,7 @@ class TestHistoricalActiveState:
 
         # Full pool across both directions goes to hk_a (uid 0).
         np.testing.assert_allclose(rewards[0], POOL_BTC_SOL + POOL_SOL_BTC, atol=1e-6)
-        np.testing.assert_allclose(rewards.sum(), POOL_BTC_SOL + POOL_SOL_BTC, atol=1e-6)
+        np.testing.assert_allclose(rewards.sum(), 1.0, atol=1e-6)
         v.state_store.close()
 
     def test_multiple_active_cycles(self, tmp_path: Path):
@@ -1413,7 +1413,7 @@ class TestHistoricalActiveState:
         assert crown == {'hk_a': 400.0, 'hk_b': 600.0}
         store.close()
 
-    def test_only_miner_deactivated_mid_window_rest_undistributed(self, tmp_path: Path):
+    def test_only_miner_deactivated_mid_window_pool_partially_recycles(self, tmp_path: Path):
         """Solo miner active at window_start, deactivates mid-window."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
         v = make_validator(tmp_path, hotkeys=hotkeys, block=1100)
@@ -1429,11 +1429,12 @@ class TestHistoricalActiveState:
 
         rewards, _ = calculate_miner_rewards(v, v.block)
 
-        # hk_a is the only miner with a rate, so it takes the entire btc→sol
-        # pool for the blocks it held crown. The other pools go undistributed
-        # (no rates posted) — normalization stretches at set_weights.
+        # hk_a is the only miner with a rate, so it takes the entire tao→btc
+        # pool for the blocks it held crown. btc→tao pool gets nothing (no
+        # rates posted) and recycles.
         np.testing.assert_allclose(rewards[0], POOL_BTC_SOL, atol=1e-6)
-        np.testing.assert_allclose(rewards.sum(), POOL_BTC_SOL, atol=1e-6)
+        # Everything else recycles: btc→tao pool.
+        np.testing.assert_allclose(rewards.sum(), 1.0, atol=1e-6)
         v.state_store.close()
 
     def test_pre_window_activation_is_reconstructed(self, tmp_path: Path):
@@ -1597,9 +1598,9 @@ class TestHistoricalActiveState:
 
         rewards, _ = calculate_miner_rewards(v, v.block)
 
-        # hk_b (uid 0) is the only rewardable + active miner, earns sol→btc.
+        # hk_b (uid 0) is the only rewardable + active miner, earns btc→tao.
         np.testing.assert_allclose(rewards[0], POOL_SOL_BTC, atol=1e-6)
-        np.testing.assert_allclose(rewards.sum(), POOL_SOL_BTC, atol=1e-6)
+        np.testing.assert_allclose(rewards.sum(), 1.0, atol=1e-6)
         v.state_store.close()
 
 
@@ -1619,8 +1620,8 @@ class TestEventKindOrdering:
 
 
 class TestHaltShortCircuit:
-    """Halt check at the scoring entry sidesteps event replay: scores are
-    frozen (no update) so the pre-halt weights persist — nothing burns."""
+    """Halt check at the scoring entry sidesteps event replay: full pool
+    recycles, rewards skip the crown-time path entirely."""
 
     def _make_validator_with_halt(self, tmp_path: Path, halt_return, hotkeys: list[str]) -> SimpleNamespace:
         hotkeys = pad_hotkeys_to_cover_recycle(hotkeys)
@@ -1637,21 +1638,25 @@ class TestHaltShortCircuit:
         v.update_scores = capture
         return v, captured
 
-    def test_halted_freezes_scores(self, tmp_path: Path):
+    def test_halted_short_circuits_to_full_recycle(self, tmp_path: Path):
         v, captured = self._make_validator_with_halt(tmp_path, halt_return=True, hotkeys=['hk_a', 'hk_b'])
         score_and_reward_miners(v)
-        # update_scores never runs during a halt — pre-halt weights persist.
-        assert captured == {}
+        rewards = captured['rewards']
+        recycle_uid = RECYCLE_UID if RECYCLE_UID < len(rewards) else 0
+        assert rewards[recycle_uid] == 1.0
+        # every other uid must be exactly zero
+        assert float(rewards.sum()) == 1.0
 
     def test_halted_rpc_error_still_scores(self, tmp_path: Path):
         """If the halt RPC fails, scoring proceeds as normal rather than
-        freezing every miner's score."""
+        zeroing every miner's reward."""
         v, captured = self._make_validator_with_halt(tmp_path, halt_return=RuntimeError('rpc down'), hotkeys=['hk_a'])
-        # No rate / collateral seeded → replay credits nothing, but the normal
-        # path (not the halt freeze) still runs a score update.
+        # No rate / collateral seeded → replay credits nothing → full pool
+        # still recycles, but via the normal path (not the halt short-circuit).
         score_and_reward_miners(v)
         rewards = captured['rewards']
-        assert float(rewards.sum()) == 0.0  # nothing earned, nothing burned
+        recycle_uid = RECYCLE_UID if RECYCLE_UID < len(rewards) else 0
+        assert rewards[recycle_uid] > 0  # recycle got something via normal path
 
 
 class TestCapacityFactorHelper:
@@ -1740,7 +1745,7 @@ class TestCapacityWeighting:
 
     def test_quarter_collateral_pays_sixteenth(self, tmp_path: Path):
         """Collateral at 1/4 of required (1.1 x max_swap) → convex capacity (1/4)^2 =
-        1/16 reward, the rest goes undistributed."""
+        1/16 reward, the rest recycles."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
         v = make_validator(
             tmp_path,
@@ -1751,10 +1756,11 @@ class TestCapacityWeighting:
         self.seed_sol_btc_crown(v, 'hk_a')
         rewards, _ = calculate_miner_rewards(v, v.block)
         np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 0.0625, atol=1e-6)
-        # The shortfall is not routed anywhere — it goes undistributed and
-        # set_weights normalization stretches the distributed mass to 100%.
-        assert rewards[RECYCLE_UID] == 0.0
-        np.testing.assert_allclose(rewards.sum(), POOL_BTC_SOL * 0.0625, atol=1e-6)
+        # Pool conservation: hk_a got POOL_BTC_SOL*0.0625; the rest of both buckets
+        # and the unallocated pool all recycle, so recycle = 1 - that share.
+        recycle_uid = RECYCLE_UID if RECYCLE_UID < len(rewards) else 0
+        np.testing.assert_allclose(rewards[recycle_uid], 1.0 - POOL_BTC_SOL * 0.0625, atol=1e-6)
+        np.testing.assert_allclose(rewards.sum(), 1.0, atol=1e-6)
         v.state_store.close()
 
     def test_over_max_caps_at_full(self, tmp_path: Path):
@@ -1773,16 +1779,17 @@ class TestCapacityWeighting:
 
     def test_zero_collateral_zeros_reward(self, tmp_path: Path):
         """A *known* zero collateral event with max_swap set → factor 0 → no
-        reward, nothing distributed. Seeded as an explicit present-0 event (not
-        an absent series, which now fails open — see
+        reward, full recycle. Seeded as an explicit present-0 event (not an
+        absent series, which now fails open — see
         test_unknown_collateral_fails_open)."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
         v = make_validator(tmp_path, hotkeys, max_swap_amount=500_000_000)
         seed_collateral(v.event_watcher, 'hk_a', 0, block=0)  # present, known zero
         self.seed_sol_btc_crown(v, 'hk_a')
         rewards, _ = calculate_miner_rewards(v, v.block)
+        recycle_uid = RECYCLE_UID if RECYCLE_UID < len(rewards) else 0
         assert rewards[0] == 0.0
-        np.testing.assert_allclose(rewards.sum(), 0.0, atol=1e-6)
+        np.testing.assert_allclose(rewards[recycle_uid], 1.0, atol=1e-6)
         v.state_store.close()
 
     def test_rate_tie_broken_by_collateral(self, tmp_path: Path):
@@ -2014,8 +2021,7 @@ class TestCapacityVolumeInteraction:
         v.state_store.close()
 
     def test_full_pool_conservation_with_all_factors(self, tmp_path: Path):
-        """Distributed mass never exceeds the pool and none lands on the
-        recycle UID, regardless of capacity/volume shortfalls."""
+        """Reward sum + recycle = 1.0 always, regardless of capacity/volume shortfalls."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a', 'hk_b'])
         v = make_validator(
             tmp_path,
@@ -2033,8 +2039,7 @@ class TestCapacityVolumeInteraction:
         conn.commit()
         v.state_store.insert_clearing_rate(9_900, 'hk_b', 'sol', 'btc', 1_500_000_000, 1_500_000_000, 'sk13')
         rewards, _ = calculate_miner_rewards(v, v.block)
-        assert 0.0 < float(rewards.sum()) <= 1.0 + 1e-6
-        assert rewards[RECYCLE_UID] == 0.0
+        np.testing.assert_allclose(rewards.sum(), 1.0, atol=1e-6)
         v.state_store.close()
 
 
@@ -2043,7 +2048,7 @@ class TestEligibilityGateEndToEnd:
 
     The gate is a hard 0/1 multiplier off the on-chain MinerState counters —
     no ramp. An eligible crown holder earns its full crown share; an ineligible
-    one earns nothing and its share goes undistributed. Boundary cases (the success floor
+    one earns nothing and the share recycles. Boundary cases (the success floor
     and the failure cap) are exercised here through the full reward pipeline."""
 
     def seed_btc_tao_crown(self, v: SimpleNamespace, hotkey: str, rate: float = 200.0) -> None:
@@ -2093,16 +2098,17 @@ class TestEligibilityGateEndToEnd:
         np.testing.assert_allclose(rewards[0], 0.0, atol=1e-6)
         v.state_store.close()
 
-    def test_ineligible_share_goes_undistributed(self, tmp_path: Path):
-        """An ineligible holder's crown share is not paid to anyone — neither
-        the owner UID nor other miners."""
+    def test_ineligible_share_recycles(self, tmp_path: Path):
+        """An ineligible holder's crown share recycles to the owner UID, not to
+        other miners — pool conservation holds."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
         v = make_validator(tmp_path, hotkeys, miner_counters={'hk_a': (1, 0)})
         self.seed_btc_tao_crown(v, 'hk_a')
         rewards, _ = calculate_miner_rewards(v, v.block)
-        # hk_a gated to 0; nothing is distributed and nothing is burned.
-        assert rewards[RECYCLE_UID] == 0.0
-        np.testing.assert_allclose(rewards.sum(), 0.0, atol=1e-6)
+        recycle_uid = RECYCLE_UID if RECYCLE_UID < len(rewards) else 0
+        # hk_a gated to 0; both pools recycle in full.
+        np.testing.assert_allclose(rewards[recycle_uid], 1.0, atol=1e-6)
+        np.testing.assert_allclose(rewards.sum(), 1.0, atol=1e-6)
         v.state_store.close()
 
 

--- a/tests/test_solana_scoring_integration.py
+++ b/tests/test_solana_scoring_integration.py
@@ -202,12 +202,10 @@ def test_scoring_round_off_solana_events(env):
 
     v = _validator_ns(admin, store, index, metagraph, last_scored_time=now - 600)
 
-    # Round 1 — real eligibility: every miner ineligible → nothing distributed
-    # (no burn; set_weights normalization stretches whatever is distributed).
+    # Round 1 — real eligibility: every miner ineligible → full pool recycles.
     rewards, _ = calculate_miner_rewards(v, now + 60)
     assert rewards[0] == 0.0 and rewards[1] == 0.0 and rewards[2] == 0.0  # A, B, S
-    assert rewards[RECYCLE_UID] == 0.0
-    assert float(rewards.sum()) == pytest.approx(0.0, abs=1e-5)
+    assert rewards[RECYCLE_UID] == pytest.approx(1.0, abs=1e-5)
 
     # Round 2 — patch all eligible: the btc→sol pool is credited to crown holder A.
     # B (lower rate) and S (higher rate but unexecutable) both earn nothing — the

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "allways"
-version = "2.0.1"
+version = "2.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "base58" },


### PR DESCRIPTION
Reverts #590. The penalty shortfall is routed to `RECYCLE_UID` again instead of being left undistributed for `set_weights`' L1 normalization to stretch back over the earners.

The burn is dynamic by construction — it's whatever the pool didn't earn in a given round, so it tracks how well the field is actually performing rather than being a fixed rate.

## Why revert

#590's reasoning was that burning costs the subnet emission (`price × (1 - miner_burn)`), and that's true. But its incentive note — "penalties keep their full relative bite (ratios between miners are unchanged)" — is also the problem. L1 normalization is a monotone rescaling: it preserves every pairwise ratio and always pays out 100% of the pool. So a penalty only bites *relative* to other miners. If the whole field under-performs on a soft multiplier, normalization pays them exactly as if they hadn't.

Concretely: capacity is `min(1, (collateral / (1.1 × max_swap))²)`. Under normalization, a network where every crown holder posts 0.15 SOL of collateral pays out identically to one where they all post 15 SOL — the multiplier cancels. Burning makes the shortfall absolute, so an under-collateralized field visibly forfeits emission instead of quietly splitting the full pool.

That's the trade being re-taken deliberately: less subnet emission when miners under-perform, in exchange for penalties that mean something in absolute terms.

## What's restored

- `calculate_miner_rewards`: recycle top-up (`rewards[recycle_uid] += recycled`)
- `build_halted_rewards`: full pool recycles during a halt, rather than freezing scores
- `set_weights`: empty/NaN scores route the full pool to `RECYCLE_UID` instead of skipping the round — which also re-avoids bittensor's uniform-1/n fallback
- `log_scoring_trace`: `recycled=… → UID53 (subnet owner) cause=…` instead of `undistributed=…`
- `storage.py` halt docstring points back at `build_halted_rewards`

Version goes to **2.0.2** — forward, not back to the pre-#590 2.0.0.

## Note for sequencing

This conflicts with #594 (remove the volume component) in exactly one place: the shortfall block at the end of `calculate_miner_rewards`, which both PRs touch. A trial merge produces a single conflict in `allways/validator/scoring.py` and nothing else. Whichever lands second needs that one hunk resolved.

## Tests

`806 passed`, 6 deselected. `ruff check` + `ruff format --check` clean. The recycle-pinning tests #590 rewrote are restored to asserting `RECYCLE_UID` receives the shortfall.