### PR TITLE
Rename providers to the Asset/Chain model

### DIFF
--- a/allways/assets/__init__.py
+++ b/allways/assets/__init__.py
@@ -2,37 +2,40 @@ from typing import Dict, Optional, Set, Tuple, Type
 
 import bittensor as bt
 
-from allways.chain_providers.base import ChainProvider, TransactionInfo
-from allways.chain_providers.bitcoin import BitcoinProvider
-from allways.chain_providers.ethereum import EthereumProvider
-from allways.chain_providers.solana import SolanaProvider
-from allways.chain_providers.subtensor import SubtensorProvider
+from allways.assets.base import Asset, TransactionInfo
+from allways.assets.bitcoin import Bitcoin
+from allways.assets.chain import Chain
+from allways.assets.ethereum import EvmCoin
+from allways.assets.solana import Sol
+from allways.assets.subtensor import Tao
 
 __all__ = [
-    'ChainProvider',
+    'Asset',
+    'Chain',
     'TransactionInfo',
-    'BitcoinProvider',
-    'SubtensorProvider',
-    'SolanaProvider',
-    'EthereumProvider',
-    'create_chain_providers',
+    'Bitcoin',
+    'Tao',
+    'Sol',
+    'EvmCoin',
+    'create_assets',
 ]
 
-# Registry: (chain_id, provider_class, kwarg names to forward)
-PROVIDER_REGISTRY: Tuple[Tuple[str, Type[ChainProvider], Tuple[str, ...]], ...] = (
-    ('btc', BitcoinProvider, ()),
-    ('tao', SubtensorProvider, ('subtensor', 'wallet')),
-    ('sol', SolanaProvider, ('solana_rpc_url', 'solana_keypair')),
-    ('eth', EthereumProvider, ()),
+# Registry: (chain_id, asset class, kwarg names to forward). The wire id is a "chain"
+# (program strings, DB columns, /chains); in code it resolves to an Asset.
+ASSET_REGISTRY: Tuple[Tuple[str, Type[Asset], Tuple[str, ...]], ...] = (
+    ('btc', Bitcoin, ()),
+    ('tao', Tao, ('subtensor', 'wallet')),
+    ('sol', Sol, ('solana_rpc_url', 'solana_keypair')),
+    ('eth', EvmCoin, ()),
 )
 
 
-def create_chain_providers(
+def create_assets(
     check: bool = False,
     require_send: bool = True,
     required_chains: Optional[Set[str]] = None,
     **kwargs,
-) -> Dict[str, ChainProvider]:
+) -> Dict[str, Asset]:
     """Initialize all available chain providers.
 
     Args:
@@ -47,11 +50,11 @@ def create_chain_providers(
                          chains required (validators verify every chain).
 
     Keyword arguments are forwarded to providers that need them.
-    e.g. create_chain_providers(subtensor=subtensor)
+    e.g. create_assets(subtensor=subtensor)
     """
-    providers: Dict[str, ChainProvider] = {}
+    providers: Dict[str, Asset] = {}
 
-    for chain_id, cls, kwarg_names in PROVIDER_REGISTRY:
+    for chain_id, cls, kwarg_names in ASSET_REGISTRY:
         required = required_chains is None or chain_id in required_chains
         try:
             provider_kwargs = {k: kwargs[k] for k in kwarg_names if k in kwargs}

--- a/allways/assets/base.py
+++ b/allways/assets/base.py
@@ -5,6 +5,7 @@ from typing import Any, Optional, Tuple
 
 import bittensor as bt
 
+from allways.assets.chain import Chain
 from allways.chains import ChainDefinition
 
 
@@ -24,13 +25,18 @@ class TransactionInfo:
     block_time: Optional[int] = None  # Block's mined time, unix seconds (replay-freshness floor; B2)
 
 
-class ChainProvider(ABC):
-    """Abstract interface for chain verification.
+class Asset(ABC):
+    """A thing you can swap: verify a payment of it, send it, gate it.
 
-    Adding a new chain:
-    1. Add ChainDefinition to chains.py
-    2. Implement this interface
-    3. Add {ENV_PREFIX}_* vars to .env
+    Every asset lives on a `Chain` (`self.chain`). Single-asset networks (btc/tao/sol,
+    and eth until a second EVM asset lands) fuse the two: the class implements both and
+    `.chain` returns itself. The registry row stays a `ChainDefinition` in chains.py —
+    the wire says chain; in code an id resolves to an Asset.
+
+    Adding a new asset:
+    1. Add its ChainDefinition to chains.py
+    2. Implement this interface (or reuse a family class, e.g. an ERC-20)
+    3. Register it in ASSET_REGISTRY; add {ENV_PREFIX}_* vars to .env
     """
 
     # True if this provider's RPCs hit the shared substrate websocket, so
@@ -40,6 +46,13 @@ class ChainProvider(ABC):
 
     @abstractmethod
     def get_chain(self) -> ChainDefinition: ...
+
+    @property
+    def chain(self) -> Chain:
+        """The network this asset lives on. Fused single-asset classes are their own chain."""
+        if isinstance(self, Chain):
+            return self
+        raise NotImplementedError(f'{type(self).__name__} must bind a Chain')
 
     def describe(self) -> str:
         """One-line summary of the backend/API this provider talks to, for startup logs."""

--- a/allways/assets/bitcoin.py
+++ b/allways/assets/bitcoin.py
@@ -10,7 +10,8 @@ from bitcoin_message_tool.bmt import sign_message, verify_message
 from embit.networks import NETWORKS
 from embit.script import address_to_scriptpubkey
 
-from allways.chain_providers.base import ChainProvider, ProviderUnreachableError, TransactionInfo
+from allways.assets.base import Asset, ProviderUnreachableError, TransactionInfo
+from allways.assets.chain import Chain
 from allways.chains import CHAIN_BTC, ChainDefinition
 
 ADDR_TYPE_P2PKH = 'p2pkh'
@@ -94,7 +95,7 @@ def esplora_tag(base: str) -> str:
     return parts[-2] if len(parts) >= 2 else host
 
 
-class BitcoinProvider(ChainProvider):
+class Bitcoin(Asset, Chain):
     """Bitcoin chain provider: embit + Esplora HTTP API (no local node required).
 
     Verification reads the Esplora API; signing/broadcast uses embit with a WIF from

--- a/allways/assets/chain.py
+++ b/allways/assets/chain.py
@@ -1,0 +1,17 @@
+from abc import ABC, abstractmethod
+from typing import Optional
+
+
+class Chain(ABC):
+    """A network you can talk to: reach it, read blocks/txs, know its id.
+
+    Assets live on chains (`Asset.chain`). Single-asset networks fuse the two — the
+    asset class also implements Chain and `.chain` returns itself — and split the day
+    the chain hosts its second asset. Multi-asset families (EVM) bind a shared,
+    config-driven Chain instance per network instead of a class per chain.
+    """
+
+    @abstractmethod
+    def get_current_block_height(self) -> Optional[int]:
+        """Chain tip block height. None on transient backend failure."""
+        ...

--- a/allways/assets/ethereum.py
+++ b/allways/assets/ethereum.py
@@ -11,7 +11,8 @@ from eth_account import Account
 from eth_account.messages import encode_defunct
 from eth_utils import is_checksum_address
 
-from allways.chain_providers.base import ChainProvider, ProviderUnreachableError, TransactionInfo
+from allways.assets.base import Asset, ProviderUnreachableError, TransactionInfo
+from allways.assets.chain import Chain
 from allways.chains import CHAIN_ETH, ChainDefinition
 
 LOG_ETH = '[EthRpc]'
@@ -49,7 +50,7 @@ def rpc_tag(base: str) -> str:
     return parts[-2] if len(parts) >= 2 else host
 
 
-class EthereumProvider(ChainProvider):
+class EvmCoin(Asset, Chain):
     """Ethereum chain provider: eth-account + public JSON-RPC (no local node required).
 
     Plain EOA value transfers only, by design: a swap leg is verified off the transaction's

--- a/allways/assets/solana.py
+++ b/allways/assets/solana.py
@@ -8,14 +8,15 @@ from solders.keypair import Keypair
 from solders.pubkey import Pubkey
 from solders.signature import Signature
 
-from allways.chain_providers.base import ChainProvider, ProviderUnreachableError, TransactionInfo
+from allways.assets.base import Asset, ProviderUnreachableError, TransactionInfo
+from allways.assets.chain import Chain
 from allways.chains import CHAIN_SOL, ChainDefinition
 from allways.solana.rpc import SolanaRpc, resolve_rpc_url
 
 LOG_SOL = '[Solana]'
 
 
-class SolanaProvider(ChainProvider):
+class Sol(Asset, Chain):
     """Solana swap-leg provider for native SOL transfers.
 
     The SOL leg of a launch pair (sol↔btc, sol↔tao) is a peer-to-peer user↔miner
@@ -245,7 +246,7 @@ class SolanaProvider(ChainProvider):
         Signs with the provider's own keypair (callers pass no key material). Returns
         (signature, slot) or None. Retries on stale-blockhash like the program client."""
         if self.keypair is None:
-            bt.logging.error('SOL send_amount called on a read-only SolanaProvider (no keypair)')
+            bt.logging.error('SOL send_amount called on a read-only Sol (no keypair)')
             return None
         try:
             from solders.hash import Hash

--- a/allways/assets/subtensor.py
+++ b/allways/assets/subtensor.py
@@ -5,13 +5,14 @@ import bittensor as bt
 from bittensor import Keypair
 from bittensor.utils import is_valid_ss58_address, ss58_encode
 
-from allways.chain_providers.base import ChainProvider, ProviderUnreachableError, TransactionInfo
+from allways.assets.base import Asset, ProviderUnreachableError, TransactionInfo
+from allways.assets.chain import Chain
 from allways.chains import CHAIN_TAO, ChainDefinition
 
 LOG_SUB = '[Subtensor]'
 
 
-class SubtensorProvider(ChainProvider):
+class Tao(Asset, Chain):
     """TAO chain provider using bt.Subtensor and substrate-interface.
 
     Owns its signing ``bt.Wallet`` when one is supplied at construction, so
@@ -487,7 +488,7 @@ class SubtensorProvider(ChainProvider):
     @staticmethod
     def match_transfer(ext, tx_hash: str, is_raw: bool) -> Optional[Tuple[str, int, str]]:
         """Try to match an extrinsic against a tx hash. Returns (dest, amount, sender) or None."""
-        decoded = SubtensorProvider.decode_transfer(ext, is_raw)
+        decoded = Tao.decode_transfer(ext, is_raw)
         if decoded is None or decoded[0] != tx_hash:
             return None
         _, dest, amount, sender = decoded
@@ -631,7 +632,7 @@ class SubtensorProvider(ChainProvider):
     ) -> Optional[Tuple[str, int]]:
         """Send TAO via subtensor transfer. Amount is in rao."""
         if self.wallet is None:
-            bt.logging.error('TAO send_amount called on a read-only SubtensorProvider (no wallet)')
+            bt.logging.error('TAO send_amount called on a read-only Tao (no wallet)')
             return None
         try:
             response = self.subtensor.transfer(

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -602,9 +602,9 @@ def _source_provider(from_chain: str, client, config):
     bt wallet / BTC WIF), from the same registry the neurons use — so a new spoke chain works with
     zero changes here. Uses the CLI's live RPC (never a fresh localhost default). Returns None
     (→ manual fallback) if the provider can't be built with send credentials."""
-    from allways.chain_providers import PROVIDER_REGISTRY
+    from allways.assets import ASSET_REGISTRY
 
-    entry = next((e for e in PROVIDER_REGISTRY if e[0] == from_chain), None)
+    entry = next((e for e in ASSET_REGISTRY if e[0] == from_chain), None)
     if entry is None:
         return None
     _id, cls, kwarg_names = entry

--- a/allways/miner/fulfillment.py
+++ b/allways/miner/fulfillment.py
@@ -17,7 +17,7 @@ from typing import Dict, Optional, Set, Tuple
 import bittensor as bt
 
 from allways import dev_signal
-from allways.chain_providers.base import ChainProvider, ProviderUnreachableError
+from allways.assets.base import Asset, ProviderUnreachableError
 from allways.constants import FEE_DIVISOR, MINER_TIMEOUT_CUSHION_SECS, SENT_CACHE_DISCARD_MARGIN_SECS
 from allways.solana.client import SolanaClientError, SolanaSwap
 from allways.utils.logging import log_on_change
@@ -54,13 +54,13 @@ class SwapFulfiller:
     def __init__(
         self,
         solana_client,
-        chain_providers: Dict[str, ChainProvider],
+        assets: Dict[str, Asset],
         sent_cache_path: Optional[Path] = None,
         my_addresses: Optional[Dict[str, str]] = None,
         fee_divisor: int = FEE_DIVISOR,
     ):
         self.client = solana_client
-        self.providers = chain_providers
+        self.providers = assets
         self.fee_divisor = fee_divisor
         # Chain → miner's own deposit/fulfillment address, populated at startup from this miner's own
         # quotes and refreshed by the miner loop when a new quote is posted. Shared dict so the miner

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -97,7 +97,7 @@ async def forward(self: Validator) -> None:
 
 
 def clear_provider_caches(self: Validator) -> None:
-    for provider in self.chain_providers.values():
+    for provider in self.assets.values():
         if hasattr(provider, 'clear_cache'):
             provider.clear_cache()
         provider.clear_pass_tip()  # reset the per-pass hoisted chain tip (one getSlot/pass, not per-leg)

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -13,7 +13,7 @@ import bittensor as bt
 from bittensor import Keypair
 from solders.pubkey import Pubkey
 
-from allways.chain_providers.base import ProviderUnreachableError
+from allways.assets.base import ProviderUnreachableError
 from allways.cli.swap_commands.swap_intake import (
     candidate_miners,
     compute_intake_amounts,
@@ -118,7 +118,7 @@ def reserve_on_behalf(
 
     # Deliverability gate — BEFORE any funds move: a dest that provably refuses transfers
     # (e.g. a reverting contract wallet) must bounce here, not strand a paid swap later.
-    provider = getattr(validator, 'axon_chain_providers', {}).get(to_chain)
+    provider = getattr(validator, 'axon_assets', {}).get(to_chain)
     if provider is not None and not provider.can_deliver_to(user_to_addr, amts.to_amount):
         return ReserveResult(False, 'destination address rejects incoming transfers')
 
@@ -303,7 +303,7 @@ def confirm_deposit(validator, miner_hotkey: str, from_tx_hash: str, from_tx_blo
     if bytes(reservation.claimed_swap_key) != EMPTY_SWAP_KEY:
         return ConfirmResult(False, 'Reservation already has a claimed swap')
 
-    provider = validator.axon_chain_providers.get(reservation.from_chain)
+    provider = validator.axon_assets.get(reservation.from_chain)
     if provider is None:
         return ConfirmResult(False, f'Unsupported source chain: {reservation.from_chain}')
 
@@ -355,7 +355,7 @@ def scan_deposit(validator, miner_hotkey: str) -> Optional[str]:
         return None
     if bytes(reservation.claimed_swap_key) != EMPTY_SWAP_KEY:
         return None
-    provider = validator.axon_chain_providers.get(reservation.from_chain)
+    provider = validator.axon_assets.get(reservation.from_chain)
     scan = getattr(provider, 'find_recent_outgoing', None)
     if scan is None:
         return None

--- a/allways/validator/solana_swap_loop.py
+++ b/allways/validator/solana_swap_loop.py
@@ -17,7 +17,7 @@ import bittensor as bt
 from solders.pubkey import Pubkey
 
 from allways import dev_signal
-from allways.chain_providers.base import ProviderUnreachableError
+from allways.assets.base import ProviderUnreachableError
 from allways.chains import compute_extension_target_secs, get_chain
 from allways.constants import EXTENSION_PADDING_SECONDS
 from allways.solana import pdas
@@ -109,12 +109,12 @@ class SolanaSwapLoop:
     def __init__(
         self,
         solana_client: Any,
-        chain_providers: Dict[str, Any],
+        assets: Dict[str, Any],
         fee_divisor: int = 100,
         read_only: bool = False,
     ):
         self.client = solana_client
-        self.providers = chain_providers
+        self.providers = assets
         self.fee_divisor = fee_divisor
         self.read_only = read_only
         self.reject_warned: Set[str] = set()  # dedupe rate-reject warnings, one per swap key

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -20,7 +20,7 @@ load_dotenv()
 import bittensor as bt  # noqa: E402
 from bittensor import Keypair as BtKeypair  # noqa: E402
 
-from allways.chain_providers import create_chain_providers  # noqa: E402
+from allways.assets import create_assets  # noqa: E402
 from allways.constants import FORWARD_STALL_THRESHOLD_SECONDS, NUMERAIRE_CHAIN  # noqa: E402
 from allways.miner.fulfillment import SwapFulfiller  # noqa: E402
 from allways.miner.swap_poller import SwapPoller  # noqa: E402
@@ -62,7 +62,7 @@ class Miner(BaseMinerNeuron):
         except Exception as e:
             bt.logging.warning(f'Could not read own quotes at startup ({e}); requiring all chain providers.')
             required_chains = None
-        self.chain_providers = create_chain_providers(
+        self.assets = create_assets(
             check=True,
             required_chains=required_chains,
             subtensor=self.subtensor,
@@ -84,7 +84,7 @@ class Miner(BaseMinerNeuron):
 
         self.swap_fulfiller = SwapFulfiller(
             solana_client=self.solana_client,
-            chain_providers=self.chain_providers,
+            assets=self.assets,
             sent_cache_path=sent_cache_path,
             my_addresses=self.my_addresses,
         )
@@ -196,7 +196,7 @@ class Miner(BaseMinerNeuron):
         chain providers need the refreshed connection.
         """
         self.reconnect_subtensor()
-        tao_provider = self.chain_providers.get('tao')
+        tao_provider = self.assets.get('tao')
         if tao_provider and hasattr(tao_provider, 'subtensor'):
             tao_provider.subtensor = self.subtensor
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -23,7 +23,7 @@ import bittensor as bt  # noqa: E402
 import wandb  # noqa: E402
 
 from allways import __version__  # noqa: E402
-from allways.chain_providers import create_chain_providers  # noqa: E402
+from allways.assets import create_assets  # noqa: E402
 from allways.constants import (  # noqa: E402
     FEE_DIVISOR,
     FORWARD_STALL_THRESHOLD_SECONDS,
@@ -77,7 +77,7 @@ class Validator(BaseValidatorNeuron):
         # One rpc-url source of truth shared by every SOL consumer: the chain
         # providers (source-leg verification) and the solana_client below.
         solana_rpc_url = resolve_rpc_url()
-        self.chain_providers = create_chain_providers(
+        self.assets = create_assets(
             check=True, require_send=False, subtensor=self.subtensor, solana_rpc_url=solana_rpc_url
         )
         self.fee_divisor = FEE_DIVISOR
@@ -116,7 +116,7 @@ class Validator(BaseValidatorNeuron):
         self.solana_client = AllwaysSolanaClient(solana_rpc_url, keypair=keys.load_or_create())
         warn_if_unbound(self.solana_client)
         self.solana_swap_loop = SolanaSwapLoop(
-            self.solana_client, self.chain_providers, fee_divisor=self.fee_divisor, read_only=solana_read_only
+            self.solana_client, self.assets, fee_divisor=self.fee_divisor, read_only=solana_read_only
         )
         # Crown-time state is sourced entirely from Solana program events (B3.6):
         # `event_ingest` polls the program's signature stream each forward step,
@@ -153,7 +153,7 @@ class Validator(BaseValidatorNeuron):
         # read registration + source chains off these; scoring bounds come off Solana.
         self.axon_lock = threading.RLock()
         self.axon_subtensor = bt.Subtensor(config=self.config)
-        self.axon_chain_providers = create_chain_providers(subtensor=self.axon_subtensor, solana_rpc_url=solana_rpc_url)
+        self.axon_assets = create_assets(subtensor=self.axon_subtensor, solana_rpc_url=solana_rpc_url)
         bt.logging.debug(f'Validator components: fee_divisor={self.fee_divisor}')
 
         # Attach synapse handlers to axon
@@ -199,7 +199,7 @@ class Validator(BaseValidatorNeuron):
     def reconnect_and_propagate(self):
         """Rebuild the main subtensor and update components that hold it."""
         self.reconnect_subtensor()
-        tao_provider = self.chain_providers.get('tao')
+        tao_provider = self.assets.get('tao')
         if tao_provider and hasattr(tao_provider, 'subtensor'):
             tao_provider.subtensor = self.subtensor
 

--- a/smart-contracts/solana/programs/allways_swap_manager/src/error.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/error.rs
@@ -137,4 +137,8 @@ pub enum ErrorCode {
     InvalidUser,
     #[msg("round_key does not match the keccak hash of the submitted weights snapshot")]
     WeightsRoundKeyMismatch,
+
+    // --- Chain-id canonicalization ---
+    #[msg("Chain ids must be lowercase")]
+    ChainNotLowercase,
 }

--- a/smart-contracts/solana/programs/allways_swap_manager/src/error.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/error.rs
@@ -137,8 +137,4 @@ pub enum ErrorCode {
     InvalidUser,
     #[msg("round_key does not match the keccak hash of the submitted weights snapshot")]
     WeightsRoundKeyMismatch,
-
-    // --- Chain-id canonicalization ---
-    #[msg("Chain ids must be lowercase")]
-    ChainNotLowercase,
 }

--- a/tests/test_assets_optional.py
+++ b/tests/test_assets_optional.py
@@ -3,7 +3,7 @@ chains still fail hard — a tao<->sol miner must start without BTC creds, a btc
 
 import pytest
 
-from allways import chain_providers as cp
+from allways import assets as cp
 
 
 class _Boom:
@@ -21,20 +21,20 @@ class _Ok:
 
 @pytest.fixture
 def registry(monkeypatch):
-    monkeypatch.setattr(cp, 'PROVIDER_REGISTRY', (('btc', _Boom, ()), ('sol', _Ok, ())))
+    monkeypatch.setattr(cp, 'ASSET_REGISTRY', (('btc', _Boom, ()), ('sol', _Ok, ())))
 
 
 def test_unrequired_failure_degrades_to_warning(registry):
-    providers = cp.create_chain_providers(check=True, required_chains={'sol'})
+    providers = cp.create_assets(check=True, required_chains={'sol'})
     assert 'sol' in providers
     assert 'btc' not in providers
 
 
 def test_required_failure_still_raises(registry):
     with pytest.raises(RuntimeError, match='failed startup check'):
-        cp.create_chain_providers(check=True, required_chains={'btc', 'sol'})
+        cp.create_assets(check=True, required_chains={'btc', 'sol'})
 
 
 def test_none_means_all_required(registry):
     with pytest.raises(RuntimeError, match='failed startup check'):
-        cp.create_chain_providers(check=True)
+        cp.create_assets(check=True)

--- a/tests/test_axon_solana_handlers.py
+++ b/tests/test_axon_solana_handlers.py
@@ -12,7 +12,7 @@ from types import SimpleNamespace
 import bittensor as bt
 from solders.keypair import Keypair as SolKeypair
 
-from allways.chain_providers.base import TransactionInfo
+from allways.assets.base import TransactionInfo
 from allways.solana.client import swap_key_from_tx_hash
 from allways.synapses import MinerActivateSynapse, SwapConfirmSynapse
 from allways.validator import axon_handlers
@@ -78,7 +78,7 @@ def make_validator(solana_client, provider=None):
         axon_lock=threading.RLock(),
         config=SimpleNamespace(netuid=1),
         metagraph=SimpleNamespace(hotkeys=[HOTKEY]),
-        axon_chain_providers={'btc': provider} if provider else {},
+        axon_assets={'btc': provider} if provider else {},
     )
 
 

--- a/tests/test_bitcoin_signing.py
+++ b/tests/test_bitcoin_signing.py
@@ -1,4 +1,4 @@
-"""Tests for BIP-137 message signing and verification in BitcoinProvider."""
+"""Tests for BIP-137 message signing and verification in Bitcoin."""
 
 import os
 from types import SimpleNamespace
@@ -6,12 +6,12 @@ from unittest.mock import MagicMock, patch
 
 from bitcoin_message_tool.bmt import sign_message, verify_message
 
-from allways.chain_providers.bitcoin import (
+from allways.assets.bitcoin import (
     ADDR_TYPE_P2PKH,
     ADDR_TYPE_P2SH_P2WPKH,
     ADDR_TYPE_P2TR,
     ADDR_TYPE_P2WPKH,
-    BitcoinProvider,
+    Bitcoin,
     detect_address_type,
     to_mainnet_address,
 )
@@ -103,18 +103,18 @@ class TestBIP137SignVerify:
         assert valid
 
 
-def make_lightweight_provider() -> BitcoinProvider:
-    """Construct a BitcoinProvider in lightweight mode for sign/verify tests.
+def make_lightweight_provider() -> Bitcoin:
+    """Construct a Bitcoin in lightweight mode for sign/verify tests.
 
     Lightweight mode doesn't hit a node for sign/verify — it's pure
     cryptographic work. BTC_MODE and BTC_PRIVATE_KEY are set via env patch.
     """
     with patch.dict(os.environ, {'BTC_MODE': 'lightweight', 'BTC_PRIVATE_KEY': TEST_WIF}, clear=False):
-        return BitcoinProvider()
+        return Bitcoin()
 
 
-class TestBitcoinProviderSignFromProof:
-    """Direct coverage of BitcoinProvider.sign_from_proof — the wrapper our
+class TestBitcoinSignFromProof:
+    """Direct coverage of Bitcoin.sign_from_proof — the wrapper our
     validator/CLI actually invoke, not the underlying library."""
 
     def test_p2wpkh_address_produces_valid_signature(self):
@@ -163,7 +163,7 @@ class TestBitcoinProviderSignFromProof:
         """Lightweight mode + no key arg + no BTC_PRIVATE_KEY env → empty sig."""
         with patch.dict(os.environ, {'BTC_MODE': 'lightweight'}, clear=False):
             os.environ.pop('BTC_PRIVATE_KEY', None)
-            provider = BitcoinProvider()
+            provider = Bitcoin()
             addr, _, _ = sign_message(TEST_WIF, 'p2wpkh', 'x', deterministic=True)
 
             signature = provider.sign_from_proof(addr, TEST_MESSAGE, key=None)
@@ -182,8 +182,8 @@ class TestBitcoinProviderSignFromProof:
         assert signature != ''
 
 
-class TestBitcoinProviderVerifyFromProof:
-    """Direct coverage of BitcoinProvider.verify_from_proof."""
+class TestBitcoinVerifyFromProof:
+    """Direct coverage of Bitcoin.verify_from_proof."""
 
     def test_valid_signature_verifies(self):
         provider = make_lightweight_provider()

--- a/tests/test_block_time.py
+++ b/tests/test_block_time.py
@@ -11,9 +11,9 @@ from unittest.mock import MagicMock
 import pytest
 from bittensor.utils import ss58_encode
 
-from allways.chain_providers.base import ProviderUnreachableError, TransactionInfo
-from allways.chain_providers.bitcoin import BitcoinProvider
-from allways.chain_providers.subtensor import SubtensorProvider
+from allways.assets.base import ProviderUnreachableError, TransactionInfo
+from allways.assets.bitcoin import Bitcoin
+from allways.assets.subtensor import Tao
 
 BLOCK_TIME = 1_700_000_123
 
@@ -40,7 +40,7 @@ def test_transaction_info_defaults_block_time_none():
 
 def test_btc_api_surfaces_block_time(monkeypatch):
     monkeypatch.setenv('BTC_MODE', 'lightweight')
-    p = BitcoinProvider()
+    p = Bitcoin()
 
     tx_json = {
         'status': {
@@ -70,7 +70,7 @@ def test_btc_api_surfaces_block_time(monkeypatch):
 
 
 def test_subtensor_get_block_time_millis_to_seconds():
-    p = SubtensorProvider.__new__(SubtensorProvider)  # skip __init__ (no real subtensor needed)
+    p = Tao.__new__(Tao)  # skip __init__ (no real subtensor needed)
     substrate = MagicMock()
     substrate.get_block_hash.return_value = '0xabc'
     substrate.query.return_value = SimpleNamespace(value=BLOCK_TIME * 1000)  # pallet returns millis
@@ -81,7 +81,7 @@ def test_subtensor_get_block_time_millis_to_seconds():
 
 
 def test_subtensor_get_block_time_none_on_error():
-    p = SubtensorProvider.__new__(SubtensorProvider)
+    p = Tao.__new__(Tao)
     substrate = MagicMock()
     substrate.get_block_hash.side_effect = RuntimeError('rpc down')
     p.subtensor = SimpleNamespace(substrate=substrate)
@@ -93,7 +93,7 @@ def test_subtensor_get_block_time_none_on_error():
 
 
 def _scan_provider(head, blocks):
-    p = SubtensorProvider.__new__(SubtensorProvider)  # skip __init__ (no real subtensor needed)
+    p = Tao.__new__(Tao)  # skip __init__ (no real subtensor needed)
     p.subtensor = MagicMock()
     p.subtensor.get_current_block.return_value = head
     p.block_cache = {}
@@ -179,8 +179,8 @@ def test_tao_scanner_bounds_first_scan_to_lookback():
     seen = []
     p.get_block = lambda n: seen.append(n) or None
     assert p.find_recent_outgoing('userTAO', 'minerTAO', 5000) is None
-    assert len(seen) == SubtensorProvider.SCAN_LOOKBACK_BLOCKS
-    assert seen[0] == 1000 - SubtensorProvider.SCAN_LOOKBACK_BLOCKS + 1
+    assert len(seen) == Tao.SCAN_LOOKBACK_BLOCKS
+    assert seen[0] == 1000 - Tao.SCAN_LOOKBACK_BLOCKS + 1
 
 
 def test_tao_scanner_none_when_head_unreachable():
@@ -256,8 +256,8 @@ def test_settled_credit_sums_multiple_credits_from_one_extrinsic():
 )
 def test_transfer_event_shapes_are_all_understood(record):
     """scalecodec emits several shapes across runtime versions; all must decode identically."""
-    assert SubtensorProvider._event_extrinsic_idx(record) == 0
-    assert SubtensorProvider._transfer_from_event(record) == ('A', 'B', 7)
+    assert Tao._event_extrinsic_idx(record) == 0
+    assert Tao._transfer_from_event(record) == ('A', 'B', 7)
 
 
 def test_non_transfer_events_are_not_read_as_transfers():
@@ -276,15 +276,12 @@ def test_non_transfer_events_are_not_read_as_transfers():
             },
         },
     ):
-        assert (
-            SubtensorProvider._transfer_from_event(record) is None
-            or SubtensorProvider._event_extrinsic_idx(record) is None
-        )
+        assert Tao._transfer_from_event(record) is None or Tao._event_extrinsic_idx(record) is None
 
 
 def test_events_unavailable_raises_rather_than_reading_as_absent():
     """Fail closed as 'unknown', not 'no transfer' — the latter is slash-eligible upstream."""
-    p = SubtensorProvider.__new__(SubtensorProvider)
+    p = Tao.__new__(Tao)
     p.events_cache = {}
     p.subtensor = SimpleNamespace(substrate=SimpleNamespace(get_events=MagicMock(side_effect=RuntimeError('rpc down'))))
     with pytest.raises(ProviderUnreachableError):
@@ -312,7 +309,7 @@ def test_raw_extrinsic_sender_is_read_past_the_multiaddress_variant_byte():
         + dest
         + _compact(5_000)  # Balances.transfer_keep_alive
     )
-    parsed = SubtensorProvider.parse_raw_extrinsic((_compact(len(body)) + body).hex())
+    parsed = Tao.parse_raw_extrinsic((_compact(len(body)) + body).hex())
     assert parsed is not None
     assert parsed['sender'] == ss58_encode(sender, ss58_format=42)
     assert parsed['dest'] == ss58_encode(dest, ss58_format=42)
@@ -322,10 +319,10 @@ def test_raw_extrinsic_sender_is_read_past_the_multiaddress_variant_byte():
 def test_raw_extrinsic_rejects_non_id_multiaddress_rather_than_shifting():
     """A non-Id signer variant has no bare AccountId to read, so it must fail closed."""
     body = bytes([0x84, 0x01]) + bytes(range(32)) + bytes([0x01]) + b'\x11' * 64 + bytes([0x00] * 3)
-    assert SubtensorProvider.parse_raw_extrinsic((_compact(len(body)) + body).hex()) is None
+    assert Tao.parse_raw_extrinsic((_compact(len(body)) + body).hex()) is None
 
 
 def test_match_transfer_still_matches_by_hash_through_shared_decode():
     ext = {'extrinsic_hash': '0xabc', 'dest': 'minerTAO', 'amount': 7, 'sender': 'userTAO'}
-    assert SubtensorProvider.match_transfer(ext, '0xabc', True) == ('minerTAO', 7, 'userTAO')
-    assert SubtensorProvider.match_transfer(ext, '0xother', True) is None
+    assert Tao.match_transfer(ext, '0xabc', True) == ('minerTAO', 7, 'userTAO')
+    assert Tao.match_transfer(ext, '0xother', True) is None

--- a/tests/test_btc_tip_hoist.py
+++ b/tests/test_btc_tip_hoist.py
@@ -15,9 +15,9 @@ class _Resp:
 
 def _provider(monkeypatch):
     monkeypatch.setenv('BTC_MODE', 'lightweight')
-    from allways.chain_providers.bitcoin import BitcoinProvider
+    from allways.assets.bitcoin import Bitcoin
 
-    return BitcoinProvider()
+    return Bitcoin()
 
 
 def test_confirmations_from_cached_tip(monkeypatch):

--- a/tests/test_dev_signal.py
+++ b/tests/test_dev_signal.py
@@ -67,7 +67,7 @@ class TestWithholdDestFault:
         monkeypatch.setenv('ALLWAYS_DEV_FAULTS', str(flags))
         monkeypatch.setenv('ALLWAYS_DEV_SIGNAL', str(out))
         provider = MagicMock()
-        f = SwapFulfiller(solana_client=MagicMock(), chain_providers={'tao': provider})
+        f = SwapFulfiller(solana_client=MagicMock(), assets={'tao': provider})
         assert f.send_dest_funds(make_swap(), 341_550_000) is None
         provider.send_amount.assert_not_called()
         refuse = json.loads(out.read_text())
@@ -77,5 +77,5 @@ class TestWithholdDestFault:
         monkeypatch.delenv('ALLWAYS_DEV_FAULTS', raising=False)
         provider = MagicMock()
         provider.send_amount.return_value = ('txhash', 7)
-        f = SwapFulfiller(solana_client=MagicMock(), chain_providers={'tao': provider})
+        f = SwapFulfiller(solana_client=MagicMock(), assets={'tao': provider})
         assert f.send_dest_funds(make_swap(), 341_550_000) == ('txhash', 7)

--- a/tests/test_ethereum_provider.py
+++ b/tests/test_ethereum_provider.py
@@ -1,4 +1,4 @@
-"""EthereumProvider unit tests — all offline (RPC layer mocked, signing is pure crypto).
+"""EvmCoin unit tests — all offline (RPC layer mocked, signing is pure crypto).
 
 Covers the ETH-specific hazards: EIP-55 casing at every comparison boundary, inclusion≠settlement
 (reverted txs carry intact to/value fields), receipt-unavailable must read as 'unknown' not
@@ -9,8 +9,8 @@ from typing import Optional
 
 import pytest
 
-from allways.chain_providers.base import ProviderUnreachableError
-from allways.chain_providers.ethereum import EthereumProvider
+from allways.assets.base import ProviderUnreachableError
+from allways.assets.ethereum import EvmCoin
 
 # Well-known dev key (hardhat account #0) — never funded on mainnet, deterministic address.
 TEST_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
@@ -25,7 +25,7 @@ def provider(monkeypatch):
     monkeypatch.setenv('ETH_NETWORK', 'mainnet')
     monkeypatch.delenv('ETH_RPC_URLS', raising=False)
     monkeypatch.delenv('ETH_PRIVATE_KEY', raising=False)
-    return EthereumProvider()
+    return EvmCoin()
 
 
 def rpc_stub(provider, responses: dict):
@@ -427,12 +427,12 @@ class TestNetworkGuard:
         # A typo ('seplia') silently becoming mainnet would pay real ETH against test swaps.
         monkeypatch.setenv('ETH_NETWORK', 'seplia')
         with pytest.raises(ValueError, match='ETH_NETWORK'):
-            EthereumProvider()
+            EvmCoin()
 
     def test_unset_defaults_to_mainnet(self, monkeypatch):
         monkeypatch.delenv('ETH_NETWORK', raising=False)
         monkeypatch.delenv('ETH_RPC_URLS', raising=False)
-        assert EthereumProvider().network == 'mainnet'
+        assert EvmCoin().network == 'mainnet'
 
 
 class TestAbsenceQuorum:

--- a/tests/test_fulfillment.py
+++ b/tests/test_fulfillment.py
@@ -31,7 +31,7 @@ def at_now(monkeypatch):
 
 
 def make_fulfiller(**kw) -> SwapFulfiller:
-    return SwapFulfiller(solana_client=MagicMock(), chain_providers={}, **kw)
+    return SwapFulfiller(solana_client=MagicMock(), assets={}, **kw)
 
 
 def make_swap(

--- a/tests/test_input_validation_regressions.py
+++ b/tests/test_input_validation_regressions.py
@@ -9,7 +9,7 @@
 
 import bittensor as bt
 
-from allways.chain_providers.subtensor import SubtensorProvider
+from allways.assets.subtensor import Tao
 from allways.validator.reserve_engine import confirm_deposit
 
 
@@ -17,7 +17,7 @@ def test_is_valid_address_verifies_checksum_not_just_shape():
     # PR #312: is_valid_address must verify the SS58 checksum. A genuinely-valid key passes; a 48-char
     # base58 string with a corrupted payload/checksum fails. Generate the valid address so the test
     # stays correct across bittensor SS58-format changes.
-    p = SubtensorProvider.__new__(SubtensorProvider)  # no live subtensor needed for pure validation
+    p = Tao.__new__(Tao)  # no live subtensor needed for pure validation
     valid = bt.Keypair.create_from_uri('//RegressionTest').ss58_address
     assert p.is_valid_address(valid) is True, 'a genuinely valid SS58 must pass'
 

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -99,7 +99,7 @@ def test_undeliverable_destination_rejects_before_any_bid():
     # B-lite reserve gate: a dest that provably refuses transfers bounces before funds move.
     client = FakeClient()
     validator = _validator(client)
-    validator.axon_chain_providers = {'btc': SimpleNamespace(can_deliver_to=lambda addr, amt: False)}
+    validator.axon_assets = {'btc': SimpleNamespace(can_deliver_to=lambda addr, amt: False)}
     result = reserve_on_behalf(validator, HOTKEY, 'sol', 'btc', USER_PK, str(USER_PK), 'userBTCaddr', 10**9)
     assert not result.ok
     assert 'rejects incoming transfers' in result.reason
@@ -381,7 +381,7 @@ def test_malformed_swap_key_raises_value_error(tmp_path):
 # confirms (the crank defers voting until confirmations accrue); fast-fails without a claim on absent/mismatch
 # (None) or a stale MINED deposit, so the short reservation TTL frees the miner.
 import allways.validator.reserve_engine as rc  # noqa: E402
-from allways.chain_providers.base import ProviderUnreachableError, TransactionInfo  # noqa: E402
+from allways.assets.base import ProviderUnreachableError, TransactionInfo  # noqa: E402
 from allways.validator.reserve_engine import confirm_deposit  # noqa: E402
 
 CONFIRM_CREATED_AT = 1000
@@ -455,9 +455,7 @@ def _tx(*, confirmed, block_time, confirmations=0):
 def _confirm(reservation, tx_info, *, unreachable=False):
     client = _ConfirmClient(reservation)
     provider = _FakeProvider(tx_info, unreachable=unreachable)
-    validator = SimpleNamespace(
-        solana_client=client, axon_chain_providers={'btc': provider}, axon_lock=threading.RLock()
-    )
+    validator = SimpleNamespace(solana_client=client, axon_assets={'btc': provider}, axon_lock=threading.RLock())
     return confirm_deposit(validator, HOTKEY, 'srctxhash'), client
 
 
@@ -544,7 +542,7 @@ def test_confirm_measures_runway_after_the_source_rpc(monkeypatch):
 
     validator = SimpleNamespace(
         solana_client=client,
-        axon_chain_providers={'btc': _SlowProvider(_tx(confirmed=False, block_time=None))},
+        axon_assets={'btc': _SlowProvider(_tx(confirmed=False, block_time=None))},
         axon_lock=threading.RLock(),
     )
     monkeypatch.setattr(rc.time, 'time', lambda: clock['t'])
@@ -576,9 +574,7 @@ def test_confirm_claims_even_if_the_extension_fails():
     client = _ConfirmClient(_near_expiry(20))
     client.extend_raises = True
     provider = _FakeProvider(_tx(confirmed=False, block_time=None))
-    validator = SimpleNamespace(
-        solana_client=client, axon_chain_providers={'btc': provider}, axon_lock=threading.RLock()
-    )
+    validator = SimpleNamespace(solana_client=client, axon_assets={'btc': provider}, axon_lock=threading.RLock())
     r = confirm_deposit(validator, HOTKEY, 'srctxhash')
     assert r.ok and client.claims
 
@@ -615,7 +611,7 @@ def _scan_validator(tmp_path, reservation, provider):
 
     client = StatusClient(reservation=reservation)
     validator, store = _status_validator(tmp_path, client)
-    validator.axon_chain_providers = {'btc': provider} if provider else {}
+    validator.axon_assets = {'btc': provider} if provider else {}
     return scan_deposit, validator, store
 
 
@@ -631,7 +627,7 @@ def test_scan_deposit_finds_hash_for_live_unclaimed_reservation(tmp_path):
 def test_scan_deposit_none_when_provider_cannot_scan(tmp_path):
     # A provider without find_recent_outgoing (hypothetical new chain) degrades to manual/wallet paths.
     scan_deposit, validator, store = _scan_validator(tmp_path, _scan_reservation(FUTURE), object())
-    validator.axon_chain_providers = {'btc': object()}
+    validator.axon_assets = {'btc': object()}
     assert scan_deposit(validator, HOTKEY) is None
     store.close()
 

--- a/tests/test_self_transfer_guard.py
+++ b/tests/test_self_transfer_guard.py
@@ -10,11 +10,11 @@ reward-side limits, so it still passes here.
 
 from typing import Optional
 
-from allways.chain_providers.base import ChainProvider, TransactionInfo
+from allways.assets.base import Asset, TransactionInfo
 from allways.chains import CHAIN_TAO, ChainDefinition
 
 
-class FakeProvider(ChainProvider):
+class FakeProvider(Asset):
     """Returns a single canned tx; only the base post-checks are exercised."""
 
     def __init__(self, tx: TransactionInfo):

--- a/tests/test_solana_provider.py
+++ b/tests/test_solana_provider.py
@@ -1,4 +1,4 @@
-"""Unit tests for SolanaProvider (B7) — the native-SOL swap-leg provider.
+"""Unit tests for Sol (B7) — the native-SOL swap-leg provider.
 
 No chain: a fake RPC returns canned getTransaction/getSlot/getBalance results. Covers fetch/verify,
 block_time extraction, amount matching (>=), confirmations, failed/missing tx, unreachable backend,
@@ -9,8 +9,8 @@ import pytest
 import requests
 from solders.keypair import Keypair
 
-from allways.chain_providers.base import ProviderUnreachableError
-from allways.chain_providers.solana import SolanaProvider
+from allways.assets.base import ProviderUnreachableError
+from allways.assets.solana import Sol
 from allways.chains import CHAIN_SOL
 
 
@@ -51,7 +51,7 @@ class FakeRpc:
 
 
 def provider_with(rpc, keypair=None):
-    p = SolanaProvider(solana_rpc_url='fake://rpc', solana_keypair=keypair)
+    p = Sol(solana_rpc_url='fake://rpc', solana_keypair=keypair)
     p.rpc = rpc
     return p
 

--- a/tests/test_solana_provider_integration.py
+++ b/tests/test_solana_provider_integration.py
@@ -1,6 +1,6 @@
 """Integration: verify a REAL SOL transfer on a local solana-test-validator (B7).
 
-Spins up a throwaway validator, funds a sender, sends lamports via SolanaProvider.send_amount (a
+Spins up a throwaway validator, funds a sender, sends lamports via Sol.send_amount (a
 SystemProgram transfer), then proves the provider reads it back: amount match, sender attribution,
 and the on-chain blockTime (the replay-freshness floor). No swap-manager program needed — the SOL
 swap leg is a peer-to-peer transfer, verified like a BTC deposit.
@@ -16,7 +16,7 @@ import time
 import pytest
 from solders.keypair import Keypair
 
-from allways.chain_providers.solana import SolanaProvider
+from allways.assets.solana import Sol
 from allways.solana.rpc import SolanaRpc
 
 pytestmark = pytest.mark.integration
@@ -64,8 +64,8 @@ def test_send_then_verify_real_transfer(validator):
     recipient = Keypair()
     _fund(str(sender.pubkey()))
 
-    sender_provider = SolanaProvider(solana_rpc_url=RPC, solana_keypair=sender)
-    reader = SolanaProvider(solana_rpc_url=RPC)  # read-only, no keypair
+    sender_provider = Sol(solana_rpc_url=RPC, solana_keypair=sender)
+    reader = Sol(solana_rpc_url=RPC)  # read-only, no keypair
 
     # Connection check (read-only path).
     reader.check_connection(require_send=False)

--- a/tests/test_solana_swap_loop.py
+++ b/tests/test_solana_swap_loop.py
@@ -7,7 +7,7 @@ Mocks the solana client (get_swaps / get_reservation) + chain providers; no chai
 
 from types import SimpleNamespace
 
-from allways.chain_providers.base import ProviderUnreachableError
+from allways.assets.base import ProviderUnreachableError
 from allways.solana.client import benign_marker, swap_key_from_tx_hash
 from allways.validator.solana_swap_loop import (
     _BENIGN_RESOLVE_MARKERS,

--- a/tests/test_swap_now_reservation.py
+++ b/tests/test_swap_now_reservation.py
@@ -372,10 +372,10 @@ def test_can_send_from_gates_on_signer(monkeypatch):
     funds move (prevents the wrong-key deposit the validator would reject)."""
     from types import SimpleNamespace
 
-    from allways.chain_providers.solana import SolanaProvider
+    from allways.assets.solana import Sol
 
     kp = SimpleNamespace(pubkey=lambda: 'PINNED')
-    p = SolanaProvider.__new__(SolanaProvider)
+    p = Sol.__new__(Sol)
     p.keypair = kp
     assert p.can_send_from('PINNED') is True
     assert p.can_send_from('SOMEONE_ELSE') is False

--- a/tests/test_tao_settlement.py
+++ b/tests/test_tao_settlement.py
@@ -10,8 +10,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from allways.chain_providers.base import ProviderUnreachableError
-from allways.chain_providers.subtensor import SubtensorProvider
+from allways.assets.base import ProviderUnreachableError
+from allways.assets.subtensor import Tao
 
 MINER = 'minerTAO'
 USER = 'userTAO'
@@ -31,7 +31,7 @@ def _transfer_event(dest, amount, sender, extrinsic_idx=0):
 
 
 def _provider(*, call_amount=5_000, events, head=BLOCK + 10):
-    p = SubtensorProvider.__new__(SubtensorProvider)  # skip __init__ (no real subtensor needed)
+    p = Tao.__new__(Tao)  # skip __init__ (no real subtensor needed)
     p.subtensor = MagicMock()
     p.subtensor.get_current_block.return_value = head
     p.block_cache = {}
@@ -138,7 +138,7 @@ def test_events_are_fetched_once_per_block():
     real_events = [_transfer_event(MINER, 5_000, USER)]
     p.subtensor.substrate = SimpleNamespace(get_events=lambda h: calls.append(h) or real_events)
     del p.get_block_events  # exercise the real caching path
-    p.get_block_events = SubtensorProvider.get_block_events.__get__(p)
+    p.get_block_events = Tao.get_block_events.__get__(p)
     assert p.settled_credit(BLOCK, 0, MINER) == (USER, 5_000)
     assert p.settled_credit(BLOCK, 0, MINER) == (USER, 5_000)
     assert len(calls) == 1
@@ -164,7 +164,7 @@ def test_unreadable_transfer_payload_raises_rather_than_reading_as_absent(attrib
         'event': {'module_id': 'Balances', 'event_id': 'Transfer', 'attributes': attributes},
     }
     with pytest.raises(ProviderUnreachableError):
-        SubtensorProvider._transfer_from_event(record)
+        Tao._transfer_from_event(record)
 
 
 def test_unreadable_payload_on_a_non_transfer_event_is_still_just_absent():
@@ -173,7 +173,7 @@ def test_unreadable_payload_on_a_non_transfer_event_is_still_just_absent():
         'extrinsic_idx': 0,
         'event': {'module_id': 'Balances', 'event_id': 'Withdraw', 'attributes': 'unexpected-scalar'},
     }
-    assert SubtensorProvider._transfer_from_event(record) is None
+    assert Tao._transfer_from_event(record) is None
 
 
 def test_unreadable_transfer_payload_surfaces_through_settled_credit():


### PR DESCRIPTION
## Summary
Behavior-frozen naming sweep ahead of the first token asset (USDC on Arbitrum). The provider layer conflated chain and asset — one class per chain, named for the chain, providing its native coin. This renames the layer to say what it is: an Asset (a thing you can swap: verify a payment of it, send it, gate it) living on a Chain (a network you can talk to).

## Changes
- chain_providers/ -> assets/; ChainProvider -> Asset
- New Chain ABC (assets/chain.py); every Asset exposes .chain
- Single-asset networks stay fused: Bitcoin/Tao/Sol/EvmCoin implement (Asset, Chain), .chain returns self; they split the day their chain hosts a second asset
- BitcoinProvider -> Bitcoin, SubtensorProvider -> Tao, SolanaProvider -> Sol, EthereumProvider -> EvmCoin; PROVIDER_REGISTRY -> ASSET_REGISTRY; create_chain_providers -> create_assets
- Wire vocabulary untouched: chains.py registry (ChainDefinition, CHAIN_*, SUPPORTED_CHAINS, get_chain), program strings, DB columns, /chains — the das drift gate parses chains.py by name and path, so the registry deliberately keeps chain vocabulary

Zero behavior change: full suite passes with only mechanical name swaps in tests (954 passed).