### PR TITLE
Phrase swap bounds in the taker's source asset

### DIFF
--- a/allways/cli/swap_commands/swap_intake.py
+++ b/allways/cli/swap_commands/swap_intake.py
@@ -82,17 +82,34 @@ def compute_intake_amounts(from_chain: str, to_chain: str, from_amount: int, rat
     return IntakeAmounts(collateral_amount=collateral_amount, from_amount=from_amount, to_amount=to_amount)
 
 
-def swap_viable(collateral_amount: int, collateral: int, min_swap: int, max_swap: int) -> Tuple[bool, str]:
-    """Pre-flight the contract's open_or_request guards (bounds + collateral). Reason empty on success.
+# swap_gate verdicts — the contract's open_or_request guards as data, formatted by the caller.
+GATE_BELOW_MIN = 'below_min'
+GATE_ABOVE_MAX = 'above_max'
+GATE_LOW_COLLATERAL = 'low_collateral'
+
+
+def swap_gate(collateral_amount: int, collateral: int, min_swap: int, max_swap: int) -> str:
+    """Pre-flight the contract's open_or_request guards (bounds + collateral). '' when viable.
 
     Bounds are SOL lamports (0 = unset sentinel → that side not enforced)."""
     if min_swap > 0 and collateral_amount < min_swap:
-        return False, f'below min swap ({min_swap / 1e9:.4f} SOL)'
+        return GATE_BELOW_MIN
     if max_swap > 0 and collateral_amount > max_swap:
+        return GATE_ABOVE_MAX
+    if collateral < required_collateral(collateral_amount):
+        return GATE_LOW_COLLATERAL
+    return ''
+
+
+def swap_viable(collateral_amount: int, collateral: int, min_swap: int, max_swap: int) -> Tuple[bool, str]:
+    """``swap_gate`` with SOL-denominated messages — the miner/CLI-facing phrasing."""
+    gate = swap_gate(collateral_amount, collateral, min_swap, max_swap)
+    if gate == GATE_BELOW_MIN:
+        return False, f'below min swap ({min_swap / 1e9:.4f} SOL)'
+    if gate == GATE_ABOVE_MAX:
         return False, f'above max swap ({max_swap / 1e9:.4f} SOL)'
-    needed = required_collateral(collateral_amount)
-    if collateral < needed:
-        return False, f'miner collateral too low (needs {needed / 1e9:.4f} SOL)'
+    if gate == GATE_LOW_COLLATERAL:
+        return False, f'miner collateral too low (needs {required_collateral(collateral_amount) / 1e9:.4f} SOL)'
     return True, ''
 
 
@@ -117,7 +134,7 @@ def viable_intakes(
         amts = compute_intake_amounts(from_chain, to_chain, from_amount, c.rate_display)
         if amts.to_amount <= 0:
             continue
-        if swap_viable(amts.collateral_amount, c.collateral, min_swap, max_swap)[0]:
+        if not swap_gate(amts.collateral_amount, c.collateral, min_swap, max_swap):
             out.append((c, amts))
     return out
 
@@ -132,16 +149,6 @@ def _bound_in_source(bound_lamports: int, from_chain: str, rate_display: str) ->
         return sol
     src_amount = bound_lamports / 1e9 * float(rate_display)
     return f'≈{src_amount:.6g} {from_chain.upper()} ({sol} leg)'
-
-
-def _taker_reason(why: str, from_chain: str, rate_display: str, min_swap: int, max_swap: int) -> str:
-    """Rephrase ``swap_viable``'s SOL-denominated bound reasons for the taker. Prefix-coupled to
-    swap_viable's strings — pinned by test_unviable_reason_below_min_swap."""
-    if why.startswith('below min swap'):
-        return f'below min swap ({_bound_in_source(min_swap, from_chain, rate_display)})'
-    if why.startswith('above max swap'):
-        return f'above max swap ({_bound_in_source(max_swap, from_chain, rate_display)})'
-    return why
 
 
 def unviable_reason(
@@ -170,9 +177,14 @@ def unviable_reason(
         if amts.to_amount <= 0:
             reasons.append('amount too small')
             continue
-        ok, why = swap_viable(amts.collateral_amount, c.collateral, min_swap, max_swap)
-        if not ok:
-            reasons.append(_taker_reason(why, from_chain, c.rate_display, min_swap, max_swap))
+        gate = swap_gate(amts.collateral_amount, c.collateral, min_swap, max_swap)
+        if gate == GATE_BELOW_MIN:
+            reasons.append(f'below min swap ({_bound_in_source(min_swap, from_chain, c.rate_display)})')
+        elif gate == GATE_ABOVE_MAX:
+            reasons.append(f'above max swap ({_bound_in_source(max_swap, from_chain, c.rate_display)})')
+        elif gate == GATE_LOW_COLLATERAL:
+            needed = required_collateral(amts.collateral_amount)
+            reasons.append(f'miner collateral too low (needs {needed / 1e9:.4f} SOL)')
     return '; '.join(dict.fromkeys(reasons)) or 'no executable quote'
 
 

--- a/allways/cli/swap_commands/swap_intake.py
+++ b/allways/cli/swap_commands/swap_intake.py
@@ -122,6 +122,28 @@ def viable_intakes(
     return out
 
 
+def _bound_in_source(bound_lamports: int, from_chain: str, rate_display: str) -> str:
+    """A SOL-leg bound phrased in the taker's source asset at this candidate's canonical rate.
+
+    Bounds are contract facts in SOL lamports; takers think in what they're sending. Display
+    conversion only (float, marked ≈) — never fed back into any gate."""
+    sol = f'{bound_lamports / 1e9:.4f} {NUMERAIRE_CHAIN.upper()}'
+    if from_chain == NUMERAIRE_CHAIN:
+        return sol
+    src_amount = bound_lamports / 1e9 * float(rate_display)
+    return f'≈{src_amount:.6g} {from_chain.upper()} ({sol} leg)'
+
+
+def _taker_reason(why: str, from_chain: str, rate_display: str, min_swap: int, max_swap: int) -> str:
+    """Rephrase ``swap_viable``'s SOL-denominated bound reasons for the taker. Prefix-coupled to
+    swap_viable's strings — pinned by test_unviable_reason_below_min_swap."""
+    if why.startswith('below min swap'):
+        return f'below min swap ({_bound_in_source(min_swap, from_chain, rate_display)})'
+    if why.startswith('above max swap'):
+        return f'above max swap ({_bound_in_source(max_swap, from_chain, rate_display)})'
+    return why
+
+
 def unviable_reason(
     candidates: List[MinerCandidate],
     from_chain: str,
@@ -150,7 +172,7 @@ def unviable_reason(
             continue
         ok, why = swap_viable(amts.collateral_amount, c.collateral, min_swap, max_swap)
         if not ok:
-            reasons.append(why)
+            reasons.append(_taker_reason(why, from_chain, c.rate_display, min_swap, max_swap))
     return '; '.join(dict.fromkeys(reasons)) or 'no executable quote'
 
 

--- a/tests/test_swap_intake.py
+++ b/tests/test_swap_intake.py
@@ -176,10 +176,20 @@ def test_candidate_miners_excludes_inactive():
 
 def test_unviable_reason_below_min_swap():
     # 0.1 TAO at 1.2 TAO/SOL → 0.0833 SOL leg, under a 0.1 SOL min — the exact taker-facing case.
+    # The bound must read in the SOURCE asset: 0.1 SOL × 1.2 TAO/SOL = 0.12 TAO.
     cands = [MinerCandidate(miner='m', rate_display='1.2', collateral=2 * SOL)]
     assert select_best_miner(cands, 'tao', 'sol', 100_000_000, SOL // 10, SOL) is None
     reason = unviable_reason(cands, 'tao', 'sol', 100_000_000, SOL // 10, SOL)
     assert 'below min swap' in reason
+    assert '≈0.12 TAO' in reason
+    assert '0.1000 SOL leg' in reason
+
+
+def test_unviable_reason_sol_source_stays_exact():
+    # SOL is the bounded asset itself — no ≈ conversion, just the exact bound.
+    cands = [MinerCandidate(miner='m', rate_display='1.2', collateral=2 * SOL)]
+    reason = unviable_reason(cands, 'sol', 'tao', SOL // 20, SOL // 10, SOL)
+    assert reason == 'below min swap (0.1000 SOL)'
 
 
 def test_unviable_reason_no_direction():


### PR DESCRIPTION
Follow-up to #610: bound rejections read in what the taker is sending — `below min swap (≈0.12 TAO (0.1000 SOL leg))` for tao→sol instead of SOL-only; exact `0.1000 SOL` (no ≈) when SOL is the source. Same for above-max.

Conversion is display-only float at each candidate's canonical rate, never fed into a gate; swap_viable itself is untouched (its strings are the contract mirror, prefix-coupling pinned by test).

Tests: 29/29 (test_swap_intake + test_seam_http) in the entrius/allways:test image; ruff clean.