### PR TITLE
Add ETH delivery gates: reserve preflight, gas estimate, slash exemption

### DIFF
--- a/allways/chain_providers/base.py
+++ b/allways/chain_providers/base.py
@@ -194,6 +194,14 @@ class ChainProvider(ABC):
     @abstractmethod
     def is_valid_address(self, address: str) -> bool: ...
 
+    def can_deliver_to(self, address: str, amount: int) -> bool:
+        """Reserve-time gate: False only on positive evidence the destination cannot receive."""
+        return True
+
+    def delivery_refused(self, address: str, since_unix: int) -> bool:
+        """Slash gate: True only on positive evidence delivery was refusable since ``since_unix``."""
+        return False
+
     @abstractmethod
     def sign_from_proof(self, address: str, message: str, key: Optional[Any] = None) -> str:
         """Sign a source proof message with the given key. Returns hex signature."""

--- a/allways/chain_providers/ethereum.py
+++ b/allways/chain_providers/ethereum.py
@@ -1,5 +1,6 @@
 import os
 import re
+import time
 from collections import OrderedDict
 from typing import Any, Dict, Optional, Tuple
 from urllib.parse import urlparse
@@ -27,6 +28,10 @@ DEFAULT_RPC_URLS = {
 }
 
 TRANSFER_GAS = 21_000
+# Refuse destinations whose receive hook wants more than this — bounds the miner's gas
+# spend against a hostile contract; the slash gate exempts code-bearing dests anyway.
+MAX_TRANSFER_GAS = 100_000
+ZERO_ADDRESS = '0x' + '00' * 20
 
 _HEX_ADDR_RE = re.compile(r'^0x[0-9a-fA-F]{40}$')
 
@@ -415,12 +420,17 @@ class EthereumProvider(ChainProvider):
             # 2× base fee absorbs six consecutive maximally-full blocks before the cap binds.
             max_fee = 2 * base_fee + tip_fee
 
+            gas = self._transfer_gas(acct.address, to_address, amount)
+            if gas is None:
+                self._send_error(f'destination {to_address} refuses ETH transfers — not sending')
+                return None
+
             nonce = int(self.eth_rpc('eth_getTransactionCount', [acct.address, 'pending']), 16)
 
             balance = self.get_balance(acct.address)
-            needed = amount + TRANSFER_GAS * max_fee
+            needed = amount + gas * max_fee
             if balance < needed:
-                self._send_error(f'Insufficient ETH: have {balance} wei, need {amount} + {TRANSFER_GAS * max_fee} gas')
+                self._send_error(f'Insufficient ETH: have {balance} wei, need {amount} + {gas * max_fee} gas')
                 return None
 
             signed = Account.sign_transaction(
@@ -429,7 +439,7 @@ class EthereumProvider(ChainProvider):
                     'nonce': nonce,
                     'to': to_address,
                     'value': amount,
-                    'gas': TRANSFER_GAS,
+                    'gas': gas,
                     'maxFeePerGas': max_fee,
                     'maxPriorityFeePerGas': tip_fee,
                 },
@@ -486,6 +496,39 @@ class EthereumProvider(ChainProvider):
                 return txid
             del self.broadcasted_txids[txid]
         return None
+
+    def _transfer_gas(self, from_addr: str, to_addr: str, amount: int) -> Optional[int]:
+        """Gas limit via eth_estimateGas (+20% headroom for smart-wallet receive hooks); None
+        when the destination refuses or wants absurd gas. Estimator trouble falls back to the
+        plain-transfer minimum rather than blocking an EOA payout."""
+        try:
+            est = int(self.eth_rpc('eth_estimateGas', [{'from': from_addr, 'to': to_addr, 'value': hex(amount)}]), 16)
+        except Exception as e:
+            return None if 'revert' in str(e).lower() else TRANSFER_GAS
+        gas = est + est // 5
+        return None if gas > MAX_TRANSFER_GAS else gas
+
+    def can_deliver_to(self, address: str, amount: int) -> bool:
+        """Reserve-time gate: an EOA can never refuse a transfer; a code-bearing dest must pass
+        a simulated transfer. Fails open — only a positive revert blocks a reservation."""
+        try:
+            if (self.eth_rpc('eth_getCode', [address, 'latest']) or '0x') == '0x':
+                return True
+            self.eth_rpc('eth_estimateGas', [{'from': ZERO_ADDRESS, 'to': address, 'value': hex(amount)}])
+            return True
+        except Exception as e:
+            return 'revert' not in str(e).lower()
+
+    def delivery_refused(self, address: str, since_unix: int) -> bool:
+        """Slash gate: code at the destination — now or sampled across the window since
+        ``since_unix`` — is positive evidence a transfer could fail; never slash over it.
+        getCode is dest-only (miner can't influence it) where a simulation is gameable by
+        either side. Raises when the chain view is unavailable (caller defers)."""
+        tip = int(self.eth_rpc('eth_blockNumber', []), 16)
+        # Probe depth clamped to what non-archive public nodes serve (~128 blocks).
+        span = min(120, max(0, int(time.time()) - int(since_unix)) // self.get_chain().seconds_per_block)
+        probes = ['latest'] + [hex(max(0, tip - span // d)) for d in (1, 2)]
+        return any((self.eth_rpc('eth_getCode', [address, b]) or '0x') != '0x' for b in probes)
 
     _SETTLED_CACHE_MAX = _SETTLED_CACHE_MAX_DEFAULT
 

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -116,6 +116,12 @@ def reserve_on_behalf(
     if not ok:
         return ReserveResult(False, reason)
 
+    # Deliverability gate — BEFORE any funds move: a dest that provably refuses transfers
+    # (e.g. a reverting contract wallet) must bounce here, not strand a paid swap later.
+    provider = getattr(validator, 'axon_chain_providers', {}).get(to_chain)
+    if provider is not None and not provider.can_deliver_to(user_to_addr, amts.to_amount):
+        return ReserveResult(False, 'destination address rejects incoming transfers')
+
     try:
         user_pk = Pubkey.from_string(user_pubkey)
     except Exception:

--- a/allways/validator/solana_swap_loop.py
+++ b/allways/validator/solana_swap_loop.py
@@ -174,6 +174,17 @@ class SolanaSwapLoop:
             return False
         return True
 
+    def _dest_refuses(self, swap: Any) -> bool:
+        """Evidence the dest can't receive (or the check is unavailable) — either way, never slash on it."""
+        provider = self.providers.get(swap.to_chain)
+        if provider is None:
+            return False
+        try:
+            return provider.delivery_refused(swap.user_to_addr, int(swap.initiated_at))
+        except Exception as e:
+            bt.logging.warning(f'{self._label(swap)}: delivery_refused check failed ({e}) — deferring, not slashing')
+            return True
+
     def _get_reservation(self, miner: Any) -> Any:
         try:
             return self.client.get_reservation(miner)
@@ -252,11 +263,11 @@ class SolanaSwapLoop:
         why = (
             f'src={s_status} dst={d_status} [{_confs(swap.to_chain, d_info)}] timeout_in={int(swap.timeout_at) - now}s'
         )
-        return (
-            SwapAction(SwapDecision.TIMEOUT, reason=f'{why} + overdue — dest unverifiable, slashing')
-            if overdue
-            else SwapAction(SwapDecision.WAIT, reason=f'{why} — awaiting a verifiable+fresh dest leg')
-        )
+        if not overdue:
+            return SwapAction(SwapDecision.WAIT, reason=f'{why} — awaiting a verifiable+fresh dest leg')
+        if self._dest_refuses(swap):
+            return SwapAction(SwapDecision.WAIT, reason=f'{why} + overdue but dest refuses delivery — not slashing')
+        return SwapAction(SwapDecision.TIMEOUT, reason=f'{why} + overdue — dest unverifiable, slashing')
 
     def _reject_logged(self, swap: Any, expected_to: int) -> None:
         """Warn once per swap key that to_amount diverges from the pinned rate (security-relevant, greppable)."""
@@ -334,6 +345,8 @@ class SolanaSwapLoop:
             return self._decide_pending_attestation(swap, now)
         if status == 'Active':
             # Never extend: no mark_fulfilled = no broadcast evidence, so an overdue Active is slash-eligible.
+            if overdue and self._dest_refuses(swap):
+                return SwapAction(SwapDecision.WAIT, reason='overdue but dest refuses delivery — not slashing')
             return SwapAction(
                 SwapDecision.TIMEOUT if overdue else SwapDecision.WAIT,
                 reason='overdue, miner never fulfilled — slashing' if overdue else 'awaiting miner mark_fulfilled',

--- a/tests/test_ethereum_provider.py
+++ b/tests/test_ethereum_provider.py
@@ -652,3 +652,87 @@ class TestScannerCursorParking:
         assert provider.scan_cursors[key] == 79
         state['broken'] = False
         assert provider.find_recent_outgoing(TEST_ADDR, RECIPIENT, 10**18) == self.MATCH['hash']
+
+
+class TestDeliveryGates:
+    """B-lite: simulation where helpful (reserve UX, miner gas), getCode where the decision
+    must be ungameable (slash gate)."""
+
+    def _revert(self, params):
+        raise RuntimeError('rpc error execution reverted')
+
+    def test_can_deliver_to_eoa_true_without_simulation(self, provider):
+        calls = counting_rpc_stub(provider, {'eth_getCode': '0x'})
+        assert provider.can_deliver_to(RECIPIENT, 10**15)
+        assert 'eth_estimateGas' not in calls
+
+    def test_can_deliver_to_accepting_contract(self, provider):
+        rpc_stub(provider, {'eth_getCode': '0x6080', 'eth_estimateGas': '0xb000'})
+        assert provider.can_deliver_to(RECIPIENT, 10**15)
+
+    def test_can_deliver_to_reverting_contract_false(self, provider):
+        rpc_stub(provider, {'eth_getCode': '0x6080', 'eth_estimateGas': self._revert})
+        assert not provider.can_deliver_to(RECIPIENT, 10**15)
+
+    def test_can_deliver_to_fails_open_on_rpc_trouble(self, provider):
+        def down(params):
+            raise ConnectionError('down')
+
+        rpc_stub(provider, {'eth_getCode': down})
+        assert provider.can_deliver_to(RECIPIENT, 10**15)
+
+    def test_delivery_refused_code_at_latest(self, provider):
+        rpc_stub(
+            provider, {'eth_blockNumber': hex(1000), 'eth_getCode': lambda p: '0xef0100' if p[1] == 'latest' else '0x'}
+        )
+        assert provider.delivery_refused(RECIPIENT, 0)
+
+    def test_delivery_refused_code_only_in_window_history(self, provider):
+        # Code was attached mid-window then detached — the historical probe still sees it.
+        rpc_stub(
+            provider, {'eth_blockNumber': hex(1000), 'eth_getCode': lambda p: '0x' if p[1] == 'latest' else '0x6080'}
+        )
+        assert provider.delivery_refused(RECIPIENT, 0)
+
+    def test_delivery_refused_clean_eoa_false(self, provider):
+        rpc_stub(provider, {'eth_blockNumber': hex(1000), 'eth_getCode': '0x'})
+        assert not provider.delivery_refused(RECIPIENT, 0)
+
+    def test_delivery_refused_raises_when_view_unavailable(self, provider):
+        def down(params):
+            raise ConnectionError('down')
+
+        rpc_stub(provider, {'eth_blockNumber': hex(1000), 'eth_getCode': down})
+        with pytest.raises(Exception):
+            provider.delivery_refused(RECIPIENT, 0)
+
+
+class TestTransferGas:
+    @pytest.fixture(autouse=True)
+    def _key(self, provider, monkeypatch):
+        monkeypatch.setenv('ETH_PRIVATE_KEY', TEST_KEY)
+
+    def _send(self, provider, estimate):
+        responses = dict(SEND_RESPONSES, eth_sendRawTransaction='0x' + 'cc' * 32, eth_estimateGas=estimate)
+        rpc_stub(provider, responses)
+        return provider.send_amount(RECIPIENT, 10**15)
+
+    def test_estimate_sizes_the_send_with_headroom(self, provider):
+        assert self._send(provider, hex(50_000)) is not None  # 60k limit, under cap
+
+    def test_reverting_destination_refuses_send(self, provider):
+        def revert(params):
+            raise RuntimeError('rpc error execution reverted')
+
+        assert self._send(provider, revert) is None
+        assert 'refuses' in provider.last_send_error
+
+    def test_absurd_estimate_refuses_send(self, provider):
+        assert self._send(provider, hex(500_000)) is None
+        assert 'refuses' in provider.last_send_error
+
+    def test_estimator_down_falls_back_to_plain_transfer_gas(self, provider):
+        def down(params):
+            raise ConnectionError('down')
+
+        assert self._send(provider, down) is not None

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -95,6 +95,17 @@ def test_open_happy_path_persists_routed_request():
     store.close()
 
 
+def test_undeliverable_destination_rejects_before_any_bid():
+    # B-lite reserve gate: a dest that provably refuses transfers bounces before funds move.
+    client = FakeClient()
+    validator = _validator(client)
+    validator.axon_chain_providers = {'btc': SimpleNamespace(can_deliver_to=lambda addr, amt: False)}
+    result = reserve_on_behalf(validator, HOTKEY, 'sol', 'btc', USER_PK, str(USER_PK), 'userBTCaddr', 10**9)
+    assert not result.ok
+    assert 'rejects incoming transfers' in result.reason
+    assert client.calls == []  # bounced before the on-chain bid
+
+
 def test_inactive_miner_rejects():
     r, store = _reserve(FakeClient(active=False))
     assert not r.ok and 'not active' in r.reason

--- a/tests/test_solana_swap_loop.py
+++ b/tests/test_solana_swap_loop.py
@@ -66,7 +66,13 @@ class RecordingProvider:
         self.block_time = block_time
         self.grace = grace
         self.confirmations = confirmations
+        self.refuses = False
         self.calls = []
+
+    def delivery_refused(self, address, since_unix):
+        if self.refuses == 'unreachable':
+            raise ProviderUnreachableError('down')
+        return self.refuses
 
     def get_chain(self):
         return SimpleNamespace(replay_grace_secs=self.grace)
@@ -153,6 +159,25 @@ def test_fulfilled_overdue_absent_dest_times_out():
     loop, providers = loop_with(result=True)
     providers['sol'].result = None  # dest tx absent
     assert loop.decide(make_swap(status='Fulfilled', timeout_at=1000), now=1500).decision == SwapDecision.TIMEOUT
+
+
+def test_fulfilled_overdue_refusing_dest_waits_no_slash():
+    # B-lite slash gate: positive evidence the dest can't receive (code seen in window) → never slash.
+    loop, providers = loop_with(result=None)
+    providers['sol'].refuses = True
+    assert loop.decide(make_swap(status='Fulfilled', timeout_at=1000), now=1500).decision == SwapDecision.WAIT
+
+
+def test_fulfilled_overdue_refusal_check_down_defers():
+    loop, providers = loop_with(result=None)
+    providers['sol'].refuses = 'unreachable'
+    assert loop.decide(make_swap(status='Fulfilled', timeout_at=1000), now=1500).decision == SwapDecision.WAIT
+
+
+def test_active_overdue_refusing_dest_waits_no_slash():
+    loop, providers = loop_with(result=None)
+    providers['sol'].refuses = True
+    assert loop.decide(make_swap(status='Active', timeout_at=1000), now=1500).decision == SwapDecision.WAIT
 
 
 def test_fulfilled_overdue_but_verifiable_still_confirms():


### PR DESCRIPTION
**TLDR: a scammer could give a swap a wallet address that refuses money. The miner's payment bounces, and the protocol punishes the miner for "not paying" — the scammer collects the penalty. This PR makes the system check "can this address actually receive money?" at every step, so the scam loses money instead of making it, and normal smart wallets start working.**

## The problem

Ethereum has two kinds of wallets: plain ones, and "smart" ones that run a little program when money arrives (Safe, Argent, most modern team wallets). Our miners send payments with only enough fee budget for a plain wallet — so a payment to any smart wallet always fails.

A scammer can weaponize that: start a swap and give a wallet that's programmed to reject money as the payout address. The miner's payment bounces, the swap expires, and the protocol reads that as "the miner never paid" — it takes 1.10x from the miner's deposit and hands it to the scammer, who only put in 1.0x. A guaranteed 10% profit, repeatable against every ETH miner. Honest smart-wallet users trip the same wire by accident.

## The fix — three checks

1. **At booking, before the user pays anything.** Test whether money sent to that address would actually arrive. If not, refuse the swap right there with a clear error. No one's funds ever enter a doomed swap.
2. **When the miner pays.** The miner first asks the network what this payment needs and whether it will go through. Smart wallets now get paid properly; a money-rejecting address makes the miner decline rather than throw a payment at a wall.
3. **Before punishing a miner.** One question: was the payout address a plain wallet the entire time? A plain wallet *cannot* refuse money — Ethereum guarantees it — so if it was plain and nothing arrived, the miner really didn't pay: punish. But if the address ever had a program on it during the swap, the recipient could have sabotaged the payment: don't punish. The answer comes from the blockchain's permanent public record of the *user's* address — neither side can alter it after the fact.

## Why the scam is now dead

Refusing wallet up front → booking rejected, scammer pays nothing, gets nothing. Sneak the program on *after* booking → the miner declines and keeps the scammer's payment, and no punishment lands. Every route now costs the scammer money. Meanwhile a regular person with a Safe wallet just gets their payout.

Other chains untouched (checks are no-ops outside ETH). Stacked on #618. Tests: 954 passed (16 new).