### PR TITLE
Persist the direction pool on every score row

### DIFF
--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -208,12 +208,14 @@ class ScoreRow:
     actually used, in the shape the ``miner_scores`` / ``current_miner_scores``
     tables persist. ``reward`` is the direction's final emission share (post
     eligibility gate); the other fields are its inputs, so the dashboard can
-    write the multiplication out."""
+    write the multiplication out. ``pool`` rides along because it is
+    volume-weighted per round — a reader cannot re-derive it."""
 
     hotkey: str
     from_chain: str
     to_chain: str
     eligible: bool
+    pool: float
     crown_share: float
     capacity: float
     reward: float
@@ -251,6 +253,7 @@ def build_direction_score_rows(
                 from_chain=from_chain,
                 to_chain=to_chain,
                 eligible=eligible,
+                pool=pool,
                 crown_share=crown_share_dir,
                 capacity=cap,
                 reward=(1.0 if eligible else 0.0) * pool * crown_share_dir * cap,
@@ -451,6 +454,7 @@ def miner_score_tuples(score_rows: List[ScoreRow], ts: int) -> List[Tuple]:
             r.from_chain,
             r.to_chain,
             r.eligible,
+            r.pool,
             r.crown_share,
             r.capacity,
             r.reward,

--- a/allways/validator/storage/queries.py
+++ b/allways/validator/storage/queries.py
@@ -55,10 +55,11 @@ DO UPDATE SET credit = EXCLUDED.credit,
 # the crown ledger. Idempotent on retry of the same round.
 BULK_UPSERT_MINER_SCORES = """
 INSERT INTO miner_scores (round_ts, hotkey, from_chain, to_chain, eligible,
-                          crown_share, capacity, reward)
-VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                          pool, crown_share, capacity, reward)
+VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
 ON CONFLICT (round_ts, hotkey, from_chain, to_chain)
 DO UPDATE SET eligible    = EXCLUDED.eligible,
+              pool        = EXCLUDED.pool,
               crown_share = EXCLUDED.crown_share,
               capacity    = EXCLUDED.capacity,
               reward      = EXCLUDED.reward
@@ -73,6 +74,6 @@ DELETE FROM current_miner_scores
 
 BULK_INSERT_CURRENT_MINER_SCORES = """
 INSERT INTO current_miner_scores (ts, hotkey, from_chain, to_chain, eligible,
-                                  crown_share, capacity, reward, updated_at)
-VALUES (%s, %s, %s, %s, %s, %s, %s, %s, NOW())
+                                  pool, crown_share, capacity, reward, updated_at)
+VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())
 """

--- a/allways/validator/storage/repository.py
+++ b/allways/validator/storage/repository.py
@@ -100,7 +100,7 @@ class Repository(BaseRepository):
         commit: bool = True,
     ) -> int:
         """Upsert per-round score snapshots. Rows: (round_ts, hotkey, from_chain,
-        to_chain, eligible, crown_share, capacity, reward)."""
+        to_chain, eligible, pool, crown_share, capacity, reward)."""
         if not rows:
             return 0
         try:
@@ -121,7 +121,7 @@ class Repository(BaseRepository):
         commit: bool = True,
     ) -> int:
         """Wipe + rewrite the live score tip. Rows: (ts, hotkey, from_chain,
-        to_chain, eligible, crown_share, capacity, reward).
+        to_chain, eligible, pool, crown_share, capacity, reward).
         The table only holds the in-progress round, so
         the delete is unconditional; one transaction so readers never see a
         partial tip. An empty row list clears it (halt, or no crown holder)."""

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -2436,15 +2436,18 @@ class TestScoreSnapshots:
         kwargs = v.database_storage.flush_scoring_window.call_args.kwargs
         rows = kwargs['miner_score_rows']
         assert len(rows) == 1
-        (round_ts, hotkey, from_c, to_c, eligible, crown_share, capacity, reward) = rows[0]
+        (round_ts, hotkey, from_c, to_c, eligible, pool, crown_share, capacity, reward) = rows[0]
         assert round_ts == v.block  # round keyed by window_end
         assert (hotkey, from_c, to_c) == ('hk_a', 'btc', 'sol')
         assert eligible is True
         np.testing.assert_allclose((crown_share, capacity), (1.0, 1.0))
+        # hk_a's own swap put all the window's volume on the BTC pair, so the
+        # pool is tilted — and the row carries it, because a reader given only
+        # the other factors could not tell which pool the round paid on.
+        np.testing.assert_allclose(pool, POOL_BUSY_PAIR_LEG, atol=1e-9)
         # The persisted factors reproduce the persisted reward, and the
-        # persisted reward is what the weights actually paid. hk_a's own swap
-        # put all the window's volume on the BTC pair, so its pool is tilted.
-        expected = POOL_BUSY_PAIR_LEG * crown_share * capacity
+        # persisted reward is what the weights actually paid.
+        expected = pool * crown_share * capacity
         np.testing.assert_allclose(reward, expected, atol=1e-9)
         np.testing.assert_allclose(reward, rewards[0], atol=1e-6)
 
@@ -2463,10 +2466,11 @@ class TestScoreSnapshots:
         rewards, _ = calculate_miner_rewards(v, v.block)
         rows = v.database_storage.flush_scoring_window.call_args.kwargs['miner_score_rows']
         assert len(rows) == 1
-        row = rows[0]
-        assert row[4] is False  # eligible
-        np.testing.assert_allclose(row[5], 1.0)  # crown_share still recorded
-        assert row[7] == 0.0  # reward
+        (_ts, _hk, _from_c, _to_c, eligible, pool, crown_share, _cap, reward) = rows[0]
+        assert eligible is False
+        np.testing.assert_allclose(crown_share, 1.0)  # crown_share still recorded
+        assert pool > 0.0  # the pool the round would have paid on is recorded too
+        assert reward == 0.0
         assert rewards[0] == 0.0
         v.state_store.close()
 


### PR DESCRIPTION
Stacked on #599 — merge that first.

#599 made the direction pools volume-weighted, which means a pool is no longer a constant anyone downstream can re-derive: it varies per round and per direction. The score rows the validator persists carry every other factor of the reward multiplication (`eligible × pool × crown_share × capacity`) but not the pool, so the dashboard has been assuming a flat `1 / directions` — and would stop reproducing the persisted reward as soon as the pools moved.

This adds `pool` to `ScoreRow`, threads it through `miner_score_tuples`, and writes it in both statements (`BULK_UPSERT_MINER_SCORES`, `BULK_INSERT_CURRENT_MINER_SCORES`). `build_direction_score_rows` already received the pool as an argument, so both the round scorer and the live tip record exactly what they paid on — no new computation and no change to the reward shape.

**Deploy order: entrius/allways-db#46 must merge and migrate before this ships.** `flush_scoring_window` pipelines `crown_holders`, `miner_scores` and the sync cursor into one transaction, so an INSERT naming a column that doesn't exist aborts the whole flush — the crown ledger write goes with it. Weights and emissions are unaffected (dashboard storage only), but the dashboard would silently stop advancing.

Tests: the round-flush shape test now destructures `pool` and asserts it equals the tilted busy-pair leg, then reproduces the reward from the persisted factors alone rather than from an imported constant — so a future pool change can't quietly desync the ledger from the math. The ineligible-holder test pins that the pool is recorded even when the gate zeroes the reward, which is what lets the dashboard show *why* a round paid nothing. 785 passed, 6 deselected.

Companion PRs: entrius/allways-db#46, entrius/das-allways#73, entrius/allways-ui#157.
