### PR TITLE
Add miner risk disclaimer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ Currently live with BTC ↔ TAO. Designed to scale to any verifiable asset.
 
 ## Miner Risk Disclaimer
 
-The miner in this repository is **reference software, provided as-is with no warranty**. Mining Allways puts real capital at risk: collateral is slashable, signing keys are live, and swaps you fail to fulfill cost you SOL. Bugs — in this software, in the protocol, or in your own setup — can lose money.
-
-You alone decide whether to run, how much collateral to post, how large a max swap to quote, and how many UIDs to operate. Those are your decisions and your risk, and the risk scales with them. **Losses are not reimbursable.** Size your exposure to what you can afford to lose.
+The miner in this repository is **reference software**. Review the code thoroughly and build it out with your own safety and optimization measures before running it. Running the base miner, or anything you build on top of it, is at your own risk.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ Native transactions across independent assets — no wrapped tokens, no bridges,
 Allways creates a verification layer above independent systems. Assets move natively. Miners complete transactions, validators independently verify the results, and a smart contract enforces outcomes through collateral and slashing.
 
 Currently live with BTC ↔ TAO. Designed to scale to any verifiable asset.
+
+## Miner Risk Disclaimer
+
+The miner in this repository is **reference software, provided as-is with no warranty**. Mining Allways puts real capital at risk: collateral is slashable, signing keys are live, and swaps you fail to fulfill cost you SOL. Bugs — in this software, in the protocol, or in your own setup — can lose money.
+
+You alone decide whether to run, how much collateral to post, how large a max swap to quote, and how many UIDs to operate. Those are your decisions and your risk, and the risk scales with them. **Losses are not reimbursable.** Size your exposure to what you can afford to lose.
+
 ## Getting Started
 
 ### Requirements


### PR DESCRIPTION
Adds a Miner Risk Disclaimer section stating the miner is reference software provided as-is, that collateral is slashable, and that losses are not reimbursable.

Mirrors the `:::danger` block added to the miner guide in allways-docs-ui#86. The existing footer disclaimer is protocol-wide; this one is miner-specific and sits above the fold.