### PR TITLE
Reject non-lowercase chain ids at program intake

### DIFF
--- a/smart-contracts/solana/programs/allways_swap_manager/Cargo.toml
+++ b/smart-contracts/solana/programs/allways_swap_manager/Cargo.toml
@@ -26,6 +26,7 @@ solana-keccak-hasher = "3.1.0"
 
 [dev-dependencies]
 litesvm = "0.10.0"
+solana-account = "3.0.0"
 # SlotHashes: seeded into LiteSVM so resolve_pool's draw runs against the canonical sysvar layout
 # rather than a test-only fallback seed.
 solana-sysvar = "3.1.1"

--- a/smart-contracts/solana/programs/allways_swap_manager/src/error.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/error.rs
@@ -93,8 +93,6 @@ pub enum ErrorCode {
     SameChain,
     #[msg("A required string field is empty")]
     EmptyField,
-    #[msg("Chain ids must be lowercase")]
-    ChainNotLowercase,
 
     // --- Phase 9: reservation lottery ---
     #[msg("Miner has an open reservation pool for a different pair; wait for it to resolve")]
@@ -139,4 +137,8 @@ pub enum ErrorCode {
     InvalidUser,
     #[msg("round_key does not match the keccak hash of the submitted weights snapshot")]
     WeightsRoundKeyMismatch,
+
+    // --- Chain-id canonicalization (appended: earlier codes are frozen — client.py maps them by number) ---
+    #[msg("Chain ids must be lowercase")]
+    ChainNotLowercase,
 }

--- a/smart-contracts/solana/programs/allways_swap_manager/src/error.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/error.rs
@@ -93,6 +93,8 @@ pub enum ErrorCode {
     SameChain,
     #[msg("A required string field is empty")]
     EmptyField,
+    #[msg("Chain ids must be lowercase")]
+    ChainNotLowercase,
 
     // --- Phase 9: reservation lottery ---
     #[msg("Miner has an open reservation pool for a different pair; wait for it to resolve")]

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/open_or_request.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/open_or_request.rs
@@ -83,6 +83,7 @@ pub fn handler(ctx: Context<OpenOrRequest>, from_chain: String, to_chain: String
         from_chain.len() <= MAX_CHAIN_LEN && to_chain.len() <= MAX_CHAIN_LEN,
         ErrorCode::StringTooLong
     );
+    crate::validate::chain_ids_lowercase(&from_chain, &to_chain)?;
 
     require!(ctx.accounts.miner_state.active, ErrorCode::MinerNotActive);
     require!(

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/set_quote.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/set_quote.rs
@@ -66,6 +66,7 @@ pub fn handler(
         ErrorCode::StringTooLong
     );
     require!(from_chain != to_chain, ErrorCode::SameChain);
+    crate::validate::chain_ids_lowercase(&from_chain, &to_chain)?;
 
     // Floor to RATE_SIG_FIGS significant figures before it is stored OR emitted, so the pinned swap
     // rate, the off-chain crown ranking, and the indexer/UI all read the same canonical value. A

--- a/smart-contracts/solana/programs/allways_swap_manager/src/validate.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/validate.rs
@@ -9,6 +9,16 @@ use crate::constants::{
 };
 use crate::error::ErrorCode;
 
+/// Chain ids must be lowercase at intake. The program's chain-identity sites disagree on casing
+/// (the grace table matches case-insensitively, the numeraire collateral bind and the quote/pool
+/// PDA seeds are byte-exact), so a mixed-case id silently sizes collateral against the wrong leg
+/// and splits quote records. One gate at the two intake doors kills the whole class.
+pub fn chain_ids_lowercase(from_chain: &str, to_chain: &str) -> Result<()> {
+    let lower = |s: &str| !s.bytes().any(|b| b.is_ascii_uppercase());
+    require!(lower(from_chain) && lower(to_chain), ErrorCode::ChainNotLowercase);
+    Ok(())
+}
+
 /// Quorum threshold as a percent of the validator set. Floored at a majority: anything below 51 lets
 /// a single validator (or a sub-majority clique) pass votes alone once the set has >1 member.
 pub fn consensus_threshold(percent: u8) -> Result<()> {

--- a/smart-contracts/solana/programs/allways_swap_manager/src/validate.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/validate.rs
@@ -9,10 +9,12 @@ use crate::constants::{
 };
 use crate::error::ErrorCode;
 
-/// Chain ids must be lowercase at intake. The program's chain-identity sites disagree on casing
-/// (the grace table matches case-insensitively, the numeraire collateral bind and the quote/pool
-/// PDA seeds are byte-exact), so a mixed-case id silently sizes collateral against the wrong leg
-/// and splits quote records. One gate at the two intake doors kills the whole class.
+/// Chain ids must be lowercase at intake. The program's chain-identity sites disagree on ASCII
+/// casing (the grace table matches case-insensitively, the numeraire collateral bind and the
+/// quote/pool PDA seeds are byte-exact), so "SOL" aliases "sol" in some sites while acting as a
+/// different chain in the money-critical ones — silently sizing collateral against the wrong leg.
+/// This gate at the two intake doors kills the ASCII-casing alias class; any other unknown string
+/// (typos, homoglyphs) is simply a distinct id that matches no real quote and dies unfunded.
 pub fn chain_ids_lowercase(from_chain: &str, to_chain: &str) -> Result<()> {
     let lower = |s: &str| !s.bytes().any(|b| b.is_ascii_uppercase());
     require!(lower(from_chain) && lower(to_chain), ErrorCode::ChainNotLowercase);

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
@@ -62,8 +62,8 @@ const TEST_POOL_WINDOW_SECS: i64 = 3;
 const FROM_ADDR: &str = "userBTCaddr";
 // Fixed taker pinned by the lottery (the Swap's user/payout come from the reservation, not the claim).
 const PINNED_USER: Pubkey = Pubkey::new_from_array([7u8; 32]);
-const FROM_CHAIN: &str = "BTC";
-const TO_CHAIN: &str = "SOL";
+const FROM_CHAIN: &str = "btc";
+const TO_CHAIN: &str = "sol";
 const MINER_FROM: &str = "minerBTCaddr";
 const MINER_TO: &str = "minerSOLaddr";
 const RATE: u128 = 1_500_000_000_000_000_000; // 1.5 × RATE_PRECISION (1e18)
@@ -973,14 +973,14 @@ fn onchain_set_quote_creates_pda() {
     let rpc = rpc();
     let miner = funded_keypair(&rpc, 10 * LAMPORTS_PER_SOL);
 
-    send(&rpc, set_quote_ix(&miner.pubkey(), "BTC", "SOL", RATE), &miner.pubkey(), &miner)
+    send(&rpc, set_quote_ix(&miner.pubkey(), "btc", "sol", RATE), &miner.pubkey(), &miner)
         .expect("set_quote");
 
-    let a = rpc.get_account(&quote_pda(&miner.pubkey(), "BTC", "SOL")).expect("quote account");
+    let a = rpc.get_account(&quote_pda(&miner.pubkey(), "btc", "sol")).expect("quote account");
     let q = MinerQuote::try_deserialize(&mut a.data.as_slice()).unwrap();
     assert_eq!(q.miner, miner.pubkey());
-    assert_eq!(q.from_chain, "BTC");
-    assert_eq!(q.to_chain, "SOL");
+    assert_eq!(q.from_chain, "btc");
+    assert_eq!(q.to_chain, "sol");
     assert_eq!(q.rate, RATE);
     assert!(q.updated_at > 0, "updated_at set from on-chain clock");
 }
@@ -992,11 +992,11 @@ fn onchain_remove_quote_closes_pda() {
     let rpc = rpc();
     let miner = funded_keypair(&rpc, 10 * LAMPORTS_PER_SOL);
 
-    send(&rpc, set_quote_ix(&miner.pubkey(), "BTC", "SOL", RATE), &miner.pubkey(), &miner).expect("set");
-    assert!(account_exists(&rpc, &quote_pda(&miner.pubkey(), "BTC", "SOL")), "quote exists after set");
+    send(&rpc, set_quote_ix(&miner.pubkey(), "btc", "sol", RATE), &miner.pubkey(), &miner).expect("set");
+    assert!(account_exists(&rpc, &quote_pda(&miner.pubkey(), "btc", "sol")), "quote exists after set");
 
-    send(&rpc, remove_quote_ix(&miner.pubkey(), "BTC", "SOL"), &miner.pubkey(), &miner).expect("remove");
-    assert!(!account_exists(&rpc, &quote_pda(&miner.pubkey(), "BTC", "SOL")), "quote closed after remove");
+    send(&rpc, remove_quote_ix(&miner.pubkey(), "btc", "sol"), &miner.pubkey(), &miner).expect("remove");
+    assert!(!account_exists(&rpc, &quote_pda(&miner.pubkey(), "btc", "sol")), "quote closed after remove");
 }
 
 #[test]

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_extensions.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_extensions.rs
@@ -32,8 +32,8 @@ const COLLATERAL: u64 = 10_000_000_000;
 const SOL_AMOUNT: u64 = 2_000_000_000;
 
 const FROM_ADDR: &str = "userBTCaddr";
-const FROM_CHAIN: &str = "BTC";
-const TO_CHAIN: &str = "SOL";
+const FROM_CHAIN: &str = "btc";
+const TO_CHAIN: &str = "sol";
 const MINER_FROM: &str = "minerBTCaddr";
 const MINER_TO: &str = "minerSOLaddr";
 const RATE: u128 = 1_500_000_000_000_000_000; // 1.5 × RATE_PRECISION (1e18)

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_quote.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_quote.rs
@@ -216,6 +216,19 @@ fn test_same_chain_rejected() {
 }
 
 #[test]
+fn test_uppercase_chain_id_rejected() {
+    // "sol"-vs-"SOL" aliasing sizes collateral against the wrong leg and splits quote PDAs;
+    // intake must reject any casing but lowercase.
+    let (mut svm, program_id) = setup();
+    let miner = Keypair::new();
+    svm.airdrop(&miner.pubkey(), 10_000_000_000).unwrap();
+    for (f, t) in [("BTC", "tao"), ("btc", "TAO"), ("Btc", "tao")] {
+        let r = send(&mut svm, set_quote_ix(&program_id, &miner.pubkey(), f, t, "a", "b", RATE_PRECISION, 1), &miner.pubkey(), &miner);
+        assert!(r.is_err(), "non-lowercase chain id {f}->{t} must be rejected");
+    }
+}
+
+#[test]
 fn test_empty_field_rejected() {
     let (mut svm, program_id) = setup();
     let miner = Keypair::new();

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_reservation.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_reservation.rs
@@ -14,7 +14,7 @@ use {
         AccountDeserialize, InstructionData, ToAccountMetas,
     },
     allways_swap_manager::constants::{FINALIZE_WINDOW_SECS, POOL_WINDOW_SECS, RESERVATION_FEE_LAMPORTS},
-    allways_swap_manager::state::{MinerState, Pool, Reservation, Treasury},
+    allways_swap_manager::state::{MinerQuote, MinerState, Pool, Reservation, Treasury},
     litesvm::LiteSVM,
     solana_hash::Hash,
     solana_keypair::Keypair,
@@ -514,15 +514,38 @@ fn test_requires_active_miner() {
 }
 
 #[test]
-fn test_open_rejects_uppercase_chain_id() {
-    // A "SOL"-cased hub leg would dodge the byte-exact numeraire bind and size collateral
-    // against the spoke leg. No casing variant may open: the mixed-case quote PDA cannot exist
-    // (set_quote guard) and the intake guard rejects even a legacy pre-guard one.
+fn test_open_rejects_legacy_uppercase_quote() {
+    // A "SOL"-cased hub leg would dodge the byte-exact numeraire bind and size collateral against
+    // the spoke leg. Through the public path a mixed-case open dies earlier (its quote PDA cannot
+    // exist — set_quote guard), so plant a pre-guard "SOL"/"btc" quote directly and prove the
+    // open_or_request guard itself refuses it.
+    use anchor_lang::AccountSerialize;
     let (mut svm, _admin, vals, miner) = setup(0, 0);
-    for (f, t) in [("SOL", "btc"), ("sol", "BTC"), ("Sol", "btc")] {
-        let r = send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), f, t), &vals[0].pubkey(), &vals[0]);
-        assert!(r.is_err(), "non-lowercase chain id {f}->{t} must be rejected");
-    }
+    let (pda, bump) = Pubkey::find_program_address(
+        &[b"quote", miner.pubkey().as_ref(), "SOL".as_bytes(), "btc".as_bytes()],
+        &pid(),
+    );
+    let legacy = MinerQuote {
+        miner: miner.pubkey(),
+        from_chain: "SOL".into(),
+        to_chain: "btc".into(),
+        miner_from_addr: MFROM.into(),
+        miner_to_addr: MTO.into(),
+        rate: RATE,
+        liquidity: 0,
+        updated_at: BASE_TS,
+        bump,
+    };
+    let mut data = vec![];
+    legacy.try_serialize(&mut data).unwrap();
+    svm.set_account(
+        pda,
+        solana_account::Account { lamports: 10_000_000, data, owner: pid(), executable: false, rent_epoch: 0 },
+    )
+    .unwrap();
+    let err = send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "SOL", "btc"), &vals[0].pubkey(), &vals[0])
+        .unwrap_err();
+    assert!(err.contains("ChainNotLowercase"), "intake guard must reject the legacy quote, got: {err}");
 }
 
 #[test]

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_reservation.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_reservation.rs
@@ -343,7 +343,7 @@ fn setup(min_swap: u64, max_swap: u64) -> (LiteSVM, Keypair, Vec<Keypair>, Keypa
     let miner = Keypair::new();
     svm.airdrop(&miner.pubkey(), 100_000_000_000).unwrap();
     send(&mut svm, post_ix(&miner.pubkey(), 10_000_000_000), &miner.pubkey(), &miner).expect("post");
-    send(&mut svm, set_quote_ix(&miner.pubkey(), "BTC", "SOL", MFROM, MTO, RATE), &miner.pubkey(), &miner).expect("quote");
+    send(&mut svm, set_quote_ix(&miner.pubkey(), "btc", "sol", MFROM, MTO, RATE), &miner.pubkey(), &miner).expect("quote");
     send(&mut svm, vote_activate_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0]).expect("a0");
     send(&mut svm, vote_activate_ix(&vals[1].pubkey(), &miner.pubkey()), &vals[1].pubkey(), &vals[1]).expect("a1");
     (svm, admin, vals, miner)
@@ -355,11 +355,11 @@ fn test_open_pins_quote_and_charges_fee() {
     let _user = Keypair::new().pubkey();
     let t0 = treasury(&svm);
 
-    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL"), &vals[0].pubkey(), &vals[0]).expect("open");
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[0].pubkey(), &vals[0]).expect("open");
 
     let p = pool(&svm, &miner.pubkey());
-    assert_eq!(p.from_chain, "BTC");
-    assert_eq!(p.to_chain, "SOL");
+    assert_eq!(p.from_chain, "btc");
+    assert_eq!(p.to_chain, "sol");
     assert_eq!(p.miner_from_addr, MFROM, "pinned from MinerQuote");
     assert_eq!(p.miner_to_addr, MTO);
     assert_eq!(p.rate, RATE);
@@ -375,8 +375,8 @@ fn test_each_request_charges_fee() {
     let (mut svm, _admin, vals, miner) = setup(0, 0);
     let _user = Keypair::new().pubkey();
     let t0 = treasury(&svm);
-    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL"), &vals[0].pubkey(), &vals[0]).expect("open");
-    send(&mut svm, open_ix(&vals[1].pubkey(), &miner.pubkey(), "BTC", "SOL"), &vals[1].pubkey(), &vals[1]).expect("join");
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[0].pubkey(), &vals[0]).expect("open");
+    send(&mut svm, open_ix(&vals[1].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[1].pubkey(), &vals[1]).expect("join");
     assert_eq!(treasury(&svm), t0 + 2 * RESERVATION_FEE_LAMPORTS, "both opener and joiner pay");
     assert_eq!(pool(&svm, &miner.pubkey()).requests.len(), 2);
 }
@@ -386,8 +386,8 @@ fn test_repeat_bid_is_idempotent() {
     // A bid carries only the router — no taker, no amounts. A repeat call from the same router while
     // the pool is open is an idempotent no-op (no AlreadyRequested reject, no duplicate entry).
     let (mut svm, _admin, vals, miner) = setup(0, 0);
-    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL"), &vals[0].pubkey(), &vals[0]).expect("open");
-    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL"), &vals[0].pubkey(), &vals[0]).expect("repeat");
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[0].pubkey(), &vals[0]).expect("open");
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[0].pubkey(), &vals[0]).expect("repeat");
 
     let p = pool(&svm, &miner.pubkey());
     assert_eq!(p.requests.len(), 1, "repeat bid does not duplicate the router's seat");
@@ -398,10 +398,10 @@ fn test_repeat_bid_is_idempotent() {
 fn test_pair_mismatch_rejected() {
     let (mut svm, _admin, vals, miner) = setup(0, 0);
     // Miner also quotes BTC→TAO so that quote account exists for the join attempt.
-    send(&mut svm, set_quote_ix(&miner.pubkey(), "BTC", "TAO", MFROM, "minerTAOaddr", 2_000_000_000_000_000_000), &miner.pubkey(), &miner).expect("quote2");
+    send(&mut svm, set_quote_ix(&miner.pubkey(), "btc", "tao", MFROM, "minerTAOaddr", 2_000_000_000_000_000_000), &miner.pubkey(), &miner).expect("quote2");
     let _user = Keypair::new().pubkey();
-    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL"), &vals[0].pubkey(), &vals[0]).expect("open BTC/SOL");
-    let mism = send(&mut svm, open_ix(&vals[1].pubkey(), &miner.pubkey(), "BTC", "TAO"), &vals[1].pubkey(), &vals[1]);
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[0].pubkey(), &vals[0]).expect("open BTC/SOL");
+    let mism = send(&mut svm, open_ix(&vals[1].pubkey(), &miner.pubkey(), "btc", "tao"), &vals[1].pubkey(), &vals[1]);
     assert!(mism.is_err(), "joining with a different pair than the pinned one must be rejected");
 }
 
@@ -409,7 +409,7 @@ fn test_pair_mismatch_rejected() {
 fn test_single_requester_resolve_then_finalize_creates_reservation() {
     let (mut svm, _admin, vals, miner) = setup(0, 0);
     let user = Keypair::new().pubkey();
-    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL"), &vals[0].pubkey(), &vals[0]).expect("open");
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[0].pubkey(), &vals[0]).expect("open");
 
     // before close → cannot resolve
     let early = send(&mut svm, resolve_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0]);
@@ -424,8 +424,8 @@ fn test_single_requester_resolve_then_finalize_creates_reservation() {
     assert_eq!(r.reserved_until, 0, "reservation is UNFILLED right after the draw");
     assert_eq!(r.router, vals[0].pubkey(), "seat winner pinned");
     assert_eq!(r.finalize_by, BASE_TS + POOL_WINDOW_SECS + 1 + FINALIZE_WINDOW_SECS, "finalize deadline set");
-    assert_eq!(r.from_chain, "BTC");
-    assert_eq!(r.to_chain, "SOL");
+    assert_eq!(r.from_chain, "btc");
+    assert_eq!(r.to_chain, "sol");
     assert_eq!(r.miner_from_addr, MFROM, "pinned miner quote carried into reservation");
     assert_eq!(r.miner_to_addr, MTO);
     assert_eq!(r.rate, RATE);
@@ -449,8 +449,8 @@ fn test_multi_requester_resolve_picks_one() {
     let (mut svm, _admin, vals, miner) = setup(0, 0);
     let u0 = Keypair::new().pubkey();
     let u1 = Keypair::new().pubkey();
-    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL"), &vals[0].pubkey(), &vals[0]).expect("open");
-    send(&mut svm, open_ix(&vals[1].pubkey(), &miner.pubkey(), "BTC", "SOL"), &vals[1].pubkey(), &vals[1]).expect("join");
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[0].pubkey(), &vals[0]).expect("open");
+    send(&mut svm, open_ix(&vals[1].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[1].pubkey(), &vals[1]).expect("join");
 
     set_clock(&mut svm, BASE_TS + POOL_WINDOW_SECS + 1);
     arm_and_resolve(&mut svm, &vals[2], &miner.pubkey()).expect("resolve");
@@ -475,9 +475,9 @@ fn test_resolve_empty_pool_fails() {
 fn test_join_after_close_fails() {
     let (mut svm, _admin, vals, miner) = setup(0, 0);
     let _user = Keypair::new().pubkey();
-    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL"), &vals[0].pubkey(), &vals[0]).expect("open");
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[0].pubkey(), &vals[0]).expect("open");
     set_clock(&mut svm, BASE_TS + POOL_WINDOW_SECS + 1);
-    let late = send(&mut svm, open_ix(&vals[1].pubkey(), &miner.pubkey(), "BTC", "SOL"), &vals[1].pubkey(), &vals[1]);
+    let late = send(&mut svm, open_ix(&vals[1].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[1].pubkey(), &vals[1]);
     assert!(late.is_err(), "joining after the window closed must fail (must resolve first)");
 }
 
@@ -487,7 +487,7 @@ fn test_amount_bounds_fire_at_finalize() {
     // succeed; finalize with an out-of-bounds collateral_amount is rejected, in-bounds succeeds.
     let (mut svm, _admin, vals, miner) = setup(1_000_000_000, 5_000_000_000);
     let user = Keypair::new().pubkey();
-    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL"), &vals[0].pubkey(), &vals[0]).expect("bid");
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[0].pubkey(), &vals[0]).expect("bid");
     set_clock(&mut svm, BASE_TS + POOL_WINDOW_SECS + 1);
     arm_and_resolve(&mut svm, &vals[0], &miner.pubkey()).expect("resolve");
 
@@ -507,23 +507,35 @@ fn test_requires_active_miner() {
     let inactive = Keypair::new();
     svm.airdrop(&inactive.pubkey(), 100_000_000_000).unwrap();
     send(&mut svm, post_ix(&inactive.pubkey(), 1_000_000_000), &inactive.pubkey(), &inactive).expect("post");
-    send(&mut svm, set_quote_ix(&inactive.pubkey(), "BTC", "SOL", MFROM, MTO, RATE), &inactive.pubkey(), &inactive).expect("quote");
+    send(&mut svm, set_quote_ix(&inactive.pubkey(), "btc", "sol", MFROM, MTO, RATE), &inactive.pubkey(), &inactive).expect("quote");
     let _user = Keypair::new().pubkey();
-    let res = send(&mut svm, open_ix(&vals[0].pubkey(), &inactive.pubkey(), "BTC", "SOL"), &vals[0].pubkey(), &vals[0]);
+    let res = send(&mut svm, open_ix(&vals[0].pubkey(), &inactive.pubkey(), "btc", "sol"), &vals[0].pubkey(), &vals[0]);
     assert!(res.is_err(), "inactive miner cannot be pooled");
+}
+
+#[test]
+fn test_open_rejects_uppercase_chain_id() {
+    // A "SOL"-cased hub leg would dodge the byte-exact numeraire bind and size collateral
+    // against the spoke leg. No casing variant may open: the mixed-case quote PDA cannot exist
+    // (set_quote guard) and the intake guard rejects even a legacy pre-guard one.
+    let (mut svm, _admin, vals, miner) = setup(0, 0);
+    for (f, t) in [("SOL", "btc"), ("sol", "BTC"), ("Sol", "btc")] {
+        let r = send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), f, t), &vals[0].pubkey(), &vals[0]);
+        assert!(r.is_err(), "non-lowercase chain id {f}->{t} must be rejected");
+    }
 }
 
 #[test]
 fn test_open_blocked_while_reserved() {
     let (mut svm, _admin, vals, miner) = setup(0, 0);
     let user = Keypair::new().pubkey();
-    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL"), &vals[0].pubkey(), &vals[0]).expect("open");
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[0].pubkey(), &vals[0]).expect("open");
     set_clock(&mut svm, BASE_TS + POOL_WINDOW_SECS + 1);
     resolve_and_fill(&mut svm, &vals[0], &miner.pubkey(), &user, "u1", "uSOL", 2_000_000_000, 1);
     assert!(reservation(&svm, &miner.pubkey()).reserved_until > 0);
 
     // a new open is blocked while the reservation is active (filled)
-    let blocked = send(&mut svm, open_ix(&vals[1].pubkey(), &miner.pubkey(), "BTC", "SOL"), &vals[1].pubkey(), &vals[1]);
+    let blocked = send(&mut svm, open_ix(&vals[1].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[1].pubkey(), &vals[1]);
     assert!(blocked.is_err(), "cannot open a new pool while a reservation is active");
 }
 
@@ -531,7 +543,7 @@ fn test_open_blocked_while_reserved() {
 fn test_open_pool_blocks_deactivate() {
     let (mut svm, _admin, vals, miner) = setup(0, 0);
     let _user = Keypair::new().pubkey();
-    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL"), &vals[0].pubkey(), &vals[0]).expect("open");
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[0].pubkey(), &vals[0]).expect("open");
     assert_ne!(pool(&svm, &miner.pubkey()).opened_at, 0);
 
     // miner is busy the moment a pool opens (pre-resolve) — cannot self-deactivate
@@ -543,7 +555,7 @@ fn test_open_pool_blocks_deactivate() {
 fn test_reservation_blocks_deactivate_until_expiry() {
     let (mut svm, _admin, vals, miner) = setup(0, 0);
     let user = Keypair::new().pubkey();
-    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL"), &vals[0].pubkey(), &vals[0]).expect("open");
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[0].pubkey(), &vals[0]).expect("open");
     set_clock(&mut svm, BASE_TS + POOL_WINDOW_SECS + 1);
     resolve_and_fill(&mut svm, &vals[0], &miner.pubkey(), &user, "u", "uSOL", 2_000_000_000, 1);
     assert!(is_active(&svm, &miner.pubkey()));
@@ -608,7 +620,7 @@ fn test_finalize_requires_overcollateralization() {
     let (mut svm, _admin, vals, miner) = setup(0, 0);
     let user = Keypair::new().pubkey();
     assert_eq!(collateral(&svm, &miner.pubkey()), 10_000_000_000);
-    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL"), &vals[0].pubkey(), &vals[0]).expect("bid");
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[0].pubkey(), &vals[0]).expect("bid");
     set_clock(&mut svm, BASE_TS + POOL_WINDOW_SECS + 1);
     arm_and_resolve(&mut svm, &vals[0], &miner.pubkey()).expect("resolve");
 
@@ -626,7 +638,7 @@ fn test_cannot_force_deactivate_while_pooled() {
     // is only for idle miners (preserves the busy ⟹ active invariant; user req / review #3).
     let (mut svm, _admin, vals, miner) = setup(0, 0);
     let _user = Keypair::new().pubkey();
-    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL"), &vals[0].pubkey(), &vals[0]).expect("open");
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[0].pubkey(), &vals[0]).expect("open");
     let blocked = send(&mut svm, vote_deactivate_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0]);
     assert!(blocked.is_err(), "cannot force-deactivate a miner with an open pool");
     assert!(is_active(&svm, &miner.pubkey()), "miner stays active");
@@ -636,7 +648,7 @@ fn test_cannot_force_deactivate_while_pooled() {
 fn test_cannot_force_deactivate_while_reserved() {
     let (mut svm, _admin, vals, miner) = setup(0, 0);
     let _user = Keypair::new().pubkey();
-    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL"), &vals[0].pubkey(), &vals[0]).expect("open");
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[0].pubkey(), &vals[0]).expect("open");
     set_clock(&mut svm, BASE_TS + POOL_WINDOW_SECS + 1);
     arm_and_resolve(&mut svm, &vals[0], &miner.pubkey()).expect("resolve");
     let blocked = send(&mut svm, vote_deactivate_ix(&vals[1].pubkey(), &miner.pubkey()), &vals[1].pubkey(), &vals[1]);
@@ -678,7 +690,7 @@ fn test_finalize_rejects_self_swap_and_default_user() {
     // M1: a miner naming ITSELF as taker would buy eligibility (successful_swaps) with wash swaps;
     // the default pubkey as taker would burn a timeout refund. Both rejected at the fill.
     let (mut svm, _admin, vals, miner) = setup(0, 0);
-    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL"), &vals[0].pubkey(), &vals[0]).expect("bid");
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[0].pubkey(), &vals[0]).expect("bid");
     set_clock(&mut svm, BASE_TS + POOL_WINDOW_SECS + 1);
     arm_and_resolve(&mut svm, &vals[0], &miner.pubkey()).expect("resolve");
 
@@ -701,9 +713,9 @@ fn test_repeat_bid_is_free() {
     // First bid pays the reservation fee; a same-router repeat bid in the same window is free.
     let (mut svm, _admin, vals, miner) = setup(0, 0);
     let t0 = treasury(&svm);
-    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL"), &vals[0].pubkey(), &vals[0]).expect("open");
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[0].pubkey(), &vals[0]).expect("open");
     assert_eq!(treasury(&svm), t0 + RESERVATION_FEE_LAMPORTS, "first entry pays the fee");
-    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL"), &vals[0].pubkey(), &vals[0]).expect("repeat");
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[0].pubkey(), &vals[0]).expect("repeat");
     assert_eq!(treasury(&svm), t0 + RESERVATION_FEE_LAMPORTS, "in-window repeat bid is free (no extra fee)");
 }
 
@@ -711,9 +723,9 @@ fn test_repeat_bid_is_free() {
 fn test_bid_after_window_close_fails() {
     // Once the window closes, no further bids (must resolve first).
     let (mut svm, _admin, vals, miner) = setup(0, 0);
-    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL"), &vals[0].pubkey(), &vals[0]).expect("open");
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[0].pubkey(), &vals[0]).expect("open");
     set_clock(&mut svm, BASE_TS + POOL_WINDOW_SECS + 1);
-    let late = send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL"), &vals[0].pubkey(), &vals[0]);
+    let late = send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[0].pubkey(), &vals[0]);
     assert!(late.is_err(), "cannot bid after the window closed");
 }
 
@@ -723,7 +735,7 @@ fn test_bid_after_window_close_fails() {
 fn open_and_close(svm: &mut LiteSVM, vals: &[Keypair], miner: &Keypair) {
     send(
         svm,
-        open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL"),
+        open_ix(&vals[0].pubkey(), &miner.pubkey(), "btc", "sol"),
         &vals[0].pubkey(),
         &vals[0],
     )
@@ -739,7 +751,7 @@ fn test_open_does_not_pin_seed_slot() {
     let _user = Keypair::new().pubkey();
     send(
         &mut svm,
-        open_ix(&vals[0].pubkey(), &miner.pubkey(), "BTC", "SOL"),
+        open_ix(&vals[0].pubkey(), &miner.pubkey(), "btc", "sol"),
         &vals[0].pubkey(),
         &vals[0],
     )
@@ -870,7 +882,7 @@ fn close_unfilled_ix(caller: &Pubkey, miner: &Pubkey) -> Instruction {
 /// Bid + arm/resolve a single-bidder pool, leaving an UNFILLED reservation whose router is `vals[0]`.
 /// Clock left at BASE_TS + POOL_WINDOW_SECS + 1.
 fn bid_and_draw(svm: &mut LiteSVM, vals: &[Keypair], miner: &Pubkey) {
-    send(svm, open_ix(&vals[0].pubkey(), miner, "BTC", "SOL"), &vals[0].pubkey(), &vals[0]).expect("bid");
+    send(svm, open_ix(&vals[0].pubkey(), miner, "btc", "sol"), &vals[0].pubkey(), &vals[0]).expect("bid");
     set_clock(svm, BASE_TS + POOL_WINDOW_SECS + 1);
     arm_and_resolve(svm, &vals[0], miner).expect("resolve");
 }
@@ -898,7 +910,7 @@ fn test_open_blocked_during_pending_finalize_window() {
     assert_ne!(reservation(&svm, &miner.pubkey()).finalize_by, 0, "finalize window armed");
     let e = send(
         &mut svm,
-        open_ix(&vals[1].pubkey(), &miner.pubkey(), "BTC", "SOL"),
+        open_ix(&vals[1].pubkey(), &miner.pubkey(), "btc", "sol"),
         &vals[1].pubkey(),
         &vals[1],
     );
@@ -943,8 +955,8 @@ fn test_collateral_bind_rejects_mismatch_spoke_to_sol() {
 #[test]
 fn test_collateral_bind_rejects_mismatch_sol_to_spoke() {
     // sol→btc: sol is the SOURCE (numeraire) leg, so collateral_amount must == from_amount.
-    // NB: the bind is case-sensitive on NUMERAIRE_CHAIN == "sol" (lowercase, as the real system uses);
-    // this test uses lowercase chain ids so `from_chain == NUMERAIRE_CHAIN` holds.
+    // The bind compares from_chain == NUMERAIRE_CHAIN byte-exactly; intake rejects non-lowercase
+    // chain ids (ChainNotLowercase), so lowercase is the only casing that can reach this point.
     let (mut svm, _admin, vals, miner) = setup(0, 0);
     send(&mut svm, set_quote_ix(&miner.pubkey(), "sol", "btc", MTO, MFROM, RATE), &miner.pubkey(), &miner).expect("sol->btc quote");
     send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "sol", "btc"), &vals[0].pubkey(), &vals[0]).expect("bid");

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_swap.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_swap.rs
@@ -40,8 +40,8 @@ const LOTTERY_USER: Pubkey = Pubkey::new_from_array([7u8; 32]);
 
 // reservation quote (must be consistent reserve→initiate)
 const FROM_ADDR: &str = "userBTCaddr";
-const FROM_CHAIN: &str = "BTC";
-const TO_CHAIN: &str = "SOL";
+const FROM_CHAIN: &str = "btc";
+const TO_CHAIN: &str = "sol";
 const MINER_FROM: &str = "minerBTCaddr";
 const MINER_TO: &str = "minerSOLaddr";
 const RATE: u128 = 1_500_000_000_000_000_000; // 1.5 × RATE_PRECISION (1e18)

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_treasury.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_treasury.rs
@@ -141,13 +141,13 @@ fn setup_with_fee() -> (LiteSVM, Keypair, u64) {
 
     // Reservation via the lottery (set quote → open → warp past window → resolve; sole entrant wins).
     send(&mut svm, Instruction::new_with_bytes(pid(),
-        &allways_swap_manager::instruction::SetQuote { from_chain: "BTC".to_string(), to_chain: "SOL".to_string(), miner_from_addr: "mBTC".to_string(), miner_to_addr: "mSOL".to_string(), rate: 1_000_000_000_000_000_000, liquidity: 1 }.data(),
-        allways_swap_manager::accounts::SetQuote { miner: miner.pubkey(), quote: quote_pda(&miner.pubkey(), "BTC", "SOL"), treasury: treasury_pda(), system_program: SYS }.to_account_metas(None),
+        &allways_swap_manager::instruction::SetQuote { from_chain: "btc".to_string(), to_chain: "sol".to_string(), miner_from_addr: "mBTC".to_string(), miner_to_addr: "mSOL".to_string(), rate: 1_000_000_000_000_000_000, liquidity: 1 }.data(),
+        allways_swap_manager::accounts::SetQuote { miner: miner.pubkey(), quote: quote_pda(&miner.pubkey(), "btc", "sol"), treasury: treasury_pda(), system_program: SYS }.to_account_metas(None),
     ), &miner.pubkey(), &miner).expect("set_quote");
     let pool_user = Keypair::new().pubkey();
     send(&mut svm, Instruction::new_with_bytes(pid(),
-        &allways_swap_manager::instruction::OpenOrRequest { from_chain: "BTC".to_string(), to_chain: "SOL".to_string() }.data(),
-        allways_swap_manager::accounts::OpenOrRequest { router: vals[0].pubkey(), config: cfg(), miner: miner.pubkey(), miner_state: miner_pda(&miner.pubkey()), quote: quote_pda(&miner.pubkey(), "BTC", "SOL"), pool: pool_pda(&miner.pubkey()), treasury: treasury_pda(), reservation: resv_pda(&miner.pubkey()), system_program: SYS }.to_account_metas(None),
+        &allways_swap_manager::instruction::OpenOrRequest { from_chain: "btc".to_string(), to_chain: "sol".to_string() }.data(),
+        allways_swap_manager::accounts::OpenOrRequest { router: vals[0].pubkey(), config: cfg(), miner: miner.pubkey(), miner_state: miner_pda(&miner.pubkey()), quote: quote_pda(&miner.pubkey(), "btc", "sol"), pool: pool_pda(&miner.pubkey()), treasury: treasury_pda(), reservation: resv_pda(&miner.pubkey()), system_program: SYS }.to_account_metas(None),
     ), &vals[0].pubkey(), &vals[0]).expect("open");
     set_clock(&mut svm, BASE_TS + POOL_WINDOW_SECS + 1);
     // resolve_pool is two-phase: arm the draw on a future slot, produce it, then draw.
@@ -189,8 +189,8 @@ fn setup_with_fee() -> (LiteSVM, Keypair, u64) {
 
     let confirm = |svm: &mut LiteSVM, v: &Keypair| {
         send(svm, Instruction::new_with_bytes(pid(),
-            &allways_swap_manager::instruction::ConfirmSwap { swap_key: key, from_chain: "BTC".to_string(), to_chain: "SOL".to_string() }.data(),
-            allways_swap_manager::accounts::ConfirmSwap { validator: v.pubkey(), config: cfg(), miner: miner.pubkey(), miner_state: miner_pda(&miner.pubkey()), collateral_vault: collateral_vault_pda(&miner.pubkey()), treasury: treasury_pda(), swap: swap_pda(&key), direction_stats: Pubkey::find_program_address(&[b"stats", miner.pubkey().as_ref(), "BTC".as_bytes(), "SOL".as_bytes()], &pid()).0, vote_round: vote_pda(6, &key), system_program: SYS }.to_account_metas(None),
+            &allways_swap_manager::instruction::ConfirmSwap { swap_key: key, from_chain: "btc".to_string(), to_chain: "sol".to_string() }.data(),
+            allways_swap_manager::accounts::ConfirmSwap { validator: v.pubkey(), config: cfg(), miner: miner.pubkey(), miner_state: miner_pda(&miner.pubkey()), collateral_vault: collateral_vault_pda(&miner.pubkey()), treasury: treasury_pda(), swap: swap_pda(&key), direction_stats: Pubkey::find_program_address(&[b"stats", miner.pubkey().as_ref(), "btc".as_bytes(), "sol".as_bytes()], &pid()).0, vote_round: vote_pda(6, &key), system_program: SYS }.to_account_metas(None),
         ), &v.pubkey(), v).expect("confirm");
     };
     confirm(&mut svm, &vals[0]);


### PR DESCRIPTION
## Summary
Chain-id casing is treated inconsistently across the program: the fulfillment-grace table matches case-insensitively, while the numeraire collateral bind (finalize_reservation) and the quote/pool PDA seeds are byte-exact. A "SOL"-cased hub leg dodges the bind and sizes collateral against the spoke leg — silent and ~1000x under-collateralized once a low-decimals spoke (USDC) exists. One lowercase gate at the two intake doors kills the class.

## Changes
- validate.rs: shared chain_ids_lowercase check (one rule, one home)
- open_or_request + set_quote: call the check after existing string validation
- error.rs: ChainNotLowercase
- tests: rejection coverage for both intake doors; lowercase the mixed-case chain ids existing tests used (they documented the hazard); retire the stale case-sensitivity NB comment

No existing on-chain state is affected — the gate covers new intake only. Full suite: 130 passed / 0 failed.