### PR TITLE
Volume-weight the direction pools at pair level

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -62,12 +62,23 @@ REWARD_MINER_STATES: frozenset[MinerActivity] = frozenset({MinerActivity.AVAILAB
 # collateral_amount notional are all SOL). Referenced wherever code needs "is this the hub", instead of a literal.
 NUMERAIRE_CHAIN = 'sol'
 LAUNCH_SPOKES = ('btc', 'tao')  # chains paired against the hub; add a chain here to launch its pair
-# Emission pool per direction, split evenly across every hub↔spoke direction (both ways).
+# Direction registry and the equal-split fallback: one entry per hub↔spoke direction
+# (both ways). The per-round pool values are volume-weighted at pair level
+# (scoring.compute_direction_pools); these constants are what zero volume falls back to.
 DIRECTION_POOLS: dict[tuple[str, str], float] = {
     pair: 1.0 / (2 * len(LAUNCH_SPOKES))
     for spoke in LAUNCH_SPOKES
     for pair in ((NUMERAIRE_CHAIN, spoke), (spoke, NUMERAIRE_CHAIN))
 }
+# Volume-weighted pools: each pair's emission share follows the SOL notional it cleared
+# over the trailing window, blended with the equal split so a quiet pair never starves
+# and a busy one is capped at α + (1−α)/pairs. Weighting sits at PAIR level and splits
+# evenly between the two legs — one leg can't be inflated without inflating the pair.
+POOL_VOLUME_WINDOW_SECS = 24 * 3600  # flat trailing window the pool volumes sum over
+POOL_VOLUME_ALPHA = 0.66  # blend dial: 0 = frozen equal split, 1 = pure volume share
+# clearing_rates rows must outlive the pool volume window (plus stall headroom) — the
+# crown tables only need SCORING_WINDOW_SECS, but pools read a full day back.
+CLEARING_RETENTION_SECS = POOL_VOLUME_WINDOW_SECS + MAX_SCORING_BACKFILL_SECS
 # Capacity curve exponent (>1 = convex): capacity = min(1, (collateral / required)^k). Convex so
 # thin-parked collateral is penalised harder than linear (a miner backing the best rate on a sliver
 # earns a smaller slice than the ratio alone), pushing miners to deepen. Still capped at 1.0 — depth

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -24,10 +24,14 @@ from allways.chains import canonical_pair
 from allways.classes import ActivityTransition, MinerActivity, next_activity
 from allways.constants import (
     CAPACITY_CURVE_EXPONENT,
+    CLEARING_RETENTION_SECS,
     DIRECTION_POOLS,
     MAX_FAILED_SWAPS,
     MAX_SCORING_BACKFILL_SECS,
     MIN_SUCCESSFUL_SWAPS,
+    NUMERAIRE_CHAIN,
+    POOL_VOLUME_ALPHA,
+    POOL_VOLUME_WINDOW_SECS,
     RECYCLE_UID,
     REWARD_MINER_STATES,
     SCORING_WINDOW_BLOCKS,
@@ -159,9 +163,9 @@ def prune_crown_events(self: Validator, current_time: int) -> None:
     self.state_store.prune_active_events(cutoff)
     self.state_store.prune_activity_events(cutoff)
     self.state_store.prune_collateral_events(cutoff)
-    # clearing_rates keeps backfill headroom beyond the crown cutoff so a
-    # stalled validator can still score the volumes of a caught-up window.
-    self.state_store.prune_clearing_rates(current_time - MAX_SCORING_BACKFILL_SECS)
+    # clearing_rates outlives the crown cutoff by a full pool-volume window
+    # (plus stall headroom) — the per-round pool weighting reads a day back.
+    self.state_store.prune_clearing_rates(current_time - CLEARING_RETENTION_SECS)
     self.state_store.prune_swap_outcomes(current_time - SWAP_OUTCOME_RETENTION_SECS)
 
 
@@ -255,6 +259,42 @@ def build_direction_score_rows(
     return rows
 
 
+def compute_direction_pools(
+    clearing_volumes: Dict[Tuple[str, str], Dict[str, Tuple[int, int]]],
+) -> Dict[Tuple[str, str], float]:
+    """Volume-weighted pools from a trailing window of realized swaps
+    (``get_clearing_volumes`` shape). Each hub↔spoke *pair* earns
+    ``(1−α)/pairs + α × its share of SOL notional``, split evenly between its
+    two directions — weighting at pair level means one leg can't be inflated
+    without inflating the whole pair. No volume anywhere → the equal split."""
+    pair_directions: Dict[Tuple[str, str], List[Tuple[str, str]]] = {}
+    for from_chain, to_chain in DIRECTION_POOLS:
+        pair_directions.setdefault(canonical_pair(from_chain, to_chain), []).append((from_chain, to_chain))
+
+    pair_volumes: Dict[Tuple[str, str], int] = {}
+    for pair, directions in pair_directions.items():
+        volume = 0
+        for from_chain, to_chain in directions:
+            # Hub-and-spoke: every direction has SOL on exactly one leg, so the
+            # SOL side is the notional comparable across pairs (all lamports).
+            leg = 0 if from_chain == NUMERAIRE_CHAIN else 1
+            volume += sum(sums[leg] for sums in clearing_volumes.get((from_chain, to_chain), {}).values())
+        pair_volumes[pair] = volume
+
+    total_volume = sum(pair_volumes.values())
+    if total_volume <= 0:
+        return dict(DIRECTION_POOLS)
+
+    pools: Dict[Tuple[str, str], float] = {}
+    equal_pair_share = 1.0 / len(pair_directions)
+    for pair, directions in pair_directions.items():
+        volume_share = pair_volumes[pair] / total_volume
+        pair_share = (1.0 - POOL_VOLUME_ALPHA) * equal_pair_share + POOL_VOLUME_ALPHA * volume_share
+        for direction in directions:
+            pools[direction] = pair_share / len(directions)
+    return pools
+
+
 def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndarray, Set[int]]:
     """Replay the crown-time event stream, derive per-miner rewards
     (eligible × pool × crown_share × capacity), recycle the rest.
@@ -304,7 +344,13 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
         bt.logging.warning(f'min_swap_amount read failed: {e}')
         min_swap_amount = 0
 
-    for (from_chain, to_chain), pool in DIRECTION_POOLS.items():
+    # Pools follow realized demand: one volume read for the trailing day, shared
+    # by every direction this round so the pools it pays sum to exactly 1.
+    pools = compute_direction_pools(
+        self.state_store.get_clearing_volumes(current_time - POOL_VOLUME_WINDOW_SECS, current_time)
+    )
+
+    for (from_chain, to_chain), pool in pools.items():
         trace = DirectionTrace(pool=pool)
         direction_traces[(from_chain, to_chain)] = trace
         intervals: Optional[List[Tuple[int, int, List[str], float]]] = None
@@ -435,7 +481,8 @@ def snapshot_current_miner_scores(self: Validator, at_time: Optional[int] = None
         bt.logging.warning(f'swap-bounds read failed in live score snapshot: {e}')
         min_swap_amount = max_swap_amount = 0
     rows: List[ScoreRow] = []
-    for (from_chain, to_chain), pool in DIRECTION_POOLS.items():
+    pools = compute_direction_pools(self.state_store.get_clearing_volumes(ts - POOL_VOLUME_WINDOW_SECS, ts))
+    for (from_chain, to_chain), pool in pools.items():
         trace = DirectionTrace(pool=pool)
         crown_time = replay_crown_time_window(
             store=self.state_store,

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -14,6 +14,7 @@ from allways.constants import (
     MAX_FAILED_SWAPS,
     MAX_SCORING_BACKFILL_SECS,
     MIN_SUCCESSFUL_SWAPS,
+    POOL_VOLUME_ALPHA,
     RECYCLE_UID,
     SCORING_WINDOW_BLOCKS,
     required_collateral,
@@ -24,6 +25,7 @@ from allways.validator.event_index import SolanaEventIndex
 from allways.validator.scoring import (
     build_eligibility,
     calculate_miner_rewards,
+    compute_direction_pools,
     crown_can_fund,
     crown_holders_at_instant,
     due_for_scoring,
@@ -40,6 +42,9 @@ from allways.validator.state_store import ValidatorStateStore
 # Mirror production pool shares so these stay in sync if DIRECTION_POOLS changes.
 POOL_BTC_SOL = DIRECTION_POOLS[('btc', 'sol')]
 POOL_SOL_BTC = DIRECTION_POOLS[('sol', 'btc')]
+# Leg pool when one pair carried ALL the window's clearing volume: the pair
+# share tilts to (1−α)/2 + α and splits evenly across its two directions.
+POOL_BUSY_PAIR_LEG = ((1 - POOL_VOLUME_ALPHA) / 2 + POOL_VOLUME_ALPHA) / 2
 MIN_COLLATERAL = 100_000_000  # 0.1 TAO
 
 METADATA_PATH = Path(__file__).parent.parent / 'allways' / 'metadata' / 'allways_swap_manager.json'
@@ -370,6 +375,48 @@ class TestGetClearingVolumes:
         store.insert_clearing_rate(9_900, 'hk_a', 'btc', 'sol', 3, 1, 'sk10')
         assert store.get_clearing_volumes(9_700, 10_000)[('btc', 'sol')]['hk_a'] == (10**30 + 10, 2)
         store.close()
+
+
+class TestComputeDirectionPools:
+    """Pair-level volume weighting: each pair's share is (1−α)/pairs + α·volume_share
+    of trailing SOL notional, split evenly between its two legs; zero volume falls
+    back to the equal DIRECTION_POOLS split."""
+
+    # With two launch pairs: a pair's floor share is (1−α)/2, its cap α + (1−α)/2.
+    FLOOR_LEG = (1 - POOL_VOLUME_ALPHA) / 2 / 2
+
+    def test_no_volume_falls_back_to_equal_split(self):
+        assert compute_direction_pools({}) == DIRECTION_POOLS
+
+    def test_single_pair_volume_tilts_both_its_legs_equally(self):
+        pools = compute_direction_pools({('btc', 'sol'): {'hk_a': (5, 100)}})
+        assert pools[('btc', 'sol')] == pytest.approx(self.FLOOR_LEG + POOL_VOLUME_ALPHA / 2)
+        assert pools[('sol', 'btc')] == pools[('btc', 'sol')]  # quiet leg rides its pair
+        assert pools[('sol', 'tao')] == pytest.approx(self.FLOOR_LEG)
+        assert pools[('tao', 'sol')] == pytest.approx(self.FLOOR_LEG)
+        assert sum(pools.values()) == pytest.approx(1.0)
+
+    def test_volume_is_the_sol_leg_summed_per_pair(self):
+        # BTC pair: 300 SOL (to_amount is the SOL leg of btc→sol); TAO pair:
+        # 100 SOL (from_amount is the SOL leg of sol→tao). Spoke-side legs are
+        # deliberately huge to prove they never enter the weighting.
+        pools = compute_direction_pools(
+            {
+                ('btc', 'sol'): {'hk_a': (10**15, 200), 'hk_b': (10**15, 100)},
+                ('sol', 'tao'): {'hk_c': (100, 10**15)},
+            }
+        )
+        floor_pair = (1 - POOL_VOLUME_ALPHA) / 2
+        assert pools[('btc', 'sol')] == pytest.approx((floor_pair + POOL_VOLUME_ALPHA * 0.75) / 2)
+        assert pools[('tao', 'sol')] == pytest.approx((floor_pair + POOL_VOLUME_ALPHA * 0.25) / 2)
+        assert sum(pools.values()) == pytest.approx(1.0)
+
+    def test_leg_direction_within_pair_is_irrelevant(self):
+        # 500 SOL cleared btc→sol vs 500 SOL cleared sol→btc: same pair volume,
+        # identical pools — one leg can't be tilted independently of its twin.
+        forward = compute_direction_pools({('btc', 'sol'): {'hk': (1, 500)}})
+        reverse = compute_direction_pools({('sol', 'btc'): {'hk': (500, 1)}})
+        assert forward == reverse
 
 
 class TestCrownHoldersHelper:
@@ -1925,8 +1972,9 @@ class TestWeightingTraceRecorders:
 
 
 class TestVolumeIsNotARewardTerm:
-    """Realized volume no longer enters the reward. These pin that: the ledger
-    can say anything and the payout is still pool x crown_share x capacity."""
+    """Realized volume never enters a MINER's multiplier — payout is still
+    pool x crown_share x capacity with no per-miner volume term. Volume only
+    sizes the direction pools, at pair level (compute_direction_pools)."""
 
     def seed_sol_btc_crown(self, v: SimpleNamespace, hotkey: str, rate: float = 0.00020) -> None:
         conn = v.state_store.require_connection()
@@ -1950,21 +1998,22 @@ class TestVolumeIsNotARewardTerm:
         )
 
     def test_zero_volume_crown_holder_earns_full_reward(self, tmp_path: Path):
-        """Regression: a crown holder that served nothing used to keep only
-        1-alpha (0.25) of its crown reward. It now earns the full pool."""
+        """A crown holder that served nothing still earns the full direction
+        pool — whoever's volume tilted it, only crown decides who's paid."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a', 'hk_b'])
         v = make_validator(tmp_path, hotkeys)
         self.seed_sol_btc_crown(v, 'hk_a')
         # B posts no rate, so it never holds crown — it only serves the volume.
         self.insert_volume(v, 'hk_b', from_amount=1_000_000_000)
         rewards, _ = calculate_miner_rewards(v, v.block)
-        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL, atol=1e-6)
+        np.testing.assert_allclose(rewards[0], POOL_BUSY_PAIR_LEG, atol=1e-6)
         assert rewards[1] == 0.0
         v.state_store.close()
 
-    def test_idle_network_pays_the_same_as_a_busy_one(self, tmp_path: Path):
-        """The old term made a direction that traded pay less than one that sat
-        idle. Same crown, same capacity -> same reward either way."""
+    def test_pair_volume_tilts_the_pool_not_the_miner_term(self, tmp_path: Path):
+        """An idle network falls back to the equal split; a pair that carried
+        volume tilts its legs' pools up. The miner's own multiplier is
+        unchanged either way — same crown, same capacity, bigger pool."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
         v_idle = make_validator(tmp_path / 'idle', hotkeys)
         self.seed_sol_btc_crown(v_idle, 'hk_a')
@@ -1977,8 +2026,8 @@ class TestVolumeIsNotARewardTerm:
         busy_rewards, _ = calculate_miner_rewards(v_busy, v_busy.block)
         v_busy.state_store.close()
 
-        np.testing.assert_allclose(idle_rewards[0], busy_rewards[0], atol=1e-9)
         np.testing.assert_allclose(idle_rewards[0], POOL_BTC_SOL, atol=1e-6)
+        np.testing.assert_allclose(busy_rewards[0], POOL_BUSY_PAIR_LEG, atol=1e-6)
 
     def test_crown_split_ignores_who_served(self, tmp_path: Path):
         """Two holders splitting crown evenly split the pool evenly, even when
@@ -2016,8 +2065,8 @@ class TestCapacityVolumeInteraction:
         # B serves all the volume; A still holds the crown and is paid on it.
         v.state_store.insert_clearing_rate(9_900, 'hk_b', 'btc', 'sol', 1_000_000_000, 1_000_000_000, 'sk12')
         rewards, _ = calculate_miner_rewards(v, v.block)
-        # A: pool × crown 1.0 × eligible 1 × capacity 0.25.
-        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * 1.0 * 0.25, atol=1e-6)
+        # A: pool (BTC pair carried all volume) × crown 1.0 × eligible 1 × capacity 0.25.
+        np.testing.assert_allclose(rewards[0], POOL_BUSY_PAIR_LEG * 1.0 * 0.25, atol=1e-6)
         v.state_store.close()
 
     def test_full_pool_conservation_with_all_factors(self, tmp_path: Path):
@@ -2393,8 +2442,9 @@ class TestScoreSnapshots:
         assert eligible is True
         np.testing.assert_allclose((crown_share, capacity), (1.0, 1.0))
         # The persisted factors reproduce the persisted reward, and the
-        # persisted reward is what the weights actually paid.
-        expected = POOL_BTC_SOL * crown_share * capacity
+        # persisted reward is what the weights actually paid. hk_a's own swap
+        # put all the window's volume on the BTC pair, so its pool is tilted.
+        expected = POOL_BUSY_PAIR_LEG * crown_share * capacity
         np.testing.assert_allclose(reward, expected, atol=1e-9)
         np.testing.assert_allclose(reward, rewards[0], atol=1e-6)
 


### PR DESCRIPTION
## What

Makes each swap direction's emission pool follow realized demand instead of the flat 0.25. Stacked on #597 (contains its commit until that merges; only the top commit is this PR).

- **Pair-level weighting**: the two legs of a hub↔spoke pair are weighted as one unit — the pair's share follows the SOL notional it cleared, then splits evenly between its legs. One leg can't be inflated without inflating its twin, and half of any inflation accrues to the rival leg's crown holders, which structurally blunts single-direction wash.
- **Blend, not clamp**: `pair_share = (1−α)/pairs + α·volume_share` with `α = 0.66`. Floor `(1−α)/pairs` and cap `α + (1−α)/pairs` are derived, so adding a spoke to `LAUNCH_SPOKES` rescales everything with no constants to retune. Pools always sum to exactly 1.
- **Window**: flat trailing 24h sum via the existing `get_clearing_volumes` read. `clearing_rates` retention grows from ~2h to window + backfill headroom.
- **Fallback**: zero volume everywhere → the equal `DIRECTION_POOLS` split (also what bootstraps a brand-new pair).

Reward shape is unchanged: `eligible × pool × crown_share × capacity`; the shortfall still burns (#597). Both pool consumers (`calculate_miner_rewards` and `snapshot_current_miner_scores`) call the same `compute_direction_pools`, so the paid ledger and the live tip can't disagree on the formula.

## Deliberate non-goals

- **No self-flow exclusion.** `SwapCompleted` carries no taker, and excluding a crown holder's own fills would erase the honest demand signal (crown holders fill nearly all organic flow). Position: the incentive design (pair coupling + α cap) should make washing not worthwhile rather than policing it.
- **No smoothing.** The hard 24h cutoff can visibly step when a large swap ages out; an age-discounted sum is a one-line follow-up if launch traces show it matters.

## Notes for reviewers

- With today's demand split (TAO pair ~69% / BTC pair ~31% of SOL notional), pools land at ~0.32/0.32 (TAO legs) and ~0.18/0.18 (BTC legs) instead of flat 0.25s.
- The dashboard persists `pool` per direction in the crown trace — allways-ui should be checked for any hardcoded 0.25 assumption now that the value varies per round.
- `TestVolumeIsNotARewardTerm` is repointed: volume still never enters a *miner's* multiplier; it now sizes the *pair* pools, and the tests pin both halves of that.