### PR TITLE
Bump allways to 2.2.0 for the ETH spoke

### DIFF
--- a/allways/__init__.py
+++ b/allways/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '2.1.0'
+__version__ = '2.2.0'
 version_split = __version__.split('.')
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "allways"
-version = "2.1.0"
+version = "2.2.0"
 description = "Allways - Universal Transaction Layer: Collateral-backed cross-chain swaps on Bittensor Subnet 7"
 license = "MIT"
 requires-python = ">=3.10,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "allways"
-version = "2.1.0"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "base58" },


### PR DESCRIPTION
`test` and `main` are both sitting at 2.1.0, so the ETH spoke (#613) is currently indistinguishable from the pre-ETH release by version. Minor bump — new spoke, backward compatible, no breaking API.

Two spots, the only places the version lives:
- `pyproject.toml:3`
- `allways/__init__.py:1`

`__spec_version__` derives from it (`1000·major + 10·minor + patch`), so this moves 2010 → 2020. That value is passed as `version_key` on `set_weights` (`neurons/base/validator.py:227`) and has no other consumer — there's no miner/validator compatibility gate — but validators will report two different version keys until the rollout finishes.

Unrelated to the Solana program's `CONFIG_VERSION`, which versions on its own axis.