### PR TITLE
Collateral-floor sweep: drive vote_deactivate after a min_collateral raise

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -114,6 +114,9 @@ RECONCILE_QUIET_SECS = 600
 SECONDS_PER_BLOCK = 12
 WEIGHTS_STAKE_BUCKET_ALPHA = 50_000  # alpha per draw-weight unit; floor rounding
 WEIGHTS_VOTE_INTERVAL_BLOCKS = 3_600  # ~12h — posting boundary cadence
+# Contract vote-round lifetime — mirrors constants.rs. A non-empty round older than this is
+# stale: record_vote clears and reopens it, and prior voters may legally vote again.
+VOTE_ROUND_TTL_SECS = 1_800
 # In-epoch retry throttle: one attempt per contract vote-round lifetime (VOTE_ROUND_TTL_SECS),
 # so an unlanded round has expired (and is reopenable with our snapshot) by the time we retry.
 WEIGHTS_VOTE_RETRY_SECS = 1_800

--- a/allways/solana/client.py
+++ b/allways/solana/client.py
@@ -595,6 +595,21 @@ class AllwaysSolanaClient:
         ]
         return self._send([self._ix('vote_activate', b'', metas)])
 
+    def vote_deactivate(self, miner) -> str:
+        """Vote to force-deactivate an idle active miner; on quorum active flips false.
+        The contract rejects busy miners (in-flight swap / unexpired busy_until)."""
+        validator = self.keypair.pubkey()
+        m = _as_pubkey(miner)
+        metas = [
+            AccountMeta(validator, True, True),
+            AccountMeta(pdas.config_pda(self.program_id), False, False),
+            AccountMeta(m, False, False),
+            AccountMeta(pdas.miner_state_pda(m, self.program_id), False, True),
+            AccountMeta(pdas.vote_round_pda(pdas.REQ_DEACTIVATE, m, self.program_id), False, True),
+            AccountMeta(SYSTEM_PROGRAM, False, False),
+        ]
+        return self._send([self._ix('vote_deactivate', b'', metas)])
+
     def vote_set_weights(self, weights: List[int], validator_keys: List[bytes]) -> str:
         """Vote the validator draw-weight vector (index-aligned to Config.validators); on quorum it applies.
         The round PDA is keyed by the snapshot hash, so competing proposals coexist instead of blocking."""

--- a/allways/solana/client.py
+++ b/allways/solana/client.py
@@ -19,6 +19,7 @@ from solders.keypair import Keypair
 from solders.pubkey import Pubkey
 from solders.transaction import Transaction
 
+from allways.constants import VOTE_ROUND_TTL_SECS
 from allways.solana import layouts, pdas
 from allways.solana.program import resolve_program_id
 from allways.solana.rpc import SolanaRpc
@@ -243,10 +244,17 @@ class AllwaysSolanaClient:
     def get_vote_round(self, req_type: int, target=None):
         return self._get('VoteRound', pdas.vote_round_pda(req_type, target, self.program_id))
 
-    def has_voted(self, req_type: int, target, voter) -> bool:
-        """True if `voter` (Pubkey/bytes) already recorded a vote in this round — skip a wasted re-vote."""
+    def has_voted(self, req_type: int, target, voter, now: Optional[int] = None) -> bool:
+        """True if `voter` (Pubkey/bytes) has a LIVE vote in this round — skip a wasted re-vote.
+        Mirrors record_vote's staleness rule: a non-empty round older than VOTE_ROUND_TTL_SECS is
+        reopenable and prior voters may legally vote again, so a stale-round vote must not gate a
+        retry — a first pass that missed quorum would otherwise strand the target forever, with
+        every prior voter skipping on each recheck."""
         vr = self.get_vote_round(req_type, target)
-        if vr is None:
+        if vr is None or not vr.voters:
+            return False
+        age = (now if now is not None else int(time.time())) - int(vr.created_at)
+        if age > VOTE_ROUND_TTL_SECS:
             return False
         vb = bytes(_as_pubkey(voter))
         return any(bytes(v) == vb for v in vr.voters)

--- a/allways/solana/layouts.py
+++ b/allways/solana/layouts.py
@@ -348,6 +348,7 @@ IX_DISCRIMINATORS = {
     'timeout_swap': bytes([18, 157, 212, 120, 145, 200, 239, 63]),
     'close_stale_claim': bytes([185, 69, 27, 37, 187, 78, 157, 188]),  # reap an orphaned PendingAttestation claim
     'vote_activate': bytes([24, 233, 47, 230, 116, 115, 109, 41]),
+    'vote_deactivate': bytes([243, 169, 237, 143, 48, 91, 0, 119]),
     'mark_fulfilled': bytes([40, 188, 159, 127, 20, 151, 228, 191]),
     'extend_timeout': bytes([246, 84, 96, 134, 76, 55, 57, 33]),
     'extend_reservation': bytes([97, 77, 20, 170, 71, 8, 163, 187]),

--- a/allways/validator/bounds_cache.py
+++ b/allways/validator/bounds_cache.py
@@ -42,6 +42,9 @@ class SolanaConfigCache:
     def min_swap_amount(self) -> int:
         return int(self._fresh_config().min_swap_amount)
 
+    def min_collateral(self) -> int:
+        return int(self._fresh_config().min_collateral)
+
     def max_swap_amount(self) -> int:
         return int(self._fresh_config().max_swap_amount)
 

--- a/allways/validator/floor_sweep.py
+++ b/allways/validator/floor_sweep.py
@@ -23,6 +23,7 @@ import bittensor as bt
 from solders.pubkey import Pubkey
 
 from allways.solana import pdas
+from allways.solana.client import benign_marker
 
 if TYPE_CHECKING:
     from neurons.validator import Validator
@@ -105,8 +106,17 @@ class CollateralFloorSweep:
                 return False
             if self._client.has_voted(pdas.REQ_DEACTIVATE, miner, self._client.keypair.pubkey()):
                 return False
-            sig = self._client.vote_deactivate(miner)
-            bt.logging.info(f'floor sweep: voted to deactivate {miner} (collateral < {floor}): {sig}')
+            try:
+                sig = self._client.vote_deactivate(miner)
+                bt.logging.info(f'floor sweep: voted to deactivate {miner} (collateral < {floor}): {sig}')
+            except Exception as e:
+                # The has_voted read and the send can race (our vote lands in
+                # between, or the stale-round clock disagrees by seconds) — the
+                # contract's AlreadyVoted is an authoritative no-op, not a failure.
+                if benign_marker(e, ('AlreadyVoted',)):
+                    bt.logging.debug(f'floor sweep: {miner}: vote already recorded')
+                else:
+                    raise
         except Exception as e:
             bt.logging.warning(f'floor sweep: {miner}: {e}')
         return False

--- a/allways/validator/floor_sweep.py
+++ b/allways/validator/floor_sweep.py
@@ -1,0 +1,106 @@
+"""Collateral-floor sweep: vote out miners stranded active under a raised floor.
+
+``set_min_collateral`` only rewrites the Config — it never touches MinerState, and
+the contract's auto-deactivation (``apply_penalty``) fires only on fee/slash paths
+an under-floor miner can no longer reach, because ``open_or_request`` refuses to
+reserve them. Left alone they stay active forever: unreservable by takers yet still
+earning crown. This sweep is the missing driver for the contract's
+``vote_deactivate`` quorum path.
+
+Cost model: a floor raise is a rare admin event, so the steady-state step is a
+single integer comparison against the TTL-cached Config (no RPC). The
+getProgramAccounts scan runs only when the cached floor rises — or once on the
+first step after boot, which covers a raise that happened while this validator was
+offline. Stragglers (busy miners the contract refuses to kick, votes awaiting
+quorum) are rechecked with per-miner account reads on a slow retry cadence until
+the pending set drains.
+"""
+
+import time
+from typing import TYPE_CHECKING, Callable, Optional, Set
+
+import bittensor as bt
+from solders.pubkey import Pubkey
+
+from allways.solana import pdas
+
+if TYPE_CHECKING:
+    from neurons.validator import Validator
+
+
+class CollateralFloorSweep:
+    RETRY_SECS = 300
+
+    def __init__(self, solana_client, read_only: bool = False, clock: Optional[Callable[[], float]] = None):
+        self._client = solana_client
+        self._read_only = read_only
+        self._clock = clock or time.time
+        self._last_floor: Optional[int] = None
+        # Miner pubkey strings still needing a kick (busy, or vote short of quorum).
+        self._pending: Set[str] = set()
+        self._next_retry: float = 0.0
+
+    def step(self, floor: int) -> None:
+        """One forward-step tick. Steady state (floor unchanged, nothing pending)
+        costs one int comparison; everything heavier is gated behind a raise."""
+        first = self._last_floor is None
+        raised = not first and floor > self._last_floor
+        self._last_floor = floor
+        now = self._clock()
+        if first or raised:
+            self._scan(floor, now)
+        elif self._pending and now >= self._next_retry:
+            self._recheck(floor, now)
+
+    def _scan(self, floor: int, now: float) -> None:
+        """Full MinerState scan — the rare, arm-time path."""
+        self._pending = set()
+        for _, ms in self._client.get_all('MinerState'):
+            miner = self._miner_key(ms)
+            if not self._resolve(miner, ms, floor, now):
+                self._pending.add(miner)
+        self._next_retry = now + self.RETRY_SECS
+        if self._pending:
+            bt.logging.info(f'floor sweep: {len(self._pending)} active miner(s) under floor {floor}, pending kick')
+
+    def _recheck(self, floor: int, now: float) -> None:
+        """Per-miner account reads for the stragglers only."""
+        for miner in list(self._pending):
+            ms = self._client.get_miner_state(miner)
+            if ms is None or self._resolve(miner, ms, floor, now):
+                self._pending.discard(miner)
+        self._next_retry = now + self.RETRY_SECS
+
+    def _resolve(self, miner: str, ms, floor: int, now: float) -> bool:
+        """Returns True when this miner needs nothing further. A cast vote is not
+        'resolved' — the miner stays pending until quorum flips it inactive, so a
+        validator restart or a reset round can never strand a half-kicked miner."""
+        try:
+            if not ms.active or int(ms.collateral) >= floor:
+                return True
+            # The contract rejects kicks on busy miners; retry once they idle.
+            if ms.has_active_swap or now < int(ms.busy_until):
+                return False
+            if self._read_only:
+                bt.logging.info(f'floor sweep: WOULD vote_deactivate {miner} (watch mode)')
+                return False
+            if self._client.has_voted(pdas.REQ_DEACTIVATE, miner, self._client.keypair.pubkey()):
+                return False
+            sig = self._client.vote_deactivate(miner)
+            bt.logging.info(f'floor sweep: voted to deactivate {miner} (collateral < {floor}): {sig}')
+        except Exception as e:
+            bt.logging.warning(f'floor sweep: {miner}: {e}')
+        return False
+
+    @staticmethod
+    def _miner_key(ms) -> str:
+        return str(Pubkey.from_bytes(bytes(ms.miner)))
+
+
+def maybe_sweep_floor(self: 'Validator') -> None:
+    """One never-raises sweep tick off the TTL-cached Config — a sweep hiccup
+    must not break the forward pass, and the read adds no RPC of its own."""
+    try:
+        self.floor_sweep.step(self.solana_config_cache.min_collateral())
+    except Exception as e:
+        bt.logging.warning(f'floor sweep: {e}')

--- a/allways/validator/floor_sweep.py
+++ b/allways/validator/floor_sweep.py
@@ -36,40 +36,59 @@ class CollateralFloorSweep:
         self._read_only = read_only
         self._clock = clock or time.time
         self._last_floor: Optional[int] = None
+        # Scan owed: set on boot and on every raise edge, cleared only by a
+        # completed scan — an RPC failure at the raise moment keeps it set, so
+        # the sweep retries on the slow cadence instead of losing the event.
+        self._armed = False
         # Miner pubkey strings still needing a kick (busy, or vote short of quorum).
         self._pending: Set[str] = set()
         self._next_retry: float = 0.0
 
     def step(self, floor: int) -> None:
-        """One forward-step tick. Steady state (floor unchanged, nothing pending)
-        costs one int comparison; everything heavier is gated behind a raise."""
-        first = self._last_floor is None
-        raised = not first and floor > self._last_floor
-        self._last_floor = floor
+        """One forward-step tick. Steady state (floor unchanged, nothing armed
+        or pending) costs two comparisons; everything heavier sits behind a
+        raise edge or the retry cursor."""
         now = self._clock()
-        if first or raised:
+        if self._last_floor is None or floor > self._last_floor:
+            # Arm, and reset the cursor so a genuine raise scans immediately
+            # instead of waiting out a previous back-off. The edge fires once
+            # per raise (floor commits below), so this can't re-fire per step.
+            self._armed = True
+            self._next_retry = now
+        self._last_floor = floor
+        if now < self._next_retry:
+            return
+        if self._armed:
             self._scan(floor, now)
-        elif self._pending and now >= self._next_retry:
+            self._armed = False
+        elif self._pending:
             self._recheck(floor, now)
 
     def _scan(self, floor: int, now: float) -> None:
-        """Full MinerState scan — the rare, arm-time path."""
+        """Full MinerState scan — the rare, arm-time path. The retry cursor
+        advances before the RPC so a throwing scan backs off instead of
+        re-firing every forward step."""
+        self._next_retry = now + self.RETRY_SECS
         self._pending = set()
         for _, ms in self._client.get_all('MinerState'):
             miner = self._miner_key(ms)
             if not self._resolve(miner, ms, floor, now):
                 self._pending.add(miner)
-        self._next_retry = now + self.RETRY_SECS
         if self._pending:
             bt.logging.info(f'floor sweep: {len(self._pending)} active miner(s) under floor {floor}, pending kick')
 
     def _recheck(self, floor: int, now: float) -> None:
-        """Per-miner account reads for the stragglers only."""
+        """Per-miner account reads for the stragglers only. Cursor-first for the
+        same back-off reason as ``_scan``; one unreadable miner skips, not aborts."""
+        self._next_retry = now + self.RETRY_SECS
         for miner in list(self._pending):
-            ms = self._client.get_miner_state(miner)
+            try:
+                ms = self._client.get_miner_state(miner)
+            except Exception as e:
+                bt.logging.warning(f'floor sweep: {miner}: {e}')
+                continue
             if ms is None or self._resolve(miner, ms, floor, now):
                 self._pending.discard(miner)
-        self._next_retry = now + self.RETRY_SECS
 
     def _resolve(self, miner: str, ms, floor: int, now: float) -> bool:
         """Returns True when this miner needs nothing further. A cast vote is not

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -11,6 +11,7 @@ import bittensor as bt
 from allways import dev_signal
 from allways.utils.logging import log_crown_winners
 from allways.validator.binding import build_attribution
+from allways.validator.floor_sweep import maybe_sweep_floor
 from allways.validator.reserve_engine import finalize_won_seats
 from allways.validator.scoring import (
     due_for_scoring,
@@ -61,6 +62,11 @@ async def forward(self: Validator) -> None:
 
     # Block-aligned stake-weight vote: keeps Config.validators draw weights stake-true.
     maybe_vote_weights(self, now)
+
+    # Floor sweep: votes out miners stranded active under a raised min_collateral.
+    # Steady state is one comparison against the TTL-cached Config (no RPC); the
+    # miner scan runs only on boot or when the cached floor rises.
+    maybe_sweep_floor(self)
 
     if due_for_scoring(self.block, self.last_scored_block, self.initial_scoring_done):
         score_and_reward_miners(self)

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -48,6 +48,7 @@ from allways.validator.axon_handlers import (  # noqa: E402
 from allways.validator.binding import warn_if_unbound  # noqa: E402
 from allways.validator.bounds_cache import SolanaConfigCache  # noqa: E402
 from allways.validator.event_index import SolanaEventIndex  # noqa: E402
+from allways.validator.floor_sweep import CollateralFloorSweep  # noqa: E402
 from allways.validator.forward import forward  # noqa: E402
 from allways.validator.seam_http import maybe_start_seam  # noqa: E402
 from allways.validator.solana_swap_loop import SolanaSwapLoop  # noqa: E402
@@ -124,6 +125,9 @@ class Validator(BaseValidatorNeuron):
         # swap bounds + halt off the Config account (replacing substrate reads).
         self.event_ingest = SolanaEventIngest(self.solana_client)
         self.solana_config_cache = SolanaConfigCache(self.solana_client)
+        # Kicks miners stranded active under a raised min_collateral (they can't
+        # be reserved, so the contract's fee/slash auto-deactivation never fires).
+        self.floor_sweep = CollateralFloorSweep(self.solana_client, read_only=solana_read_only)
         # event_index synthesizes each reservation's RESERVE_EXPIRE at
         # block_time + reservation_ttl_secs, read off the config cache (D4).
         self.event_index = SolanaEventIndex(self.state_store, self.solana_config_cache.reservation_ttl_secs)

--- a/tests/test_floor_sweep.py
+++ b/tests/test_floor_sweep.py
@@ -1,0 +1,176 @@
+"""CollateralFloorSweep: the vote_deactivate driver for the min_collateral-raise
+edge case. The properties under test: steady state costs no RPC, the miner scan
+runs only on boot / floor raise, busy miners are retried instead of dropped, and
+a cast vote stays pending until quorum actually flips the miner inactive."""
+
+from types import SimpleNamespace
+
+from solders.pubkey import Pubkey
+
+from allways.solana import pdas
+from allways.validator.floor_sweep import CollateralFloorSweep
+
+FLOOR = 1_000_000_000  # 1 SOL
+
+MINER_A = Pubkey.new_unique()
+MINER_B = Pubkey.new_unique()
+
+
+def miner_state(miner, collateral, active=True, has_active_swap=False, busy_until=0):
+    return SimpleNamespace(
+        miner=bytes(miner),
+        collateral=collateral,
+        active=active,
+        has_active_swap=has_active_swap,
+        busy_until=busy_until,
+    )
+
+
+class FakeClient:
+    def __init__(self, states):
+        # {pubkey_str: miner_state}; mutate `states` to simulate chain changes.
+        self.states = states
+        self.keypair = SimpleNamespace(pubkey=lambda: Pubkey.new_unique())
+        self.voted = set()
+        self.calls = {'get_all': 0, 'get_miner_state': 0, 'vote_deactivate': 0}
+
+    def get_all(self, name):
+        assert name == 'MinerState'
+        self.calls['get_all'] += 1
+        return [(k, v) for k, v in self.states.items()]
+
+    def get_miner_state(self, miner):
+        self.calls['get_miner_state'] += 1
+        return self.states.get(str(miner))
+
+    def has_voted(self, req_type, miner, voter):
+        assert req_type == pdas.REQ_DEACTIVATE
+        return str(miner) in self.voted
+
+    def vote_deactivate(self, miner):
+        self.calls['vote_deactivate'] += 1
+        self.voted.add(str(miner))
+        return 'sig'
+
+
+class Clock:
+    def __init__(self, now=1000.0):
+        self.now = now
+
+    def __call__(self):
+        return self.now
+
+
+class TestSteadyState:
+    def test_first_step_scans_once_then_unchanged_floor_is_free(self):
+        client = FakeClient({str(MINER_A): miner_state(MINER_A, FLOOR)})
+        sweep = CollateralFloorSweep(client, clock=Clock())
+        sweep.step(FLOOR)
+        assert client.calls['get_all'] == 1  # boot scan covers a raise-while-offline
+        for _ in range(50):
+            sweep.step(FLOOR)
+        assert client.calls['get_all'] == 1
+        assert client.calls['get_miner_state'] == 0
+        assert client.calls['vote_deactivate'] == 0
+
+    def test_floor_decrease_does_not_rescan(self):
+        client = FakeClient({})
+        sweep = CollateralFloorSweep(client, clock=Clock())
+        sweep.step(FLOOR)
+        sweep.step(FLOOR // 2)
+        assert client.calls['get_all'] == 1
+
+
+class TestRaise:
+    def test_raise_kicks_underfloor_active_idle_miner(self):
+        client = FakeClient(
+            {
+                str(MINER_A): miner_state(MINER_A, 150_000_000),  # under new floor
+                str(MINER_B): miner_state(MINER_B, 2 * FLOOR),  # comfortably above
+            }
+        )
+        sweep = CollateralFloorSweep(client, clock=Clock())
+        sweep.step(100_000_000)  # boot at the old floor: everyone compliant
+        assert client.calls['vote_deactivate'] == 0
+        sweep.step(FLOOR)  # the raise
+        assert client.calls['get_all'] == 2
+        assert client.voted == {str(MINER_A)}
+
+    def test_inactive_and_topped_up_miners_are_ignored(self):
+        client = FakeClient(
+            {
+                str(MINER_A): miner_state(MINER_A, 100, active=False),
+                str(MINER_B): miner_state(MINER_B, FLOOR),
+            }
+        )
+        sweep = CollateralFloorSweep(client, clock=Clock())
+        sweep.step(FLOOR)
+        assert client.calls['vote_deactivate'] == 0
+
+
+class TestPending:
+    def test_busy_miner_retried_after_interval_not_before(self):
+        clock = Clock()
+        state = miner_state(MINER_A, 100, has_active_swap=True)
+        client = FakeClient({str(MINER_A): state})
+        sweep = CollateralFloorSweep(client, clock=clock)
+        sweep.step(FLOOR)
+        assert client.calls['vote_deactivate'] == 0  # busy: contract would reject
+
+        sweep.step(FLOOR)  # inside retry interval — no reads
+        assert client.calls['get_miner_state'] == 0
+
+        state.has_active_swap = False  # swap resolved on-chain
+        clock.now += CollateralFloorSweep.RETRY_SECS
+        sweep.step(FLOOR)
+        assert client.calls['get_miner_state'] == 1
+        assert client.voted == {str(MINER_A)}
+
+    def test_voted_miner_stays_pending_until_quorum_flips_inactive(self):
+        clock = Clock()
+        state = miner_state(MINER_A, 100)
+        client = FakeClient({str(MINER_A): state})
+        sweep = CollateralFloorSweep(client, clock=clock)
+        sweep.step(FLOOR)
+        assert client.calls['vote_deactivate'] == 1
+
+        # Quorum not reached yet: recheck must not double-vote (has_voted gate)
+        # but must keep the miner pending.
+        clock.now += CollateralFloorSweep.RETRY_SECS
+        sweep.step(FLOOR)
+        assert client.calls['vote_deactivate'] == 1
+
+        state.active = False  # peers reached quorum
+        clock.now += CollateralFloorSweep.RETRY_SECS
+        sweep.step(FLOOR)
+        clock.now += CollateralFloorSweep.RETRY_SECS
+        sweep.step(FLOOR)  # pending drained: no further reads
+        assert client.calls['get_miner_state'] == 2
+
+    def test_miner_topping_up_while_pending_is_released(self):
+        clock = Clock()
+        state = miner_state(MINER_A, 100, has_active_swap=True)
+        client = FakeClient({str(MINER_A): state})
+        sweep = CollateralFloorSweep(client, clock=clock)
+        sweep.step(FLOOR)
+
+        state.has_active_swap = False
+        state.collateral = FLOOR  # posted collateral to comply instead
+        clock.now += CollateralFloorSweep.RETRY_SECS
+        sweep.step(FLOOR)
+        assert client.calls['vote_deactivate'] == 0
+        clock.now += CollateralFloorSweep.RETRY_SECS
+        sweep.step(FLOOR)
+        assert client.calls['get_miner_state'] == 1  # released, no more rechecks
+
+
+class TestReadOnly:
+    def test_watch_mode_never_votes_but_keeps_watching(self):
+        clock = Clock()
+        client = FakeClient({str(MINER_A): miner_state(MINER_A, 100)})
+        sweep = CollateralFloorSweep(client, read_only=True, clock=clock)
+        sweep.step(FLOOR)
+        clock.now += CollateralFloorSweep.RETRY_SECS
+        sweep.step(FLOOR)
+        assert client.calls['vote_deactivate'] == 0
+        assert client.calls['get_miner_state'] == 1  # still tracked as pending

--- a/tests/test_floor_sweep.py
+++ b/tests/test_floor_sweep.py
@@ -33,14 +33,21 @@ class FakeClient:
         self.keypair = SimpleNamespace(pubkey=lambda: Pubkey.new_unique())
         self.voted = set()
         self.calls = {'get_all': 0, 'get_miner_state': 0, 'vote_deactivate': 0}
+        self.fail_get_all = 0  # raise on this many get_all calls before serving
+        self.fail_state_for = set()  # miner keys whose reads raise
 
     def get_all(self, name):
         assert name == 'MinerState'
         self.calls['get_all'] += 1
+        if self.fail_get_all > 0:
+            self.fail_get_all -= 1
+            raise RuntimeError('rpc down')
         return [(k, v) for k, v in self.states.items()]
 
     def get_miner_state(self, miner):
         self.calls['get_miner_state'] += 1
+        if str(miner) in self.fail_state_for:
+            raise RuntimeError('rpc down')
         return self.states.get(str(miner))
 
     def has_voted(self, req_type, miner, voter):
@@ -162,6 +169,53 @@ class TestPending:
         clock.now += CollateralFloorSweep.RETRY_SECS
         sweep.step(FLOOR)
         assert client.calls['get_miner_state'] == 1  # released, no more rechecks
+
+
+class TestRpcFailure:
+    def test_failed_arm_scan_is_retried_not_lost(self):
+        """A raise whose scan RPC fails must stay armed: the floor is only
+        committed after a successful scan, so the raise re-fires on the retry
+        cadence instead of being swallowed forever."""
+        clock = Clock()
+        client = FakeClient({str(MINER_A): miner_state(MINER_A, 100)})
+        client.fail_get_all = 1
+        sweep = CollateralFloorSweep(client, clock=clock)
+        try:
+            sweep.step(FLOOR)  # production wraps this in maybe_sweep_floor
+        except RuntimeError:
+            pass
+        assert client.voted == set()
+
+        sweep.step(FLOOR)  # inside back-off: no immediate re-scan hammering
+        assert client.calls['get_all'] == 1
+
+        clock.now += CollateralFloorSweep.RETRY_SECS
+        sweep.step(FLOOR)
+        assert client.calls['get_all'] == 2
+        assert client.voted == {str(MINER_A)}
+
+    def test_one_unreadable_pending_miner_does_not_block_the_rest(self):
+        clock = Clock()
+        client = FakeClient(
+            {
+                str(MINER_A): miner_state(MINER_A, 100, has_active_swap=True),
+                str(MINER_B): miner_state(MINER_B, 100, has_active_swap=True),
+            }
+        )
+        sweep = CollateralFloorSweep(client, clock=clock)
+        sweep.step(FLOOR)  # both pending (busy)
+
+        for ms in client.states.values():
+            ms.has_active_swap = False
+        client.fail_state_for = {str(MINER_A)}
+        clock.now += CollateralFloorSweep.RETRY_SECS
+        sweep.step(FLOOR)
+        assert client.voted == {str(MINER_B)}  # B kicked despite A's read failing
+
+        client.fail_state_for = set()
+        clock.now += CollateralFloorSweep.RETRY_SECS
+        sweep.step(FLOOR)  # next cadence, not next step
+        assert client.voted == {str(MINER_A), str(MINER_B)}
 
 
 class TestReadOnly:

--- a/tests/test_floor_sweep.py
+++ b/tests/test_floor_sweep.py
@@ -218,6 +218,54 @@ class TestRpcFailure:
         assert client.voted == {str(MINER_A), str(MINER_B)}
 
 
+class TestStaleVoteRound:
+    def test_stale_round_vote_does_not_gate_a_revote(self):
+        """The contract reopens a round older than VOTE_ROUND_TTL_SECS and lets
+        prior voters vote again; the client's has_voted must mirror that, or a
+        first pass that missed quorum leaves every prior voter skipping forever
+        and the miner stranded (review finding on #616)."""
+        from solders.keypair import Keypair
+
+        from allways.constants import VOTE_ROUND_TTL_SECS
+        from allways.solana.client import AllwaysSolanaClient
+
+        voter = Keypair().pubkey()
+        client = AllwaysSolanaClient('http://127.0.0.1:1', program_id=Pubkey.new_unique(), keypair=Keypair())
+        round_ = SimpleNamespace(voters=[voter], created_at=10_000)
+        client.get_vote_round = lambda req_type, target: round_
+
+        live = 10_000 + VOTE_ROUND_TTL_SECS  # exactly at the TTL: still live
+        assert client.has_voted(pdas.REQ_DEACTIVATE, MINER_A, voter, now=live) is True
+        stale = 10_000 + VOTE_ROUND_TTL_SECS + 1
+        assert client.has_voted(pdas.REQ_DEACTIVATE, MINER_A, voter, now=stale) is False
+
+        # An empty round is closed/reset — never a gate.
+        client.get_vote_round = lambda req_type, target: SimpleNamespace(voters=[], created_at=0)
+        assert client.has_voted(pdas.REQ_DEACTIVATE, MINER_A, voter, now=live) is False
+
+    def test_already_voted_race_is_benign_and_miner_stays_pending(self):
+        """If the vote lands AlreadyVoted (the has_voted read raced the send),
+        the sweep treats it as an on-chain no-op — and the miner stays pending
+        until quorum flips it inactive."""
+        clock = Clock()
+        state = miner_state(MINER_A, 100)
+        client = FakeClient({str(MINER_A): state})
+
+        def racing_vote(miner):
+            client.calls['vote_deactivate'] += 1
+            raise RuntimeError('custom program error. Error Message: AlreadyVoted.')
+
+        client.vote_deactivate = racing_vote
+        sweep = CollateralFloorSweep(client, clock=clock)
+        sweep.step(FLOOR)
+        assert client.calls['vote_deactivate'] == 1
+
+        state.active = False  # quorum reached via peers
+        clock.now += CollateralFloorSweep.RETRY_SECS
+        sweep.step(FLOOR)  # still pending → rechecked → released
+        assert client.calls['get_miner_state'] == 1
+
+
 class TestReadOnly:
     def test_watch_mode_never_votes_but_keeps_watching(self):
         clock = Clock()


### PR DESCRIPTION
## What

Stacked on #614. The precondition for raising `min_collateral` (planned 0.5–1 SOL): without this, an admin floor raise strands every under-floor miner as a permanent zombie — `set_min_collateral` doesn't touch `MinerState`, `open_or_request` refuses to reserve them, so the fee/slash `apply_penalty` path that auto-deactivates under-floor miners can never fire. They stay `active` indefinitely, unreservable by takers but still earning crown. The contract's `vote_deactivate` quorum instruction handles exactly this case; it just had no driver — no discriminator in `layouts.py`, no client method, no validator loop.

## Cost model (the "be smart about RPC" part)

- **Steady state: zero added RPC.** The sweep reads `min_collateral` off the existing `SolanaConfigCache` (one Config read per 300s already paid for by swap bounds) and compares it to the last-seen value — one int comparison per forward step.
- **The `getProgramAccounts` scan runs only when the cached floor rises**, or once on the first step after boot (covers a raise that happened while this validator was offline). Floor decreases don't rescan.
- **Stragglers get per-miner account reads on a 300s retry cadence**, only while the pending set is non-empty: busy miners (the contract rejects kicking a miner with an in-flight swap / unexpired `busy_until` — they retry once idle; they can't take *new* swaps, so everyone converges within one fulfillment timeout), and cast votes awaiting quorum (a miner leaves pending only when the chain shows `active = false` or collateral ≥ floor, so a restart or reset round can't strand a half-kicked miner).
- `has_voted` gate prevents duplicate votes; a miner that tops up instead of getting kicked is released.

## Pieces

- `layouts.py`: `vote_deactivate` discriminator (sha256(`global:vote_deactivate`)[:8], derivation verified against the known `deactivate` discriminator).
- `client.py`: `vote_deactivate(miner)` mirroring `vote_activate` with `REQ_DEACTIVATE`.
- `bounds_cache.py`: `min_collateral()` accessor on the existing TTL cache.
- `floor_sweep.py`: the sweep + a never-raises `maybe_sweep_floor` forward hook (same containment pattern as `maybe_vote_weights`). Respects watch mode (`WOULD vote_deactivate …`).
- 8 new tests: steady-state costs nothing, raise kicks under-floor active idle miners only, busy-retry, no double-vote while awaiting quorum, top-up release, watch mode.

## Deploy order

Validators must run this **before** the `alw admin set-min-collateral` raise fires — sequence: merge → deploy to ≥67% of validator stake → raise the floor. The under-floor zombie window is then bounded by vote latency (minutes), not forever.

Full suite: 856 passed.
