### PR TITLE
Drop 'trustless' from the package description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "allways"
 version = "2.1.0"
-description = "Allways - Universal Transaction Layer: Trustless cross-chain swaps on Bittensor Subnet 7"
+description = "Allways - Universal Transaction Layer: Collateral-backed cross-chain swaps on Bittensor Subnet 7"
 license = "MIT"
 requires-python = ">=3.10,<3.15"
 authors = [{ name = "Allways" }]


### PR DESCRIPTION
## Summary

One-line follow-up to #605. The README and CLI disclaimers were corrected there, but `pyproject.toml`'s package description still read "Trustless cross-chain swaps on Bittensor Subnet 7" — and that string is a public marketing surface (PyPI listing, `pip show allways`). Replaced with the collateral-backed framing used everywhere else post-#605.

`grep -ri trustless` across the repo now returns nothing.