### PR TITLE
Resolve validators before the source send in `swap now --send`

### DIFF
--- a/allways/cli/swap_commands/post_tx.py
+++ b/allways/cli/swap_commands/post_tx.py
@@ -175,10 +175,16 @@ def post_tx_command(tx_hash: str, tx_block: int, miner_hint: str):
     console.print(f'[dim]Track it with `alw view swap {swap_key} --watch`.[/dim]')
 
 
-def relay_deposit(client, resv, miner_pk, miner_hotkey, tx_hash, tx_block=0, *, on_behalf_of=None) -> str | None:
+def relay_deposit(
+    client, resv, miner_pk, miner_hotkey, tx_hash, tx_block=0, *, on_behalf_of=None, validator_axons=None
+) -> str | None:
     """Relay a source deposit to the validators (the shared core of ``post-tx`` and the ``swap now``
     auto-send). Returns the swap_key hex on acceptance, else None. Idempotent: validators re-verify the
-    same on-chain deposit each call."""
+    same on-chain deposit each call.
+
+    ``validator_axons`` may be pre-resolved by the caller. ``swap now --send`` does this BEFORE moving
+    funds, so the fragile subtensor connect can't fail *after* the send and strand the deposit; the
+    standalone ``post-tx`` (funds already sent in a prior run) leaves it None and discovers here."""
     if tx_block == 0:
         # Slot is a verification hint (O(1) lookup); validators can scan without it. Best-effort.
         try:
@@ -208,8 +214,9 @@ def relay_deposit(client, resv, miner_pk, miner_hotkey, tx_hash, tx_block=0, *, 
         to_chain=resv.to_chain,
     )
 
-    config, _wallet, subtensor, _ = get_cli_context(need_wallet=False)
-    validator_axons = discover_validators(subtensor, int(config['netuid']))
+    if validator_axons is None:
+        config, _wallet, subtensor, _ = get_cli_context(need_wallet=False)
+        validator_axons = discover_validators(subtensor, int(config['netuid']))
     if not validator_axons:
         console.print('[red]No serving validators found on the metagraph.[/red]')
         return None

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -18,6 +18,7 @@ import click
 from allways.chains import SUPPORTED_CHAINS, get_chain
 from allways.cli.dendrite_lite import (
     broadcast_synapse,
+    discover_validators,
     find_validator_axon,
     get_ephemeral_wallet,
     invalidate_axon_cache,
@@ -678,6 +679,22 @@ def _auto_send_wizard(client, config, resv, miner_pk, from_chain, to_chain, from
     if from_chain == 'tao' and not _unlock_coldkey_for_send(provider.wallet):
         return False
 
+    from allways.cli.swap_commands.post_tx import relay_deposit
+
+    # Resolve validators BEFORE moving funds. This is the fragile network step — a subtensor websocket
+    # connect + metagraph read — and it needs nothing from the send. Doing it first means a transient
+    # connect failure aborts with the deposit untouched, instead of unwinding as a traceback *after* the
+    # money is out (which stranded a deposit past its reservation TTL, with no claim, Swap, or refund).
+    try:
+        vconfig, _vw, subtensor, _ = get_cli_context(need_wallet=False)
+        validator_axons = discover_validators(subtensor, int(vconfig['netuid']))
+    except Exception as e:  # noqa: BLE001 - funds still safe → clean fallback, nothing lost
+        console.print(f'[yellow]  Could not reach the chain to resolve validators ({e}); no funds moved.[/yellow]')
+        return False
+    if not validator_axons:
+        console.print('[yellow]  No serving validators found; no funds moved.[/yellow]')
+        return False
+
     kw = {'from_address': resv.from_addr}
     if from_chain == 'btc' and btc_fee_rate is not None:
         kw['fee_rate_override'] = btc_fee_rate
@@ -692,10 +709,16 @@ def _auto_send_wizard(client, config, resv, miner_pk, from_chain, to_chain, from
     tx_hash = sent[0]
     console.print(f'[green]  Sent[/green] {amount_disp:g} {from_chain.upper()} — [cyan]{tx_hash}[/cyan]')
 
-    from allways.cli.swap_commands.post_tx import relay_deposit
-
+    # Funds are OUT. Past this line no exception may escape as a traceback: the deposit is idempotent to
+    # relay, so any failure must become a recoverable "re-run post-tx" instruction inside the TTL.
     miner_hotkey = _miner_hotkey(client, miner_pk)
-    swap_key = relay_deposit(client, resv, miner_pk, miner_hotkey, tx_hash)
+    try:
+        swap_key = relay_deposit(client, resv, miner_pk, miner_hotkey, tx_hash, validator_axons=validator_axons)
+    except Exception as e:  # noqa: BLE001 - money committed; convert any error into a re-run, never a crash
+        fail(
+            f'  Deposit sent ({tx_hash}) but the confirm relay errored: {e}. '
+            f'Re-run `alw swap post-tx {tx_hash}` now, before the reservation expires.'
+        )
     if swap_key is None:
         fail(
             f'  Deposit sent but no validator accepted the relay yet. Re-run `alw swap post-tx {tx_hash}` in a moment.'

--- a/tests/test_swap_now_send_ordering.py
+++ b/tests/test_swap_now_send_ordering.py
@@ -1,0 +1,90 @@
+"""Regression: `alw swap now --send` must never strand a deposit on a transient chain error.
+
+Two invariants, both learned from a live BTC->SOL loss:
+
+1. Validator resolution (the subtensor websocket connect + metagraph read) happens BEFORE the source
+   send. If it fails, no funds move — the send is the last irreversible step, so a transient connect
+   error aborts cleanly with the reservation still live.
+2. Once funds ARE out, no exception may escape as a traceback. A relay that raises (e.g. a connect
+   timeout the inner burst-retry doesn't cover) must become a recoverable "re-run post-tx" exit, so a
+   supervisor can re-relay the idempotent deposit inside the reservation TTL.
+"""
+
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from allways.cli.swap_commands import swap as swap_mod
+
+
+def _resv():
+    return types.SimpleNamespace(
+        from_addr='btc-sender',
+        miner_from_addr='miner-btc-addr',
+        from_amount=145996,
+        to_amount=10**9,
+        reserved_until=2**31,
+        user='user-pk',
+        user_to_addr='sol-recv',
+        from_chain='btc',
+        to_chain='sol',
+    )
+
+
+def _provider(tx_hash='deadbeef'):
+    p = MagicMock()
+    p.can_send_from.return_value = True
+    p.send_amount.return_value = [tx_hash]
+    p.last_send_error = None
+    return p
+
+
+def _wizard(provider):
+    """Drive _auto_send_wizard with everything but the code-under-test mocked. skip_confirm=True
+    bypasses the interactive send prompt; from/to are btc->sol (the stranding case)."""
+    return swap_mod._auto_send_wizard(MagicMock(), {}, _resv(), 'miner-pk', 'btc', 'sol', 0.00145996, True, None)
+
+
+def test_chain_unreachable_during_validator_resolve_moves_no_funds():
+    provider = _provider()
+    with (
+        patch.object(swap_mod, '_source_provider', return_value=provider),
+        patch.object(swap_mod, 'get_cli_context', side_effect=TimeoutError('timed out')),
+        patch.object(swap_mod, 'discover_validators') as disc,
+    ):
+        assert _wizard(provider) is False  # clean fallback, not a crash
+    provider.send_amount.assert_not_called()  # THE invariant: funds untouched
+    disc.assert_not_called()
+
+
+def test_relay_error_after_send_is_recoverable_not_a_traceback():
+    provider = _provider(tx_hash='abc123')
+    with (
+        patch.object(swap_mod, '_source_provider', return_value=provider),
+        patch.object(swap_mod, 'get_cli_context', return_value=({'netuid': 1}, None, MagicMock(), None)),
+        patch.object(swap_mod, 'discover_validators', return_value=['axon']),
+        patch.object(swap_mod, '_miner_hotkey', return_value='miner-hotkey'),
+        patch('allways.cli.swap_commands.post_tx.relay_deposit', side_effect=TimeoutError('timed out')),
+        pytest.raises(SystemExit),
+    ):
+        # send_amount succeeds, then the relay raises: must convert to a `fail()` SystemExit, never
+        # let TimeoutError propagate.
+        _wizard(provider)
+    provider.send_amount.assert_called_once()  # money did move — so the recoverable exit is required
+
+
+def test_happy_path_passes_preresolved_axons_into_relay():
+    provider = _provider(tx_hash='ok999')
+    with (
+        patch.object(swap_mod, '_source_provider', return_value=provider),
+        patch.object(swap_mod, 'get_cli_context', return_value=({'netuid': 1}, None, MagicMock(), None)),
+        patch.object(swap_mod, 'discover_validators', return_value=['axon-a', 'axon-b']),
+        patch.object(swap_mod, '_miner_hotkey', return_value='miner-hotkey'),
+        patch.object(swap_mod, '_watch_swap'),
+        patch('allways.cli.swap_commands.post_tx.relay_deposit', return_value='swapkeyhex') as relay,
+    ):
+        assert _wizard(provider) is True
+    # Validators resolved once, pre-send, and handed to relay_deposit so it does NOT reconnect after
+    # the money is out.
+    assert relay.call_args.kwargs['validator_axons'] == ['axon-a', 'axon-b']


### PR DESCRIPTION
## Problem

A live BTC→SOL leg stranded funds. `alw swap now --send` runs send → relay → watch in one process, which is correct — but the ordering inside `_auto_send_wizard` was inverted at the dangerous moment:

1. `provider.send_amount(...)` — **money leaves the wallet**
2. `relay_deposit(...)` — which *then* calls `get_cli_context()` → `bt.Subtensor(network=...)`, opening the subtensor websocket to discover validators

That connect raised `TimeoutError: timed out`. `relay_deposit`'s burst-retry (`_RELAY_ATTEMPTS`) only wraps the `broadcast_synapse` relay, not the connect — so the exception unwound as a **bare traceback after the funds were already out**. The deposit sat with the miner past the reservation TTL, with no claim, no Swap, no timeout, and no refund. Same class as the recent `BlockhashNotFound` fix: an uncaught transient exception in a money-committed phase.

## Fix

**The source send must be the last irreversible step.** The subtensor connect + `discover_validators` need nothing from the send, so they now run **before** `send_amount`, and the resolved axons are passed into `relay_deposit`:

- A transient chain-connect failure now aborts with the **deposit untouched** and the reservation still live → clean fallback, nothing lost.
- Belt-and-suspenders: once funds *are* out, the relay is wrapped so **any** exception becomes a recoverable `Re-run alw swap post-tx <hash>` exit (non-zero), never a traceback. The relay is idempotent, so re-firing the same deposit inside the TTL is safe.

`relay_deposit` still self-discovers when `validator_axons is None`, so the standalone `alw swap post-tx` path (funds sent in a prior run) is unchanged.

## Tests

`tests/test_swap_now_send_ordering.py` pins the two invariants:
- chain unreachable during validator resolve → `send_amount` is **never called**;
- relay raises after the send → converts to a `SystemExit` recovery exit, not a propagated `TimeoutError`;
- happy path hands the pre-resolved axons to `relay_deposit` (no post-send reconnect).

Full swap/CLI suite (232 tests) green; ruff check + format clean.