### PR TITLE
Gate transfer decode to exact Balances calls

### DIFF
--- a/allways/chain_providers/subtensor.py
+++ b/allways/chain_providers/subtensor.py
@@ -24,8 +24,9 @@ class SubtensorProvider(ChainProvider):
     uses_substrate = True
 
     # Balances pallet index and transfer call indices on Subtensor.
-    # transfer_all is deliberately absent: its extrinsic carries no amount (the true amount
-    # lives only in the Balances.Transfer event), so it must never decode as a transfer.
+    # transfer_all (call index 4) is deliberately absent: its extrinsic carries no amount
+    # (the true amount lives only in the Balances.Transfer event), so it must never decode
+    # as a transfer.
     _BALANCES_PALLET = 5
     _TRANSFER_CALLS = {0: 'transfer_allow_death', 3: 'transfer_keep_alive'}
 

--- a/allways/chain_providers/subtensor.py
+++ b/allways/chain_providers/subtensor.py
@@ -23,9 +23,11 @@ class SubtensorProvider(ChainProvider):
     # RPCs run on the shared substrate websocket — callers serialise via axon_lock.
     uses_substrate = True
 
-    # Balances pallet index and transfer call indices on Subtensor
+    # Balances pallet index and transfer call indices on Subtensor.
+    # transfer_all is deliberately absent: its extrinsic carries no amount (the true amount
+    # lives only in the Balances.Transfer event), so it must never decode as a transfer.
     _BALANCES_PALLET = 5
-    _TRANSFER_CALLS = {0: 'transfer_allow_death', 3: 'transfer_keep_alive', 7: 'transfer_all'}
+    _TRANSFER_CALLS = {0: 'transfer_allow_death', 3: 'transfer_keep_alive'}
 
     def __init__(self, subtensor: bt.Subtensor, wallet: Optional['bt.Wallet'] = None):
         self.subtensor = subtensor
@@ -99,7 +101,7 @@ class SubtensorProvider(ChainProvider):
             sender_bytes = body[1:33]
             sender = ss58_encode(sender_bytes, ss58_format=42)
 
-            # Find the transfer call: pallet_index=5, call_index in {0,3,7}
+            # Find the transfer call: pallet_index=5, call_index in _TRANSFER_CALLS
             # The call data follows the signature block. Instead of parsing the full
             # signature, search for the Balances pallet marker after the signature.
             # Signature occupies ~65 bytes (1 type + 64 sig) + era + nonce + tip
@@ -308,16 +310,8 @@ class SubtensorProvider(ChainProvider):
         return dest, amount, sender
 
     @staticmethod
-    def decode_transfer(ext, is_raw: bool) -> Optional[Tuple[str, str, int, str]]:
-        """Decode a transfer extrinsic into (tx_hash, dest, amount, sender), or None if it
-        isn't a transfer. The single decode shared by the by-hash verifier (match_transfer)
-        and the by-content deposit scanner (find_recent_outgoing)."""
-        if is_raw:
-            ext_hash = ext.get('extrinsic_hash', '')
-            if not ext_hash:
-                return None
-            return ext_hash, ext.get('dest', ''), ext.get('amount', 0), ext.get('sender', '')
-
+    def _structured_call(ext) -> Optional[Tuple[str, dict, str]]:
+        """Extract (extrinsic_hash, call, sender) from a structured extrinsic, or None."""
         ext_hash = getattr(ext, 'extrinsic_hash', None) or (
             ext.get('extrinsic_hash', '') if isinstance(ext, dict) else ''
         )
@@ -325,20 +319,34 @@ class SubtensorProvider(ChainProvider):
             ext_hash = '0x' + ext_hash.hex()
         if not ext_hash:
             return None
-
         ext_data = ext.value if hasattr(ext, 'value') else ext
-        call = ext_data.get('call', {}) if isinstance(ext_data, dict) else {}
-        call_function = call.get('call_function', '')
-        call_args = call.get('call_args', [])
+        if not isinstance(ext_data, dict):
+            return None
+        return ext_hash, ext_data.get('call', {}) or {}, ext_data.get('address', '')
 
-        if 'transfer' not in call_function.lower():
+    @staticmethod
+    def decode_transfer(ext, is_raw: bool) -> Optional[Tuple[str, str, int, str]]:
+        """Decode a Balances transfer extrinsic into (tx_hash, dest, amount, sender), or None
+        if it isn't one. The single decode shared by the by-hash verifier (match_transfer)
+        and the by-content deposit scanner (find_recent_outgoing)."""
+        if is_raw:
+            ext_hash = ext.get('extrinsic_hash', '')
+            if not ext_hash:
+                return None
+            return ext_hash, ext.get('dest', ''), ext.get('amount', 0), ext.get('sender', '')
+
+        parsed = SubtensorProvider._structured_call(ext)
+        if parsed is None:
+            return None
+        ext_hash, call, sender = parsed
+        if call.get('call_module') != 'Balances':
+            return None
+        if call.get('call_function') not in SubtensorProvider._TRANSFER_CALLS.values():
             return None
 
         dest = ''
         amount = 0
-        sender = ext_data.get('address', '') if isinstance(ext_data, dict) else ''
-
-        for arg in call_args:
+        for arg in call.get('call_args', []):
             name = arg.get('name', '') if isinstance(arg, dict) else ''
             val = arg.get('value', '') if isinstance(arg, dict) else ''
             if name in ('dest', 'destination'):
@@ -347,6 +355,30 @@ class SubtensorProvider(ChainProvider):
                 amount = int(val)
 
         return ext_hash, dest, amount, sender
+
+    @staticmethod
+    def decode_stake_transfer(ext) -> Optional[dict]:
+        """Decode a SubtensorModule.transfer_stake extrinsic (structured blocks only) into its
+        args plus tx_hash/sender, or None. alpha_amount is informational — alpha deposits are
+        credited from the received stake delta, never from the extrinsic."""
+        parsed = SubtensorProvider._structured_call(ext)
+        if parsed is None:
+            return None
+        ext_hash, call, sender = parsed
+        if call.get('call_module') != 'SubtensorModule' or call.get('call_function') != 'transfer_stake':
+            return None
+
+        args = {a.get('name'): a.get('value') for a in call.get('call_args', []) if isinstance(a, dict)}
+        dest = args.get('destination_coldkey', '')
+        return {
+            'tx_hash': ext_hash,
+            'sender': sender,
+            'destination_coldkey': dest.get('Id', dest) if isinstance(dest, dict) else dest,
+            'hotkey': args.get('hotkey', ''),
+            'origin_netuid': int(args.get('origin_netuid', 0)),
+            'destination_netuid': int(args.get('destination_netuid', 0)),
+            'alpha_amount': int(args.get('alpha_amount', 0)),
+        }
 
     # Substrate has no address index (unlike Esplora / getSignaturesForAddress), so the TAO
     # deposit scanner follows the chain head incrementally: each call scans only the blocks

--- a/tests/test_decode_transfer.py
+++ b/tests/test_decode_transfer.py
@@ -1,9 +1,9 @@
 """A1 — decode_transfer is gated to Balances.{transfer_allow_death, transfer_keep_alive}.
 
 The old decode substring-matched any ``*transfer*`` call with no module check, and the raw
-SCALE path listed call index 7 (transfer_all), whose ``keep_alive`` bool parsed as the amount.
-transfer_all's true amount lives only in the Balances.Transfer event, so decoding it from the
-extrinsic must yield None in BOTH paths — never an amount the verifier could approve.
+SCALE path's call table listed transfer_all (under index 7 — its real Subtensor index is 4,
+so it never actually matched). transfer_all's true amount lives only in the Balances.Transfer
+event, so it must decode to None in BOTH paths — never an amount the verifier could approve.
 Backends are mocked — no network.
 """
 
@@ -122,4 +122,6 @@ def test_raw_path_parses_transfer_keep_alive():
 
 
 def test_raw_path_rejects_transfer_all_index():
-    assert SubtensorProvider.parse_raw_extrinsic(_raw_transfer_hex(call_idx=7)) is None
+    # transfer_all's real call index on Subtensor (verified against finney metadata) —
+    # fails if anyone maps it back into _TRANSFER_CALLS.
+    assert SubtensorProvider.parse_raw_extrinsic(_raw_transfer_hex(call_idx=4)) is None

--- a/tests/test_decode_transfer.py
+++ b/tests/test_decode_transfer.py
@@ -1,0 +1,125 @@
+"""A1 — decode_transfer is gated to Balances.{transfer_allow_death, transfer_keep_alive}.
+
+The old decode substring-matched any ``*transfer*`` call with no module check, and the raw
+SCALE path listed call index 7 (transfer_all), whose ``keep_alive`` bool parsed as the amount.
+transfer_all's true amount lives only in the Balances.Transfer event, so decoding it from the
+extrinsic must yield None in BOTH paths — never an amount the verifier could approve.
+Backends are mocked — no network.
+"""
+
+from unittest.mock import MagicMock
+
+from allways.chain_providers.subtensor import SubtensorProvider
+
+
+def _structured_ext(call_module, call_function, args, tx_hash='0xhash', sender='userTAO'):
+    return {
+        'extrinsic_hash': tx_hash,
+        'address': sender,
+        'call': {
+            'call_module': call_module,
+            'call_function': call_function,
+            'call_args': [{'name': k, 'value': v} for k, v in args.items()],
+        },
+    }
+
+
+def _transfer_args(dest='minerTAO', amount=5_000):
+    return {'dest': {'Id': dest}, 'value': amount}
+
+
+# ─── Structured path ────────────────────────────────────────────────────────
+
+
+def test_decodes_balances_transfer_keep_alive():
+    ext = _structured_ext('Balances', 'transfer_keep_alive', _transfer_args())
+    assert SubtensorProvider.decode_transfer(ext, False) == ('0xhash', 'minerTAO', 5_000, 'userTAO')
+
+
+def test_decodes_balances_transfer_allow_death():
+    ext = _structured_ext('Balances', 'transfer_allow_death', _transfer_args())
+    assert SubtensorProvider.decode_transfer(ext, False) == ('0xhash', 'minerTAO', 5_000, 'userTAO')
+
+
+def test_transfer_all_never_decodes():
+    ext = _structured_ext('Balances', 'transfer_all', {'dest': {'Id': 'minerTAO'}, 'keep_alive': True})
+    assert SubtensorProvider.decode_transfer(ext, False) is None
+
+
+def test_wrong_module_transfer_never_decodes():
+    ext = _structured_ext('EvilPallet', 'transfer_keep_alive', _transfer_args())
+    assert SubtensorProvider.decode_transfer(ext, False) is None
+
+
+def test_transfer_stake_rejected_by_decode_transfer():
+    ext = _structured_ext('SubtensorModule', 'transfer_stake', {'destination_coldkey': 'ourCold'})
+    assert SubtensorProvider.decode_transfer(ext, False) is None
+
+
+# ─── Exploit pin: transfer_all must never satisfy the verifier ──────────────
+
+
+def test_transfer_all_never_approves_fat_expectation():
+    ext = _structured_ext('Balances', 'transfer_all', {'dest': {'Id': 'minerTAO'}, 'keep_alive': False})
+    p = SubtensorProvider.__new__(SubtensorProvider)  # skip __init__ (no real subtensor needed)
+    p.subtensor = MagicMock()
+    p.subtensor.get_current_block.return_value = 100
+    p.block_cache = {}
+    p.get_block = lambda n: {'extrinsics': [ext]}
+    assert p.fetch_matching_tx('0xhash', 'minerTAO', 1_500_000_000, block_hint=100) is None
+
+
+# ─── decode_stake_transfer ──────────────────────────────────────────────────
+
+
+def test_decode_stake_transfer_extracts_all_args():
+    ext = _structured_ext(
+        'SubtensorModule',
+        'transfer_stake',
+        {
+            'destination_coldkey': {'Id': 'ourCold'},
+            'hotkey': 'ourHot',
+            'origin_netuid': 7,
+            'destination_netuid': 7,
+            'alpha_amount': 123_456,
+        },
+    )
+    assert SubtensorProvider.decode_stake_transfer(ext) == {
+        'tx_hash': '0xhash',
+        'sender': 'userTAO',
+        'destination_coldkey': 'ourCold',
+        'hotkey': 'ourHot',
+        'origin_netuid': 7,
+        'destination_netuid': 7,
+        'alpha_amount': 123_456,
+    }
+
+
+def test_decode_stake_transfer_rejects_other_calls():
+    assert (
+        SubtensorProvider.decode_stake_transfer(_structured_ext('Balances', 'transfer_keep_alive', _transfer_args()))
+        is None
+    )
+    assert SubtensorProvider.decode_stake_transfer(_structured_ext('SubtensorModule', 'add_stake', {})) is None
+    assert SubtensorProvider.decode_stake_transfer({'no': 'hash'}) is None
+
+
+# ─── Raw SCALE path ─────────────────────────────────────────────────────────
+
+
+def _raw_transfer_hex(call_idx, amount=5_000):
+    body = bytes([0x84]) + bytes([1] * 32)  # signed flag + sender AccountId
+    body += bytes([SubtensorProvider._BALANCES_PALLET, call_idx, 0x00]) + bytes([2] * 32)  # call + dest
+    body += ((amount << 2) | 0x01).to_bytes(2, 'little')  # compact amount (mode 1)
+    return '0x00' + body.hex()  # compact length prefix (value unused by the parser)
+
+
+def test_raw_path_parses_transfer_keep_alive():
+    parsed = SubtensorProvider.parse_raw_extrinsic(_raw_transfer_hex(call_idx=3))
+    assert parsed is not None
+    assert parsed['call_function'] == 'transfer_keep_alive'
+    assert parsed['amount'] == 5_000
+
+
+def test_raw_path_rejects_transfer_all_index():
+    assert SubtensorProvider.parse_raw_extrinsic(_raw_transfer_hex(call_idx=7)) is None


### PR DESCRIPTION
`decode_transfer` accepted any call with `transfer` in its name — no pallet check. Both decode paths are now gated to exact `Balances.{transfer_allow_death, transfer_keep_alive}`; adds `decode_stake_transfer` for `SubtensorModule.transfer_stake` (needed by the upcoming chain watcher).

Severity: hardening, not a live hole — `transfer_all`/`transfer_stake` decoded with `amount=0`, and both call sites require `amount >= expected`, so no payment could ever have been falsely approved. The real prior defect was false negatives (e.g. a genuine `transfer_all` payment could never verify) plus a lookalike-call surface the exact-name gate now closes. The raw path's `7: transfer_all` entry never matched anything — `transfer_all` is call index 4 on Subtensor — so it is dropped rather than fixed, and the rejection test pins index 4.

Before → after (structured path, same fixtures as the new tests):

```
transfer_all    ('0xabc', '5Miner…', 0, '5User…')    → None        # previously amount 0: a real payment that could never verify
transfer_stake  ('0xdef', '', 0, '5User…')           → None        # not a TAO transfer at all
keep_alive      ('0x123', '5Miner…', 5000, '5User…') → unchanged
```

Independent fix: the decode is only called from `fetch_matching_tx` / `find_recent_outgoing` in the same file, and `call_module` is present in the installed scalecodec serialization. Full suite: 814 passed.
