### PR TITLE
Return the quote rejection reason from seam /rate

### DIFF
--- a/allways/cli/swap_commands/swap_intake.py
+++ b/allways/cli/swap_commands/swap_intake.py
@@ -122,6 +122,38 @@ def viable_intakes(
     return out
 
 
+def unviable_reason(
+    candidates: List[MinerCandidate],
+    from_chain: str,
+    to_chain: str,
+    from_amount: int,
+    min_swap: int,
+    max_swap: int,
+) -> str:
+    """Why nothing was quotable — the gates of ``viable_intakes``, spelled out for the taker.
+
+    Only meaningful when ``select_best_miner`` returned None for the same inputs."""
+    if not candidates:
+        return 'no miner offers this direction'
+    reasons: List[str] = []
+    for c in candidates:
+        try:
+            rate = float(c.rate_display)
+        except (TypeError, ValueError):
+            continue
+        if not is_executable_rate(rate, from_chain, to_chain, min_swap, max_swap):
+            reasons.append('rate not executable')
+            continue
+        amts = compute_intake_amounts(from_chain, to_chain, from_amount, c.rate_display)
+        if amts.to_amount <= 0:
+            reasons.append('amount too small')
+            continue
+        ok, why = swap_viable(amts.collateral_amount, c.collateral, min_swap, max_swap)
+        if not ok:
+            reasons.append(why)
+    return '; '.join(dict.fromkeys(reasons)) or 'no executable quote'
+
+
 def select_best_miner(
     candidates: List[MinerCandidate],
     from_chain: str,

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -20,6 +20,7 @@ from allways.cli.swap_commands.swap_intake import (
     rate_display_from_fixed,
     select_best_miner,
     swap_viable,
+    unviable_reason,
 )
 from allways.solana.client import contract_reject_reason, swap_key_from_tx_hash
 from allways.validator.binding import hotkey_ss58, verify_binding
@@ -376,6 +377,21 @@ def best_quote(validator, from_chain: str, to_chain: str, from_amount: int) -> O
     )
     if best is None:
         return None
+    return _best_quote_result(validator, best)
+
+
+def quote_rejection_reason(validator, from_chain: str, to_chain: str, from_amount: int) -> str:
+    """Why ``best_quote`` came back empty — same candidates, same gates, spelled out."""
+    client = validator.solana_client
+    cfg = client.get_config()
+    min_swap = int(getattr(cfg, 'min_swap_amount', 0) or 0)
+    max_swap = int(getattr(cfg, 'max_swap_amount', 0) or 0)
+    return unviable_reason(
+        candidate_miners(client, from_chain, to_chain), from_chain, to_chain, from_amount, min_swap, max_swap
+    )
+
+
+def _best_quote_result(validator, best) -> Optional[BestQuote]:
     cand, amts = best
     hotkey = _miner_hotkey_for(validator, cand.miner)
     if hotkey is None:

--- a/allways/validator/seam_http.py
+++ b/allways/validator/seam_http.py
@@ -19,6 +19,7 @@ import bittensor as bt
 from allways.validator.reserve_engine import (
     best_quote,
     confirm_deposit,
+    quote_rejection_reason,
     reserve_on_behalf,
     scan_deposit,
     swap_status,
@@ -58,7 +59,8 @@ def _make_handler(validator, secret: str):
                 if url.path == '/rate':
                     bq = best_quote(validator, q['from'], q['to'], int(q['amount']))
                     if bq is None:
-                        return self._send(404, {'error': 'no executable quote for that pair/amount'})
+                        reason = quote_rejection_reason(validator, q['from'], q['to'], int(q['amount']))
+                        return self._send(404, {'error': reason})
                     return self._send(200, bq.__dict__)
                 if url.path == '/status':
                     # Optional swap_key (hex, persisted by the consumer at claim time) resolves the

--- a/tests/test_swap_intake.py
+++ b/tests/test_swap_intake.py
@@ -14,6 +14,7 @@ from allways.cli.swap_commands.swap_intake import (
     select_best_miner,
     swap_viable,
     to_smallest_units,
+    unviable_reason,
     viable_intakes,
 )
 
@@ -171,3 +172,21 @@ def test_candidate_miners_excludes_inactive():
     out = candidate_miners(client, 'tao', 'sol')
     assert [c.miner for c in out] == ['active-m']
     assert out[0].collateral == 976_466_670  # tracked field, not vault lamports
+
+
+def test_unviable_reason_below_min_swap():
+    # 0.1 TAO at 1.2 TAO/SOL → 0.0833 SOL leg, under a 0.1 SOL min — the exact taker-facing case.
+    cands = [MinerCandidate(miner='m', rate_display='1.2', collateral=2 * SOL)]
+    assert select_best_miner(cands, 'tao', 'sol', 100_000_000, SOL // 10, SOL) is None
+    reason = unviable_reason(cands, 'tao', 'sol', 100_000_000, SOL // 10, SOL)
+    assert 'below min swap' in reason
+
+
+def test_unviable_reason_no_direction():
+    assert unviable_reason([], 'tao', 'sol', SOL, 0, 0) == 'no miner offers this direction'
+
+
+def test_unviable_reason_collateral():
+    cands = [MinerCandidate(miner='m', rate_display='1.0', collateral=SOL // 10)]
+    reason = unviable_reason(cands, 'tao', 'sol', 1_000_000_000, 0, 0)
+    assert 'collateral too low' in reason


### PR DESCRIPTION
Seam /rate collapsed every rejection into "no executable quote for that pair/amount". A taker swapping 0.1 TAO->SOL on testnet (SOL leg 0.083, under the 0.1 SOL min_swap) saw the same message as a direction nobody quotes — indistinguishable from an outage.

Adds unviable_reason() beside viable_intakes() in swap_intake.py — same candidates, same gates, but it reports which one failed (direction unquoted / rate not executable / below min swap / above max swap / miner collateral too low). The seam's 404 body now carries that reason via quote_rejection_reason(); the happy path is untouched (best_quote's tail split into _best_quote_result, no behavior change).

Tests: below-min (the exact 0.1 TAO case), no-direction, and collateral reasons; full test_swap_intake + test_seam_http suites pass (28) in the entrius/allways:test image.