### PR TITLE
Add seam deposit scan and surface swap leg hashes

### DIFF
--- a/allways/chain_providers/solana.py
+++ b/allways/chain_providers/solana.py
@@ -144,6 +144,36 @@ class SolanaProvider(ChainProvider):
             return None
         return int(post[i]) - int(pre[i])
 
+    def find_recent_outgoing(self, from_addr: str, to_addr: str, amount: int) -> Optional[str]:
+        """Signature of a recent tx from ``from_addr`` crediting ``to_addr`` >= ``amount`` lamports,
+        else None. The Solana sibling of the Bitcoin scanner: a hash-finder for deposit detection —
+        ``fetch_matching_tx``/``verify_transaction`` stay the sole verifiers."""
+        try:
+            sigs = self.rpc.get_signatures_for_address(to_addr, limit=20)
+        except Exception as e:
+            bt.logging.debug(f'{LOG_SOL} find_recent_outgoing signature scan failed: {e}')
+            return None
+        for entry in sigs or []:
+            sig = entry.get('signature')
+            if not sig or entry.get('err') is not None:
+                continue
+            try:
+                tx = self.rpc.get_transaction(sig)
+            except Exception:
+                continue
+            if not tx:
+                continue
+            meta = tx.get('meta') or {}
+            if meta.get('err') is not None:
+                continue
+            keys = self._account_keys(tx, meta)
+            if not keys or keys[0] != from_addr:
+                continue
+            credit = self._match_native_credit(keys, meta, to_addr)
+            if credit is not None and credit >= amount:
+                return sig
+        return None
+
     def _confirmations(self, slot: Optional[int]) -> int:
         """Confirmations = slots since the tx's slot (the tx slot counts as 1). 0 if unknown.
 

--- a/allways/chain_providers/subtensor.py
+++ b/allways/chain_providers/subtensor.py
@@ -31,6 +31,8 @@ class SubtensorProvider(ChainProvider):
         self.subtensor = subtensor
         self.wallet = wallet
         self.block_cache: Dict[int, dict] = {}
+        # Deposit-scanner head cursors, keyed per (from, to, amount) triple — see find_recent_outgoing.
+        self.scan_cursors: Dict[Tuple[str, str, int], int] = {}
 
     def get_chain(self) -> ChainDefinition:
         return CHAIN_TAO
@@ -299,18 +301,29 @@ class SubtensorProvider(ChainProvider):
     @staticmethod
     def match_transfer(ext, tx_hash: str, is_raw: bool) -> Optional[Tuple[str, int, str]]:
         """Try to match an extrinsic against a tx hash. Returns (dest, amount, sender) or None."""
+        decoded = SubtensorProvider.decode_transfer(ext, is_raw)
+        if decoded is None or decoded[0] != tx_hash:
+            return None
+        _, dest, amount, sender = decoded
+        return dest, amount, sender
+
+    @staticmethod
+    def decode_transfer(ext, is_raw: bool) -> Optional[Tuple[str, str, int, str]]:
+        """Decode a transfer extrinsic into (tx_hash, dest, amount, sender), or None if it
+        isn't a transfer. The single decode shared by the by-hash verifier (match_transfer)
+        and the by-content deposit scanner (find_recent_outgoing)."""
         if is_raw:
             ext_hash = ext.get('extrinsic_hash', '')
-            if ext_hash != tx_hash:
+            if not ext_hash:
                 return None
-            return ext.get('dest', ''), ext.get('amount', 0), ext.get('sender', '')
+            return ext_hash, ext.get('dest', ''), ext.get('amount', 0), ext.get('sender', '')
 
         ext_hash = getattr(ext, 'extrinsic_hash', None) or (
             ext.get('extrinsic_hash', '') if isinstance(ext, dict) else ''
         )
         if isinstance(ext_hash, bytes):
             ext_hash = '0x' + ext_hash.hex()
-        if ext_hash != tx_hash:
+        if not ext_hash:
             return None
 
         ext_data = ext.value if hasattr(ext, 'value') else ext
@@ -333,7 +346,44 @@ class SubtensorProvider(ChainProvider):
             elif name == 'value':
                 amount = int(val)
 
-        return dest, amount, sender
+        return ext_hash, dest, amount, sender
+
+    # Substrate has no address index (unlike Esplora / getSignaturesForAddress), so the TAO
+    # deposit scanner follows the chain head incrementally: each call scans only the blocks
+    # minted since the last call for this (from, to, amount) triple — amortized ~1 block per
+    # watcher tick — bounded by SCAN_LOOKBACK_BLOCKS on the first call or after a gap
+    # (≈5 min of 12s blocks, mirroring the BTC scanner's window).
+    SCAN_LOOKBACK_BLOCKS = 25
+    _MAX_SCAN_CURSORS = 64
+
+    def find_recent_outgoing(self, from_addr: str, to_addr: str, amount: int) -> Optional[str]:
+        """Extrinsic hash of a recent transfer ``from_addr`` → ``to_addr`` of >= ``amount`` rao,
+        else None. The TAO sibling of the BTC/SOL deposit scanners: a hash-finder only — the
+        seam's confirm re-verifies everything by hash, so a miss here just means the manual
+        rescue paths. An unretrievable block is skipped and not revisited (the cursor moves on)."""
+        head = self.get_current_block_height()
+        if head is None:
+            return None
+        key = (from_addr, to_addr, int(amount))
+        floor = max(head - self.SCAN_LOOKBACK_BLOCKS, 0)
+        last = self.scan_cursors.get(key, floor)
+        for block_num in range(max(last, floor) + 1, head + 1):
+            block = self.get_block(block_num)
+            if not block or 'extrinsics' not in block:
+                continue
+            is_raw = block.get('_raw', False)
+            for ext in block['extrinsics']:
+                decoded = self.decode_transfer(ext, is_raw)
+                if decoded is None:
+                    continue
+                ext_hash, dest, amt, sender = decoded
+                if dest == to_addr and sender == from_addr and int(amt) >= int(amount):
+                    self.scan_cursors.pop(key, None)
+                    return ext_hash
+        self.scan_cursors[key] = head
+        if len(self.scan_cursors) > self._MAX_SCAN_CURSORS:
+            self.scan_cursors.pop(next(iter(self.scan_cursors)))
+        return None
 
     def get_current_block_height(self) -> Optional[int]:
         try:

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -330,6 +330,29 @@ def confirm_deposit(validator, miner_hotkey: str, from_tx_hash: str, from_tx_blo
     return ConfirmResult(True, '', swap_key.hex(), sig)
 
 
+def scan_deposit(validator, miner_hotkey: str) -> Optional[str]:
+    """Tx hash of a user deposit matching the miner's live unclaimed reservation, if the source
+    chain's provider can scan by address (BTC esplora, SOL signatures; TAO has no address index →
+    always None, that leg stays manual/wallet-driven). A hash-finder only — ``confirm_deposit``
+    remains the sole verifier, so a loose match can never mis-claim."""
+    client = validator.solana_client
+    miner_pk = resolve_miner_pubkey(validator, miner_hotkey)
+    if miner_pk is None:
+        return None
+    reservation = client.get_reservation(miner_pk)
+    if reservation is None:
+        return None
+    if reservation.reserved_until == 0 or reservation.reserved_until < time.time():
+        return None
+    if bytes(reservation.claimed_swap_key) != EMPTY_SWAP_KEY:
+        return None
+    provider = validator.axon_chain_providers.get(reservation.from_chain)
+    scan = getattr(provider, 'find_recent_outgoing', None)
+    if scan is None:
+        return None
+    return scan(reservation.from_addr, reservation.miner_from_addr, int(reservation.from_amount))
+
+
 @dataclass
 class BestQuote:
     miner_hotkey: str
@@ -430,6 +453,9 @@ def swap_status(validator, miner_hotkey: str, swap_key_hex: str = '') -> SwapSta
     if swap_key == EMPTY_SWAP_KEY:
         return SwapStatus('reserved', reservation.reserved_until, str(reservation.user), detail=detail)
     swap = client.get_swap(swap_key)
+    if swap is not None:
+        detail['from_tx_hash'] = swap.from_tx_hash
+        detail['to_tx_hash'] = swap.to_tx_hash
     stage = _swap_stage(validator, swap, swap_key)
     return SwapStatus(stage, reservation.reserved_until, str(reservation.user), swap_key.hex(), detail)
 
@@ -452,6 +478,8 @@ def _swap_status_by_key(validator, swap_key_hex: str) -> SwapStatus:
         'from_amount': int(swap.from_amount),
         'to_amount': int(swap.to_amount),
         'miner_from_addr': swap.miner_from_addr,
+        'from_tx_hash': swap.from_tx_hash,
+        'to_tx_hash': swap.to_tx_hash,
     }
     return SwapStatus(stage, 0, str(swap.user), swap_key_hex, detail)
 

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -331,10 +331,10 @@ def confirm_deposit(validator, miner_hotkey: str, from_tx_hash: str, from_tx_blo
 
 
 def scan_deposit(validator, miner_hotkey: str) -> Optional[str]:
-    """Tx hash of a user deposit matching the miner's live unclaimed reservation, if the source
-    chain's provider can scan by address (BTC esplora, SOL signatures; TAO has no address index →
-    always None, that leg stays manual/wallet-driven). A hash-finder only — ``confirm_deposit``
-    remains the sole verifier, so a loose match can never mis-claim."""
+    """Tx hash of a user deposit matching the miner's live unclaimed reservation. Every launch
+    chain scans: BTC by esplora address index, SOL by signature index, TAO by an incremental
+    head-follow block scan (Substrate has no address index). A hash-finder only —
+    ``confirm_deposit`` remains the sole verifier, so a loose match can never mis-claim."""
     client = validator.solana_client
     miner_pk = resolve_miner_pubkey(validator, miner_hotkey)
     if miner_pk is None:

--- a/allways/validator/seam_http.py
+++ b/allways/validator/seam_http.py
@@ -14,7 +14,13 @@ from urllib.parse import parse_qs, urlparse
 
 import bittensor as bt
 
-from allways.validator.reserve_engine import best_quote, confirm_deposit, reserve_on_behalf, swap_status
+from allways.validator.reserve_engine import (
+    best_quote,
+    confirm_deposit,
+    reserve_on_behalf,
+    scan_deposit,
+    swap_status,
+)
 
 SEAM_HOST = '127.0.0.1'
 
@@ -57,6 +63,9 @@ def _make_handler(validator, secret: str):
                     # swap directly — the only route to post-attestation stages, since vote_initiate
                     # consumes the reservation at quorum.
                     return self._send(200, swap_status(validator, q['miner_hotkey'], q.get('swap_key', '')).__dict__)
+                if url.path == '/deposit-scan':
+                    # Hash-finder for the offering's deposit watcher — /confirm stays the verifier.
+                    return self._send(200, {'tx_hash': scan_deposit(validator, q['miner_hotkey'])})
                 if url.path == '/health':
                     return self._send(200, {'ok': True})
             except (KeyError, ValueError) as e:

--- a/tests/test_block_time.py
+++ b/tests/test_block_time.py
@@ -83,3 +83,70 @@ def test_subtensor_get_block_time_none_on_error():
     substrate.get_block_hash.side_effect = RuntimeError('rpc down')
     p.subtensor = SimpleNamespace(substrate=substrate)
     assert p.get_block_time(1) is None
+
+
+# ─── TAO deposit scanner (find_recent_outgoing) ─────────────────────────────
+# Substrate has no address index, so the scanner follows the head incrementally.
+
+
+def _scan_provider(head, blocks):
+    p = SubtensorProvider.__new__(SubtensorProvider)  # skip __init__ (no real subtensor needed)
+    p.subtensor = MagicMock()
+    p.subtensor.get_current_block.return_value = head
+    p.block_cache = {}
+    p.scan_cursors = {}
+    p.get_block = lambda n: blocks.get(n)
+    return p
+
+
+def _raw_transfer_block(txid, dest, amount, sender):
+    return {
+        '_raw': True,
+        'extrinsics': [{'extrinsic_hash': txid, 'dest': dest, 'amount': amount, 'sender': sender}],
+    }
+
+
+def test_tao_scanner_finds_matching_transfer_in_new_blocks():
+    blocks = {100: _raw_transfer_block('0xdep', 'minerTAO', 5000, 'userTAO')}
+    p = _scan_provider(head=100, blocks=blocks)
+    assert p.find_recent_outgoing('userTAO', 'minerTAO', 5000) == '0xdep'
+    # A hit clears the cursor so a fresh reservation with the same triple rescans.
+    assert p.scan_cursors == {}
+
+
+def test_tao_scanner_skips_wrong_sender_and_underpay_then_advances_cursor():
+    blocks = {
+        99: _raw_transfer_block('0xother', 'minerTAO', 5000, 'someoneElse'),
+        100: _raw_transfer_block('0xsmall', 'minerTAO', 4999, 'userTAO'),
+    }
+    p = _scan_provider(head=100, blocks=blocks)
+    assert p.find_recent_outgoing('userTAO', 'minerTAO', 5000) is None
+    assert p.scan_cursors[('userTAO', 'minerTAO', 5000)] == 100
+    # Next tick scans ONLY blocks past the cursor — the amortized-O(1) property.
+    seen = []
+    p.get_block = lambda n: seen.append(n) or blocks.get(n)
+    p.subtensor.get_current_block.return_value = 102
+    blocks[102] = _raw_transfer_block('0xdep', 'minerTAO', 6000, 'userTAO')
+    assert p.find_recent_outgoing('userTAO', 'minerTAO', 5000) == '0xdep'
+    assert seen == [101, 102]
+
+
+def test_tao_scanner_bounds_first_scan_to_lookback():
+    p = _scan_provider(head=1000, blocks={})
+    seen = []
+    p.get_block = lambda n: seen.append(n) or None
+    assert p.find_recent_outgoing('userTAO', 'minerTAO', 5000) is None
+    assert len(seen) == SubtensorProvider.SCAN_LOOKBACK_BLOCKS
+    assert seen[0] == 1000 - SubtensorProvider.SCAN_LOOKBACK_BLOCKS + 1
+
+
+def test_tao_scanner_none_when_head_unreachable():
+    p = _scan_provider(head=100, blocks={})
+    p.subtensor.get_current_block.side_effect = RuntimeError('down')
+    assert p.find_recent_outgoing('userTAO', 'minerTAO', 5000) is None
+
+
+def test_match_transfer_still_matches_by_hash_through_shared_decode():
+    ext = {'extrinsic_hash': '0xabc', 'dest': 'minerTAO', 'amount': 7, 'sender': 'userTAO'}
+    assert SubtensorProvider.match_transfer(ext, '0xabc', True) == ('minerTAO', 7, 'userTAO')
+    assert SubtensorProvider.match_transfer(ext, '0xother', True) is None

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -273,6 +273,8 @@ def _live_swap(variant: str):
         from_amount=1_000_000_000,
         to_amount=210_000,
         miner_from_addr='minerSOLaddr',
+        from_tx_hash='srcTxHash',
+        to_tx_hash='',
     )
 
 
@@ -568,3 +570,80 @@ def test_confirm_claims_even_if_the_extension_fails():
     )
     r = confirm_deposit(validator, HOTKEY, 'srctxhash')
     assert r.ok and client.claims
+
+
+# --- scan_deposit: the deposit watcher's hash-finder (confirm_deposit stays the verifier) ---
+
+
+class _ScanProvider:
+    def __init__(self, tx_hash=None):
+        self.tx_hash = tx_hash
+        self.calls = []
+
+    def find_recent_outgoing(self, from_addr, to_addr, amount):
+        self.calls.append((from_addr, to_addr, amount))
+        return self.tx_hash
+
+
+def _scan_reservation(reserved_until, claimed=False):
+    return SimpleNamespace(
+        reserved_until=reserved_until,
+        claimed_swap_key=(b'\x09' * 32) if claimed else b'\x00' * 32,
+        user='userSOLpk',
+        from_chain='btc',
+        to_chain='sol',
+        from_amount=10_000,
+        to_amount=47_000_000,
+        miner_from_addr='tb1qminer',
+        from_addr='tb1quser',
+    )
+
+
+def _scan_validator(tmp_path, reservation, provider):
+    from allways.validator.reserve_engine import scan_deposit
+
+    client = StatusClient(reservation=reservation)
+    validator, store = _status_validator(tmp_path, client)
+    validator.axon_chain_providers = {'btc': provider} if provider else {}
+    return scan_deposit, validator, store
+
+
+def test_scan_deposit_finds_hash_for_live_unclaimed_reservation(tmp_path):
+    provider = _ScanProvider('depositTx')
+    scan_deposit, validator, store = _scan_validator(tmp_path, _scan_reservation(FUTURE), provider)
+    assert scan_deposit(validator, HOTKEY) == 'depositTx'
+    # Scans against the PINNED reservation triple — declared sender, miner deposit addr, exact amount.
+    assert provider.calls == [('tb1quser', 'tb1qminer', 10_000)]
+    store.close()
+
+
+def test_scan_deposit_none_when_provider_cannot_scan(tmp_path):
+    # TAO (no address index) exposes no find_recent_outgoing — the leg stays manual/wallet-driven.
+    scan_deposit, validator, store = _scan_validator(tmp_path, _scan_reservation(FUTURE), object())
+    validator.axon_chain_providers = {'btc': object()}
+    assert scan_deposit(validator, HOTKEY) is None
+    store.close()
+
+
+def test_scan_deposit_none_when_reservation_expired_claimed_or_absent(tmp_path):
+    import time as _time
+
+    provider = _ScanProvider('depositTx')
+    scan_deposit, validator, store = _scan_validator(tmp_path, _scan_reservation(int(_time.time()) - 5), provider)
+    assert scan_deposit(validator, HOTKEY) is None  # expired — no late auto-claims, ever
+    validator.solana_client._reservation = _scan_reservation(FUTURE, claimed=True)
+    assert scan_deposit(validator, HOTKEY) is None  # already claimed
+    validator.solana_client._reservation = None
+    assert scan_deposit(validator, HOTKEY) is None  # nothing reserved
+    assert provider.calls == []
+    store.close()
+
+
+def test_status_by_key_detail_carries_leg_hashes(tmp_path):
+    from allways.validator.reserve_engine import swap_status
+
+    client = StatusClient(swap=_live_swap('Fulfilled'), reservation=SimpleNamespace(reserved_until=0))
+    validator, store = _status_validator(tmp_path, client)
+    s = swap_status(validator, HOTKEY, (b'\x05' * 32).hex())
+    assert s.detail['from_tx_hash'] == 'srcTxHash' and s.detail['to_tx_hash'] == ''
+    store.close()

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -618,7 +618,7 @@ def test_scan_deposit_finds_hash_for_live_unclaimed_reservation(tmp_path):
 
 
 def test_scan_deposit_none_when_provider_cannot_scan(tmp_path):
-    # TAO (no address index) exposes no find_recent_outgoing — the leg stays manual/wallet-driven.
+    # A provider without find_recent_outgoing (hypothetical new chain) degrades to manual/wallet paths.
     scan_deposit, validator, store = _scan_validator(tmp_path, _scan_reservation(FUTURE), object())
     validator.axon_chain_providers = {'btc': object()}
     assert scan_deposit(validator, HOTKEY) is None

--- a/tests/test_solana_provider.py
+++ b/tests/test_solana_provider.py
@@ -242,3 +242,46 @@ def test_chain_metadata():
     assert chain is CHAIN_SOL
     assert chain.id == 'sol' and chain.native_unit == 'lamport' and chain.decimals == 9
     assert chain.min_onchain_amount == 890880  # rent-exempt floor (0-data System account)
+
+
+class ScanRpc(FakeRpc):
+    """FakeRpc + an address-signature index for the deposit scanner."""
+
+    def __init__(self, sigs, txs, raise_scan=False):
+        super().__init__()
+        self.sigs = sigs
+        self.txs = txs
+        self.raise_scan = raise_scan
+
+    def get_signatures_for_address(self, address, before=None, until=None, limit=1000, commitment='confirmed'):
+        if self.raise_scan:
+            raise ConnectionError('rpc down')
+        return self.sigs
+
+    def get_transaction(self, sig, commitment='confirmed'):
+        return self.txs.get(sig)
+
+
+class TestFindRecentOutgoing:
+    def test_finds_matching_deposit(self):
+        tx = make_tx('MINER', 5000, sender='USER')
+        p = provider_with(ScanRpc([{'signature': 'sigA', 'err': None}], {'sigA': tx}))
+        assert p.find_recent_outgoing('USER', 'MINER', 5000) == 'sigA'
+
+    def test_skips_wrong_sender_and_underpay(self):
+        wrong_sender = make_tx('MINER', 5000, sender='OTHER')
+        underpay = make_tx('MINER', 4999, sender='USER')
+        hit = make_tx('MINER', 5000, sender='USER')
+        sigs = [{'signature': s, 'err': None} for s in ('s1', 's2', 's3')]
+        p = provider_with(ScanRpc(sigs, {'s1': wrong_sender, 's2': underpay, 's3': hit}))
+        assert p.find_recent_outgoing('USER', 'MINER', 5000) == 's3'
+
+    def test_skips_errored_entries_and_failed_txs(self):
+        failed = make_tx('MINER', 5000, sender='USER', err={'InstructionError': []})
+        sigs = [{'signature': 's1', 'err': 'x'}, {'signature': 's2', 'err': None}]
+        p = provider_with(ScanRpc(sigs, {'s1': make_tx('MINER', 5000, sender='USER'), 's2': failed}))
+        assert p.find_recent_outgoing('USER', 'MINER', 5000) is None
+
+    def test_scan_failure_returns_none(self):
+        p = provider_with(ScanRpc([], {}, raise_scan=True))
+        assert p.find_recent_outgoing('USER', 'MINER', 5000) is None


### PR DESCRIPTION
Seam primitives for the Ventura offering's swap-UX phase (background deposit detection + receipt explorer links). Read-only additions; no behavior change for existing consumers.

- `scan_deposit(validator, miner_hotkey)` + seam `GET /deposit-scan`: tx hash of a deposit matching the miner's live unclaimed reservation, scanning by the pinned triple (declared sender, miner deposit address, exact amount). A hash-finder only — `confirm_deposit` remains the sole verifier. Returns null for expired/claimed/absent reservations (no late auto-claims) and for chains without an address index (TAO).
- `SolanaProvider.find_recent_outgoing`: Solana sibling of the Bitcoin esplora scanner — `getSignaturesForAddress` on the deposit address, sender + balance-delta matched.
- `swap_status` detail now carries `from_tx_hash`/`to_tx_hash` from the live Swap PDA (both status paths) so the offering can persist them before the PDA closes.

Tests: 78 passing across reserve_engine/solana_provider/seam suites (new: scan hit + pinned-triple args, no-scanner chain, expired/claimed/absent guards, by-key detail hashes, SOL scanner match/skip/failure cases).