### PR TITLE
Serve delivery hash from the fulfillment index post-close

### DIFF
--- a/allways/validator/event_index.py
+++ b/allways/validator/event_index.py
@@ -89,6 +89,14 @@ class SolanaEventIndex:
             return True
         if name == 'PoolResolved':
             return self._apply_reservation(hotkey, block_time)
+        if name == 'SwapFulfilled':
+            # Persist the delivery hash for post-close receipts — the Swap PDA (and its
+            # to_tx_hash) is gone once the swap completes, and the offering's receipt links
+            # both legs. No activity edge: FULFILL_END comes from the terminal events.
+            self.state_store.record_swap_fulfillment(
+                bytes(rec.fields['swap_key']).hex(), str(rec.fields['to_tx_hash']), block_time
+            )
+            return True
         if name in _FULFILL_TRANSITIONS:
             self.state_store.insert_activity_event(block_time, hotkey, _FULFILL_TRANSITIONS[name])
             outcome = _OUTCOME_BY_EVENT.get(name)

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -470,7 +470,13 @@ def _swap_status_by_key(validator, swap_key_hex: str) -> SwapStatus:
     swap = validator.solana_client.get_swap(swap_key)
     stage = _swap_stage(validator, swap, swap_key)
     if swap is None:
-        return SwapStatus(stage, swap_key=swap_key_hex)
+        # Closed PDA: the delivery hash survives in the fulfillment index — receipts read it
+        # from here, since the consumer may only poll again after the account is gone.
+        detail = {}
+        to_tx_hash = validator.state_store.get_swap_fulfillment(swap_key_hex)
+        if to_tx_hash:
+            detail['to_tx_hash'] = to_tx_hash
+        return SwapStatus(stage, swap_key=swap_key_hex, detail=detail)
     # Same detail shape as the reservation path — the Swap PDA carries the full legs.
     detail = {
         'from_chain': swap.from_chain,

--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -357,11 +357,30 @@ class ValidatorStateStore:
         return row['outcome'] if row is not None else None
 
     def prune_swap_outcomes(self, cutoff_block: int) -> None:
-        """Drop outcome rows older than ``cutoff_block``. No anchor row — each row is
-        an independent terminal fact, only queried while the offering still polls."""
+        """Drop outcome (and fulfillment-hash) rows older than ``cutoff_block``. No anchor row —
+        each row is an independent terminal fact, only queried while the offering still polls."""
         if cutoff_block <= 0:
             return
         self._execute('DELETE FROM swap_outcomes WHERE block_time < ?', (cutoff_block,))
+        self._execute('DELETE FROM swap_fulfillments WHERE block_time < ?', (cutoff_block,))
+
+    # ─── swap_fulfillments (delivery-leg hash for post-close receipts) ──
+
+    def record_swap_fulfillment(self, swap_key: str, to_tx_hash: str, block_time: int) -> None:
+        """Persist the miner's delivery tx hash (``SwapFulfilled`` event) keyed by swap_key hex.
+        The Swap PDA — and its ``to_tx_hash`` — closes at terminal, so this index is the seam's
+        only post-close source of the delivery leg. Upsert: a cursor-reset re-ingest is a no-op."""
+        self._execute(
+            """
+            INSERT INTO swap_fulfillments (swap_key, to_tx_hash, block_time) VALUES (?, ?, ?)
+            ON CONFLICT(swap_key) DO UPDATE SET to_tx_hash = excluded.to_tx_hash, block_time = excluded.block_time
+            """,
+            (swap_key, to_tx_hash, block_time),
+        )
+
+    def get_swap_fulfillment(self, swap_key: str) -> Optional[str]:
+        row = self._fetchone('SELECT to_tx_hash FROM swap_fulfillments WHERE swap_key = ?', (swap_key,))
+        return row['to_tx_hash'] if row is not None else None
 
     # ─── routed_requests (on-behalf reservation queue) ──────────────────
     # The ONLY table not rebuildable from chain events: a routed user's details
@@ -677,6 +696,15 @@ class ValidatorStateStore:
                 CREATE TABLE IF NOT EXISTS swap_outcomes (
                     swap_key    TEXT PRIMARY KEY,
                     outcome     TEXT NOT NULL,
+                    block_time  INTEGER NOT NULL
+                );
+
+                -- Delivery-leg tx hash per swap (SwapFulfilled), keyed by swap_key hex.
+                -- The Swap PDA closes at terminal, so post-close receipts read the
+                -- delivery hash from here. Same retention sweep as swap_outcomes.
+                CREATE TABLE IF NOT EXISTS swap_fulfillments (
+                    swap_key    TEXT PRIMARY KEY,
+                    to_tx_hash  TEXT NOT NULL,
                     block_time  INTEGER NOT NULL
                 );
 

--- a/tests/test_event_index.py
+++ b/tests/test_event_index.py
@@ -598,3 +598,24 @@ class TestReconcileLiveState:
         assert len(store.load_all_active_events()) == 1
         assert len(store.load_all_collateral_events()) == 1
         store.close()
+
+
+class TestSwapFulfillmentHash:
+    def test_swap_fulfilled_persists_delivery_hash(self, tmp_path: Path):
+        store = make_store(tmp_path)
+        idx = SolanaEventIndex(store)
+        idx.ingest([rec('SwapFulfilled', block_time=300, to_tx_hash='destTx', to_amount=500)], ATTR)
+        assert store.get_swap_fulfillment(DEFAULT_SWAP_KEY.hex()) == 'destTx'
+        # Re-ingest (cursor reset) is a no-op upsert, and unknown keys read None.
+        idx.ingest([rec('SwapFulfilled', block_time=300, to_tx_hash='destTx', to_amount=500)], ATTR)
+        assert store.get_swap_fulfillment(DEFAULT_SWAP_KEY.hex()) == 'destTx'
+        assert store.get_swap_fulfillment('ff' * 32) is None
+        store.close()
+
+    def test_fulfillment_hash_pruned_with_outcomes(self, tmp_path: Path):
+        store = make_store(tmp_path)
+        idx = SolanaEventIndex(store)
+        idx.ingest([rec('SwapFulfilled', block_time=100, to_tx_hash='destTx', to_amount=500)], ATTR)
+        store.prune_swap_outcomes(200)
+        assert store.get_swap_fulfillment(DEFAULT_SWAP_KEY.hex()) is None
+        store.close()

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -647,3 +647,17 @@ def test_status_by_key_detail_carries_leg_hashes(tmp_path):
     s = swap_status(validator, HOTKEY, (b'\x05' * 32).hex())
     assert s.detail['from_tx_hash'] == 'srcTxHash' and s.detail['to_tx_hash'] == ''
     store.close()
+
+
+def test_closed_pda_by_key_serves_delivery_hash_from_fulfillment_index(tmp_path):
+    # The Swap PDA (and its to_tx_hash) is gone at terminal — the receipt's delivery link must
+    # survive via the SwapFulfilled ingest, served on the closed-PDA by-key path.
+    from allways.validator.reserve_engine import swap_status
+
+    key = b'\x08' * 32
+    validator, store = _status_validator(tmp_path, StatusClient(swap=None))
+    store.record_swap_outcome(key.hex(), 'completed', 100)
+    store.record_swap_fulfillment(key.hex(), 'destTx', 90)
+    s = swap_status(validator, HOTKEY, key.hex())
+    assert s.stage == 'completed' and s.detail == {'to_tx_hash': 'destTx'}
+    store.close()


### PR DESCRIPTION
Stacked on #598. Closes the receipt's delivery-link gap: the Swap PDA (and its `to_tx_hash`) closes at terminal, so a consumer that only polls after completion — tab closed, stages jumping between polls — could never learn the delivery hash (observed: `to_tx_hash` NULL on completed swaps in the offering DB).

- `SwapFulfilled` ingest (previously dropped as not crown-relevant) now persists `swap_key → to_tx_hash` into a new `swap_fulfillments` table — written deterministically every forward step, independent of any consumer's polling. No activity edge; upsert-idempotent for cursor-reset replays.
- Seam `/status` by-key on a closed PDA serves `detail.to_tx_hash` from the index, so ANY later poll within the 7d retention (same sweep as `swap_outcomes`) heals the receipt. The offering server already write-onces this field — zero consumer changes.

Tests: 792 passing (new: ingest + idempotency, retention sweep, closed-PDA status serving the hash).