### PR TITLE
Verify TAO transfers by settlement rather than by the decoded call

### DIFF
--- a/allways/__init__.py
+++ b/allways/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '2.0.2'
+__version__ = '2.1.0'
 version_split = __version__.split('.')
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))

--- a/allways/chain_providers/subtensor.py
+++ b/allways/chain_providers/subtensor.py
@@ -307,15 +307,22 @@ class SubtensorProvider(ChainProvider):
         if not block_hash:
             raise ProviderUnreachableError(f'TAO block hash unavailable for {block_num}')
 
+        # Reached only once an extrinsic was located in this block, so the block provably holds one
+        # and must emit its ApplyExtrinsic records. An empty list is a broken response, not an
+        # empty block, and reporting it as no-credit would false-slash on an RPC hiccup alone.
+        events = self.get_block_events(block_hash)
+        if not events:
+            raise ProviderUnreachableError(f'no events returned for block {block_num}, which holds extrinsics')
+
         credited = 0
         sender = ''
         indexed = 0
-        events = self.get_block_events(block_hash)
         for record in events:
-            if self._event_extrinsic_idx(record) is None:
+            idx = self._event_extrinsic_idx(record)
+            if idx is None:
                 continue
             indexed += 1
-            if self._event_extrinsic_idx(record) != extrinsic_idx:
+            if idx != extrinsic_idx:
                 continue
             transfer = self._transfer_from_event(record)
             if transfer is None:
@@ -326,10 +333,8 @@ class SubtensorProvider(ChainProvider):
             credited += ev_amount
             sender = sender or ev_sender
 
-        # Any block holding extrinsics emits ApplyExtrinsic records, so recognising none of them
-        # means the phase shape moved, not that the block is empty. Same reasoning as above: that
-        # is 'unknown', and reporting it as no-credit would false-slash on shape drift alone.
-        if events and not indexed:
+        # Recognising none of them means the phase shape moved, not that nothing was applied.
+        if not indexed:
             raise ProviderUnreachableError(
                 f'no ApplyExtrinsic phase recognised in {len(events)} events at block {block_num}'
             )

--- a/allways/chain_providers/subtensor.py
+++ b/allways/chain_providers/subtensor.py
@@ -255,6 +255,12 @@ class SubtensorProvider(ChainProvider):
                 return None
             attributes = balances['Transfer']
 
+        # Past this point the record IS a Balances.Transfer, so a payload we can't read is
+        # 'unknown', never 'absent'. Returning None here would read a real deposit as moving
+        # no funds — on a dest leg that is slash-eligible, so shape drift would false-slash.
+        def unreadable(detail: str) -> ProviderUnreachableError:
+            return ProviderUnreachableError(f'unreadable Balances.Transfer payload ({detail}): {attributes!r:.200}')
+
         if isinstance(attributes, dict):
             sender = attributes.get('from')
             dest = attributes.get('to')
@@ -265,16 +271,16 @@ class SubtensorProvider(ChainProvider):
             if isinstance(sender, dict):
                 sender, dest, amount = (p.get('value') for p in (sender, dest, amount))
         else:
-            return None
+            raise unreadable(f'{type(attributes).__name__}')
 
         sender = cls._as_ss58(sender)
         dest = cls._as_ss58(dest)
         if not sender or not dest:
-            return None
+            raise unreadable('unresolved from/to')
         try:
             return sender, dest, int(amount)
-        except (TypeError, ValueError):
-            return None
+        except (TypeError, ValueError) as e:
+            raise unreadable('non-numeric amount') from e
 
     @staticmethod
     def _as_ss58(value: Any) -> str:
@@ -303,7 +309,12 @@ class SubtensorProvider(ChainProvider):
 
         credited = 0
         sender = ''
-        for record in self.get_block_events(block_hash):
+        indexed = 0
+        events = self.get_block_events(block_hash)
+        for record in events:
+            if self._event_extrinsic_idx(record) is None:
+                continue
+            indexed += 1
             if self._event_extrinsic_idx(record) != extrinsic_idx:
                 continue
             transfer = self._transfer_from_event(record)
@@ -314,6 +325,14 @@ class SubtensorProvider(ChainProvider):
                 continue
             credited += ev_amount
             sender = sender or ev_sender
+
+        # Any block holding extrinsics emits ApplyExtrinsic records, so recognising none of them
+        # means the phase shape moved, not that the block is empty. Same reasoning as above: that
+        # is 'unknown', and reporting it as no-credit would false-slash on shape drift alone.
+        if events and not indexed:
+            raise ProviderUnreachableError(
+                f'no ApplyExtrinsic phase recognised in {len(events)} events at block {block_num}'
+            )
 
         if credited <= 0:
             return None

--- a/allways/chain_providers/subtensor.py
+++ b/allways/chain_providers/subtensor.py
@@ -31,6 +31,8 @@ class SubtensorProvider(ChainProvider):
         self.subtensor = subtensor
         self.wallet = wallet
         self.block_cache: Dict[int, dict] = {}
+        self.block_hash_cache: Dict[int, str] = {}
+        self.events_cache: Dict[str, list] = {}
         # Deposit-scanner head cursors, keyed per (from, to, amount) triple — see find_recent_outgoing.
         self.scan_cursors: Dict[Tuple[str, str, int], int] = {}
 
@@ -53,6 +55,8 @@ class SubtensorProvider(ChainProvider):
     def clear_cache(self):
         """Clear the block cache. Call at the start of each poll cycle."""
         self.block_cache.clear()
+        self.block_hash_cache.clear()
+        self.events_cache.clear()
 
     @staticmethod
     def decode_compact(data: bytes) -> Tuple[int, int]:
@@ -93,11 +97,12 @@ class SubtensorProvider(ChainProvider):
             if not (body[0] & 0x80):
                 return None
 
-            # Sender AccountId is at bytes 1..33
-            if len(body) < 33:
+            # body[1] is the MultiAddress variant; only Id (0x00) carries a bare AccountId, at
+            # body[2:34]. Reading from body[1] straddles the variant byte and yields a shifted
+            # (valid-looking but wrong) ss58, so anything else fails closed.
+            if len(body) < 34 or body[1] != 0x00:
                 return None
-            sender_bytes = body[1:33]
-            sender = ss58_encode(sender_bytes, ss58_format=42)
+            sender = ss58_encode(body[2:34], ss58_format=42)
 
             # Find the transfer call: pallet_index=5, call_index in {0,3,7}
             # The call data follows the signature block. Instead of parsing the full
@@ -137,12 +142,21 @@ class SubtensorProvider(ChainProvider):
         except Exception:
             return None
 
+    def get_block_hash(self, block_num: int) -> Optional[str]:
+        """Block hash for a height, cached per poll cycle (settlement checks re-need it)."""
+        if block_num in self.block_hash_cache:
+            return self.block_hash_cache[block_num]
+        block_hash = self.subtensor.substrate.get_block_hash(block_num)
+        if block_hash:
+            self.block_hash_cache[block_num] = block_hash
+        return block_hash
+
     def get_block(self, block_num: int) -> Optional[dict]:
         """Fetch a block, using cache to avoid redundant RPC calls within a poll cycle."""
         if block_num in self.block_cache:
             return self.block_cache[block_num]
 
-        block_hash = self.subtensor.substrate.get_block_hash(block_num)
+        block_hash = self.get_block_hash(block_num)
         if not block_hash:
             return None
 
@@ -164,10 +178,13 @@ class SubtensorProvider(ChainProvider):
             raw_block = result.get('result', {}).get('block', {})
             raw_exts = raw_block.get('extrinsics', [])
 
+            # Keep the true position: this list is filtered to transfers, but the settlement
+            # check keys events on the extrinsic's index within the full block.
             parsed_exts = []
-            for ext_hex in raw_exts:
+            for idx, ext_hex in enumerate(raw_exts):
                 parsed = self.parse_raw_extrinsic(ext_hex)
                 if parsed:
+                    parsed['extrinsic_idx'] = idx
                     parsed_exts.append(parsed)
 
             block = {'extrinsics': parsed_exts, '_raw': True}
@@ -176,6 +193,131 @@ class SubtensorProvider(ChainProvider):
         except Exception as e:
             bt.logging.debug(f'Raw block fetch failed for block {block_num}: {e}')
             return None
+
+    def get_block_events(self, block_hash: str) -> list:
+        """System.Events for a block, cached per poll cycle.
+
+        Raises ProviderUnreachableError when events can't be read: callers must treat that as
+        'unknown', never as 'no transfer'. Returning None here would map to a slash-eligible
+        verdict on a node hiccup.
+        """
+        if block_hash in self.events_cache:
+            return self.events_cache[block_hash]
+        try:
+            events = self.subtensor.substrate.get_events(block_hash)
+        except Exception as e:
+            raise ProviderUnreachableError(f'TAO events unavailable for {block_hash[:16]}...: {e}') from e
+        if events is None:
+            raise ProviderUnreachableError(f'TAO events unavailable for {block_hash[:16]}...')
+        events = list(events)
+        self.events_cache[block_hash] = events
+        return events
+
+    @staticmethod
+    def _event_extrinsic_idx(record: Any) -> Optional[int]:
+        """Index of the extrinsic that emitted this event record, or None if not extrinsic-applied."""
+        if not isinstance(record, dict):
+            return None
+        idx = record.get('extrinsic_idx')
+        if isinstance(idx, int):
+            return idx
+        phase = record.get('phase')
+        if isinstance(phase, dict):
+            applied = phase.get('ApplyExtrinsic')
+            if isinstance(applied, int):
+                return applied
+        return None
+
+    @classmethod
+    def _transfer_from_event(cls, record: Any) -> Optional[Tuple[str, str, int]]:
+        """(sender, dest, amount) if this record is a Balances.Transfer, else None.
+
+        Tolerates the shapes scalecodec emits across runtime/metadata versions: flat
+        module_id/event_id with dict or positional attributes, and the nested
+        {'Balances': {'Transfer': ...}} variant form.
+        """
+        if not isinstance(record, dict):
+            return None
+        event = record.get('event', record)
+        if not isinstance(event, dict):
+            return None
+
+        attributes: Any = None
+        module = event.get('module_id') or event.get('module') or event.get('pallet')
+        name = event.get('event_id') or event.get('event') or event.get('name')
+        if isinstance(module, str) and isinstance(name, str):
+            if module != 'Balances' or name != 'Transfer':
+                return None
+            attributes = event.get('attributes', event.get('params'))
+        else:
+            balances = event.get('Balances')
+            if not isinstance(balances, dict) or 'Transfer' not in balances:
+                return None
+            attributes = balances['Transfer']
+
+        if isinstance(attributes, dict):
+            sender = attributes.get('from')
+            dest = attributes.get('to')
+            amount = attributes.get('amount', attributes.get('value'))
+        elif isinstance(attributes, (list, tuple)) and len(attributes) >= 3:
+            sender, dest, amount = attributes[0], attributes[1], attributes[2]
+            # Older shapes wrap each param as {'name': ..., 'value': ...}.
+            if isinstance(sender, dict):
+                sender, dest, amount = (p.get('value') for p in (sender, dest, amount))
+        else:
+            return None
+
+        sender = cls._as_ss58(sender)
+        dest = cls._as_ss58(dest)
+        if not sender or not dest:
+            return None
+        try:
+            return sender, dest, int(amount)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _as_ss58(value: Any) -> str:
+        """Normalise an AccountId event field (ss58 str, {'Id': ...}, or raw bytes) to ss58."""
+        if isinstance(value, dict):
+            value = value.get('Id', value.get('value'))
+        if isinstance(value, (bytes, bytearray)) and len(value) == 32:
+            return ss58_encode(bytes(value), ss58_format=42)
+        if isinstance(value, str):
+            if value.startswith('0x') and len(value) == 66:
+                return ss58_encode(bytes.fromhex(value[2:]), ss58_format=42)
+            return value
+        return ''
+
+    def settled_credit(self, block_num: int, extrinsic_idx: int, recipient: str) -> Optional[Tuple[str, int]]:
+        """(sender, credited_rao) actually paid to ``recipient`` by this extrinsic, else None.
+
+        Inclusion in a block is not settlement: a signed transfer that dispatches with an error
+        (e.g. insufficient balance) still occupies a block and still decodes to the intended
+        dest/amount. Only a Balances.Transfer event proves funds moved, so the event — not the
+        call — is what the amount and sender are read from.
+        """
+        block_hash = self.get_block_hash(block_num)
+        if not block_hash:
+            raise ProviderUnreachableError(f'TAO block hash unavailable for {block_num}')
+
+        credited = 0
+        sender = ''
+        for record in self.get_block_events(block_hash):
+            if self._event_extrinsic_idx(record) != extrinsic_idx:
+                continue
+            transfer = self._transfer_from_event(record)
+            if transfer is None:
+                continue
+            ev_sender, ev_dest, ev_amount = transfer
+            if ev_dest != recipient:
+                continue
+            credited += ev_amount
+            sender = sender or ev_sender
+
+        if credited <= 0:
+            return None
+        return sender, credited
 
     def get_block_time(self, block_num: int) -> Optional[int]:
         """Block's mined time in unix seconds, via the Timestamp pallet at that block hash (millis ÷ 1000).
@@ -251,25 +393,45 @@ class SubtensorProvider(ChainProvider):
 
                 is_raw = block.get('_raw', False)
 
-                for ext in block['extrinsics']:
+                for position, ext in enumerate(block['extrinsics']):
                     match = self.match_transfer(ext, tx_hash, is_raw)
                     if match is None:
                         continue
 
                     tx_hash_seen = True
-                    dest, amount, sender = match
+                    dest, amount, _ = match
                     confs = current_block - block_num
-                    if dest == expected_recipient and amount >= expected_amount:
-                        return TransactionInfo(
-                            tx_hash=tx_hash,
-                            confirmed=confs >= self.get_chain().min_confirmations,
-                            sender=sender,
-                            recipient=dest,
-                            amount=amount,
-                            block_number=block_num,
-                            confirmations=confs,
-                            block_time=self.get_block_time(block_num),
+                    if dest != expected_recipient or amount < expected_amount:
+                        continue
+
+                    # The call only states intent. Require the Balances.Transfer event before
+                    # treating this as a deposit, and take the amount/sender from the event.
+                    ext_idx = ext.get('extrinsic_idx', position) if is_raw else position
+                    settled = self.settled_credit(block_num, ext_idx, expected_recipient)
+                    if settled is None:
+                        bt.logging.warning(
+                            f'{LOG_SUB} tx {tx_hash[:16]}... is in block {block_num} but moved no funds '
+                            f'to {expected_recipient[:8]}... (dispatch failed) — rejecting'
                         )
+                        continue
+                    settled_sender, settled_amount = settled
+                    if settled_amount < expected_amount:
+                        bt.logging.warning(
+                            f'{LOG_SUB} tx {tx_hash[:16]}... settled {settled_amount} rao to '
+                            f'{expected_recipient[:8]}..., below the {expected_amount} required — rejecting'
+                        )
+                        continue
+
+                    return TransactionInfo(
+                        tx_hash=tx_hash,
+                        confirmed=confs >= self.get_chain().min_confirmations,
+                        sender=settled_sender,
+                        recipient=expected_recipient,
+                        amount=settled_amount,
+                        block_number=block_num,
+                        confirmations=confs,
+                        block_time=self.get_block_time(block_num),
+                    )
 
             if tx_hash_seen:
                 bt.logging.warning(
@@ -372,14 +534,23 @@ class SubtensorProvider(ChainProvider):
             if not block or 'extrinsics' not in block:
                 continue
             is_raw = block.get('_raw', False)
-            for ext in block['extrinsics']:
+            for position, ext in enumerate(block['extrinsics']):
                 decoded = self.decode_transfer(ext, is_raw)
                 if decoded is None:
                     continue
                 ext_hash, dest, amt, sender = decoded
-                if dest == to_addr and sender == from_addr and int(amt) >= int(amount):
-                    self.scan_cursors.pop(key, None)
-                    return ext_hash
+                if dest != to_addr or sender != from_addr or int(amt) < int(amount):
+                    continue
+                # Call-level match is only a candidate; confirm the funds actually moved.
+                ext_idx = ext.get('extrinsic_idx', position) if is_raw else position
+                try:
+                    settled = self.settled_credit(block_num, ext_idx, to_addr)
+                except ProviderUnreachableError:
+                    continue
+                if settled is None or settled[1] < int(amount):
+                    continue
+                self.scan_cursors.pop(key, None)
+                return ext_hash
         self.scan_cursors[key] = head
         if len(self.scan_cursors) > self._MAX_SCAN_CURSORS:
             self.scan_cursors.pop(next(iter(self.scan_cursors)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "allways"
-version = "2.0.2"
+version = "2.1.0"
 description = "Allways - Universal Transaction Layer: Trustless cross-chain swaps on Bittensor Subnet 7"
 license = "MIT"
 requires-python = ">=3.10,<3.15"

--- a/tests/test_block_time.py
+++ b/tests/test_block_time.py
@@ -8,7 +8,10 @@ providers actually populate block_time: BTC from Esplora status.block_time, TAO 
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from allways.chain_providers.base import TransactionInfo
+import pytest
+from bittensor.utils import ss58_encode
+
+from allways.chain_providers.base import ProviderUnreachableError, TransactionInfo
 from allways.chain_providers.bitcoin import BitcoinProvider
 from allways.chain_providers.subtensor import SubtensorProvider
 
@@ -94,15 +97,33 @@ def _scan_provider(head, blocks):
     p.subtensor = MagicMock()
     p.subtensor.get_current_block.return_value = head
     p.block_cache = {}
+    p.block_hash_cache = {}
+    p.events_cache = {}
     p.scan_cursors = {}
     p.get_block = lambda n: blocks.get(n)
+    p.get_block_hash = lambda n: f'0xblock{n}'
+    p.get_block_events = lambda h: (blocks.get(int(h.removeprefix('0xblock'))) or {}).get('_events', [])
     return p
 
 
-def _raw_transfer_block(txid, dest, amount, sender):
+def _transfer_event(dest, amount, sender, extrinsic_idx=0):
+    return {
+        'extrinsic_idx': extrinsic_idx,
+        'event': {
+            'module_id': 'Balances',
+            'event_id': 'Transfer',
+            'attributes': {'from': sender, 'to': dest, 'amount': amount},
+        },
+    }
+
+
+def _raw_transfer_block(txid, dest, amount, sender, settled=True):
+    """A block holding one transfer. ``settled=False`` models a dispatch that failed: the
+    extrinsic is in the block and decodes normally, but emits no Balances.Transfer event."""
     return {
         '_raw': True,
         'extrinsics': [{'extrinsic_hash': txid, 'dest': dest, 'amount': amount, 'sender': sender}],
+        '_events': [_transfer_event(dest, amount, sender)] if settled else [],
     }
 
 
@@ -144,6 +165,142 @@ def test_tao_scanner_none_when_head_unreachable():
     p = _scan_provider(head=100, blocks={})
     p.subtensor.get_current_block.side_effect = RuntimeError('down')
     assert p.find_recent_outgoing('userTAO', 'minerTAO', 5000) is None
+
+
+def test_tao_scanner_ignores_transfer_that_moved_no_funds():
+    """An included-but-failed transfer decodes to the right dest/amount and must still be ignored."""
+    blocks = {100: _raw_transfer_block('0xdep', 'minerTAO', 5000, 'userTAO', settled=False)}
+    p = _scan_provider(head=100, blocks=blocks)
+    assert p.find_recent_outgoing('userTAO', 'minerTAO', 5000) is None
+
+
+def test_tao_scanner_ignores_transfer_settled_below_the_asking_amount():
+    blocks = {100: _raw_transfer_block('0xdep', 'minerTAO', 5000, 'userTAO')}
+    blocks[100]['_events'] = [_transfer_event('minerTAO', 4999, 'userTAO')]
+    p = _scan_provider(head=100, blocks=blocks)
+    assert p.find_recent_outgoing('userTAO', 'minerTAO', 5000) is None
+
+
+def test_settled_credit_reads_amount_and_sender_from_the_event():
+    """The event is authoritative: a call claiming more than it moved settles at the event amount."""
+    blocks = {100: _raw_transfer_block('0xdep', 'minerTAO', 9_999, 'userTAO')}
+    blocks[100]['_events'] = [_transfer_event('minerTAO', 5_000, 'userTAO')]
+    p = _scan_provider(head=100, blocks=blocks)
+    assert p.settled_credit(100, 0, 'minerTAO') == ('userTAO', 5_000)
+
+
+def test_settled_credit_ignores_events_from_other_extrinsics_and_recipients():
+    blocks = {100: _raw_transfer_block('0xdep', 'minerTAO', 5000, 'userTAO')}
+    blocks[100]['_events'] = [
+        _transfer_event('minerTAO', 5_000, 'userTAO', extrinsic_idx=7),  # different extrinsic
+        _transfer_event('someoneElse', 5_000, 'userTAO', extrinsic_idx=0),  # different recipient
+    ]
+    p = _scan_provider(head=100, blocks=blocks)
+    assert p.settled_credit(100, 0, 'minerTAO') is None
+
+
+def test_settled_credit_sums_multiple_credits_from_one_extrinsic():
+    blocks = {100: _raw_transfer_block('0xdep', 'minerTAO', 5000, 'userTAO')}
+    blocks[100]['_events'] = [
+        _transfer_event('minerTAO', 3_000, 'userTAO'),
+        _transfer_event('minerTAO', 2_000, 'userTAO'),
+    ]
+    p = _scan_provider(head=100, blocks=blocks)
+    assert p.settled_credit(100, 0, 'minerTAO') == ('userTAO', 5_000)
+
+
+@pytest.mark.parametrize(
+    'record',
+    [
+        {
+            'phase': {'ApplyExtrinsic': 0},
+            'event': {
+                'module_id': 'Balances',
+                'event_id': 'Transfer',
+                'attributes': {'from': 'A', 'to': 'B', 'amount': 7},
+            },
+        },
+        {'extrinsic_idx': 0, 'event': {'module_id': 'Balances', 'event_id': 'Transfer', 'attributes': ['A', 'B', 7]}},
+        {'extrinsic_idx': 0, 'event': {'Balances': {'Transfer': {'from': 'A', 'to': 'B', 'amount': 7}}}},
+        {
+            'extrinsic_idx': 0,
+            'event': {
+                'module_id': 'Balances',
+                'event_id': 'Transfer',
+                'attributes': {'from': {'Id': 'A'}, 'to': {'Id': 'B'}, 'amount': 7},
+            },
+        },
+    ],
+)
+def test_transfer_event_shapes_are_all_understood(record):
+    """scalecodec emits several shapes across runtime versions; all must decode identically."""
+    assert SubtensorProvider._event_extrinsic_idx(record) == 0
+    assert SubtensorProvider._transfer_from_event(record) == ('A', 'B', 7)
+
+
+def test_non_transfer_events_are_not_read_as_transfers():
+    for record in (
+        {'extrinsic_idx': 0, 'event': {'module_id': 'System', 'event_id': 'ExtrinsicFailed', 'attributes': {}}},
+        {
+            'extrinsic_idx': 0,
+            'event': {'module_id': 'Balances', 'event_id': 'Withdraw', 'attributes': {'who': 'A', 'amount': 7}},
+        },
+        {
+            'phase': 'Finalization',
+            'event': {
+                'module_id': 'Balances',
+                'event_id': 'Transfer',
+                'attributes': {'from': 'A', 'to': 'B', 'amount': 7},
+            },
+        },
+    ):
+        assert (
+            SubtensorProvider._transfer_from_event(record) is None
+            or SubtensorProvider._event_extrinsic_idx(record) is None
+        )
+
+
+def test_events_unavailable_raises_rather_than_reading_as_absent():
+    """Fail closed as 'unknown', not 'no transfer' — the latter is slash-eligible upstream."""
+    p = SubtensorProvider.__new__(SubtensorProvider)
+    p.events_cache = {}
+    p.subtensor = SimpleNamespace(substrate=SimpleNamespace(get_events=MagicMock(side_effect=RuntimeError('rpc down'))))
+    with pytest.raises(ProviderUnreachableError):
+        p.get_block_events('0xabc')
+
+
+def _compact(value):
+    if value < 64:
+        return bytes([value << 2])
+    if value < 2**14:
+        return ((value << 2) | 0b01).to_bytes(2, 'little')
+    return ((value << 2) | 0b10).to_bytes(4, 'little')
+
+
+def test_raw_extrinsic_sender_is_read_past_the_multiaddress_variant_byte():
+    """body[1] is the MultiAddress variant; the AccountId starts at body[2], not body[1]."""
+    sender, dest = bytes(range(32)), bytes(range(100, 132))
+    body = (
+        bytes([0x84, 0x00])
+        + sender  # version, MultiAddress::Id + signer
+        + bytes([0x01])
+        + b'\x11' * 64  # sr25519 signature (filler avoids a false call match)
+        + bytes([0x00, 0x00, 0x00])  # era, nonce, tip
+        + bytes([0x05, 0x03, 0x00])
+        + dest
+        + _compact(5_000)  # Balances.transfer_keep_alive
+    )
+    parsed = SubtensorProvider.parse_raw_extrinsic((_compact(len(body)) + body).hex())
+    assert parsed is not None
+    assert parsed['sender'] == ss58_encode(sender, ss58_format=42)
+    assert parsed['dest'] == ss58_encode(dest, ss58_format=42)
+    assert parsed['amount'] == 5_000
+
+
+def test_raw_extrinsic_rejects_non_id_multiaddress_rather_than_shifting():
+    """A non-Id signer variant has no bare AccountId to read, so it must fail closed."""
+    body = bytes([0x84, 0x01]) + bytes(range(32)) + bytes([0x01]) + b'\x11' * 64 + bytes([0x00] * 3)
+    assert SubtensorProvider.parse_raw_extrinsic((_compact(len(body)) + body).hex()) is None
 
 
 def test_match_transfer_still_matches_by_hash_through_shared_decode():

--- a/tests/test_block_time.py
+++ b/tests/test_block_time.py
@@ -117,13 +117,35 @@ def _transfer_event(dest, amount, sender, extrinsic_idx=0):
     }
 
 
+def _failed_dispatch_events(sender):
+    """What a failed transfer leaves behind: the fee is taken, no Transfer is emitted."""
+    return [
+        {
+            'extrinsic_idx': 0,
+            'event': {
+                'module_id': 'Balances',
+                'event_id': 'Withdraw',
+                'attributes': {'who': sender, 'amount': 166_249},
+            },
+        },
+        {
+            'extrinsic_idx': 0,
+            'event': {
+                'module_id': 'System',
+                'event_id': 'ExtrinsicFailed',
+                'attributes': {'dispatch_error': {'Token': 'FundsUnavailable'}},
+            },
+        },
+    ]
+
+
 def _raw_transfer_block(txid, dest, amount, sender, settled=True):
-    """A block holding one transfer. ``settled=False`` models a dispatch that failed: the
-    extrinsic is in the block and decodes normally, but emits no Balances.Transfer event."""
+    """A block holding one transfer. ``settled=False`` models a dispatch that failed: the extrinsic
+    is in the block and decodes normally, but the events carry only the fee, no Balances.Transfer."""
     return {
         '_raw': True,
         'extrinsics': [{'extrinsic_hash': txid, 'dest': dest, 'amount': amount, 'sender': sender}],
-        '_events': [_transfer_event(dest, amount, sender)] if settled else [],
+        '_events': [_transfer_event(dest, amount, sender)] if settled else _failed_dispatch_events(sender),
     }
 
 

--- a/tests/test_tao_settlement.py
+++ b/tests/test_tao_settlement.py
@@ -49,10 +49,42 @@ def _provider(*, call_amount=5_000, events, head=BLOCK + 10):
     return p
 
 
+def _failed_dispatch_events(extrinsic_idx=0):
+    """What a failed transfer actually leaves behind: the fee is taken, no Transfer is emitted."""
+    return [
+        {
+            'extrinsic_idx': extrinsic_idx,
+            'event': {'module_id': 'Balances', 'event_id': 'Withdraw', 'attributes': {'who': USER, 'amount': 166_249}},
+        },
+        {
+            'extrinsic_idx': extrinsic_idx,
+            'event': {
+                'module_id': 'TransactionPayment',
+                'event_id': 'TransactionFeePaid',
+                'attributes': {'who': USER, 'actual_fee': 166_249, 'tip': 0},
+            },
+        },
+        {
+            'extrinsic_idx': extrinsic_idx,
+            'event': {
+                'module_id': 'System',
+                'event_id': 'ExtrinsicFailed',
+                'attributes': {'dispatch_error': {'Token': 'FundsUnavailable'}},
+            },
+        },
+    ]
+
+
 def test_included_but_failed_transfer_is_not_a_deposit():
     """The exploited path: extrinsic sits in the block, decodes perfectly, moved nothing."""
-    p = _provider(events=[])
+    p = _provider(events=_failed_dispatch_events())
     assert p.fetch_matching_tx(TXID, MINER, 5_000, block_hint=BLOCK) is None
+
+
+def test_fee_events_alone_are_not_mistaken_for_settlement():
+    """Withdraw/TransactionFeePaid touch the payer's balance but are not a credit to anyone."""
+    p = _provider(events=_failed_dispatch_events())
+    assert p.settled_credit(BLOCK, 0, MINER) is None
 
 
 def test_settled_transfer_is_accepted():
@@ -110,3 +142,67 @@ def test_events_are_fetched_once_per_block():
     assert p.settled_credit(BLOCK, 0, MINER) == (USER, 5_000)
     assert p.settled_credit(BLOCK, 0, MINER) == (USER, 5_000)
     assert len(calls) == 1
+
+
+# ─── shape drift must read as unknown, never as "no funds moved" ─────────────
+# A silent None here would reject real deposits, and on a dest leg that is slash-eligible.
+
+
+@pytest.mark.parametrize(
+    'attributes',
+    [
+        'unexpected-scalar',
+        {'sender': 'A', 'receiver': 'B', 'value': 7},  # renamed keys
+        ['A', 'B'],  # too few positional params
+        {'from': 'A', 'to': 'B', 'amount': 'not-a-number'},
+        {'from': None, 'to': 'B', 'amount': 7},
+    ],
+)
+def test_unreadable_transfer_payload_raises_rather_than_reading_as_absent(attributes):
+    record = {
+        'extrinsic_idx': 0,
+        'event': {'module_id': 'Balances', 'event_id': 'Transfer', 'attributes': attributes},
+    }
+    with pytest.raises(ProviderUnreachableError):
+        SubtensorProvider._transfer_from_event(record)
+
+
+def test_unreadable_payload_on_a_non_transfer_event_is_still_just_absent():
+    """The strictness applies only once the record is known to be a Balances.Transfer."""
+    record = {
+        'extrinsic_idx': 0,
+        'event': {'module_id': 'Balances', 'event_id': 'Withdraw', 'attributes': 'unexpected-scalar'},
+    }
+    assert SubtensorProvider._transfer_from_event(record) is None
+
+
+def test_unreadable_transfer_payload_surfaces_through_settled_credit():
+    p = _provider(
+        events=[
+            {
+                'extrinsic_idx': 0,
+                'event': {'module_id': 'Balances', 'event_id': 'Transfer', 'attributes': 'unexpected-scalar'},
+            }
+        ]
+    )
+    with pytest.raises(ProviderUnreachableError):
+        p.settled_credit(BLOCK, 0, MINER)
+
+
+def test_unrecognised_phase_shape_raises_rather_than_matching_nothing():
+    """If the phase shape moves, no record matches the index filter — that is unknown, not absent."""
+    p = _provider(
+        events=[
+            {
+                'stage': {'Applied': 0},
+                'event': {'module_id': 'System', 'event_id': 'ExtrinsicSuccess', 'attributes': {}},
+            }
+        ]
+    )
+    with pytest.raises(ProviderUnreachableError):
+        p.settled_credit(BLOCK, 0, MINER)
+
+
+def test_block_with_no_events_at_all_is_not_treated_as_shape_drift():
+    p = _provider(events=[])
+    assert p.settled_credit(BLOCK, 0, MINER) is None

--- a/tests/test_tao_settlement.py
+++ b/tests/test_tao_settlement.py
@@ -203,6 +203,9 @@ def test_unrecognised_phase_shape_raises_rather_than_matching_nothing():
         p.settled_credit(BLOCK, 0, MINER)
 
 
-def test_block_with_no_events_at_all_is_not_treated_as_shape_drift():
+def test_empty_event_list_is_unknown_not_a_no_credit():
+    """We only get here having found an extrinsic in this block, so it must emit ApplyExtrinsic
+    records. No events means a broken response, not a block where nothing settled."""
     p = _provider(events=[])
-    assert p.settled_credit(BLOCK, 0, MINER) is None
+    with pytest.raises(ProviderUnreachableError):
+        p.settled_credit(BLOCK, 0, MINER)

--- a/tests/test_tao_settlement.py
+++ b/tests/test_tao_settlement.py
@@ -1,0 +1,112 @@
+"""TAO legs are verified by settlement, not by the decoded call.
+
+A signed transfer that dispatches with an error (insufficient balance, for one) is still included
+in a block and still decodes to the intended dest/amount. Only a Balances.Transfer event proves the
+funds moved, so that event is what the verifier reads. Backends are mocked — no network.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from allways.chain_providers.base import ProviderUnreachableError
+from allways.chain_providers.subtensor import SubtensorProvider
+
+MINER = 'minerTAO'
+USER = 'userTAO'
+TXID = '0xdeposit'
+BLOCK = 500
+
+
+def _transfer_event(dest, amount, sender, extrinsic_idx=0):
+    return {
+        'extrinsic_idx': extrinsic_idx,
+        'event': {
+            'module_id': 'Balances',
+            'event_id': 'Transfer',
+            'attributes': {'from': sender, 'to': dest, 'amount': amount},
+        },
+    }
+
+
+def _provider(*, call_amount=5_000, events, head=BLOCK + 10):
+    p = SubtensorProvider.__new__(SubtensorProvider)  # skip __init__ (no real subtensor needed)
+    p.subtensor = MagicMock()
+    p.subtensor.get_current_block.return_value = head
+    p.block_cache = {}
+    p.block_hash_cache = {}
+    p.events_cache = {}
+    p.scan_cursors = {}
+    block = {
+        '_raw': True,
+        'extrinsics': [{'extrinsic_hash': TXID, 'dest': MINER, 'amount': call_amount, 'sender': USER}],
+    }
+    p.get_block = lambda n: block if n == BLOCK else None
+    p.get_block_hash = lambda n: f'0xblock{n}'
+    p.get_block_events = lambda h: events
+    p.get_block_time = lambda n: 1_700_000_000
+    return p
+
+
+def test_included_but_failed_transfer_is_not_a_deposit():
+    """The exploited path: extrinsic sits in the block, decodes perfectly, moved nothing."""
+    p = _provider(events=[])
+    assert p.fetch_matching_tx(TXID, MINER, 5_000, block_hint=BLOCK) is None
+
+
+def test_settled_transfer_is_accepted():
+    p = _provider(events=[_transfer_event(MINER, 5_000, USER)])
+    info = p.fetch_matching_tx(TXID, MINER, 5_000, block_hint=BLOCK)
+    assert info is not None
+    assert (info.sender, info.recipient, info.amount) == (USER, MINER, 5_000)
+    assert info.block_number == BLOCK
+
+
+def test_amount_comes_from_the_event_not_the_call():
+    """A call claiming 5000 that only settled 4999 is a short deposit, not a match."""
+    p = _provider(call_amount=5_000, events=[_transfer_event(MINER, 4_999, USER)])
+    assert p.fetch_matching_tx(TXID, MINER, 5_000, block_hint=BLOCK) is None
+
+
+def test_settlement_to_another_recipient_does_not_count():
+    p = _provider(events=[_transfer_event('someoneElse', 5_000, USER)])
+    assert p.fetch_matching_tx(TXID, MINER, 5_000, block_hint=BLOCK) is None
+
+
+def test_sender_is_taken_from_the_event():
+    """Upstream pins the sender against the reservation, so it must reflect who actually paid."""
+    p = _provider(events=[_transfer_event(MINER, 5_000, 'actualPayer')])
+    info = p.fetch_matching_tx(TXID, MINER, 5_000, block_hint=BLOCK)
+    assert info is not None and info.sender == 'actualPayer'
+
+
+def test_unreadable_events_surface_as_unreachable_not_as_absent():
+    """'Unknown' must not collapse into 'no transfer' — that verdict is slash-eligible upstream."""
+    p = _provider(events=[])
+
+    def boom(_):
+        raise ProviderUnreachableError('events unavailable')
+
+    p.get_block_events = boom
+    with pytest.raises(ProviderUnreachableError):
+        p.fetch_matching_tx(TXID, MINER, 5_000, block_hint=BLOCK)
+
+
+def test_overpayment_still_settles():
+    p = _provider(events=[_transfer_event(MINER, 9_000, USER)])
+    info = p.fetch_matching_tx(TXID, MINER, 5_000, block_hint=BLOCK)
+    assert info is not None and info.amount == 9_000
+
+
+def test_events_are_fetched_once_per_block():
+    calls = []
+    p = _provider(events=[_transfer_event(MINER, 5_000, USER)])
+    p.events_cache = {}
+    real_events = [_transfer_event(MINER, 5_000, USER)]
+    p.subtensor.substrate = SimpleNamespace(get_events=lambda h: calls.append(h) or real_events)
+    del p.get_block_events  # exercise the real caching path
+    p.get_block_events = SubtensorProvider.get_block_events.__get__(p)
+    assert p.settled_credit(BLOCK, 0, MINER) == (USER, 5_000)
+    assert p.settled_credit(BLOCK, 0, MINER) == (USER, 5_000)
+    assert len(calls) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "allways"
-version = "2.0.2"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "base58" },


### PR DESCRIPTION
Small correctness fix in the TAO chain provider.

## What

`fetch_matching_tx` and `find_recent_outgoing` matched on the decoded `Balances.transfer` call. On Substrate a signed extrinsic that is included in a block but dispatches with an error (insufficient balance, for one) still decodes to the intended dest and amount, so it satisfied the match without having moved any funds. Inclusion is not settlement.

Both paths now require a `Balances.Transfer` event emitted by that extrinsic before treating it as a deposit, and read the amount and sender from the event rather than from the call.

Supporting changes:

- Extrinsic index is preserved through the raw-block path, since events key on position within the full block.
- Unreadable events raise `ProviderUnreachableError` rather than returning "no match". Callers map that to skip/retry; a plain `None` is slash-eligible upstream, so a node hiccup must not land there.
- Block hashes and per-block events are cached alongside the existing block cache and cleared on the same `clear_cache` cycle, so this adds at most one extra storage read per block touched.
- `parse_raw_extrinsic` read the signer at `body[1:33]`, straddling the MultiAddress variant byte and producing a shifted (valid-looking but wrong) ss58. Corrected to `body[2:34]`; non-Id signer variants now fail closed. Note this only affected the raw fallback path — the primary path takes the sender from the decoded extrinsic.

## Scope

TAO only. The Solana provider already gates on `meta.err` and reads pre/post balance deltas; the Bitcoin provider reads vouts of a confirmed tx. Both verify effect. Substrate is the one backend of the three where inclusion and effect can diverge, so the shared `fetch_matching_tx` shape carried an assumption that does not hold there.

## Tests

`tests/test_tao_settlement.py` (new) covers the by-hash verifier: included-but-unsettled returns None, amount and sender come from the event, settlement to another recipient or below the asking amount does not match, overpayment still settles, and unreadable events raise rather than read as absent.

`tests/test_block_time.py` extends the scanner cases with the unsettled and short-settled variants, `settled_credit` unit cases, and the extrinsic-decode fix. The event-shape normaliser is parametrised over the shapes scalecodec emits across runtime versions.

825 passed, ruff clean.

## Before merge

The event-shape normaliser was written against the `get_events()` contract and covered by parametrised tests, but I could not reach a websocket endpoint to confirm the exact dict shape this runtime returns. Worth one smoke test against a live node — verify a known-good TAO leg still resolves — before this goes out.