### PR TITLE
Correct the custody/control disclaimer and drop 'trustless'

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Universal Transaction Layer**
 
-Trustless native transactions across independent assets — Bittensor Subnet 7 (SN7).
+Native transactions across independent assets — no wrapped tokens, no bridges, no custodian. Bittensor Subnet 7 (SN7).
 
 [![Twitter](https://img.shields.io/twitter/follow/allways_io?style=social)](https://x.com/allways_io)
 
@@ -101,4 +101,4 @@ MIT License
 
 ---
 
-<sub>Allways is permissionless, open-source, beta software. The protocol facilitates trustless peer-to-peer transactions — the creators and contributors do not custody, control, or intermediate any funds. Use at your own risk. This software is provided "as is" without warranty of any kind. Nothing herein constitutes financial advice, and the creators assume no liability for losses arising from use of the protocol.</sub>
+<sub>Allways is permissionless, open-source, beta software. Swaps settle directly between counterparty wallets; the protocol never takes custody of user funds, and the protocol fee is charged against miner collateral rather than any user transfer. Validator operators, including those run by the project, verify swap outcomes but cannot redirect or receive any transferred amount. Use at your own risk. This software is provided "as is" without warranty of any kind. Nothing herein constitutes financial advice, and the creators assume no liability for losses arising from use of the protocol.</sub>

--- a/allways/cli/help.py
+++ b/allways/cli/help.py
@@ -13,9 +13,11 @@ from rich.panel import Panel
 from rich.table import Table
 
 DISCLAIMER = (
-    'Allways is permissionless, open-source, beta software. The protocol facilitates trustless'
-    ' peer-to-peer transactions -- the creators and contributors do not custody, control, or'
-    ' intermediate any funds. Use at your own risk. No warranty. Not financial advice.'
+    'Allways is permissionless, open-source, beta software. Swaps settle directly between'
+    ' counterparty wallets; the protocol never takes custody of user funds, and the protocol fee is'
+    ' charged against miner collateral rather than any user transfer. Validator operators, including'
+    ' those run by the project, verify swap outcomes but cannot redirect or receive any transferred'
+    ' amount. Use at your own risk. No warranty. Not financial advice.'
 )
 
 


### PR DESCRIPTION
First slice of the legal-accuracy copy pass. Text only — no behaviour change.

## The problem

The standing disclaimer (README + CLI) claims:

> the creators and contributors do not custody, control, or intermediate any funds

Clause by clause against the contract:

- **"do not custody"** — true. The program never holds user funds; settlement is wallet-to-wallet and collateral sits in per-miner PDAs. Kept.
- **"do not control"** — false. `Config.admin` is a single `Pubkey`, and sixteen instructions are gated on it (`lib.rs:59-105`, `:238`): `add_validator`, `remove_validator`, `set_consensus_threshold`, `set_halted`, eleven economic setters, and `withdraw_treasury`. One signature can evict the validator set and lower the quorum threshold in the same transaction.
- **"do not intermediate"** — false for the router path. `finalize_reservation.rs:17` has `router` as the only `Signer`; the handler takes the taker and both addresses as plain arguments and pins them at `:122-124`. Naming who receives what is intermediating.

An inaccurate disclaimer is an affirmative representation, which is a worse position than not making one.

## The replacement

States what the code actually does, and picks up two facts that help and weren't being claimed:

- the 1% fee is debited from **miner collateral**, not from any user transfer (`confirm_swap.rs:124`)
- validators judge outcomes but cannot redirect or receive a transferred amount — `timeout_swap.rs:100` moves the slash under `constraint = swap.user == user.key()`, pinned at finalize, and the fee destination is a program-derived constant

## "Trustless"

Dropped from the README tagline. Settlement assumes an honest-majority validator quorum, and a single admin key can currently reconstitute that quorum, so the word overstates. The mechanical claim — *no wrapped tokens, no bridges, no custodian* — is accurate and more informative.

Companion PRs cover the same copy in allways-ui and allways-docs-ui.