### PR TITLE
Harden ETH provider slash paths and send idempotency

### DIFF
--- a/allways/chain_providers/ethereum.py
+++ b/allways/chain_providers/ethereum.py
@@ -78,8 +78,10 @@ class EthereumProvider(ChainProvider):
         # (key-by-hash); a reorg changes it → miss → full refetch. Only fully-settled entries
         # (status 1 + timestamp) are cached — never pending/absent/reverted.
         self._settled_cache: OrderedDict[str, dict] = OrderedDict()
-        # Own broadcasts, tx_hash → (to, amount): send dedup scoped to this process (#461 class).
-        self.broadcasted_txids: Dict[str, Tuple[str, int]] = {}
+        # Own broadcasts, tx_hash → (to, amount, head at broadcast): send dedup scoped to this
+        # process and to SCAN_LOOKBACK_BLOCKS (#461 class — a later same-amount swap must never
+        # resolve to an earlier swap's consumed tx).
+        self.broadcasted_txids: Dict[str, Tuple[str, int, int]] = {}
         # Deposit-scanner head cursors, keyed per (from, to, amount) — see find_recent_outgoing.
         self.scan_cursors: Dict[Tuple[str, str, int], int] = {}
 
@@ -386,22 +388,23 @@ class EthereumProvider(ChainProvider):
             self._send_error(f'ETH key derives {acct.address} but committed address is {from_address} — key mismatch')
             return None
 
+        head = self.get_current_block_height()
+        if head is None:
+            self._send_error('cannot read the chain head to scope send dedup — not sending')
+            return None
+
         try:
             # A prior own broadcast to this dest blocks a fresh send unless provably absent
             # from every endpoint — probing by hash sees the mempool; never risk paying twice.
             want = (self.normalize_address(to_address), int(amount))
-            for txid, dest in self.broadcasted_txids.items():
-                if dest != want:
-                    continue
-                try:
-                    if self.eth_rpc('eth_getTransactionByHash', [txid], null_needs_quorum=True) is not None:
-                        bt.logging.info(f'Reusing prior tx {txid} from {acct.address} → {to_address} ({amount} wei)')
-                        return (txid, 0)
-                except Exception as e:
-                    self._send_error(
-                        f'prior broadcast {txid[:16]}... unresolved ({e}) — refusing a possible double send'
-                    )
-                    return None
+            try:
+                prior = self._prior_broadcast(want, head)
+            except Exception as e:
+                self._send_error(f'prior broadcast unresolved ({e}) — refusing a possible double send')
+                return None
+            if prior:
+                bt.logging.info(f'Reusing prior tx {prior} from {acct.address} → {to_address} ({amount} wei)')
+                return (prior, 0)
 
             latest = self.eth_rpc('eth_getBlockByNumber', ['latest', False])
             base_fee = int((latest or {}).get('baseFeePerGas') or '0x0', 16)
@@ -435,7 +438,7 @@ class EthereumProvider(ChainProvider):
             expected_txid = signed.hash.hex()
             expected_txid = expected_txid if expected_txid.startswith('0x') else f'0x{expected_txid}'
             # Record pre-broadcast so a retry can reclaim it even if the response is lost.
-            self.broadcasted_txids[expected_txid] = want
+            self.broadcasted_txids[expected_txid] = (*want, head)
 
             raw = getattr(signed, 'raw_transaction', None) or getattr(signed, 'rawTransaction')
             raw_hex = raw.hex()
@@ -458,6 +461,31 @@ class EthereumProvider(ChainProvider):
         except Exception as e:
             self._send_error(f'ETH send failed: {type(e).__name__}: {e}')
             return None
+
+    def _prior_broadcast(self, want: Tuple[str, int], head: int) -> Optional[str]:
+        """Reusable tx hash from a prior own broadcast to (to, amount); None when a fresh send is
+        provably safe; raises when an in-flight duplicate can't be ruled out. Reuse requires the
+        tx to be in the mempool or settled (status 1) — a reverted tx moved no funds and clears.
+        Entries age out after SCAN_LOOKBACK_BLOCKS (the old mined-scan bound), so a later
+        same-amount swap can never resolve to an earlier swap's consumed tx."""
+        for txid, (to_norm, amt, seen) in list(self.broadcasted_txids.items()):
+            if head - seen > self.SCAN_LOOKBACK_BLOCKS:
+                del self.broadcasted_txids[txid]
+                continue
+            if (to_norm, amt) != want:
+                continue
+            tx = self.eth_rpc('eth_getTransactionByHash', [txid], null_needs_quorum=True)
+            if tx is None:
+                continue
+            if tx.get('blockNumber') is None:
+                return txid
+            receipt = self.eth_rpc('eth_getTransactionReceipt', [txid])
+            if receipt is None:
+                raise RuntimeError(f'prior tx {txid[:16]}... mined but its receipt is unavailable')
+            if int(receipt.get('status') or '0x0', 16) == 1:
+                return txid
+            del self.broadcasted_txids[txid]
+        return None
 
     _SETTLED_CACHE_MAX = _SETTLED_CACHE_MAX_DEFAULT
 
@@ -486,7 +514,7 @@ class EthereumProvider(ChainProvider):
                 block = self.eth_rpc('eth_getBlockByNumber', [hex(block_num), True])
             except Exception:
                 # Never leap an unreadable block — park just below it and retry next call.
-                self.scan_cursors[key] = block_num - 1
+                self._set_cursor(key, block_num - 1)
                 return None
             for tx in (block or {}).get('transactions', []):
                 if self.normalize_address(tx.get('from') or '') != want_from:
@@ -504,7 +532,10 @@ class EthereumProvider(ChainProvider):
                     continue
                 self.scan_cursors.pop(key, None)
                 return tx['hash']
-        self.scan_cursors[key] = head
+        self._set_cursor(key, head)
+        return None
+
+    def _set_cursor(self, key: Tuple[str, str, int], height: int) -> None:
+        self.scan_cursors[key] = height
         if len(self.scan_cursors) > self._MAX_SCAN_CURSORS:
             self.scan_cursors.pop(next(iter(self.scan_cursors)))
-        return None

--- a/allways/chain_providers/ethereum.py
+++ b/allways/chain_providers/ethereum.py
@@ -62,8 +62,8 @@ class EthereumProvider(ChainProvider):
             self.network = 'mainnet'
             bt.logging.warning('ETH_NETWORK unset — defaulting to mainnet; set ETH_NETWORK=sepolia for testnet.')
         if self.network not in CHAIN_IDS:
-            bt.logging.warning(f'Unknown ETH_NETWORK {self.network!r} (expected {list(CHAIN_IDS)}); using mainnet.')
-            self.network = 'mainnet'
+            # A typo silently becoming mainnet would pay real ETH against test swaps.
+            raise ValueError(f'Unknown ETH_NETWORK {self.network!r} — expected one of {list(CHAIN_IDS)}')
 
         # Same rationale as the BTC provider: long-running validators + pooled idle TLS
         # sockets that public CDNs silently drop → wedged reads until timeout.
@@ -78,9 +78,8 @@ class EthereumProvider(ChainProvider):
         # (key-by-hash); a reorg changes it → miss → full refetch. Only fully-settled entries
         # (status 1 + timestamp) are cached — never pending/absent/reverted.
         self._settled_cache: OrderedDict[str, dict] = OrderedDict()
-        # Scopes find_recent_outgoing reuse to this process — a fresh send can't return a
-        # tx hash already consumed by an earlier swap.
-        self.broadcasted_txids: set[str] = set()
+        # Own broadcasts, tx_hash → (to, amount): send dedup scoped to this process (#461 class).
+        self.broadcasted_txids: Dict[str, Tuple[str, int]] = {}
         # Deposit-scanner head cursors, keyed per (from, to, amount) — see find_recent_outgoing.
         self.scan_cursors: Dict[Tuple[str, str, int], int] = {}
 
@@ -105,15 +104,20 @@ class EthereumProvider(ChainProvider):
 
     # --- JSON-RPC plumbing (failover mirrors the BTC provider's Esplora narration) ---
 
-    def eth_rpc(self, method: str, params: list, timeout: int = 15) -> Any:
+    def eth_rpc(self, method: str, params: list, timeout: int = 15, null_needs_quorum: bool = False) -> Any:
         """Call ``method`` against each endpoint in order, narrating every failover.
 
         A JSON-RPC ``error`` object is treated as endpoint trouble (rate limit, pruned
         state, method gap) and falls through; ``result: null`` is authoritative data
         ("no such tx") and is returned as None. Raises the last error when all fail.
+
+        ``null_needs_quorum``: return None only when every endpoint reachably agrees;
+        null + an unreachable endpoint raises. For paths where "absent" costs money —
+        one stale node in a public load balancer must not read as "never happened".
         """
         payload = {'jsonrpc': '2.0', 'id': 1, 'method': method, 'params': params}
         last_err: Optional[Exception] = None
+        saw_null = False
         for i, base in enumerate(self.rpc_bases):
             pos = f'[{i + 1}/{len(self.rpc_bases)}]'
             tag = rpc_tag(base)
@@ -144,11 +148,20 @@ class EthereumProvider(ChainProvider):
                 bt.logging.warning(f'EthRpc {pos} {tag} {method} → rpc error {err}; {tail}')
                 continue
 
+            result = body.get('result')
+            if result is None and null_needs_quorum:
+                saw_null = True
+                bt.logging.debug(f'EthRpc {pos} {tag} {method} → null; seeking quorum from remaining endpoint(s)')
+                continue
             if i > 0:
                 bt.logging.info(f'EthRpc {pos} {tag} {method} → ok (served after {i} fallback(s))')
             else:
                 bt.logging.debug(f'EthRpc {pos} {tag} {method} → ok')
-            return body.get('result')
+            return result
+        if saw_null and last_err is None:
+            return None
+        if saw_null:
+            raise ProviderUnreachableError(f'{method}: null without quorum (an endpoint was unreachable): {last_err}')
         raise last_err or RuntimeError('all ETH RPCs failed')
 
     def check_connection(self, require_send: bool = True) -> None:
@@ -191,7 +204,7 @@ class EthereumProvider(ChainProvider):
         ProviderUnreachableError rather than risking a false slash verdict.
         """
         try:
-            tx = self.eth_rpc('eth_getTransactionByHash', [tx_hash])
+            tx = self.eth_rpc('eth_getTransactionByHash', [tx_hash], null_needs_quorum=True)
         except Exception as e:
             raise ProviderUnreachableError(f'ETH RPC unreachable: {e}') from e
         if tx is None:
@@ -249,27 +262,25 @@ class EthereumProvider(ChainProvider):
             confirmations = max(0, tip - block_number + 1) if tip is not None else 0
             is_confirmed = confirmations >= self.get_chain().min_confirmations
 
-            # Block timestamp (replay-freshness floor) + best-effort canonical-chain check: any
-            # failure here leaves the accept-path intact rather than breaking on an RPC hiccup.
-            block_time = None
+            # The freshness gate fails closed on a missing block_time, so an unreadable
+            # timestamp must be 'unknown' (raise), never a verdict — same as the receipt above.
             try:
                 block = self.eth_rpc('eth_getBlockByNumber', [hex(block_number), False])
-                if block:
-                    block_time = int(block.get('timestamp') or '0x0', 16) or None
-                    if is_confirmed and block.get('hash') and block['hash'] != receipt.get('blockHash'):
-                        bt.logging.warning(f'{LOG_ETH} tx {tx_hash[:16]}... block was reorged out — rejecting')
-                        return None
             except Exception as e:
-                bt.logging.debug(f'{LOG_ETH} block-time/canonical check skipped for {tx_hash[:16]}...: {e}')
+                raise ProviderUnreachableError(f'ETH block fetch failed for {tx_hash[:16]}...: {e}') from e
+            block_time = int((block or {}).get('timestamp') or '0x0', 16) or None
+            if block_time is None:
+                raise ProviderUnreachableError(
+                    f'ETH tx {tx_hash[:16]}... is mined but block {block_number} has no readable timestamp'
+                )
+            if is_confirmed and block.get('hash') and block['hash'] != receipt.get('blockHash'):
+                bt.logging.warning(f'{LOG_ETH} tx {tx_hash[:16]}... block was reorged out — rejecting')
+                return None
 
             # Cache only a fully-settled, internally-consistent read (status 1, timestamped,
             # tx/receipt agree on the block hash) — pending/absent/reverted are never cached.
             receipt_block_hash = receipt.get('blockHash') or ''
-            if (
-                receipt_block_hash
-                and block_time is not None
-                and (not tx_block_hash or tx_block_hash == receipt_block_hash)
-            ):
+            if receipt_block_hash and (not tx_block_hash or tx_block_hash == receipt_block_hash):
                 self._settled_cache[tx_hash] = {
                     'block_hash': receipt_block_hash,
                     'block_number': block_number,
@@ -376,12 +387,21 @@ class EthereumProvider(ChainProvider):
             return None
 
         try:
-            # Reuse only txids this process broadcast — otherwise (from, to, amount) would
-            # match a prior-swap tx the contract has already consumed (#461 class).
-            existing = self.find_recent_outgoing(acct.address, to_address, amount)
-            if existing and existing in self.broadcasted_txids:
-                bt.logging.info(f'Reusing prior tx {existing} from {acct.address} → {to_address} ({amount} wei)')
-                return (existing, 0)
+            # A prior own broadcast to this dest blocks a fresh send unless provably absent
+            # from every endpoint — probing by hash sees the mempool; never risk paying twice.
+            want = (self.normalize_address(to_address), int(amount))
+            for txid, dest in self.broadcasted_txids.items():
+                if dest != want:
+                    continue
+                try:
+                    if self.eth_rpc('eth_getTransactionByHash', [txid], null_needs_quorum=True) is not None:
+                        bt.logging.info(f'Reusing prior tx {txid} from {acct.address} → {to_address} ({amount} wei)')
+                        return (txid, 0)
+                except Exception as e:
+                    self._send_error(
+                        f'prior broadcast {txid[:16]}... unresolved ({e}) — refusing a possible double send'
+                    )
+                    return None
 
             latest = self.eth_rpc('eth_getBlockByNumber', ['latest', False])
             base_fee = int((latest or {}).get('baseFeePerGas') or '0x0', 16)
@@ -414,32 +434,30 @@ class EthereumProvider(ChainProvider):
             )
             expected_txid = signed.hash.hex()
             expected_txid = expected_txid if expected_txid.startswith('0x') else f'0x{expected_txid}'
-            # Record before broadcasting so a same-session retry can reclaim it via
-            # find_recent_outgoing even if the response is lost (mirrors the BTC provider).
-            self.broadcasted_txids.add(expected_txid)
+            # Record pre-broadcast so a retry can reclaim it even if the response is lost.
+            self.broadcasted_txids[expected_txid] = want
 
             raw = getattr(signed, 'raw_transaction', None) or getattr(signed, 'rawTransaction')
             raw_hex = raw.hex()
             raw_hex = raw_hex if raw_hex.startswith('0x') else f'0x{raw_hex}'
             try:
                 tx_hash = self.eth_rpc('eth_sendRawTransaction', [raw_hex], timeout=30)
-            except Exception as e:
-                if self.tx_exists(expected_txid):
-                    return (expected_txid, 0)
-                self._send_error(f'ETH broadcast failed: {e}')
+            except Exception as broadcast_err:
+                # The tx may have been accepted anyway — check before declaring failure.
+                try:
+                    if self.eth_rpc('eth_getTransactionByHash', [expected_txid], null_needs_quorum=True) is not None:
+                        return (expected_txid, 0)
+                except Exception:
+                    pass
+                self._send_error(f'ETH broadcast failed: {broadcast_err}')
                 return None
 
             bt.logging.info(f'Sent {amount} wei to {to_address} (tx: {tx_hash}, maxFee: {max_fee})')
-            return (tx_hash, 0)
+            # A quirky null broadcast reply must never persist as a blank tx hash.
+            return (tx_hash or expected_txid, 0)
         except Exception as e:
             self._send_error(f'ETH send failed: {type(e).__name__}: {e}')
             return None
-
-    def tx_exists(self, txid: str) -> bool:
-        try:
-            return self.eth_rpc('eth_getTransactionByHash', [txid]) is not None
-        except Exception:
-            return False
 
     _SETTLED_CACHE_MAX = _SETTLED_CACHE_MAX_DEFAULT
 
@@ -467,7 +485,9 @@ class EthereumProvider(ChainProvider):
             try:
                 block = self.eth_rpc('eth_getBlockByNumber', [hex(block_num), True])
             except Exception:
-                continue
+                # Never leap an unreadable block — park just below it and retry next call.
+                self.scan_cursors[key] = block_num - 1
+                return None
             for tx in (block or {}).get('transactions', []):
                 if self.normalize_address(tx.get('from') or '') != want_from:
                     continue

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -80,8 +80,8 @@ CHAIN_ETH = ChainDefinition(
     # ~1 beacon epoch. True finality is 2 epochs (~64 blocks); post-merge reorgs deeper than
     # 2 blocks are vanishingly rare, so 32 buys near-finality without doubling the leg time.
     min_confirmations=32,
-    # No protocol dust floor on ETH; economic floor ≈ a few × the 21k-gas transfer fee, so a
-    # leg can never be worth less than the gas it burns (5e13 wei = 0.00005 ETH).
+    # Rate sanity floor, not an economic guarantee: 0.00005 ETH covers a 21k-gas transfer
+    # fee only below ~2.4 gwei — miners price real gas into their quotes.
     min_onchain_amount=50_000_000_000_000,
     # Timestamps must strictly exceed the parent's, so a mined deposit can never stamp
     # earlier than a reservation created before it — no BTC-style median-time lag.

--- a/tests/test_ethereum_provider.py
+++ b/tests/test_ethereum_provider.py
@@ -31,7 +31,7 @@ def provider(monkeypatch):
 def rpc_stub(provider, responses: dict):
     """Replace eth_rpc with a method→response map. A callable value is invoked with params."""
 
-    def fake_rpc(method, params, timeout=15):
+    def fake_rpc(method, params, timeout=15, **kw):
         value = responses[method]
         return value(params) if callable(value) else value
 
@@ -69,7 +69,7 @@ def counting_rpc_stub(provider, responses: dict):
     """rpc_stub that also tallies calls per method into the returned dict."""
     calls: dict = {}
 
-    def fake_rpc(method, params, timeout=15):
+    def fake_rpc(method, params, timeout=15, **kw):
         calls[method] = calls.get(method, 0) + 1
         value = responses[method]
         return value(params) if callable(value) else value
@@ -420,3 +420,177 @@ class TestFindRecentOutgoing:
         assert provider.find_recent_outgoing(TEST_ADDR, RECIPIENT, 1) is None
         key = (TEST_ADDR.lower(), RECIPIENT.lower(), 1)
         assert provider.scan_cursors[key] == 100
+
+
+class TestNetworkGuard:
+    def test_unknown_network_raises(self, monkeypatch):
+        # A typo ('seplia') silently becoming mainnet would pay real ETH against test swaps.
+        monkeypatch.setenv('ETH_NETWORK', 'seplia')
+        with pytest.raises(ValueError, match='ETH_NETWORK'):
+            EthereumProvider()
+
+    def test_unset_defaults_to_mainnet(self, monkeypatch):
+        monkeypatch.delenv('ETH_NETWORK', raising=False)
+        monkeypatch.delenv('ETH_RPC_URLS', raising=False)
+        assert EthereumProvider().network == 'mainnet'
+
+
+class TestAbsenceQuorum:
+    """'Absent' (the verdict that slashes) requires every endpoint to reachably agree."""
+
+    class _Resp:
+        status_code = 200
+
+        def __init__(self, body):
+            self._body = body
+
+        def json(self):
+            return self._body
+
+    def _posts(self, provider, per_url: dict):
+        def post(url, json=None, timeout=15):
+            value = per_url[url]
+            if isinstance(value, Exception):
+                raise value
+            return self._Resp({'result': value})
+
+        provider.http.post = post
+        provider.rpc_bases = list(per_url)
+
+    def test_second_endpoint_overrules_a_stale_null(self, provider):
+        self._posts(provider, {'https://a.example': None, 'https://b.example': {'hash': TX}})
+        assert provider.eth_rpc('eth_getTransactionByHash', [TX], null_needs_quorum=True) == {'hash': TX}
+
+    def test_unanimous_null_is_absent(self, provider):
+        self._posts(provider, {'https://a.example': None, 'https://b.example': None})
+        assert provider.eth_rpc('eth_getTransactionByHash', [TX], null_needs_quorum=True) is None
+
+    def test_null_plus_unreachable_raises(self, provider):
+        self._posts(provider, {'https://a.example': None, 'https://b.example': ConnectionError('down')})
+        with pytest.raises(ProviderUnreachableError):
+            provider.eth_rpc('eth_getTransactionByHash', [TX], null_needs_quorum=True)
+
+    def test_without_flag_null_returns_immediately(self, provider):
+        self._posts(provider, {'https://a.example': None, 'https://b.example': {'hash': TX}})
+        assert provider.eth_rpc('eth_getTransactionByHash', [TX]) is None
+
+
+class TestBlockTimeUnknownNotStale:
+    """An unreadable block-time must raise (SKIP), not read as 'replay' and slash."""
+
+    def test_block_fetch_failure_raises(self, provider):
+        responses = mined_tx_responses()
+
+        def boom(params):
+            raise RuntimeError('node behind')
+
+        responses['eth_getBlockByNumber'] = boom
+        rpc_stub(provider, responses)
+        with pytest.raises(ProviderUnreachableError):
+            provider.fetch_matching_tx(TX, RECIPIENT, 10**18)
+
+    def test_missing_timestamp_raises(self, provider):
+        responses = mined_tx_responses()
+        responses['eth_getBlockByNumber'] = {}
+        rpc_stub(provider, responses)
+        with pytest.raises(ProviderUnreachableError):
+            provider.fetch_matching_tx(TX, RECIPIENT, 10**18)
+
+
+SEND_RESPONSES = {
+    'eth_getBlockByNumber': {'baseFeePerGas': hex(10**9)},
+    'eth_maxPriorityFeePerGas': hex(10**9),
+    'eth_getTransactionCount': '0x0',
+    'eth_getBalance': hex(10**19),
+}
+
+
+class TestSendResilience:
+    @pytest.fixture(autouse=True)
+    def _key(self, provider, monkeypatch):
+        # After `provider`, whose fixture delenvs the key.
+        monkeypatch.setenv('ETH_PRIVATE_KEY', TEST_KEY)
+
+    def test_null_broadcast_response_still_returns_the_local_hash(self, provider):
+        # The hash is computed locally from the signed tx — a quirky 'result: null' from the
+        # broadcast must never become a blank hash in the miner's persisted send record.
+        rpc_stub(provider, dict(SEND_RESPONSES, eth_sendRawTransaction=None))
+        result = provider.send_amount(RECIPIENT, 10**15)
+        assert result is not None
+        tx_hash, _ = result
+        assert tx_hash and tx_hash.startswith('0x')
+        assert tx_hash in provider.broadcasted_txids
+
+    def test_lost_broadcast_response_recovers_via_lookup(self, provider):
+        def boom(params):
+            raise ConnectionError('reset mid-flight')
+
+        rpc_stub(
+            provider,
+            dict(SEND_RESPONSES, eth_sendRawTransaction=boom, eth_getTransactionByHash={'hash': 'seen'}),
+        )
+        result = provider.send_amount(RECIPIENT, 10**15)
+        assert result is not None
+        assert result[0] in provider.broadcasted_txids
+
+    def test_unprovable_broadcast_fails_closed(self, provider):
+        def boom(params):
+            raise ConnectionError('down')
+
+        rpc_stub(provider, dict(SEND_RESPONSES, eth_sendRawTransaction=boom, eth_getTransactionByHash=boom))
+        assert provider.send_amount(RECIPIENT, 10**15) is None
+        assert 'broadcast failed' in provider.last_send_error
+
+    def test_prior_broadcast_in_mempool_is_reused_not_resent(self, provider):
+        provider.broadcasted_txids[TX] = (RECIPIENT.lower(), 10**15)
+        # No eth_sendRawTransaction in the map: a resend attempt would fail the test.
+        rpc_stub(provider, dict(SEND_RESPONSES, eth_getTransactionByHash={'hash': TX}))
+        assert provider.send_amount(RECIPIENT, 10**15) == (TX, 0)
+
+    def test_unresolved_prior_broadcast_blocks_a_fresh_send(self, provider):
+        def boom(params):
+            raise ConnectionError('down')
+
+        provider.broadcasted_txids[TX] = (RECIPIENT.lower(), 10**15)
+        rpc_stub(provider, dict(SEND_RESPONSES, eth_getTransactionByHash=boom))
+        assert provider.send_amount(RECIPIENT, 10**15) is None
+        assert 'double send' in provider.last_send_error
+
+    def test_prior_broadcast_to_other_dest_does_not_interfere(self, provider):
+        provider.broadcasted_txids[TX] = ('0x' + '22' * 20, 10**15)
+        rpc_stub(provider, dict(SEND_RESPONSES, eth_sendRawTransaction='0x' + 'cc' * 32))
+        result = provider.send_amount(RECIPIENT, 10**15)
+        assert result == ('0x' + 'cc' * 32, 0)
+
+
+class TestScannerCursorParking:
+    """An unreadable block parks the cursor — leaping it would orphan a deposit forever."""
+
+    MATCH = {
+        'hash': '0x' + 'aa' * 32,
+        'from': TEST_ADDR.lower(),
+        'to': RECIPIENT.lower(),
+        'value': hex(10**18),
+    }
+
+    def test_failed_block_parks_cursor_then_recovers(self, provider):
+        state = {'broken': True}
+
+        def rpc(method, params, timeout=15, **kw):
+            if method == 'eth_blockNumber':
+                return hex(100)
+            if method == 'eth_getBlockByNumber':
+                block_num = int(params[0], 16)
+                if block_num == 80 and state['broken']:
+                    raise RuntimeError('read failed')
+                return {'transactions': [self.MATCH] if block_num == 80 else []}
+            if method == 'eth_getTransactionReceipt':
+                return {'status': '0x1'}
+            raise AssertionError(method)
+
+        provider.eth_rpc = rpc
+        key = (TEST_ADDR.lower(), RECIPIENT.lower(), 10**18)
+        assert provider.find_recent_outgoing(TEST_ADDR, RECIPIENT, 10**18) is None
+        assert provider.scan_cursors[key] == 79
+        state['broken'] = False
+        assert provider.find_recent_outgoing(TEST_ADDR, RECIPIENT, 10**18) == self.MATCH['hash']

--- a/tests/test_ethereum_provider.py
+++ b/tests/test_ethereum_provider.py
@@ -498,6 +498,7 @@ class TestBlockTimeUnknownNotStale:
 
 
 SEND_RESPONSES = {
+    'eth_blockNumber': hex(100),
     'eth_getBlockByNumber': {'baseFeePerGas': hex(10**9)},
     'eth_maxPriorityFeePerGas': hex(10**9),
     'eth_getTransactionCount': '0x0',
@@ -542,22 +543,79 @@ class TestSendResilience:
         assert 'broadcast failed' in provider.last_send_error
 
     def test_prior_broadcast_in_mempool_is_reused_not_resent(self, provider):
-        provider.broadcasted_txids[TX] = (RECIPIENT.lower(), 10**15)
+        provider.broadcasted_txids[TX] = (RECIPIENT.lower(), 10**15, 95)
         # No eth_sendRawTransaction in the map: a resend attempt would fail the test.
         rpc_stub(provider, dict(SEND_RESPONSES, eth_getTransactionByHash={'hash': TX}))
         assert provider.send_amount(RECIPIENT, 10**15) == (TX, 0)
+
+    def test_settled_prior_broadcast_is_reused(self, provider):
+        provider.broadcasted_txids[TX] = (RECIPIENT.lower(), 10**15, 95)
+        rpc_stub(
+            provider,
+            dict(
+                SEND_RESPONSES,
+                eth_getTransactionByHash={'hash': TX, 'blockNumber': hex(96)},
+                eth_getTransactionReceipt={'status': '0x1'},
+            ),
+        )
+        assert provider.send_amount(RECIPIENT, 10**15) == (TX, 0)
+
+    def test_reverted_prior_broadcast_clears_and_sends_fresh(self, provider):
+        # A reverted tx moved no funds — reusing its hash would hand the validator a
+        # rejected leg forever. It must clear and allow a fresh send.
+        provider.broadcasted_txids[TX] = (RECIPIENT.lower(), 10**15, 95)
+        rpc_stub(
+            provider,
+            dict(
+                SEND_RESPONSES,
+                eth_getTransactionByHash={'hash': TX, 'blockNumber': hex(96)},
+                eth_getTransactionReceipt={'status': '0x0'},
+                eth_sendRawTransaction='0x' + 'cc' * 32,
+            ),
+        )
+        assert provider.send_amount(RECIPIENT, 10**15) == ('0x' + 'cc' * 32, 0)
+        assert TX not in provider.broadcasted_txids
+
+    def test_prior_broadcast_outside_window_is_pruned_not_reused(self, provider):
+        # Head 100, seen at 60 → beyond SCAN_LOOKBACK_BLOCKS: a later same-amount swap must
+        # never resolve to an earlier swap's consumed tx (freshness would slash the miner).
+        provider.broadcasted_txids[TX] = (RECIPIENT.lower(), 10**15, 60)
+        rpc_stub(provider, dict(SEND_RESPONSES, eth_sendRawTransaction='0x' + 'cc' * 32))
+        assert provider.send_amount(RECIPIENT, 10**15) == ('0x' + 'cc' * 32, 0)
+        assert TX not in provider.broadcasted_txids
+
+    def test_mined_prior_with_unavailable_receipt_blocks_send(self, provider):
+        provider.broadcasted_txids[TX] = (RECIPIENT.lower(), 10**15, 95)
+        rpc_stub(
+            provider,
+            dict(
+                SEND_RESPONSES,
+                eth_getTransactionByHash={'hash': TX, 'blockNumber': hex(96)},
+                eth_getTransactionReceipt=None,
+            ),
+        )
+        assert provider.send_amount(RECIPIENT, 10**15) is None
+        assert 'double send' in provider.last_send_error
 
     def test_unresolved_prior_broadcast_blocks_a_fresh_send(self, provider):
         def boom(params):
             raise ConnectionError('down')
 
-        provider.broadcasted_txids[TX] = (RECIPIENT.lower(), 10**15)
+        provider.broadcasted_txids[TX] = (RECIPIENT.lower(), 10**15, 95)
         rpc_stub(provider, dict(SEND_RESPONSES, eth_getTransactionByHash=boom))
         assert provider.send_amount(RECIPIENT, 10**15) is None
         assert 'double send' in provider.last_send_error
 
+    def test_unreadable_chain_head_blocks_send(self, provider):
+        def down(params):
+            raise ConnectionError('down')
+
+        rpc_stub(provider, dict(SEND_RESPONSES, eth_blockNumber=down))
+        assert provider.send_amount(RECIPIENT, 10**15) is None
+        assert 'chain head' in provider.last_send_error
+
     def test_prior_broadcast_to_other_dest_does_not_interfere(self, provider):
-        provider.broadcasted_txids[TX] = ('0x' + '22' * 20, 10**15)
+        provider.broadcasted_txids[TX] = ('0x' + '22' * 20, 10**15, 95)
         rpc_stub(provider, dict(SEND_RESPONSES, eth_sendRawTransaction='0x' + 'cc' * 32))
         result = provider.send_amount(RECIPIENT, 10**15)
         assert result == ('0x' + 'cc' * 32, 0)


### PR DESCRIPTION
Surgical fixes for the ETH-spoke review findings (#1 smart-wallet slash exploit is parked pending design go-ahead). One file of production changes.

## Validator slash paths (false-slash prevention)
- **Absence quorum** (`eth_rpc null_needs_quorum`): a tx-lookup null is authoritative only when every endpoint reachably agrees; null + an unreachable endpoint raises `ProviderUnreachableError` (SKIP). One stale server in a public load balancer can no longer slash an honest miner.
- **Block-time unknown ≠ stale**: a failed block/timestamp fetch on a mined, settled tx raises (SKIP) instead of returning `block_time=None`, which the freshness gate fails closed on — previously a slash.

## Miner send correctness
- Broadcast success always returns the locally-computed tx hash — a `result: null` broadcast reply can no longer persist a blank hash that permanently bricks the swap's retry loop.
- `send_amount` probes its own prior broadcasts by hash (mempool-inclusive) before sending again; an unresolvable probe aborts instead of risking a double pay.

## Config / scanner
- Unknown `ETH_NETWORK` (typo) raises instead of silently defaulting to mainnet.
- Deposit scanner parks its cursor below an unreadable block instead of skipping it forever.
- ETH dust-floor comment corrected (rate sanity floor, not an economic guarantee).

Tests: 933 passed (19 new: quorum matrix, block-time unknown, send resilience, cursor parking, network guard).