### PR TITLE
Depth-weighted crown rate band (CROWN_RATE_BAND)

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -32,6 +32,13 @@ RATE_PRECISION = 10**18
 # stored, and the validator floors on ingest to close the pre-redeploy migration window. Below
 # this precision an undercut is imperceptible to takers, so the crown ignores it (equal buckets tie).
 RATE_SIG_FIGS = 5
+# Crown rate band: quotes within this fraction of the best qualified rate share the
+# crown in proportion to collateral depth instead of losing outright to a one-tick
+# undercut. Sized from mainnet data: absorbs quote staleness (~0.03% median executed-rate
+# drift inside an hour) and rate gaps takers demonstrably ignore (~0.5%), while staying
+# far below genuine pricing tiers (~2.6% between quote clusters) so a materially better
+# rate still evicts the band and takes the crown outright. 0 restores exact-tie behaviour.
+CROWN_RATE_BAND = 0.005
 
 # ─── Transaction Fees ────────────────────────────────────
 # Small headroom kept aside for extrinsic fees so a deposit doesn't burn gas

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -25,6 +25,7 @@ from allways.classes import ActivityTransition, MinerActivity, next_activity
 from allways.constants import (
     CAPACITY_CURVE_EXPONENT,
     CLEARING_RETENTION_SECS,
+    CROWN_RATE_BAND,
     DIRECTION_POOLS,
     MAX_FAILED_SWAPS,
     MAX_SCORING_BACKFILL_SECS,
@@ -337,7 +338,7 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
     # replay_crown_time_window is a no-op when intervals_out is None, so
     # disabled validators pay zero cost here.
     storage_enabled = self.database_storage.is_enabled()
-    intervals_by_dir: Dict[Tuple[str, str], List[Tuple[int, int, List[str], float]]] = {}
+    intervals_by_dir: Dict[Tuple[str, str], List[Tuple[int, int, Dict[str, float], float]]] = {}
     try:
         max_swap_amount = int(self.solana_config_cache.max_swap_amount())
     except Exception as e:
@@ -358,7 +359,7 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
     for (from_chain, to_chain), pool in pools.items():
         trace = DirectionTrace(pool=pool)
         direction_traces[(from_chain, to_chain)] = trace
-        intervals: Optional[List[Tuple[int, int, List[str], float]]] = None
+        intervals: Optional[List[Tuple[int, int, Dict[str, float], float]]] = None
         if storage_enabled:
             intervals = []
             intervals_by_dir[(from_chain, to_chain)] = intervals
@@ -654,6 +655,26 @@ def crown_can_fund(hotkey, rate, from_chain, to_chain, min_swap_lamports, max_sw
     return min_leg == 0 or collaterals.get(hotkey, 0) >= required_collateral(min_leg)
 
 
+def crown_depth_shares(
+    holders: List[str],
+    collaterals: Dict[str, int],
+    max_swap_lamports: int,
+) -> Dict[str, float]:
+    """Split one interval's crown credit across band holders in proportion to
+    collateral depth, so matching the leader's rate earns share only to the
+    extent it is backed — depth becomes something a rival can take from you.
+    Depth is capped at ``required_collateral(max_swap)``: collateral past a
+    full-capacity fill buys no extra share (same never-pay-to-win bound
+    ``capacity_factor`` applies at 1.0). All-zero depth (bounds unset in tests,
+    or a band of unknown collaterals) falls back to an even split."""
+    cap = required_collateral(max_swap_lamports) if max_swap_lamports > 0 else None
+    depths = {hk: min(collaterals.get(hk, 0), cap) if cap else collaterals.get(hk, 0) for hk in holders}
+    total = sum(depths.values())
+    if total <= 0:
+        return {hk: 1.0 / len(holders) for hk in holders}
+    return {hk: depth / total for hk, depth in depths.items()}
+
+
 def make_crown_predicates(from_chain, to_chain, min_swap_lamports, max_swap_lamports, collaterals):
     """Crown-eligibility predicates ``(executable_check, can_fund)`` shared by the
     scoring replay and the live snapshot, so the live crown view can never diverge
@@ -686,13 +707,16 @@ def replay_crown_time_window(
     window_end: int,
     rewardable_hotkeys: Set[str],
     trace: Optional[DirectionTrace] = None,
-    intervals_out: Optional[List[Tuple[int, int, List[str], float]]] = None,
+    intervals_out: Optional[List[Tuple[int, int, Dict[str, float], float]]] = None,
     min_swap_lamports: int = 0,
     max_swap_lamports: int = 0,
+    rate_band: float = CROWN_RATE_BAND,
 ) -> Dict[str, float]:
     """Walk the merged event stream, return ``{hotkey: crown_seconds_float}``.
-    Among miners tied on the best rate the crown goes to the deepest collateral;
-    only a dead-heat on both rate and collateral splits evenly. A miner qualifies for crown
+    Every qualified miner within ``rate_band`` of the best qualified rate holds
+    the crown together, splitting each interval by collateral depth
+    (``crown_depth_shares``); band 0 narrows the holder set to the exact best
+    rate, where depth still apportions any tie. A miner qualifies for crown
     at an instant iff they are on the current metagraph, were active at
     that instant, in a rewardable activity state (∈ REWARD_MINER_STATES — a
     reserved/fulfilling miner forfeits), had a positive rate posted, and their
@@ -748,6 +772,7 @@ def replay_crown_time_window(
             lower_rate_wins=lower_rate_wins,
             executable_rate_check=executable_check,
             can_fund_at_rate=can_fund if bounds_set else None,
+            rate_band=rate_band,
         )
         if not holders:
             if trace is not None:
@@ -756,16 +781,15 @@ def replay_crown_time_window(
         winner_rate = rates_for_instant.get(holders[0], 0.0)
         if trace is not None and winner_rate > 0:
             trace.best_rate = winner_rate
-        # Among holders tied on the best rate, the crown goes to the deepest collateral:
-        # matching the leader's rate only earns if you also back it with the most depth,
-        # so posting a sharp quote on a sliver no longer wins a free share. A genuine
-        # dead-heat — same rate AND same collateral — still splits evenly.
-        max_coll = max(collaterals.get(hk, 0) for hk in holders)
-        winners = [hk for hk in holders if collaterals.get(hk, 0) == max_coll]
+        # Holders are every qualified miner within CROWN_RATE_BAND of the best
+        # rate; the interval splits across them by collateral depth, so a
+        # one-tick undercut no longer takes the crown outright and depth is the
+        # axis a rival must beat you on inside the band.
+        shares = crown_depth_shares(holders, collaterals, max_swap_lamports)
         if intervals_out is not None:
-            intervals_out.append((interval_start, interval_end, list(winners), winner_rate))
-        split = duration / len(winners)
-        for hk in winners:
+            intervals_out.append((interval_start, interval_end, dict(shares), winner_rate))
+        for hk, share in shares.items():
+            split = duration * share
             crown_time[hk] = crown_time.get(hk, 0.0) + split
             # Unknown collateral counts as zero, matching can_fund's fail-closed
             # (the reconcile seeds a baseline for every bound active miner);
@@ -873,39 +897,39 @@ def snapshot_current_crown_holders(
             lower_rate_wins=lower_rate_wins,
             executable_rate_check=executable_check,
             can_fund_at_rate=can_fund if bounds_set else None,
+            rate_band=CROWN_RATE_BAND,
         )
         if holders:
-            # Same rate tie-break as the scoring replay: the deepest collateral among
-            # tied-rate holders takes the crown, so the live table agrees with what the
-            # round scorer will credit. A dead-heat on both rate and collateral still splits.
-            max_coll = max(collaterals.get(hk, 0) for hk in holders)
-            winners = [hk for hk in holders if collaterals.get(hk, 0) == max_coll]
-            share = 1.0 / len(winners)
-            rate = rates.get(winners[0], 0.0)
-            rows_by_direction[(from_chain, to_chain)] = [(from_chain, to_chain, hk, share, rate, ts) for hk in winners]
+            # Same band + depth split as the scoring replay, so the live table agrees
+            # with what the round scorer will credit. Every row carries the band's
+            # anchor (best) rate — the direction's crown rate as a taker sees it.
+            shares = crown_depth_shares(holders, collaterals, max_swap_amount)
+            rate = rates.get(holders[0], 0.0)
+            rows_by_direction[(from_chain, to_chain)] = [
+                (from_chain, to_chain, hk, share, rate, ts) for hk, share in shares.items()
+            ]
         else:
             rows_by_direction[(from_chain, to_chain)] = []
     return rows_by_direction
 
 
 def intervals_to_crown_rows(
-    intervals: List[Tuple[int, int, List[str], float]],
+    intervals: List[Tuple[int, int, Dict[str, float], float]],
     from_chain: str,
     to_chain: str,
 ) -> List[Tuple[int, int, str, str, str, float, float]]:
     """Convert uniform-state crown intervals to crown_holders rows.
 
-    For each (started_at, ended_at, holders, rate) emit one row per holder
-    with credit = 1/len(holders), so the per-interval per-direction credits
-    sum to 1.0 — the validator's fair-tie semantics. A holder's crown *time*
+    For each (started_at, ended_at, shares, rate) emit one row per holder
+    carrying its depth-proportional credit (``crown_depth_shares`` output, so
+    per-interval per-direction credits sum to 1.0). A holder's crown *time*
     over a window is then ``SUM((ended_at - started_at) * credit)``, matching
     the duration the scoring replay already integrates (no per-tick expansion)."""
     rows: List[Tuple[int, int, str, str, str, float, float]] = []
-    for lo, hi, holders, rate in intervals:
-        if not holders or hi <= lo:
+    for lo, hi, shares, rate in intervals:
+        if not shares or hi <= lo:
             continue
-        share = 1.0 / len(holders)
-        for hotkey in holders:
+        for hotkey, share in shares.items():
             rows.append((lo, hi, from_chain, to_chain, hotkey, share, rate))
     return rows
 
@@ -918,11 +942,18 @@ def crown_holders_at_instant(
     lower_rate_wins: bool = False,
     executable_rate_check: Optional[Callable[[float], bool]] = None,
     can_fund_at_rate: Optional[Callable[[str, float], bool]] = None,
+    rate_band: float = 0.0,
 ) -> List[str]:
     """Take the miners posting the best rate, but only if they satisfy every
     other condition (rewardable, active, activity ∈ REWARD_MINER_STATES, rate >
     0, executable). If the best rate has no qualified miner, fall through to the
     next-best rate.
+
+    ``rate_band`` widens the winning set: every qualified miner whose rate is
+    within that fraction of the best *qualified* rate is a holder (best first).
+    The anchor is the best qualified rate, not the best posted one — an
+    unqualified sentinel can't drag the band out of everyone else's reach.
+    0 keeps the historical exact-best-rate behaviour.
 
     ``lower_rate_wins`` flips the sort: rates are stored as canonical_dest
     per canonical_source (TAO per BTC), so higher-is-better only holds in
@@ -969,9 +1000,20 @@ def crown_holders_at_instant(
         if rate > 0:
             by_rate.setdefault(rate, []).append(hotkey)
 
-    for rate in sorted(by_rate, reverse=not lower_rate_wins):
+    ordered = sorted(by_rate, reverse=not lower_rate_wins)
+    for i, rate in enumerate(ordered):
         winners = [hk for hk in by_rate[rate] if qualifies(hk)]
-        if winners:
-            return winners
+        if not winners:
+            continue
+        if rate_band > 0:
+            # Anchor at the best qualified rate, then sweep worse levels while
+            # they stay inside the band. Levels are already sorted best-first,
+            # so the first out-of-band level ends the sweep.
+            edge = rate * (1 + rate_band) if lower_rate_wins else rate * (1 - rate_band)
+            for worse in ordered[i + 1 :]:
+                if (worse > edge) if lower_rate_wins else (worse < edge):
+                    break
+                winners.extend(hk for hk in by_rate[worse] if qualifies(hk))
+        return winners
 
     return []

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -28,6 +28,7 @@ from allways.validator.scoring import (
     calculate_miner_rewards,
     compute_direction_pools,
     crown_can_fund,
+    crown_depth_shares,
     crown_holders_at_instant,
     due_for_scoring,
     is_eligible,
@@ -473,6 +474,55 @@ class TestCrownHoldersHelper:
         sentinel still wins. Ensures existing callers aren't surprised."""
         rates = {'sentinel': 1e10, 'sane': 326.0}
         assert crown_holders_at_instant(rates, {'sentinel', 'sane'}) == ['sentinel']
+
+
+class TestCrownRateBand:
+    """rate_band semantics: qualified quotes within the band of the best
+    qualified rate hold the crown together, anchor first."""
+
+    def test_near_rates_join_band_higher_wins(self):
+        # b is 0.45% off the leader (inside a 0.5% band); c at 1.5% stays out.
+        rates = {'a': 0.00020, 'b': 0.0001991, 'c': 0.000197}
+        holders = crown_holders_at_instant(rates, {'a', 'b', 'c'}, rate_band=0.005)
+        assert holders == ['a', 'b']
+
+    def test_near_rates_join_band_lower_wins(self):
+        # Lower is better: b asks 0.4% more (inside), c 1.2% more (outside).
+        rates = {'a': 250.0, 'b': 251.0, 'c': 253.0}
+        holders = crown_holders_at_instant(rates, {'a', 'b', 'c'}, lower_rate_wins=True, rate_band=0.005)
+        assert holders == ['a', 'b']
+
+    def test_band_anchors_on_best_qualified_rate(self):
+        # A busy leader can't drag the band out of everyone else's reach: the
+        # anchor is the best *qualified* rate, and the band opens around it.
+        rates = {'busy': 0.00030, 'a': 0.00020, 'b': 0.0001995}
+        holders = crown_holders_at_instant(rates, {'busy', 'a', 'b'}, rewardable_by_state={'a', 'b'}, rate_band=0.005)
+        assert holders == ['a', 'b']
+
+    def test_unqualified_band_member_excluded(self):
+        rates = {'a': 0.00020, 'b': 0.0001995}
+        holders = crown_holders_at_instant(rates, {'a', 'b'}, rewardable_by_state={'a'}, rate_band=0.005)
+        assert holders == ['a']
+
+    def test_band_zero_keeps_exact_best_only(self):
+        rates = {'a': 0.00020, 'b': 0.00019999}
+        assert crown_holders_at_instant(rates, {'a', 'b'}, rate_band=0.0) == ['a']
+
+
+class TestCrownDepthShares:
+    def test_proportional_to_collateral(self):
+        shares = crown_depth_shares(['a', 'b'], {'a': 300, 'b': 100}, 0)
+        assert shares == {'a': 0.75, 'b': 0.25}
+
+    def test_depth_capped_at_full_capacity(self):
+        # 2 SOL vs the 0.55 cap for a 0.5 max_swap: collateral past a
+        # full-capacity fill buys no extra share (never pay-to-win).
+        shares = crown_depth_shares(['whale', 'full'], {'whale': 2_000_000_000, 'full': 550_000_000}, 500_000_000)
+        assert shares == {'whale': 0.5, 'full': 0.5}
+
+    def test_all_zero_depth_splits_evenly(self):
+        shares = crown_depth_shares(['a', 'b'], {}, 500_000_000)
+        assert shares == {'a': 0.5, 'b': 0.5}
 
 
 class TestReplayCrownTime:
@@ -1840,10 +1890,11 @@ class TestCapacityWeighting:
         np.testing.assert_allclose(rewards[recycle_uid], 1.0, atol=1e-6)
         v.state_store.close()
 
-    def test_rate_tie_broken_by_collateral(self, tmp_path: Path):
-        """Two miners tie on the best rate with unequal collateral → the crown does NOT
-        split; the deeper miner takes the whole interval (tie-break #2). hk_a (deeper,
-        full capacity) earns the entire pool; hk_b earns nothing."""
+    def test_rate_tie_splits_by_collateral_depth(self, tmp_path: Path):
+        """Two miners tie on the best rate with unequal collateral → the crown splits in
+        proportion to depth (crown_depth_shares). hk_a at full capacity for max_swap 500M
+        (550M = the depth cap) takes 5/6 of the crown; hk_b's 110M takes 1/6, further
+        shrunk by its thin capacity multiplier ((110/550)^2 = 0.04)."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a', 'hk_b'])
         v = make_validator(
             tmp_path,
@@ -1859,13 +1910,39 @@ class TestCapacityWeighting:
             )
         conn.commit()
         rewards, _ = calculate_miner_rewards(v, v.block)
-        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL, atol=1e-6)
-        np.testing.assert_allclose(rewards[1], 0.0, atol=1e-6)
+        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * (5 / 6), atol=1e-6)
+        np.testing.assert_allclose(rewards[1], POOL_BTC_SOL * (1 / 6) * 0.04, atol=1e-6)
+        v.state_store.close()
+
+    def test_thin_undercut_inside_band_shares_instead_of_taking_all(self, tmp_path: Path):
+        """The headline CROWN_RATE_BAND behaviour: a thin miner posting the best rate
+        by a hair (0.4%, inside the band) no longer takes the whole crown from the
+        deep miner behind it — the interval splits by depth, 5/6 to the deep quote.
+        A third quote 1.5% off stays outside the band and earns nothing. btc→sol
+        rates are TAO-per-BTC-style asks, so lower is better: hk_thin leads."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_thin', 'hk_deep', 'hk_far'])
+        v = make_validator(
+            tmp_path,
+            hotkeys,
+            max_swap_amount=500_000_000,
+            collaterals={'hk_thin': 110_000_000, 'hk_deep': 550_000_000, 'hk_far': 550_000_000},
+        )
+        conn = v.state_store.require_connection()
+        for hk, rate in (('hk_thin', 0.000197), ('hk_deep', 0.0001979), ('hk_far', 0.00020)):
+            conn.execute(
+                'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+                (hk, 'btc', 'sol', rate, 0),
+            )
+        conn.commit()
+        rewards, _ = calculate_miner_rewards(v, v.block)
+        np.testing.assert_allclose(rewards[0], POOL_BTC_SOL * (1 / 6) * 0.04, atol=1e-6)
+        np.testing.assert_allclose(rewards[1], POOL_BTC_SOL * (5 / 6), atol=1e-6)
+        np.testing.assert_allclose(rewards[2], 0.0, atol=1e-6)
         v.state_store.close()
 
     def test_rate_and_collateral_dead_heat_splits_evenly(self, tmp_path: Path):
-        """Same best rate AND same collateral → genuine dead-heat still splits the crown
-        evenly. Collateral only breaks the tie when it differs."""
+        """Same best rate AND same collateral → equal depth shares split the crown
+        evenly, the degenerate case of the proportional split."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a', 'hk_b'])
         v = make_validator(
             tmp_path,


### PR DESCRIPTION
## What

Generalizes the crown's exact-rate tie-break into a **rate band**: every qualified miner whose quote is within `CROWN_RATE_BAND` (0.5%) of the best qualified rate holds the crown together, and each interval's credit splits **in proportion to collateral depth** via the new `crown_depth_shares` helper.

- A one-tick undercut no longer takes 100% of a direction from a deep miner — evicting the band requires a rate **more than 0.5% better**, so depth becomes the contested axis inside the band while genuinely better pricing still wins outright.
- Depth is capped at `required_collateral(max_swap)` — collateral beyond a full-capacity fill buys no extra share (same never-pay-to-win bound `capacity_factor` applies at 1.0).
- Proportional splitting is sybil-neutral: splitting one collateral pile across N hotkeys yields exactly the same total share, minus N× the fee overhead.
- `CROWN_RATE_BAND = 0` restores exact-best-rate behaviour (band off), tunable in `constants.py` without redeploy.

## Why 0.5%

Sized empirically from all 2,011 completed mainnet swaps + live quote ladders (2026-08-03):

| anchor | value | role |
|---|---|---|
| rate tick (5 sig figs) | 0.002–0.01% | sniping granularity the band must dwarf |
| median executed-rate drift, <1h | 0.004–0.03% | honest quote staleness the band must absorb |
| rate distance takers actually accepted (p50–p75 vs same-6h-bucket best) | 0.02–1.5% | differences below ~0.5% demonstrably don't decide routing |
| gap to the next genuine quote tier | ~2.6% | materially worse pricing the band must exclude |

The live SOL-TAO ladder's competitive cluster ends at ~0.75% from best; every band width from 0.75% to 2.5% produces identical membership today, and ≥3% starts crediting the 2.6%-worse tier. 0.5% keeps band escape economically live (a genuinely better-priced miner can post +0.6% and take the crown alone) while ending one-tick crown theft.

## Consistency

The scoring replay (`credit_interval`), the live snapshot (`snapshot_current_crown_holders`), and the persisted intervals (`intervals_to_crown_rows`) all flow through the same `crown_holders_at_instant(rate_band=…)` + `crown_depth_shares` pair, so the dashboard tip cannot diverge from the rewarded ledger. Interval rows now carry per-holder proportional credit (still sums to 1.0 per interval, same DB shape); snapshot rows all carry the band's anchor rate.

## Behaviour change

`test_rate_tie_broken_by_collateral` (deepest-takes-all on exact tie) is superseded by `test_rate_tie_splits_by_collateral_depth` — an exact tie now splits by depth rather than awarding the whole interval to the deepest miner. Dead-heats on rate + collateral still split evenly (degenerate case of the proportional split).

## Tests

- Band membership: near-rates join (both sort directions), band anchors on best *qualified* rate (a busy leader can't strand the band), unqualified members excluded, band 0 = exact-only.
- `crown_depth_shares`: proportional split, full-capacity depth cap, all-zero-depth even fallback.
- End-to-end: thin 0.4% undercut inside the band shares 1/6 instead of taking all; deep quote keeps 5/6; a 1.5% quote outside the band earns nothing.
- Full suite: 848 passed.

## Out of scope (follow-ups)

- allways-db / UI: crown snapshot & holder rows are shape-compatible but the UI may want to render multiple concurrent holders with fractional credit.
- `min_collateral` raise (admin tx, no code) and any ε retune once post-band equilibrium data exists — the two levers are deliberately independent.
