### PR TITLE
Make seam bind host env-configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,3 +48,11 @@ WANDB_API_KEY=
 WANDB_ENTITY=entrius-gittensor
 WANDB_PROJECT=allways-validators
 WANDB_VALIDATOR_NAME=vali
+
+# ── Offering seam (opt-in; leave unset unless this validator fronts a product offering) ──
+# Localhost HTTP the offering's own backend calls to reserve/confirm on behalf of its users.
+# Off unless ALLWAYS_SEAM_SECRET is set. Containerized validators also set ALLWAYS_SEAM_HOST=0.0.0.0
+# and share a docker network with the offering — publish no port; the secret gates every route.
+# ALLWAYS_SEAM_SECRET=
+# ALLWAYS_SEAM_PORT=8710
+# ALLWAYS_SEAM_HOST=127.0.0.1

--- a/allways/validator/seam_http.py
+++ b/allways/validator/seam_http.py
@@ -1,9 +1,11 @@
 """Localhost HTTP seam — the offering transport onto the shared kernel ops (reserve/confirm/rate/status).
 
-Loopback-only, shared-secret auth. A validator's product offering (a separate process) calls IN here to
-enter the reservation lottery on a user's behalf and to read swap status; the kernel never calls out. Not
-for public exposure — bind 127.0.0.1 and front it with the product server. Off by default: starts only when
-``ALLWAYS_SEAM_SECRET`` is set (see ``maybe_start_seam``).
+Loopback-only by default, shared-secret auth. A validator's product offering (a separate process) calls IN
+here to enter the reservation lottery on a user's behalf and to read swap status; the kernel never calls
+out. Not for public exposure. Off by default: starts only when ``ALLWAYS_SEAM_SECRET`` is set (see
+``maybe_start_seam``). A containerized validator sets ``ALLWAYS_SEAM_HOST=0.0.0.0`` — a container-loopback
+bind is unreachable even from the offering — and relies on the docker network + secret for isolation,
+publishing no port.
 """
 
 import json
@@ -22,7 +24,7 @@ from allways.validator.reserve_engine import (
     swap_status,
 )
 
-SEAM_HOST = '127.0.0.1'
+SEAM_HOST = os.environ.get('ALLWAYS_SEAM_HOST', '127.0.0.1')
 
 
 def _make_handler(validator, secret: str):


### PR DESCRIPTION
ALLWAYS_SEAM_HOST env (default 127.0.0.1 — behavior unchanged for every existing deploy).

A containerized validator can't use the loopback bind: docker port-forwards and docker networks both target the container's eth0, so a 127.0.0.1 bind inside the container is unreachable even from a co-located offering. Such deploys set ALLWAYS_SEAM_HOST=0.0.0.0 and rely on the docker network + shared secret, publishing no port.

One line plus docstring; the secret gate on every route is untouched.