### PR TITLE
Add BURN_RATE with pools scaled to the miner share

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -62,11 +62,15 @@ REWARD_MINER_STATES: frozenset[MinerActivity] = frozenset({MinerActivity.AVAILAB
 # collateral_amount notional are all SOL). Referenced wherever code needs "is this the hub", instead of a literal.
 NUMERAIRE_CHAIN = 'sol'
 LAUNCH_SPOKES = ('btc', 'tao')  # chains paired against the hub; add a chain here to launch its pair
+# Fixed burn: pools sum to MINER_POOL_SHARE instead of 1.0, so at least
+# BURN_RATE of every round recycles to RECYCLE_UID before any shortfall.
+BURN_RATE = 0.90
+MINER_POOL_SHARE = 1.0 - BURN_RATE
 # Direction registry and the equal-split fallback: one entry per hub↔spoke direction
 # (both ways). The per-round pool values are volume-weighted at pair level
 # (scoring.compute_direction_pools); these constants are what zero volume falls back to.
 DIRECTION_POOLS: dict[tuple[str, str], float] = {
-    pair: 1.0 / (2 * len(LAUNCH_SPOKES))
+    pair: MINER_POOL_SHARE / (2 * len(LAUNCH_SPOKES))
     for spoke in LAUNCH_SPOKES
     for pair in ((NUMERAIRE_CHAIN, spoke), (spoke, NUMERAIRE_CHAIN))
 }

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -29,6 +29,7 @@ from allways.constants import (
     MAX_FAILED_SWAPS,
     MAX_SCORING_BACKFILL_SECS,
     MIN_SUCCESSFUL_SWAPS,
+    MINER_POOL_SHARE,
     NUMERAIRE_CHAIN,
     POOL_VOLUME_ALPHA,
     POOL_VOLUME_WINDOW_SECS,
@@ -269,7 +270,8 @@ def compute_direction_pools(
     (``get_clearing_volumes`` shape). Each hub↔spoke *pair* earns
     ``(1−α)/pairs + α × its share of SOL notional``, split evenly between its
     two directions — weighting at pair level means one leg can't be inflated
-    without inflating the whole pair. No volume anywhere → the equal split."""
+    without inflating the whole pair. No volume anywhere → the equal split.
+    Pools sum to ``MINER_POOL_SHARE``, not 1.0 — the burn lives here."""
     pair_directions: Dict[Tuple[str, str], List[Tuple[str, str]]] = {}
     for from_chain, to_chain in DIRECTION_POOLS:
         pair_directions.setdefault(canonical_pair(from_chain, to_chain), []).append((from_chain, to_chain))
@@ -294,7 +296,7 @@ def compute_direction_pools(
         volume_share = pair_volumes[pair] / total_volume
         pair_share = (1.0 - POOL_VOLUME_ALPHA) * equal_pair_share + POOL_VOLUME_ALPHA * volume_share
         for direction in directions:
-            pools[direction] = pair_share / len(directions)
+            pools[direction] = MINER_POOL_SHARE * pair_share / len(directions)
     return pools
 
 
@@ -401,6 +403,7 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
     # The shortfall is burned to RECYCLE_UID rather than left for weight
     # normalization to stretch back over the earners. Normalization preserves
     # every ratio, so an undistributed pool would cost a shallow field nothing.
+    # Pools sum to MINER_POOL_SHARE, so at least BURN_RATE recycles every round.
     recycle_uid = RECYCLE_UID if RECYCLE_UID < n_uids else 0
     distributed = float(rewards.sum())
     recycled = max(0.0, 1.0 - distributed)

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -14,6 +14,7 @@ from allways.constants import (
     MAX_FAILED_SWAPS,
     MAX_SCORING_BACKFILL_SECS,
     MIN_SUCCESSFUL_SWAPS,
+    MINER_POOL_SHARE,
     POOL_VOLUME_ALPHA,
     RECYCLE_UID,
     SCORING_WINDOW_BLOCKS,
@@ -44,7 +45,7 @@ POOL_BTC_SOL = DIRECTION_POOLS[('btc', 'sol')]
 POOL_SOL_BTC = DIRECTION_POOLS[('sol', 'btc')]
 # Leg pool when one pair carried ALL the window's clearing volume: the pair
 # share tilts to (1−α)/2 + α and splits evenly across its two directions.
-POOL_BUSY_PAIR_LEG = ((1 - POOL_VOLUME_ALPHA) / 2 + POOL_VOLUME_ALPHA) / 2
+POOL_BUSY_PAIR_LEG = MINER_POOL_SHARE * ((1 - POOL_VOLUME_ALPHA) / 2 + POOL_VOLUME_ALPHA) / 2
 MIN_COLLATERAL = 100_000_000  # 0.1 TAO
 
 METADATA_PATH = Path(__file__).parent.parent / 'allways' / 'metadata' / 'allways_swap_manager.json'
@@ -383,18 +384,18 @@ class TestComputeDirectionPools:
     back to the equal DIRECTION_POOLS split."""
 
     # With two launch pairs: a pair's floor share is (1−α)/2, its cap α + (1−α)/2.
-    FLOOR_LEG = (1 - POOL_VOLUME_ALPHA) / 2 / 2
+    FLOOR_LEG = MINER_POOL_SHARE * (1 - POOL_VOLUME_ALPHA) / 2 / 2
 
     def test_no_volume_falls_back_to_equal_split(self):
         assert compute_direction_pools({}) == DIRECTION_POOLS
 
     def test_single_pair_volume_tilts_both_its_legs_equally(self):
         pools = compute_direction_pools({('btc', 'sol'): {'hk_a': (5, 100)}})
-        assert pools[('btc', 'sol')] == pytest.approx(self.FLOOR_LEG + POOL_VOLUME_ALPHA / 2)
+        assert pools[('btc', 'sol')] == pytest.approx(self.FLOOR_LEG + MINER_POOL_SHARE * POOL_VOLUME_ALPHA / 2)
         assert pools[('sol', 'btc')] == pools[('btc', 'sol')]  # quiet leg rides its pair
         assert pools[('sol', 'tao')] == pytest.approx(self.FLOOR_LEG)
         assert pools[('tao', 'sol')] == pytest.approx(self.FLOOR_LEG)
-        assert sum(pools.values()) == pytest.approx(1.0)
+        assert sum(pools.values()) == pytest.approx(MINER_POOL_SHARE)
 
     def test_volume_is_the_sol_leg_summed_per_pair(self):
         # BTC pair: 300 SOL (to_amount is the SOL leg of btc→sol); TAO pair:
@@ -407,9 +408,9 @@ class TestComputeDirectionPools:
             }
         )
         floor_pair = (1 - POOL_VOLUME_ALPHA) / 2
-        assert pools[('btc', 'sol')] == pytest.approx((floor_pair + POOL_VOLUME_ALPHA * 0.75) / 2)
-        assert pools[('tao', 'sol')] == pytest.approx((floor_pair + POOL_VOLUME_ALPHA * 0.25) / 2)
-        assert sum(pools.values()) == pytest.approx(1.0)
+        assert pools[('btc', 'sol')] == pytest.approx(MINER_POOL_SHARE * (floor_pair + POOL_VOLUME_ALPHA * 0.75) / 2)
+        assert pools[('tao', 'sol')] == pytest.approx(MINER_POOL_SHARE * (floor_pair + POOL_VOLUME_ALPHA * 0.25) / 2)
+        assert sum(pools.values()) == pytest.approx(MINER_POOL_SHARE)
 
     def test_leg_direction_within_pair_is_irrelevant(self):
         # 500 SOL cleared btc→sol vs 500 SOL cleared sol→btc: same pair volume,


### PR DESCRIPTION
## What

Fixed 90% burn. `BURN_RATE = 0.90` in `constants.py`; direction pools now sum to `MINER_POOL_SHARE = 1 - BURN_RATE` instead of 1.0, so at least 90% of every round recycles to `RECYCLE_UID` before any earning shortfall.

## Why at the pool source

Scaling the final rewards vector instead would break the persisted-row invariant (`reward == pool x crown_share x capacity`, what the dashboard reads as paid). Baking the share into `compute_direction_pools` keeps score rows, live tip, and trace byte-consistent with the paid weights, and the existing recycle-remainder line routes the burn with no other changes.

Tuning later = edit `BURN_RATE` only.

## Tests

- Updated hand-computed pool expectations in `test_scoring_v1.py` (pools sum to `MINER_POOL_SHARE`)
- `pytest tests/`: 804 passed