### PR TITLE
Serve rate depth levels alongside /rate

### DIFF
--- a/allways/cli/swap_commands/swap_intake.py
+++ b/allways/cli/swap_commands/swap_intake.py
@@ -11,8 +11,14 @@ from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
 from allways.chains import canonical_pair, get_chain
-from allways.constants import NUMERAIRE_CHAIN, RATE_PRECISION, required_collateral
-from allways.utils.rate import calculate_to_amount, is_executable_rate, normalize_rate, quantize_rate_fixed
+from allways.constants import COLLATERAL_REQUIREMENT_BPS, NUMERAIRE_CHAIN, RATE_PRECISION, required_collateral
+from allways.utils.rate import (
+    calculate_to_amount,
+    is_executable_rate,
+    max_from_for_to_cap,
+    normalize_rate,
+    quantize_rate_fixed,
+)
 
 
 @dataclass
@@ -137,6 +143,36 @@ def viable_intakes(
         if not swap_gate(amts.collateral_amount, c.collateral, min_swap, max_swap):
             out.append((c, amts))
     return out
+
+
+def max_intake_from_amount(
+    candidate: MinerCandidate,
+    from_chain: str,
+    to_chain: str,
+    min_swap: int,
+    max_swap: int,
+) -> int:
+    """Largest source amount (smallest units) this candidate can execute right now — the depth behind
+    its rate. The same gates as ``viable_intakes``, solved for size instead of checked at one: the
+    collateral requirement inverted exactly, clamped by ``max_swap``, 0 when even ``min_swap`` doesn't fit."""
+    try:
+        rate = float(candidate.rate_display)
+    except (TypeError, ValueError):
+        return 0
+    if not is_executable_rate(rate, from_chain, to_chain, min_swap, max_swap):
+        return 0
+    # Largest SOL leg with required_collateral(leg) <= collateral — exact inverse of the 1.1× floor.
+    cap = ((candidate.collateral + 1) * 10_000 - 1) // COLLATERAL_REQUIREMENT_BPS
+    if max_swap > 0:
+        cap = min(cap, max_swap)
+    if cap <= 0 or cap < min_swap:
+        return 0
+    if from_chain == NUMERAIRE_CHAIN:
+        return cap
+    canon_from, canon_to = canonical_pair(from_chain, to_chain)
+    return max_from_for_to_cap(
+        cap, candidate.rate_display, True, get_chain(canon_to).decimals, get_chain(canon_from).decimals
+    )
 
 
 def _bound_in_source(bound_lamports: int, from_chain: str, rate_display: str) -> str:

--- a/allways/utils/rate.py
+++ b/allways/utils/rate.py
@@ -100,6 +100,33 @@ def calculate_to_amount(
             return from_amount * rate_fixed // (RATE_PRECISION * 10 ** (-decimal_diff))
 
 
+def max_from_for_to_cap(
+    to_cap: int,
+    rate,
+    is_reverse: bool,
+    to_decimals: int,
+    from_decimals: int,
+) -> int:
+    """Largest from_amount whose ``calculate_to_amount`` stays <= ``to_cap`` — its exact floor-division
+    inverse, branch for branch, so the pair can never disagree. 0 when no positive amount fits."""
+    rate_fixed = int(rate) if isinstance(rate, int) else int(Decimal(rate) * RATE_PRECISION)
+    if rate_fixed == 0 or to_cap <= 0:
+        return 0
+    decimal_diff = to_decimals - from_decimals
+    if is_reverse:
+        if decimal_diff >= 0:
+            num, den = RATE_PRECISION, rate_fixed * 10**decimal_diff
+        else:
+            num, den = RATE_PRECISION * 10 ** (-decimal_diff), rate_fixed
+    else:
+        if decimal_diff >= 0:
+            num, den = rate_fixed * 10**decimal_diff, RATE_PRECISION
+        else:
+            num, den = rate_fixed, RATE_PRECISION * 10 ** (-decimal_diff)
+    # to = from × num // den  ⇒  largest from with from × num < (to_cap + 1) × den
+    return max(0, ((to_cap + 1) * den - 1) // num)
+
+
 def expected_swap_amounts(swap: 'SolanaSwap', fee_divisor: int) -> Tuple[int, int]:
     """Compute expected to_amount and fee-adjusted user_receives from a swap's on-chain fields.
 

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -17,11 +17,13 @@ from allways.chain_providers.base import ProviderUnreachableError
 from allways.cli.swap_commands.swap_intake import (
     candidate_miners,
     compute_intake_amounts,
+    max_intake_from_amount,
     rate_display_from_fixed,
     select_best_miner,
     swap_viable,
     unviable_reason,
 )
+from allways.constants import NUMERAIRE_CHAIN
 from allways.solana.client import contract_reject_reason, swap_key_from_tx_hash
 from allways.validator.binding import hotkey_ss58, verify_binding
 
@@ -364,31 +366,40 @@ class BestQuote:
     to_amount: int
 
 
-def best_quote(validator, from_chain: str, to_chain: str, from_amount: int) -> Optional[BestQuote]:
-    """Best executable quote for ``from_amount`` (source smallest-units): the miner giving the most dest.
+# Depth rungs served alongside /rate — enough to show the market, few enough to stay a glance.
+RATE_LEVELS_LIMIT = 5
 
-    Mirrors ``select_best_miner`` so the displayed rate == the reservable rate. None if none qualify."""
+
+@dataclass
+class RateQuote:
+    quote: Optional[BestQuote]  # best executable quote for the asked size, None if nothing fits
+    reason: str  # why quote is None ('' on a hit)
+    levels: list  # top rate rungs [{rate_display, max_from_amount}], best first
+    max_from_amount: int  # largest executable source amount across ALL quotes, not just shown rungs
+
+
+def rate_quote(validator, from_chain: str, to_chain: str, from_amount: int) -> RateQuote:
+    """Everything ``/rate`` serves, from ONE candidate scan: the best executable quote for
+    ``from_amount`` (source smallest-units; mirrors ``select_best_miner`` so the displayed rate ==
+    the reservable rate) plus the depth behind it. Rung order matches the selector's ranking (most
+    dest per source); same-rate quotes collapse to the deepest. Capacities are per-rung maxima,
+    never cumulative — a swap fills against a single miner."""
     client = validator.solana_client
     cfg = client.get_config()
     min_swap = int(getattr(cfg, 'min_swap_amount', 0) or 0)
     max_swap = int(getattr(cfg, 'max_swap_amount', 0) or 0)
-    best = select_best_miner(
-        candidate_miners(client, from_chain, to_chain), from_chain, to_chain, from_amount, min_swap, max_swap
-    )
-    if best is None:
-        return None
-    return _best_quote_result(validator, best)
-
-
-def quote_rejection_reason(validator, from_chain: str, to_chain: str, from_amount: int) -> str:
-    """Why ``best_quote`` came back empty — same candidates, same gates, spelled out."""
-    client = validator.solana_client
-    cfg = client.get_config()
-    min_swap = int(getattr(cfg, 'min_swap_amount', 0) or 0)
-    max_swap = int(getattr(cfg, 'max_swap_amount', 0) or 0)
-    return unviable_reason(
-        candidate_miners(client, from_chain, to_chain), from_chain, to_chain, from_amount, min_swap, max_swap
-    )
+    cands = candidate_miners(client, from_chain, to_chain)
+    best = select_best_miner(cands, from_chain, to_chain, from_amount, min_swap, max_swap)
+    bq = _best_quote_result(validator, best) if best else None
+    reason = '' if bq else unviable_reason(cands, from_chain, to_chain, from_amount, min_swap, max_swap)
+    depth: dict = {}
+    for cand in cands:
+        cap = max_intake_from_amount(cand, from_chain, to_chain, min_swap, max_swap)
+        if cap > 0:
+            depth[cand.rate_display] = max(depth.get(cand.rate_display, 0), cap)
+    best_first = sorted(depth.items(), key=lambda kv: float(kv[0]), reverse=from_chain == NUMERAIRE_CHAIN)
+    levels = [{'rate_display': r, 'max_from_amount': m} for r, m in best_first[:RATE_LEVELS_LIMIT]]
+    return RateQuote(bq, reason, levels, max(depth.values(), default=0))
 
 
 def _best_quote_result(validator, best) -> Optional[BestQuote]:

--- a/allways/validator/seam_http.py
+++ b/allways/validator/seam_http.py
@@ -17,9 +17,8 @@ from urllib.parse import parse_qs, urlparse
 import bittensor as bt
 
 from allways.validator.reserve_engine import (
-    best_quote,
     confirm_deposit,
-    quote_rejection_reason,
+    rate_quote,
     reserve_on_behalf,
     scan_deposit,
     swap_status,
@@ -57,11 +56,13 @@ def _make_handler(validator, secret: str):
             q = {k: v[0] for k, v in parse_qs(url.query).items()}
             try:
                 if url.path == '/rate':
-                    bq = best_quote(validator, q['from'], q['to'], int(q['amount']))
-                    if bq is None:
-                        reason = quote_rejection_reason(validator, q['from'], q['to'], int(q['amount']))
-                        return self._send(404, {'error': reason})
-                    return self._send(200, bq.__dict__)
+                    # Depth rides along on hit AND miss — the offering's oversize copy ("max right
+                    # now is X") needs the true max exactly when no quote fits the asked size.
+                    rq = rate_quote(validator, q['from'], q['to'], int(q['amount']))
+                    depth = {'levels': rq.levels, 'max_from_amount': rq.max_from_amount}
+                    if rq.quote is None:
+                        return self._send(404, {'error': rq.reason, **depth})
+                    return self._send(200, {**rq.quote.__dict__, **depth})
                 if url.path == '/status':
                     # Optional swap_key (hex, persisted by the consumer at claim time) resolves the
                     # swap directly — the only route to post-attestation stages, since vote_initiate

--- a/tests/test_seam_http.py
+++ b/tests/test_seam_http.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 from allways.validator import seam_http
-from allways.validator.reserve_engine import BestQuote, ConfirmResult, ReserveResult, SwapStatus
+from allways.validator.reserve_engine import BestQuote, ConfirmResult, RateQuote, ReserveResult, SwapStatus
 
 SECRET = 'test-secret'
 
@@ -17,7 +17,16 @@ SECRET = 'test-secret'
 def server(monkeypatch):
     monkeypatch.setattr(seam_http, 'reserve_on_behalf', lambda *a, **k: ReserveResult(True, '', 123, 'sig'))
     monkeypatch.setattr(seam_http, 'confirm_deposit', lambda *a, **k: ConfirmResult(True, '', 'deadbeef', 'sig'))
-    monkeypatch.setattr(seam_http, 'best_quote', lambda *a, **k: BestQuote('hk', 'pk', '0.0021', 1, 1, 210000))
+    monkeypatch.setattr(
+        seam_http,
+        'rate_quote',
+        lambda *a, **k: RateQuote(
+            BestQuote('hk', 'pk', '0.0021', 1, 1, 210000),
+            '',
+            [{'rate_display': '0.0021', 'max_from_amount': 2_000_000_000}],
+            2_000_000_000,
+        ),
+    )
     monkeypatch.setattr(seam_http, 'swap_status', lambda *a, **k: SwapStatus('reserved', 999, 'user', ''))
     srv = seam_http.start_seam(SimpleNamespace(), 0, SECRET)
     yield srv
@@ -96,6 +105,25 @@ def test_confirm_ok(server):
 def test_rate(server):
     code, payload = _req(server, 'GET', '/rate?from=sol&to=btc&amount=1000000000')
     assert code == 200 and payload['to_amount'] == 210000 and payload['miner_hotkey'] == 'hk'
+    assert payload['levels'] == [{'rate_display': '0.0021', 'max_from_amount': 2_000_000_000}]
+    assert payload['max_from_amount'] == 2_000_000_000
+
+
+def test_rate_miss_carries_depth(server, monkeypatch):
+    """The oversize UX needs the true max exactly when nothing fits — depth must ride the 404 too."""
+    monkeypatch.setattr(
+        seam_http,
+        'rate_quote',
+        lambda *a, **k: RateQuote(
+            None,
+            'miner collateral too low (needs 1.1000 SOL)',
+            [{'rate_display': '0.0021', 'max_from_amount': 900_000_000}],
+            900_000_000,
+        ),
+    )
+    code, payload = _req(server, 'GET', '/rate?from=sol&to=btc&amount=1000000000')
+    assert code == 404 and 'collateral too low' in payload['error']
+    assert payload['max_from_amount'] == 900_000_000 and len(payload['levels']) == 1
 
 
 def test_status(server):

--- a/tests/test_swap_intake.py
+++ b/tests/test_swap_intake.py
@@ -9,9 +9,11 @@ import pytest
 from allways.cli.swap_commands.swap_intake import (
     MinerCandidate,
     compute_intake_amounts,
+    max_intake_from_amount,
     rate_display_from_fixed,
     required_collateral,
     select_best_miner,
+    swap_gate,
     swap_viable,
     to_smallest_units,
     unviable_reason,
@@ -200,3 +202,49 @@ def test_unviable_reason_collateral():
     cands = [MinerCandidate(miner='m', rate_display='1.0', collateral=SOL // 10)]
     reason = unviable_reason(cands, 'tao', 'sol', 1_000_000_000, 0, 0)
     assert 'collateral too low' in reason
+
+
+# ---- max_intake_from_amount: the depth behind a rate, solved for size ----
+def _cand(rate, collateral):
+    return MinerCandidate(miner='m', rate_display=rate, collateral=collateral)
+
+
+def test_max_intake_sol_source_is_exact_collateral_inverse():
+    # 1.1 SOL collateral backs exactly a 1 SOL leg; one more lamport must fail the gate.
+    cap = max_intake_from_amount(_cand('0.5', 1_100_000_000), 'sol', 'btc', MIN, MAX)
+    assert cap == SOL
+    assert swap_gate(cap, 1_100_000_000, MIN, MAX) == ''
+    assert swap_gate(cap + 1, 1_100_000_000, MIN, MAX) != ''
+
+
+def test_max_intake_clamped_by_max_swap():
+    assert max_intake_from_amount(_cand('0.5', 100 * SOL), 'sol', 'btc', MIN, MAX) == MAX
+
+
+def test_max_intake_zero_when_min_swap_unreachable():
+    # Collateral backs at most ~0.09 SOL — under the 0.1 SOL min, so no viable size exists.
+    assert max_intake_from_amount(_cand('0.5', SOL // 10), 'sol', 'btc', MIN, MAX) == 0
+
+
+def test_max_intake_zero_on_junk_rate():
+    assert max_intake_from_amount(_cand('junk', 2 * SOL), 'sol', 'btc', MIN, MAX) == 0
+
+
+def test_max_intake_spoke_source_inverts_to_amount_exactly():
+    # btc→sol at 0.5 BTC/SOL: the SOL leg is to_amount. The returned max must be the LARGEST
+    # source whose derived leg still passes the gate — its successor must overshoot.
+    coll = 1_650_000_000  # backs a 1.5 SOL leg
+    max_from = max_intake_from_amount(_cand('0.5', coll), 'btc', 'sol', MIN, MAX)
+    at_max = compute_intake_amounts('btc', 'sol', max_from, '0.5')
+    past_max = compute_intake_amounts('btc', 'sol', max_from + 1, '0.5')
+    assert swap_gate(at_max.collateral_amount, coll, MIN, MAX) == ''
+    assert swap_gate(past_max.collateral_amount, coll, MIN, MAX) != ''
+    assert at_max.collateral_amount == 1_500_000_000  # 0.075 BTC → exactly the 1.5 SOL cap
+
+
+def test_max_intake_spoke_source_respects_max_swap():
+    # Deep collateral, 10 SOL max_swap: max source is the amount whose leg lands exactly on max.
+    max_from = max_intake_from_amount(_cand('0.5', 100 * SOL), 'btc', 'sol', MIN, MAX)
+    at_max = compute_intake_amounts('btc', 'sol', max_from, '0.5')
+    past_max = compute_intake_amounts('btc', 'sol', max_from + 1, '0.5')
+    assert at_max.collateral_amount <= MAX < past_max.collateral_amount


### PR DESCRIPTION
The seam /rate now carries the depth behind the quote on both hit and miss: levels (top 5 rate rungs, each with the largest source amount that rate can execute right now) and max_from_amount (largest executable size across all quotes). This lets the offering show "max X SOL at this rate" and replace protocol-jargon errors ("miner collateral too low (needs 1.1 SOL)") with "Max swap right now is X SOL" driven by data.

- utils/rate.py: max_from_for_to_cap — exact floor-division inverse of calculate_to_amount, branch for branch
- swap_intake.py: max_intake_from_amount — the viable_intakes gates solved for size (collateral 1.1x inverted exactly, max_swap clamp, 0 when min_swap unreachable)
- reserve_engine.py: best_quote + quote_rejection_reason collapsed into rate_quote — one candidate scan now serves the whole /rate payload instead of two
- Capacities are per-rung maxima, never cumulative: a swap fills against a single miner

Tests: exact-boundary units for both inversions (successor amount must fail the gate), seam payload on 200 and 404. Full suite 846 passed.