### PR TITLE
Add USDC-on-Arbitrum spoke (arbusdc)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,17 @@ ETH_NETWORK=mainnet                 # mainnet | sepolia
 # 32-byte hex key — required for miners; optional local signing for `alw swap`
 ETH_PRIVATE_KEY=
 
+# ─── Chain: Arbitrum USDC (arbusdc pairs) ──────────────────
+ARBUSDC_NETWORK=mainnet             # mainnet | sepolia (Arbitrum Sepolia)
+# OPTIONAL ordered JSON-RPC endpoints (keyed providers embed the key in the URL);
+# unset = public (publicnode, drpc)
+# ARBUSDC_RPC_URLS=https://api-arbitrum-mainnet-archive.n.dwellir.com/your_key,https://arbitrum-one-rpc.publicnode.com
+# OPTIONAL token contract override (dev/e2e fakes) — unset = Circle's canonical USDC deployment
+# ARBUSDC_TOKEN_CONTRACT=
+# 32-byte hex key — required for miners (fund USDC for legs + ETH-on-Arbitrum for gas);
+# optional local signing for `alw swap`
+ARBUSDC_PRIVATE_KEY=
+
 # ─── Miner-only ────────────────────────────────────────────
 # headless miners: unlocks the coldkey at startup for TAO sends; unset = prompt at launch
 MINER_BITTENSOR_COLDKEY_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Native transactions across independent assets — no wrapped tokens, no bridges,
 
 Allways creates a verification layer above independent systems. Assets move natively. Miners complete transactions, validators independently verify the results, and a smart contract enforces outcomes through collateral and slashing.
 
-Currently live with SOL ↔ BTC, SOL ↔ TAO, and SOL ↔ ETH (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
+Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, and SOL ↔ USDC-on-Arbitrum (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
 
 ## Miner Risk Disclaimer
 
@@ -69,7 +69,7 @@ needs to persist across restarts.
 
 ## Miner Environment Variables
 
-- `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ETH_RPC_URLS`, etc. — see `.env.example`.
+- `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARBUSDC_PRIVATE_KEY`, `{ETH,ARBUSDC}_RPC_URLS`, etc. — see `.env.example`.
 
 ## Running a Local Subtensor Lite Node (Validators)
 

--- a/allways/assets/__init__.py
+++ b/allways/assets/__init__.py
@@ -5,6 +5,7 @@ import bittensor as bt
 from allways.assets.base import Asset, SendResult, TransactionInfo
 from allways.assets.bitcoin import Bitcoin
 from allways.assets.chain import Chain
+from allways.assets.erc20 import ArbUsdc, Erc20
 from allways.assets.ethereum import Ether
 from allways.assets.solana import Sol
 from allways.assets.subtensor import Tao
@@ -19,6 +20,8 @@ __all__ = [
     'Tao',
     'Sol',
     'Ether',
+    'Erc20',
+    'ArbUsdc',
     'create_assets',
 ]
 
@@ -37,6 +40,7 @@ ASSET_REGISTRY: Tuple[AssetSpec, ...] = (
     AssetSpec('tao', Tao, ('subtensor', 'wallet')),
     AssetSpec('sol', Sol, ('solana_rpc_url', 'solana_keypair')),
     AssetSpec('eth', Ether, ()),
+    AssetSpec('arbusdc', ArbUsdc, ()),
 )
 
 

--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -1,0 +1,492 @@
+import os
+import time
+from typing import Optional, Tuple
+
+import bittensor as bt
+from eth_account import Account
+from eth_utils import keccak
+
+from allways.assets.base import ProviderUnreachableError, SendResult, TransactionInfo
+from allways.assets.evm import EVM_NETWORKS, FALLBACK_PRIORITY_FEE_WEI, EvmAsset, EvmChain
+from allways.chains import ChainDefinition, get_chain_def
+
+
+def _selector(signature: str) -> str:
+    return '0x' + keccak(text=signature)[:4].hex()
+
+
+# Computed, not transcribed — the ABI signature is the source of truth.
+TRANSFER_TOPIC0 = '0x' + keccak(text='Transfer(address,address,uint256)').hex()
+SEL_TRANSFER = _selector('transfer(address,uint256)')
+SEL_BALANCE_OF = _selector('balanceOf(address)')
+SEL_IS_BLACKLISTED = _selector('isBlacklisted(address)')
+SEL_PAUSED = _selector('paused()')
+
+# transfer() runs contract code (~65k for Circle's FiatToken) — cap bounds the miner's
+# gas spend against a pathological estimate without pinching the real cost.
+MAX_TOKEN_TRANSFER_GAS = 150_000
+# Estimator-down fallback: covers FiatToken's worst case while staying under the cap.
+DEFAULT_TOKEN_TRANSFER_GAS = 120_000
+
+# Testnet deployments per (asset id, network). The canonical mainnet deployment is the
+# registry row's asset_locator; {PREFIX}_TOKEN_CONTRACT overrides either (e2e fakes,
+# emergency repoint) — each address lives exactly once.
+TESTNET_TOKEN_CONTRACTS = {
+    # Circle-verified native USDC on Arbitrum Sepolia (developers.circle.com, 2026-08-07).
+    'arbusdc': {'sepolia': '0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d'},
+}
+
+
+def _token_contract(chain_def: ChainDefinition, network: str) -> str:
+    override = os.environ.get(f'{chain_def.env_prefix}_TOKEN_CONTRACT')
+    if override:
+        return override
+    contract = (
+        chain_def.asset_locator if network == 'mainnet' else TESTNET_TOKEN_CONTRACTS.get(chain_def.id, {}).get(network)
+    )
+    if not contract:
+        raise ValueError(
+            f'No {chain_def.id} token contract for network {network!r} — set {chain_def.env_prefix}_TOKEN_CONTRACT'
+        )
+    return contract
+
+
+def _pad_addr(address: str) -> str:
+    """Address → 32-byte ABI word (lowercase hex, no 0x)."""
+    return address.lower().removeprefix('0x').rjust(64, '0')
+
+
+def _topic_addr(topic: str) -> str:
+    """'0x' + address from a 32-byte log topic; '' when malformed (callers fail closed)."""
+    t = (topic or '').lower().removeprefix('0x')
+    if len(t) != 64 or t[:24] != '0' * 24 or not all(c in '0123456789abcdef' for c in t):
+        return ''
+    return '0x' + t[-40:]
+
+
+class Erc20(EvmAsset):
+    """A generic ERC-20 asset on an EVM chain, bound by its registry row.
+
+    Not fused: the token composes its host network's `EvmChain` (``self._chain``) — the
+    first non-fused asset, and the shape a second same-network token shares a chain
+    instance through. Settlement truth is the token contract's Transfer log, never
+    tx.value: verification accepts a tx iff its status-1 receipt carries a Transfer from
+    the PINNED contract paying the expected recipient, and the provable payer is the
+    log's `from` topic. Delivery gates are issuer-shaped: blacklist + pause, and
+    deliberately NO getCode — contract wallets receive ERC-20 fine, and a code probe
+    would hand them slash immunity.
+    """
+
+    def __init__(self, chain_def: ChainDefinition):
+        self._chain_def = chain_def
+        self._chain = EvmChain(EVM_NETWORKS[chain_def.host_chain], chain_def.env_prefix)
+        EvmAsset.__init__(self)
+        self.token_contract = _token_contract(chain_def, self.chain.network)
+        self._log = f'[{chain_def.id}]'
+
+    @property
+    def chain_def(self) -> ChainDefinition:
+        return self._chain_def
+
+    def describe(self) -> str:
+        return f'{super().describe()} — token {self.token_contract}'
+
+    def _eth_call(self, selector: str, address: str = '', block: str = 'latest') -> int:
+        """eth_call a nullary/one-address view on the token contract → uint result."""
+        data = selector + (_pad_addr(address) if address else '')
+        result = self.chain.eth_rpc('eth_call', [{'to': self.token_contract, 'data': data}, block])
+        return int(result, 16) if result and result != '0x' else 0
+
+    def check_connection(self, require_send: bool = True) -> None:
+        super().check_connection(require_send=require_send)
+        try:
+            code = self.chain.eth_rpc('eth_getCode', [self.token_contract, 'latest']) or '0x'
+        except Exception as e:
+            bt.logging.warning(f'{self._log} token contract probe failed: {e}')
+            return
+        if code == '0x':
+            # A typo'd override or wrong network would otherwise surface as every send failing.
+            raise ConnectionError(
+                f'{self.chain_def.env_prefix} token contract {self.token_contract} has no code on {self.chain.network}'
+            )
+        try:
+            if self._eth_call(SEL_PAUSED):
+                bt.logging.warning(f'{self._log} token is PAUSED — transfers will fail until the issuer unpauses')
+        except Exception as e:
+            bt.logging.warning(f'{self._log} paused() probe failed: {e}')
+
+    # --- Verification ---
+
+    def fetch_matching_tx(
+        self,
+        tx_hash: str,
+        expected_recipient: str,
+        expected_amount: int,
+        block_hint: int = 0,
+        max_scan_blocks: int = 150,  # unused — eth_getTransactionByHash is an O(1) index
+    ) -> Optional[TransactionInfo]:
+        """Look up a token transfer by tx hash and match recipient + amount off the Transfer log.
+
+        Mirrors the native EVM path (mempool match, settled cache, reorg check), with token
+        semantics: a mined match requires a status-1 receipt whose logs contain a Transfer from
+        the pinned contract; the sender is the log's `from` topic (unparseable fails closed).
+        Expecteds arrive canonicalized (verify_transaction) — only on-chain values normalize here.
+        A mined tx whose receipt/timestamp can't be read is 'unknown', never 'absent' — raise.
+        """
+        prefix = self.chain_def.env_prefix
+        try:
+            tx = self.chain.eth_rpc('eth_getTransactionByHash', [tx_hash], null_needs_quorum=True)
+        except Exception as e:
+            raise ProviderUnreachableError(f'{prefix} RPC unreachable: {e}') from e
+        if tx is None:
+            bt.logging.debug(f'{self._log} tx {tx_hash[:16]}... not found')
+            return None
+
+        if tx.get('blockNumber') is None:
+            # In the mempool: match transfer() calldata addressed to the pinned contract —
+            # a valid match, just not mined yet, so callers queue and retry.
+            match = self._pending_transfer(tx, expected_recipient, expected_amount)
+            if match is None:
+                bt.logging.warning(
+                    f'{self._log} pending tx {tx_hash[:16]}... is not a transfer paying '
+                    f'{expected_recipient} >= {expected_amount}'
+                )
+                return None
+            sender, amount = match
+            return TransactionInfo(
+                tx_hash=tx_hash,
+                confirmed=False,
+                sender=sender,
+                recipient=expected_recipient,
+                amount=amount,
+                block_number=None,
+                confirmations=0,
+                block_time=None,
+            )
+
+        # Cache hit: same blockHash as the fully-settled read this was cached under — the
+        # receipt/log/timestamp are immutable, skip 2 of the 3 RPCs on the 12s re-verify path.
+        # The blockHash equality IS the canonical-continuity check (a reorg misses → refetch).
+        # The hit must also match THIS leg (recipient + amount): unlike the native path, the
+        # match lives in the receipt logs the cache skips — a cached settled read must never
+        # vouch for a different recipient's claim on the same tx hash. Mismatch → full refetch,
+        # whose log scan gives the authoritative reject.
+        tx_block_hash = tx.get('blockHash') or ''
+        cached = self._settled_cache.get(tx_hash)
+        if (
+            cached is not None
+            and tx_block_hash
+            and cached['block_hash'] == tx_block_hash
+            and cached['recipient'] == expected_recipient
+            and cached['amount'] >= expected_amount
+        ):
+            sender, amount = cached['sender'], cached['amount']
+            block_number = cached['block_number']
+            block_time = cached['block_time']
+        else:
+            try:
+                receipt = self.chain.eth_rpc('eth_getTransactionReceipt', [tx_hash])
+            except Exception as e:
+                raise ProviderUnreachableError(f'{prefix} receipt fetch failed for {tx_hash[:16]}...: {e}') from e
+            if receipt is None:
+                raise ProviderUnreachableError(f'{prefix} tx {tx_hash[:16]}... is mined but its receipt is unavailable')
+            if int(receipt.get('status') or '0x0', 16) != 1:
+                bt.logging.warning(f'{self._log} tx {tx_hash[:16]}... reverted (status 0) — moved no funds, rejecting')
+                return None
+
+            match = self._transfer_log(receipt, expected_recipient, expected_amount)
+            if match is None:
+                bt.logging.warning(
+                    f'{self._log} tx {tx_hash[:16]}... has no Transfer log from {self.token_contract} paying '
+                    f'{expected_recipient} >= {expected_amount}'
+                )
+                return None
+            sender, amount = match
+            block_number = int(receipt['blockNumber'], 16)
+
+            # The freshness gate fails closed on a missing block_time, so an unreadable
+            # timestamp must be 'unknown' (raise), never a verdict — same as the receipt above.
+            try:
+                block = self.chain.eth_rpc('eth_getBlockByNumber', [hex(block_number), False])
+            except Exception as e:
+                raise ProviderUnreachableError(f'{prefix} block fetch failed for {tx_hash[:16]}...: {e}') from e
+            block_time = int((block or {}).get('timestamp') or '0x0', 16) or None
+            if block_time is None:
+                raise ProviderUnreachableError(
+                    f'{prefix} tx {tx_hash[:16]}... is mined but block {block_number} has no readable timestamp'
+                )
+            if block.get('hash') and receipt.get('blockHash') and block['hash'] != receipt['blockHash']:
+                bt.logging.warning(f'{self._log} tx {tx_hash[:16]}... block was reorged out — rejecting')
+                return None
+
+            receipt_block_hash = receipt.get('blockHash') or ''
+            if receipt_block_hash and (not tx_block_hash or tx_block_hash == receipt_block_hash):
+                self._settled_cache[tx_hash] = {
+                    'block_hash': receipt_block_hash,
+                    'block_number': block_number,
+                    'block_time': block_time,
+                    'sender': sender,
+                    'recipient': expected_recipient,
+                    'amount': amount,
+                }
+                while len(self._settled_cache) > self._SETTLED_CACHE_MAX:
+                    self._settled_cache.popitem(last=False)
+
+        tip = self.chain.cached_block_height()
+        confirmations = max(0, tip - block_number + 1) if tip is not None else 0
+        return TransactionInfo(
+            tx_hash=tx_hash,
+            confirmed=confirmations >= self.chain_def.min_confirmations,
+            sender=sender,
+            recipient=expected_recipient,
+            amount=amount,
+            block_number=block_number,
+            confirmations=confirmations,
+            block_time=block_time,
+        )
+
+    def _pending_transfer(self, tx: dict, expected_recipient: str, expected_amount: int) -> Optional[Tuple[str, int]]:
+        """(sender, amount) decoded from a pending transfer() calldata match, else None."""
+        norm = self.chain.normalize_address
+        if norm(tx.get('to') or '') != norm(self.token_contract):
+            return None
+        data = (tx.get('input') or '').lower().removeprefix('0x')
+        if not data.startswith(SEL_TRANSFER[2:]) or len(data) < 8 + 128:
+            return None
+        recipient = _topic_addr(data[8:72])
+        if not recipient or recipient != expected_recipient:
+            return None
+        amount = int(data[72:136], 16)
+        if amount < expected_amount:
+            return None
+        return norm(tx.get('from') or ''), amount
+
+    def _transfer_log(self, receipt: dict, expected_recipient: str, expected_amount: int) -> Optional[Tuple[str, int]]:
+        """(sender, amount) from the first Transfer log of the PINNED contract paying the
+        recipient >= amount, else None. Logs from any other contract (USDC.e, fake tokens)
+        never match; an unparseable `from` topic fails closed (unprovable payer — F5)."""
+        contract = self.chain.normalize_address(self.token_contract)
+        for log in receipt.get('logs') or []:
+            if self.chain.normalize_address(log.get('address') or '') != contract:
+                continue
+            topics = log.get('topics') or []
+            if len(topics) != 3 or (topics[0] or '').lower() != TRANSFER_TOPIC0:
+                continue
+            if _topic_addr(topics[2]) != expected_recipient:
+                continue
+            try:
+                amount = int(log.get('data') or '0x0', 16)
+            except (TypeError, ValueError):
+                continue
+            if amount < expected_amount:
+                continue
+            sender = _topic_addr(topics[1])
+            if not sender:
+                continue
+            return sender, amount
+        return None
+
+    def get_balance(self, address: str) -> int:
+        """Token balance (smallest units) at latest, 0 on failure (mirrors the other providers)."""
+        try:
+            return self._eth_call(SEL_BALANCE_OF, address)
+        except Exception as e:
+            bt.logging.error(f'{self._log} get_balance failed for {address}: {e}')
+            return 0
+
+    # --- Sending ---
+
+    def send_amount(self, to_address: str, amount: int, from_address: Optional[str] = None) -> SendResult:
+        """Send tokens via transfer() signed with {PREFIX}_PRIVATE_KEY. Amount in smallest units.
+
+        Dual-balance preflight: the token balance covers ``amount`` AND the native balance
+        covers gas — a token-rich, gas-poor miner must refuse here, not burn a revert.
+        Returns (tx_hash, 0) or None; dedup/rescue ladder mirrors the native EVM send.
+        """
+        self.last_send_error = None
+        prefix = self.chain_def.env_prefix
+        norm = self.chain.normalize_address
+        acct = self.chain._account()
+        if acct is None:
+            self._send_error(f'{self._key_env} not set or unusable')
+            return None
+        if from_address and norm(acct.address) != norm(from_address):
+            self._send_error(
+                f'{prefix} key derives {acct.address} but committed address is {from_address} — key mismatch'
+            )
+            return None
+
+        head = self.chain.get_current_block_height()
+        if head is None:
+            self._send_error('cannot read the chain head to scope send dedup — not sending')
+            return None
+
+        try:
+            # A prior own broadcast to this dest blocks a fresh send unless provably absent
+            # from every endpoint — probing by hash sees the mempool; never risk paying twice.
+            want = (norm(to_address), int(amount))
+            try:
+                prior = self._prior_broadcast(want, head)
+            except Exception as e:
+                self._send_error(f'prior broadcast unresolved ({e}) — refusing a possible double send')
+                return None
+            if prior:
+                bt.logging.info(f'Reusing prior tx {prior} from {acct.address} → {to_address} ({amount} units)')
+                return (prior, 0)
+
+            latest = self.chain.eth_rpc('eth_getBlockByNumber', ['latest', False])
+            base_fee = int((latest or {}).get('baseFeePerGas') or '0x0', 16)
+            try:
+                tip_fee = int(self.chain.eth_rpc('eth_maxPriorityFeePerGas', []), 16)
+            except Exception:
+                tip_fee = FALLBACK_PRIORITY_FEE_WEI
+            max_fee = 2 * base_fee + tip_fee
+
+            calldata = SEL_TRANSFER[2:] + _pad_addr(to_address) + f'{int(amount):064x}'
+            gas = self._transfer_gas(acct.address, calldata)
+            if gas is None:
+                self._send_error(f'destination {to_address} refuses {prefix} transfers — not sending')
+                return None
+
+            token_balance = self.get_balance(acct.address)
+            if token_balance < amount:
+                self._send_error(f'Insufficient {prefix}: have {token_balance} units, need {amount}')
+                return None
+            gas_balance = int(self.chain.eth_rpc('eth_getBalance', [acct.address, 'latest']), 16)
+            if gas_balance < gas * max_fee:
+                self._send_error(f'Insufficient gas balance: have {gas_balance} wei, need {gas * max_fee}')
+                return None
+
+            nonce = int(self.chain.eth_rpc('eth_getTransactionCount', [acct.address, 'pending']), 16)
+            signed = Account.sign_transaction(
+                {
+                    'chainId': self.chain.chain_id,
+                    'nonce': nonce,
+                    'to': self.token_contract,
+                    'value': 0,
+                    'data': '0x' + calldata,
+                    'gas': gas,
+                    'maxFeePerGas': max_fee,
+                    'maxPriorityFeePerGas': tip_fee,
+                },
+                acct.key,
+            )
+            expected_txid = signed.hash.hex()
+            expected_txid = expected_txid if expected_txid.startswith('0x') else f'0x{expected_txid}'
+            # Record pre-broadcast so a retry can reclaim it even if the response is lost.
+            self.broadcasted_txids[expected_txid] = (*want, head)
+
+            raw = getattr(signed, 'raw_transaction', None) or getattr(signed, 'rawTransaction')
+            raw_hex = raw.hex()
+            raw_hex = raw_hex if raw_hex.startswith('0x') else f'0x{raw_hex}'
+            try:
+                tx_hash = self.chain.eth_rpc('eth_sendRawTransaction', [raw_hex], timeout=30)
+            except Exception as broadcast_err:
+                # The tx may have been accepted anyway — check before declaring failure.
+                try:
+                    probe = self.chain.eth_rpc('eth_getTransactionByHash', [expected_txid], null_needs_quorum=True)
+                    if probe is not None:
+                        return (expected_txid, 0)
+                except Exception:
+                    pass
+                self._send_error(f'{prefix} broadcast failed: {broadcast_err}')
+                return None
+
+            bt.logging.info(f'Sent {amount} {prefix} units to {to_address} (tx: {tx_hash}, maxFee: {max_fee})')
+            # A quirky null broadcast reply must never persist as a blank tx hash.
+            return (tx_hash or expected_txid, 0)
+        except Exception as e:
+            self._send_error(f'{prefix} send failed: {type(e).__name__}: {e}')
+            return None
+
+    def _transfer_gas(self, from_addr: str, calldata: str) -> Optional[int]:
+        """Gas limit via eth_estimateGas (+20% headroom); None when the transfer would revert
+        (blacklisted party / paused token — don't burn gas discovering it on-chain). Estimator
+        trouble falls back to a FiatToken-sized default rather than blocking a payout on noise."""
+        params = {'from': from_addr, 'to': self.token_contract, 'data': '0x' + calldata}
+        try:
+            est = int(self.chain.eth_rpc('eth_estimateGas', [params]), 16)
+        except Exception as e:
+            return None if 'revert' in str(e).lower() else DEFAULT_TOKEN_TRANSFER_GAS
+        gas = est + est // 5
+        return None if gas > MAX_TOKEN_TRANSFER_GAS else gas
+
+    # --- Delivery gates (F3: blacklist + pause, deliberately no getCode) ---
+
+    def can_deliver_to(self, address: str, amount: int) -> bool:
+        """Reserve-time gate: the issuer can freeze an address (blacklist) or the whole token
+        (pause) — both make delivery impossible regardless of dest code and neither is the
+        miner's fault, so they must bounce the reservation. Fails open on RPC trouble."""
+        try:
+            return not self._eth_call(SEL_IS_BLACKLISTED, address) and not self._eth_call(SEL_PAUSED)
+        except Exception:
+            return True
+
+    def delivery_refused(self, address: str, since_unix: int) -> bool:
+        """Slash gate: a blacklisted destination — now or sampled across the window since
+        ``since_unix`` — is positive evidence delivery could fail; never slash over it.
+
+        The LATEST probe is the load-bearing signal (issuer freezes persist for months, so a
+        freeze that broke delivery is still visible at slash time): its RPC failure raises and
+        the caller defers — a flaky RPC postpones a slash, never falsifies one. Historical
+        samples are best-effort (public nodes serve historical eth_call only ~a minute deep at
+        1s blocks; verified live 2026-08-07): a failing sample is skipped with a warning rather
+        than deferring every slash on the pair forever."""
+        if self._eth_call(SEL_IS_BLACKLISTED, address):
+            return True
+        tip = int(self.chain.eth_rpc('eth_blockNumber', []), 16)
+        span = min(60, max(0, int(time.time()) - int(since_unix)) // self.chain_def.seconds_per_block)
+        for probe in dict.fromkeys(hex(max(0, tip - span // d)) for d in (1, 2)):
+            try:
+                if self._eth_call(SEL_IS_BLACKLISTED, address, probe):
+                    return True
+            except Exception as e:
+                bt.logging.warning(f'{self._log} historical blacklist sample at {probe} failed ({e}) — skipping')
+        return False
+
+    def find_recent_outgoing(self, from_addr: str, to_addr: str, amount: int) -> Optional[str]:
+        """Tx hash of a recent settled token transfer ``from_addr`` → ``to_addr`` of >= ``amount``,
+        else None. eth_getLogs is address-indexed (no block walk), and a Transfer log only exists
+        on a status-1 receipt, so a hit IS settled. The cursor parks on a failed range so an
+        unreadable span is retried, never leapt."""
+        head = self.chain.get_current_block_height()
+        if head is None:
+            return None
+        norm = self.chain.normalize_address
+        key = (norm(from_addr), norm(to_addr), int(amount))
+        floor = max(head - self.SCAN_LOOKBACK_BLOCKS, 0)
+        start = max(self.scan_cursors.get(key, floor), floor) + 1
+        if start > head:
+            return None
+        try:
+            logs = self.chain.eth_rpc(
+                'eth_getLogs',
+                [
+                    {
+                        'fromBlock': hex(start),
+                        'toBlock': hex(head),
+                        'address': self.token_contract,
+                        'topics': [TRANSFER_TOPIC0, '0x' + _pad_addr(from_addr), '0x' + _pad_addr(to_addr)],
+                    }
+                ],
+            )
+        except Exception:
+            self._set_cursor(key, start - 1)
+            return None
+        for log in logs or []:
+            try:
+                value = int(log.get('data') or '0x0', 16)
+            except (TypeError, ValueError):
+                continue
+            if value >= int(amount) and log.get('transactionHash'):
+                self.scan_cursors.pop(key, None)
+                return log['transactionHash']
+        self._set_cursor(key, head)
+        return None
+
+
+class ArbUsdc(Erc20):
+    """USDC on Arbitrum — a config-row binding of the generic Erc20 (see chains.CHAIN_ARBUSDC)."""
+
+    def __init__(self):
+        super().__init__(get_chain_def('arbusdc'))

--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -342,16 +342,19 @@ class Erc20(EvmAsset):
                 tip_fee = FALLBACK_PRIORITY_FEE_WEI
             max_fee = 2 * base_fee + tip_fee
 
+            # Token balance BEFORE the gas estimate: an underfunded transfer reverts in the
+            # estimator too, which would misread as the destination refusing.
+            token_balance = self.get_balance(acct.address)
+            if token_balance < amount:
+                self._send_error(f'Insufficient {prefix}: have {token_balance} units, need {amount}')
+                return None
+
             calldata = SEL_TRANSFER[2:] + _pad_addr(to_address) + f'{int(amount):064x}'
             gas = self._transfer_gas(acct.address, calldata)
             if gas is None:
                 self._send_error(f'destination {to_address} refuses {prefix} transfers — not sending')
                 return None
 
-            token_balance = self.get_balance(acct.address)
-            if token_balance < amount:
-                self._send_error(f'Insufficient {prefix}: have {token_balance} units, need {amount}')
-                return None
             gas_balance = int(self.chain.eth_rpc('eth_getBalance', [acct.address, 'latest']), 16)
             if gas_balance < gas * max_fee:
                 self._send_error(f'Insufficient gas balance: have {gas_balance} wei, need {gas * max_fee}')
@@ -422,26 +425,31 @@ class Erc20(EvmAsset):
         except Exception:
             return True
 
-    def delivery_refused(self, address: str, since_unix: int) -> bool:
-        """Slash gate: a blacklisted destination — now or sampled across the window since
-        ``since_unix`` — is positive evidence delivery could fail; never slash over it.
+    def _refused_at(self, address: str, block: str = 'latest') -> bool:
+        """Issuer refusal at ``block``: dest blacklisted, or the whole token paused."""
+        return bool(self._eth_call(SEL_IS_BLACKLISTED, address, block)) or bool(self._eth_call(SEL_PAUSED, '', block))
 
-        The LATEST probe is the load-bearing signal (issuer freezes persist for months, so a
-        freeze that broke delivery is still visible at slash time): its RPC failure raises and
-        the caller defers — a flaky RPC postpones a slash, never falsifies one. Historical
-        samples are best-effort (public nodes serve historical eth_call only ~a minute deep at
-        1s blocks; verified live 2026-08-07): a failing sample is skipped with a warning rather
-        than deferring every slash on the pair forever."""
-        if self._eth_call(SEL_IS_BLACKLISTED, address):
+    def delivery_refused(self, address: str, since_unix: int) -> bool:
+        """Slash gate: issuer refusal (blacklisted dest, or token paused — both make delivery
+        impossible through no fault of the miner) — now or sampled across the window since
+        ``since_unix`` — is positive evidence; never slash over it.
+
+        The LATEST probe is the load-bearing signal (freezes persist for months, pauses until
+        the issuer acts, so a refusal that broke delivery is still visible at slash time): its
+        RPC failure raises and the caller defers — a flaky RPC postpones a slash, never
+        falsifies one. Historical samples are best-effort (public nodes serve historical
+        eth_call only ~a minute deep at 1s blocks; verified live 2026-08-07): a failing sample
+        is skipped with a warning rather than deferring every slash on the pair forever."""
+        if self._refused_at(address):
             return True
         tip = int(self.chain.eth_rpc('eth_blockNumber', []), 16)
         span = min(60, max(0, int(time.time()) - int(since_unix)) // self.chain_def.seconds_per_block)
         for probe in dict.fromkeys(hex(max(0, tip - span // d)) for d in (1, 2)):
             try:
-                if self._eth_call(SEL_IS_BLACKLISTED, address, probe):
+                if self._refused_at(address, probe):
                     return True
             except Exception as e:
-                bt.logging.warning(f'{self._log} historical blacklist sample at {probe} failed ({e}) — skipping')
+                bt.logging.warning(f'{self._log} historical refusal sample at {probe} failed ({e}) — skipping')
         return False
 
     def find_recent_outgoing(self, from_addr: str, to_addr: str, amount: int) -> Optional[str]:

--- a/allways/assets/ethereum.py
+++ b/allways/assets/ethereum.py
@@ -1,32 +1,14 @@
-import os
-import re
 import time
-from collections import OrderedDict
-from typing import Any, Dict, Optional, Tuple
-from urllib.parse import urlparse
+from typing import Optional
 
 import bittensor as bt
-import requests
 from eth_account import Account
-from eth_account.messages import encode_defunct
-from eth_utils import is_checksum_address
 
-from allways.assets.base import Asset, ProviderUnreachableError, SendResult, TransactionInfo
-from allways.assets.chain import Chain
+from allways.assets.base import ProviderUnreachableError, SendResult, TransactionInfo
+from allways.assets.evm import ETHEREUM, FALLBACK_PRIORITY_FEE_WEI, EvmAsset, EvmChain
 from allways.chains import CHAIN_ETH, ChainDefinition
 
 LOG_ETH = '[EthRpc]'
-
-# eth_chainId is checked against the configured network at startup — a wrong-network RPC
-# (mainnet URL while ETH_NETWORK=sepolia) fails fast instead of verifying the wrong chain.
-CHAIN_IDS = {'mainnet': 1, 'sepolia': 11_155_111}
-
-# Public JSON-RPC defaults per network, tried in order. Override with ETH_RPC_URLS
-# (keyed/paid endpoints embed their key in the URL path, so no header plumbing needed).
-DEFAULT_RPC_URLS = {
-    'mainnet': ('https://ethereum-rpc.publicnode.com', 'https://eth.drpc.org'),
-    'sepolia': ('https://ethereum-sepolia-rpc.publicnode.com', 'https://sepolia.drpc.org'),
-}
 
 TRANSFER_GAS = 21_000
 # Refuse destinations whose receive hook wants more than this — bounds the miner's gas
@@ -34,166 +16,25 @@ TRANSFER_GAS = 21_000
 MAX_TRANSFER_GAS = 100_000
 ZERO_ADDRESS = '0x' + '00' * 20
 
-_HEX_ADDR_RE = re.compile(r'^0x[0-9a-fA-F]{40}$')
 
-# Settled-tx cache bound — comfortably above any realistic concurrent-leg count.
-_SETTLED_CACHE_MAX_DEFAULT = 512
-# eth_maxPriorityFeePerGas fallback when an endpoint doesn't serve it (1 gwei clears
-# comfortably in normal conditions without meaningfully overpaying a 21k-gas send).
-FALLBACK_PRIORITY_FEE_WEI = 1_000_000_000
-
-
-def rpc_tag(base: str) -> str:
-    """Short, log-friendly host label for an RPC endpoint (e.g. 'publicnode', 'drpc')."""
-    host = (urlparse(base).netloc or base).split(':')[0].removeprefix('www.')
-    parts = host.split('.')
-    return parts[-2] if len(parts) >= 2 else host
-
-
-class Ether(Asset, Chain):
+class Ether(EvmAsset, EvmChain):
     """Ethereum chain provider: eth-account + public JSON-RPC (no local node required).
 
     Plain EOA value transfers only, by design: a swap leg is verified off the transaction's
     own from/to/value, which internal (contract-mediated) transfers don't populate — and the
     sender-pinning defense needs a provable EOA sender anyway.
 
-    Addresses are hex and case-insensitive (EIP-55 is a display checksum), so every
-    comparison goes through ``normalize_address`` (lowercase) — on-chain strings keep
-    whatever casing the user committed.
+    Fused with its chain (ether is Ethereum's only asset here); the shared EVM plumbing
+    lives in `EvmChain`/`EvmAsset` and splits out the day a second Ethereum asset lands.
     """
 
     def __init__(self):
-        self.network = os.environ.get('ETH_NETWORK', '').lower()
-        if not self.network:
-            self.network = 'mainnet'
-            bt.logging.warning('ETH_NETWORK unset — defaulting to mainnet; set ETH_NETWORK=sepolia for testnet.')
-        if self.network not in CHAIN_IDS:
-            # A typo silently becoming mainnet would pay real ETH against test swaps.
-            raise ValueError(f'Unknown ETH_NETWORK {self.network!r} — expected one of {list(CHAIN_IDS)}')
-
-        # Same rationale as the BTC provider: long-running validators + pooled idle TLS
-        # sockets that public CDNs silently drop → wedged reads until timeout.
-        self.http = requests.Session()
-        self.http.headers['Connection'] = 'close'
-
-        self.last_send_error: Optional[str] = None
-        # Settled-tx cache, keyed tx_hash → {block_hash, block_number, block_time}. A mined tx's
-        # receipt and its block's timestamp are immutable per block hash, so the validator's 12s
-        # re-verify pays 1 RPC (getTransactionByHash) instead of 3 — parity with BTC's single /tx.
-        # Reorg-safe: an entry is served only while the fresh tx fetch reports the SAME blockHash
-        # (key-by-hash); a reorg changes it → miss → full refetch. Only fully-settled entries
-        # (status 1 + timestamp) are cached — never pending/absent/reverted.
-        self._settled_cache: OrderedDict[str, dict] = OrderedDict()
-        # Own broadcasts, tx_hash → (to, amount, head at broadcast): send dedup scoped to this
-        # process and to SCAN_LOOKBACK_BLOCKS (#461 class — a later same-amount swap must never
-        # resolve to an earlier swap's consumed tx).
-        self.broadcasted_txids: Dict[str, Tuple[str, int, int]] = {}
-        # Deposit-scanner head cursors, keyed per (from, to, amount) — see find_recent_outgoing.
-        self.scan_cursors: Dict[Tuple[str, str, int], int] = {}
-
-        raw = os.environ.get('ETH_RPC_URLS', '')
-        self.rpc_bases = [u.strip().rstrip('/') for u in raw.split(',') if u.strip()] or list(
-            DEFAULT_RPC_URLS[self.network]
-        )
-
-    def _send_error(self, msg: str) -> None:
-        self.last_send_error = msg
-        bt.logging.error(msg)
+        EvmChain.__init__(self, ETHEREUM, 'ETH')
+        EvmAsset.__init__(self)
 
     @property
     def chain_def(self) -> ChainDefinition:
         return CHAIN_ETH
-
-    def describe(self) -> str:
-        hosts = ', '.join(urlparse(base).netloc or base for base in self.rpc_bases)
-        return f'Ethereum JSON-RPC ({self.network}): {hosts}'
-
-    def normalize_address(self, address: str) -> str:
-        return address.lower() if isinstance(address, str) else address
-
-    # --- JSON-RPC plumbing (failover mirrors the BTC provider's Esplora narration) ---
-
-    def eth_rpc(self, method: str, params: list, timeout: int = 15, null_needs_quorum: bool = False) -> Any:
-        """Call ``method`` against each endpoint in order, narrating every failover.
-
-        A JSON-RPC ``error`` object is treated as endpoint trouble (rate limit, pruned
-        state, method gap) and falls through; ``result: null`` is authoritative data
-        ("no such tx") and is returned as None. Raises the last error when all fail.
-
-        ``null_needs_quorum``: return None only when every endpoint reachably agrees;
-        null + an unreachable endpoint raises. For paths where "absent" costs money —
-        one stale node in a public load balancer must not read as "never happened".
-        """
-        payload = {'jsonrpc': '2.0', 'id': 1, 'method': method, 'params': params}
-        last_err: Optional[Exception] = None
-        saw_null = False
-        for i, base in enumerate(self.rpc_bases):
-            pos = f'[{i + 1}/{len(self.rpc_bases)}]'
-            tag = rpc_tag(base)
-            nxt = rpc_tag(self.rpc_bases[i + 1]) if i + 1 < len(self.rpc_bases) else None
-            tail = f'falling back to: {nxt}' if nxt else 'no providers left, giving up'
-            try:
-                resp = self.http.post(base, json=payload, timeout=timeout)
-            except Exception as e:
-                last_err = e
-                bt.logging.warning(f'EthRpc {pos} {tag} {method} → request error: {e}; {tail}')
-                continue
-
-            if resp.status_code != 200:
-                last_err = requests.HTTPError(f'{base} {method}: {resp.status_code}', response=resp)
-                bt.logging.warning(f'EthRpc {pos} {tag} {method} → HTTP {resp.status_code}; {tail}')
-                continue
-
-            try:
-                body = resp.json()
-            except ValueError as e:
-                last_err = e
-                bt.logging.warning(f'EthRpc {pos} {tag} {method} → bad JSON: {e}; {tail}')
-                continue
-
-            if 'error' in body:
-                err = body['error']
-                last_err = RuntimeError(f'{base} {method}: rpc error {err}')
-                bt.logging.warning(f'EthRpc {pos} {tag} {method} → rpc error {err}; {tail}')
-                continue
-
-            result = body.get('result')
-            if result is None and null_needs_quorum:
-                saw_null = True
-                bt.logging.debug(f'EthRpc {pos} {tag} {method} → null; seeking quorum from remaining endpoint(s)')
-                continue
-            if i > 0:
-                bt.logging.info(f'EthRpc {pos} {tag} {method} → ok (served after {i} fallback(s))')
-            else:
-                bt.logging.debug(f'EthRpc {pos} {tag} {method} → ok')
-            return result
-        if saw_null and last_err is None:
-            return None
-        if saw_null:
-            raise ProviderUnreachableError(f'{method}: null without quorum (an endpoint was unreachable): {last_err}')
-        raise last_err or RuntimeError('all ETH RPCs failed')
-
-    def check_connection(self, require_send: bool = True) -> None:
-        if require_send:
-            key = os.environ.get('ETH_PRIVATE_KEY')
-            if not key:
-                raise ConnectionError('ETH signing requires the ETH_PRIVATE_KEY env var')
-            try:
-                Account.from_key(key)
-            except Exception as e:
-                raise ConnectionError(f'ETH_PRIVATE_KEY is not a valid 32-byte hex key: {e}') from e
-        try:
-            chain_id = int(self.eth_rpc('eth_chainId', [], timeout=10), 16)
-            tip = int(self.eth_rpc('eth_blockNumber', [], timeout=10), 16)
-        except Exception as e:
-            raise ConnectionError(f'Cannot reach Ethereum RPC: {e}') from e
-        expected = CHAIN_IDS[self.network]
-        if chain_id != expected:
-            raise ConnectionError(
-                f'ETH RPC serves chain id {chain_id}, expected {expected} for {self.network} — '
-                'ETH_RPC_URLS and ETH_NETWORK disagree'
-            )
-        bt.logging.success(f'{LOG_ETH} connected: network={self.network}, chain_id={chain_id}, tip={tip}')
 
     # --- Verification ---
 
@@ -213,7 +54,7 @@ class Ether(Asset, Chain):
         ProviderUnreachableError rather than risking a false slash verdict.
         """
         try:
-            tx = self.eth_rpc('eth_getTransactionByHash', [tx_hash], null_needs_quorum=True)
+            tx = self.chain.eth_rpc('eth_getTransactionByHash', [tx_hash], null_needs_quorum=True)
         except Exception as e:
             raise ProviderUnreachableError(f'ETH RPC unreachable: {e}') from e
         if tx is None:
@@ -257,7 +98,7 @@ class Ether(Asset, Chain):
             is_confirmed = confirmations >= self.chain_def.min_confirmations
         else:
             try:
-                receipt = self.eth_rpc('eth_getTransactionReceipt', [tx_hash])
+                receipt = self.chain.eth_rpc('eth_getTransactionReceipt', [tx_hash])
             except Exception as e:
                 raise ProviderUnreachableError(f'ETH receipt fetch failed for {tx_hash[:16]}...: {e}') from e
             if receipt is None:
@@ -274,7 +115,7 @@ class Ether(Asset, Chain):
             # The freshness gate fails closed on a missing block_time, so an unreadable
             # timestamp must be 'unknown' (raise), never a verdict — same as the receipt above.
             try:
-                block = self.eth_rpc('eth_getBlockByNumber', [hex(block_number), False])
+                block = self.chain.eth_rpc('eth_getBlockByNumber', [hex(block_number), False])
             except Exception as e:
                 raise ProviderUnreachableError(f'ETH block fetch failed for {tx_hash[:16]}...: {e}') from e
             block_time = int((block or {}).get('timestamp') or '0x0', 16) or None
@@ -309,71 +150,13 @@ class Ether(Asset, Chain):
             block_time=block_time,
         )
 
-    def get_current_block_height(self) -> Optional[int]:
-        try:
-            return int(self.eth_rpc('eth_blockNumber', [], timeout=10), 16)
-        except Exception as e:
-            bt.logging.debug(f'ETH get_current_block_height failed: {e}')
-            return None
-
     def get_balance(self, address: str) -> int:
         """Balance in wei at latest, 0 on failure (mirrors the other providers)."""
         try:
-            return int(self.eth_rpc('eth_getBalance', [address, 'latest']), 16)
+            return int(self.chain.eth_rpc('eth_getBalance', [address, 'latest']), 16)
         except Exception as e:
             bt.logging.error(f'ETH get_balance failed for {address}: {e}')
             return 0
-
-    def is_valid_address(self, address: str) -> bool:
-        """0x + 40 hex, and if mixed-case the EIP-55 checksum must verify (typo protection,
-        no RPC). Done by hand: eth_utils 5+ ``is_address`` accepts unprefixed hex and stopped
-        validating checksums, which would wave through exactly the typos EIP-55 exists to catch."""
-        if not isinstance(address, str) or not _HEX_ADDR_RE.match(address):
-            return False
-        body = address[2:]
-        if body == body.lower() or body == body.upper():
-            return True
-        return is_checksum_address(address)
-
-    def _account(self, key: Optional[Any] = None):
-        raw = key if isinstance(key, str) and key else os.environ.get('ETH_PRIVATE_KEY')
-        if not raw:
-            return None
-        try:
-            return Account.from_key(raw)
-        except Exception as e:
-            bt.logging.error(f'ETH private key unusable: {e}')
-            return None
-
-    def can_send_from(self, address: str) -> bool:
-        acct = self._account()
-        return acct is not None and self.chain.normalize_address(acct.address) == self.chain.normalize_address(address)
-
-    def sign_from_proof(self, address: str, message: str, key: Optional[Any] = None) -> str:
-        """EIP-191 personal_sign over ``message``. key: hex private key; None → ETH_PRIVATE_KEY."""
-        acct = self._account(key)
-        if acct is None:
-            bt.logging.error('ETH signing requires the ETH_PRIVATE_KEY env var (or an explicit key)')
-            return ''
-        if self.normalize_address(acct.address) != self.normalize_address(address):
-            bt.logging.error(f'ETH key derives {acct.address} but the proof address is {address} — key mismatch')
-            return ''
-        try:
-            signed = Account.sign_message(encode_defunct(text=message), acct.key)
-            return signed.signature.hex()
-        except Exception as e:
-            bt.logging.error(f'ETH sign_from_proof failed: {e}')
-            return ''
-
-    def verify_from_proof(self, address: str, message: str, signature: str) -> bool:
-        """Recover the EIP-191 signer and compare case-insensitively. No RPC dependency."""
-        try:
-            sig = signature if signature.startswith('0x') else f'0x{signature}'
-            recovered = Account.recover_message(encode_defunct(text=message), signature=sig)
-            return self.normalize_address(recovered) == self.normalize_address(address)
-        except Exception as e:
-            bt.logging.error(f'ETH verify_from_proof failed: {e}')
-            return False
 
     # --- Sending ---
 
@@ -385,11 +168,12 @@ class Ether(Asset, Chain):
         Returns (tx_hash, 0) or None.
         """
         self.last_send_error = None
-        acct = self._account()
+        norm = self.chain.normalize_address
+        acct = self.chain._account()
         if acct is None:
             self._send_error('ETH_PRIVATE_KEY not set or unusable')
             return None
-        if from_address and self.chain.normalize_address(acct.address) != self.chain.normalize_address(from_address):
+        if from_address and norm(acct.address) != norm(from_address):
             self._send_error(f'ETH key derives {acct.address} but committed address is {from_address} — key mismatch')
             return None
 
@@ -401,7 +185,7 @@ class Ether(Asset, Chain):
         try:
             # A prior own broadcast to this dest blocks a fresh send unless provably absent
             # from every endpoint — probing by hash sees the mempool; never risk paying twice.
-            want = (self.chain.normalize_address(to_address), int(amount))
+            want = (norm(to_address), int(amount))
             try:
                 prior = self._prior_broadcast(want, head)
             except Exception as e:
@@ -411,10 +195,10 @@ class Ether(Asset, Chain):
                 bt.logging.info(f'Reusing prior tx {prior} from {acct.address} → {to_address} ({amount} wei)')
                 return (prior, 0)
 
-            latest = self.eth_rpc('eth_getBlockByNumber', ['latest', False])
+            latest = self.chain.eth_rpc('eth_getBlockByNumber', ['latest', False])
             base_fee = int((latest or {}).get('baseFeePerGas') or '0x0', 16)
             try:
-                tip_fee = int(self.eth_rpc('eth_maxPriorityFeePerGas', []), 16)
+                tip_fee = int(self.chain.eth_rpc('eth_maxPriorityFeePerGas', []), 16)
             except Exception:
                 tip_fee = FALLBACK_PRIORITY_FEE_WEI
             # 2× base fee absorbs six consecutive maximally-full blocks before the cap binds.
@@ -425,7 +209,7 @@ class Ether(Asset, Chain):
                 self._send_error(f'destination {to_address} refuses ETH transfers — not sending')
                 return None
 
-            nonce = int(self.eth_rpc('eth_getTransactionCount', [acct.address, 'pending']), 16)
+            nonce = int(self.chain.eth_rpc('eth_getTransactionCount', [acct.address, 'pending']), 16)
 
             balance = self.get_balance(acct.address)
             needed = amount + gas * max_fee
@@ -435,7 +219,7 @@ class Ether(Asset, Chain):
 
             signed = Account.sign_transaction(
                 {
-                    'chainId': CHAIN_IDS[self.network],
+                    'chainId': self.chain.chain_id,
                     'nonce': nonce,
                     'to': to_address,
                     'value': amount,
@@ -454,11 +238,12 @@ class Ether(Asset, Chain):
             raw_hex = raw.hex()
             raw_hex = raw_hex if raw_hex.startswith('0x') else f'0x{raw_hex}'
             try:
-                tx_hash = self.eth_rpc('eth_sendRawTransaction', [raw_hex], timeout=30)
+                tx_hash = self.chain.eth_rpc('eth_sendRawTransaction', [raw_hex], timeout=30)
             except Exception as broadcast_err:
                 # The tx may have been accepted anyway — check before declaring failure.
                 try:
-                    if self.eth_rpc('eth_getTransactionByHash', [expected_txid], null_needs_quorum=True) is not None:
+                    probe = self.chain.eth_rpc('eth_getTransactionByHash', [expected_txid], null_needs_quorum=True)
+                    if probe is not None:
                         return (expected_txid, 0)
                 except Exception:
                     pass
@@ -472,37 +257,13 @@ class Ether(Asset, Chain):
             self._send_error(f'ETH send failed: {type(e).__name__}: {e}')
             return None
 
-    def _prior_broadcast(self, want: Tuple[str, int], head: int) -> Optional[str]:
-        """Reusable tx hash from a prior own broadcast to (to, amount); None when a fresh send is
-        provably safe; raises when an in-flight duplicate can't be ruled out. Reuse requires the
-        tx to be in the mempool or settled (status 1) — a reverted tx moved no funds and clears.
-        Entries age out after SCAN_LOOKBACK_BLOCKS (the old mined-scan bound), so a later
-        same-amount swap can never resolve to an earlier swap's consumed tx."""
-        for txid, (to_norm, amt, seen) in list(self.broadcasted_txids.items()):
-            if head - seen > self.SCAN_LOOKBACK_BLOCKS:
-                del self.broadcasted_txids[txid]
-                continue
-            if (to_norm, amt) != want:
-                continue
-            tx = self.eth_rpc('eth_getTransactionByHash', [txid], null_needs_quorum=True)
-            if tx is None:
-                continue
-            if tx.get('blockNumber') is None:
-                return txid
-            receipt = self.eth_rpc('eth_getTransactionReceipt', [txid])
-            if receipt is None:
-                raise RuntimeError(f'prior tx {txid[:16]}... mined but its receipt is unavailable')
-            if int(receipt.get('status') or '0x0', 16) == 1:
-                return txid
-            del self.broadcasted_txids[txid]
-        return None
-
     def _transfer_gas(self, from_addr: str, to_addr: str, amount: int) -> Optional[int]:
         """Gas limit via eth_estimateGas (+20% headroom for smart-wallet receive hooks); None
         when the destination refuses or wants absurd gas. Estimator trouble falls back to the
         plain-transfer minimum rather than blocking an EOA payout."""
+        params = {'from': from_addr, 'to': to_addr, 'value': hex(amount)}
         try:
-            est = int(self.eth_rpc('eth_estimateGas', [{'from': from_addr, 'to': to_addr, 'value': hex(amount)}]), 16)
+            est = int(self.chain.eth_rpc('eth_estimateGas', [params]), 16)
         except Exception as e:
             return None if 'revert' in str(e).lower() else TRANSFER_GAS
         gas = est + est // 5
@@ -512,9 +273,9 @@ class Ether(Asset, Chain):
         """Reserve-time gate: an EOA can never refuse a transfer; a code-bearing dest must pass
         a simulated transfer. Fails open — only a positive revert blocks a reservation."""
         try:
-            if (self.eth_rpc('eth_getCode', [address, 'latest']) or '0x') == '0x':
+            if (self.chain.eth_rpc('eth_getCode', [address, 'latest']) or '0x') == '0x':
                 return True
-            self.eth_rpc('eth_estimateGas', [{'from': ZERO_ADDRESS, 'to': address, 'value': hex(amount)}])
+            self.chain.eth_rpc('eth_estimateGas', [{'from': ZERO_ADDRESS, 'to': address, 'value': hex(amount)}])
             return True
         except Exception as e:
             return 'revert' not in str(e).lower()
@@ -524,21 +285,16 @@ class Ether(Asset, Chain):
         ``since_unix`` — is positive evidence a transfer could fail; never slash over it.
         getCode is dest-only (miner can't influence it) where a simulation is gameable by
         either side. Raises when the chain view is unavailable (caller defers)."""
-        tip = int(self.eth_rpc('eth_blockNumber', []), 16)
+        tip = int(self.chain.eth_rpc('eth_blockNumber', []), 16)
         # Probe depth clamped to what non-archive public nodes serve (~128 blocks).
         span = min(120, max(0, int(time.time()) - int(since_unix)) // self.chain_def.seconds_per_block)
         probes = ['latest'] + [hex(max(0, tip - span // d)) for d in (1, 2)]
-        return any((self.eth_rpc('eth_getCode', [address, b]) or '0x') != '0x' for b in probes)
-
-    _SETTLED_CACHE_MAX = _SETTLED_CACHE_MAX_DEFAULT
+        return any((self.chain.eth_rpc('eth_getCode', [address, b]) or '0x') != '0x' for b in probes)
 
     # Plain JSON-RPC has no address→tx index (Esplora/getSignaturesForAddress have one), so the
     # deposit scanner follows the head incrementally like the TAO provider: each call scans only
     # blocks minted since the last call for this (from, to, amount) triple, bounded by
     # SCAN_LOOKBACK_BLOCKS on the first call or after a gap (≈5 min of 12s blocks).
-    SCAN_LOOKBACK_BLOCKS = 25
-    _MAX_SCAN_CURSORS = 64
-
     def find_recent_outgoing(self, from_addr: str, to_addr: str, amount: int) -> Optional[str]:
         """Tx hash of a recent settled transfer ``from_addr`` → ``to_addr`` of >= ``amount`` wei,
         else None. A hash-finder only — the seam's confirm re-verifies everything by hash, so a
@@ -555,7 +311,7 @@ class Ether(Asset, Chain):
         last = self.scan_cursors.get(key, floor)
         for block_num in range(max(last, floor) + 1, head + 1):
             try:
-                block = self.eth_rpc('eth_getBlockByNumber', [hex(block_num), True])
+                block = self.chain.eth_rpc('eth_getBlockByNumber', [hex(block_num), True])
             except Exception:
                 # Never leap an unreadable block — park just below it and retry next call.
                 self._set_cursor(key, block_num - 1)
@@ -569,7 +325,7 @@ class Ether(Asset, Chain):
                     continue
                 # A mined match can still have reverted — require receipt status 1.
                 try:
-                    receipt = self.eth_rpc('eth_getTransactionReceipt', [tx['hash']])
+                    receipt = self.chain.eth_rpc('eth_getTransactionReceipt', [tx['hash']])
                 except Exception:
                     continue
                 if receipt is None or int(receipt.get('status') or '0x0', 16) != 1:
@@ -578,8 +334,3 @@ class Ether(Asset, Chain):
                 return tx['hash']
         self._set_cursor(key, head)
         return None
-
-    def _set_cursor(self, key: Tuple[str, str, int], height: int) -> None:
-        self.scan_cursors[key] = height
-        if len(self.scan_cursors) > self._MAX_SCAN_CURSORS:
-            self.scan_cursors.pop(next(iter(self.scan_cursors)))

--- a/allways/assets/evm.py
+++ b/allways/assets/evm.py
@@ -113,7 +113,14 @@ class EvmChain(Chain):
     def _key_env(self) -> str:
         return f'{self.env_prefix}_PRIVATE_KEY'
 
-    def eth_rpc(self, method: str, params: list, timeout: int = 15, null_needs_quorum: bool = False) -> Any:
+    def eth_rpc(
+        self,
+        method: str,
+        params: list,
+        timeout: int = 15,
+        null_needs_quorum: bool = False,
+        bases: Optional[Tuple[str, ...]] = None,
+    ) -> Any:
         """Call ``method`` against each endpoint in order, narrating every failover.
 
         A JSON-RPC ``error`` object is treated as endpoint trouble (rate limit, pruned
@@ -123,15 +130,19 @@ class EvmChain(Chain):
         ``null_needs_quorum``: return None only when every endpoint reachably agrees;
         null + an unreachable endpoint raises. For paths where "absent" costs money —
         one stale node in a public load balancer must not read as "never happened".
+
+        ``bases``: restrict the call to specific endpoints (startup per-endpoint probes);
+        None = the configured ladder.
         """
+        rpc_bases = list(bases) if bases else self.rpc_bases
         log = f'{self.network_def.label}Rpc'
         payload = {'jsonrpc': '2.0', 'id': 1, 'method': method, 'params': params}
         last_err: Optional[Exception] = None
         saw_null = False
-        for i, base in enumerate(self.rpc_bases):
-            pos = f'[{i + 1}/{len(self.rpc_bases)}]'
+        for i, base in enumerate(rpc_bases):
+            pos = f'[{i + 1}/{len(rpc_bases)}]'
             tag = rpc_tag(base)
-            nxt = rpc_tag(self.rpc_bases[i + 1]) if i + 1 < len(self.rpc_bases) else None
+            nxt = rpc_tag(rpc_bases[i + 1]) if i + 1 < len(rpc_bases) else None
             tail = f'falling back to: {nxt}' if nxt else 'no providers left, giving up'
             try:
                 resp = self.http.post(base, json=payload, timeout=timeout)
@@ -175,17 +186,29 @@ class EvmChain(Chain):
         raise last_err or RuntimeError(f'all {self.network_def.label} RPCs failed')
 
     def connect_network(self) -> Tuple[int, int]:
-        """(chain_id, tip) from the ladder; raises ConnectionError on unreachable or wrong network."""
+        """(chain_id, tip); raises ConnectionError when no endpoint answers or ANY answering
+        endpoint serves the wrong network. EVERY configured endpoint is probed: a wrong-network
+        URL deeper in the ladder would otherwise surface only mid-outage, quietly serving
+        wrong-chain verifications. An unreachable endpoint just warns — flaky ≠ misconfigured."""
+        chain_id = None
+        for base in self.rpc_bases:
+            try:
+                served = int(self.eth_rpc('eth_chainId', [], timeout=10, bases=(base,)), 16)
+            except Exception as e:
+                bt.logging.warning(f'{self.env_prefix} endpoint {rpc_tag(base)} unreachable at startup: {e}')
+                continue
+            if served != self.chain_id:
+                raise ConnectionError(
+                    f'{self.env_prefix} endpoint {rpc_tag(base)} serves chain id {served}, expected {self.chain_id} '
+                    f'for {self.network} — {self.env_prefix}_RPC_URLS and {self.env_prefix}_NETWORK disagree'
+                )
+            chain_id = served
+        if chain_id is None:
+            raise ConnectionError(f'Cannot reach any {self.network_def.label} RPC')
         try:
-            chain_id = int(self.eth_rpc('eth_chainId', [], timeout=10), 16)
             tip = int(self.eth_rpc('eth_blockNumber', [], timeout=10), 16)
         except Exception as e:
             raise ConnectionError(f'Cannot reach {self.network_def.label} RPC: {e}') from e
-        if chain_id != self.chain_id:
-            raise ConnectionError(
-                f'{self.env_prefix} RPC serves chain id {chain_id}, expected {self.chain_id} for {self.network} — '
-                f'{self.env_prefix}_RPC_URLS and {self.env_prefix}_NETWORK disagree'
-            )
         return chain_id, tip
 
     def get_current_block_height(self) -> Optional[int]:

--- a/allways/assets/evm.py
+++ b/allways/assets/evm.py
@@ -1,0 +1,343 @@
+import os
+import re
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional, Tuple
+from urllib.parse import urlparse
+
+import bittensor as bt
+import requests
+from eth_account import Account
+from eth_account.messages import encode_defunct
+from eth_utils import is_checksum_address
+
+from allways.assets.base import Asset, ProviderUnreachableError
+from allways.assets.chain import Chain
+
+_HEX_ADDR_RE = re.compile(r'^0x[0-9a-fA-F]{40}$')
+
+# eth_maxPriorityFeePerGas fallback when an endpoint doesn't serve it (1 gwei clears
+# comfortably in normal conditions without meaningfully overpaying a transfer).
+FALLBACK_PRIORITY_FEE_WEI = 1_000_000_000
+
+# Send-dedup / deposit-scan window in wall seconds (≈5 min); each chain derives its
+# block-count bound from its own block time so the window means the same everywhere.
+SCAN_LOOKBACK_SECS = 300
+
+
+def rpc_tag(base: str) -> str:
+    """Short, log-friendly host label for an RPC endpoint (e.g. 'publicnode', 'drpc')."""
+    host = (urlparse(base).netloc or base).split(':')[0].removeprefix('www.')
+    parts = host.split('.')
+    return parts[-2] if len(parts) >= 2 else host
+
+
+@dataclass(frozen=True)
+class EvmNetwork:
+    """An EVM family's per-network facts: canonical chain ids + keyless default RPC ladders.
+
+    Networks within the family (mainnet/sepolia/…) are keys of these maps; families
+    themselves (Ethereum, Arbitrum, …) are INSTANCES of this row — never subclasses.
+    eth_chainId is checked against the configured network at startup, so a wrong-network
+    RPC fails fast instead of verifying the wrong chain. Keyed/paid endpoints embed their
+    key in the URL path (via {PREFIX}_RPC_URLS), so no header plumbing is needed.
+    """
+
+    label: str
+    chain_ids: Mapping[str, int]
+    rpc_urls: Mapping[str, Tuple[str, ...]]
+
+
+ETHEREUM = EvmNetwork(
+    label='Ethereum',
+    chain_ids={'mainnet': 1, 'sepolia': 11_155_111},
+    rpc_urls={
+        'mainnet': ('https://ethereum-rpc.publicnode.com', 'https://eth.drpc.org'),
+        'sepolia': ('https://ethereum-sepolia-rpc.publicnode.com', 'https://sepolia.drpc.org'),
+    },
+)
+ARBITRUM = EvmNetwork(
+    label='Arbitrum',
+    chain_ids={'mainnet': 42_161, 'sepolia': 421_614},
+    rpc_urls={
+        'mainnet': ('https://arbitrum-one-rpc.publicnode.com', 'https://arbitrum.drpc.org'),
+        'sepolia': ('https://arbitrum-sepolia-rpc.publicnode.com', 'https://arbitrum-sepolia.drpc.org'),
+    },
+)
+
+# ChainDefinition.host_chain → the EvmNetwork that hosts the asset.
+EVM_NETWORKS: Mapping[str, EvmNetwork] = {'ethereum': ETHEREUM, 'arbitrum': ARBITRUM}
+
+
+class EvmChain(Chain):
+    """An EVM network: JSON-RPC transport (failover ladder, null quorum), hex/EIP-55
+    addresses, EIP-191 ownership proofs, tip reads.
+
+    One behavior class for the whole family; per-network facts come from the `EvmNetwork`
+    config row, env wiring from ``env_prefix`` (the hosted asset's prefix until a second
+    asset shares the instance — the chain then earns its own env identity).
+
+    Addresses are hex and case-insensitive (EIP-55 is a display checksum), so every
+    comparison goes through ``normalize_address`` (lowercase) — on-chain strings keep
+    whatever casing the user committed.
+    """
+
+    def __init__(self, network_def: EvmNetwork, env_prefix: str):
+        self.network_def = network_def
+        self.env_prefix = env_prefix
+        net_var = f'{env_prefix}_NETWORK'
+        self.network = os.environ.get(net_var, '').lower()
+        if not self.network:
+            self.network = 'mainnet'
+            testnet = next((n for n in network_def.chain_ids if n != 'mainnet'), None)
+            bt.logging.warning(f'{net_var} unset — defaulting to mainnet; set {net_var}={testnet} for testnet.')
+        if self.network not in network_def.chain_ids:
+            # A typo silently becoming mainnet would pay real funds against test swaps.
+            raise ValueError(f'Unknown {net_var} {self.network!r} — expected one of {list(network_def.chain_ids)}')
+
+        # Same rationale as the BTC provider: long-running validators + pooled idle TLS
+        # sockets that public CDNs silently drop → wedged reads until timeout.
+        self.http = requests.Session()
+        self.http.headers['Connection'] = 'close'
+
+        raw = os.environ.get(f'{env_prefix}_RPC_URLS', '')
+        self.rpc_bases = [u.strip().rstrip('/') for u in raw.split(',') if u.strip()] or list(
+            network_def.rpc_urls[self.network]
+        )
+
+    @property
+    def chain_id(self) -> int:
+        return self.network_def.chain_ids[self.network]
+
+    @property
+    def _key_env(self) -> str:
+        return f'{self.env_prefix}_PRIVATE_KEY'
+
+    def eth_rpc(self, method: str, params: list, timeout: int = 15, null_needs_quorum: bool = False) -> Any:
+        """Call ``method`` against each endpoint in order, narrating every failover.
+
+        A JSON-RPC ``error`` object is treated as endpoint trouble (rate limit, pruned
+        state, method gap) and falls through; ``result: null`` is authoritative data
+        ("no such tx") and is returned as None. Raises the last error when all fail.
+
+        ``null_needs_quorum``: return None only when every endpoint reachably agrees;
+        null + an unreachable endpoint raises. For paths where "absent" costs money —
+        one stale node in a public load balancer must not read as "never happened".
+        """
+        log = f'{self.network_def.label}Rpc'
+        payload = {'jsonrpc': '2.0', 'id': 1, 'method': method, 'params': params}
+        last_err: Optional[Exception] = None
+        saw_null = False
+        for i, base in enumerate(self.rpc_bases):
+            pos = f'[{i + 1}/{len(self.rpc_bases)}]'
+            tag = rpc_tag(base)
+            nxt = rpc_tag(self.rpc_bases[i + 1]) if i + 1 < len(self.rpc_bases) else None
+            tail = f'falling back to: {nxt}' if nxt else 'no providers left, giving up'
+            try:
+                resp = self.http.post(base, json=payload, timeout=timeout)
+            except Exception as e:
+                last_err = e
+                bt.logging.warning(f'{log} {pos} {tag} {method} → request error: {e}; {tail}')
+                continue
+
+            if resp.status_code != 200:
+                last_err = requests.HTTPError(f'{base} {method}: {resp.status_code}', response=resp)
+                bt.logging.warning(f'{log} {pos} {tag} {method} → HTTP {resp.status_code}; {tail}')
+                continue
+
+            try:
+                body = resp.json()
+            except ValueError as e:
+                last_err = e
+                bt.logging.warning(f'{log} {pos} {tag} {method} → bad JSON: {e}; {tail}')
+                continue
+
+            if 'error' in body:
+                err = body['error']
+                last_err = RuntimeError(f'{base} {method}: rpc error {err}')
+                bt.logging.warning(f'{log} {pos} {tag} {method} → rpc error {err}; {tail}')
+                continue
+
+            result = body.get('result')
+            if result is None and null_needs_quorum:
+                saw_null = True
+                bt.logging.debug(f'{log} {pos} {tag} {method} → null; seeking quorum from remaining endpoint(s)')
+                continue
+            if i > 0:
+                bt.logging.info(f'{log} {pos} {tag} {method} → ok (served after {i} fallback(s))')
+            else:
+                bt.logging.debug(f'{log} {pos} {tag} {method} → ok')
+            return result
+        if saw_null and last_err is None:
+            return None
+        if saw_null:
+            raise ProviderUnreachableError(f'{method}: null without quorum (an endpoint was unreachable): {last_err}')
+        raise last_err or RuntimeError(f'all {self.network_def.label} RPCs failed')
+
+    def connect_network(self) -> Tuple[int, int]:
+        """(chain_id, tip) from the ladder; raises ConnectionError on unreachable or wrong network."""
+        try:
+            chain_id = int(self.eth_rpc('eth_chainId', [], timeout=10), 16)
+            tip = int(self.eth_rpc('eth_blockNumber', [], timeout=10), 16)
+        except Exception as e:
+            raise ConnectionError(f'Cannot reach {self.network_def.label} RPC: {e}') from e
+        if chain_id != self.chain_id:
+            raise ConnectionError(
+                f'{self.env_prefix} RPC serves chain id {chain_id}, expected {self.chain_id} for {self.network} — '
+                f'{self.env_prefix}_RPC_URLS and {self.env_prefix}_NETWORK disagree'
+            )
+        return chain_id, tip
+
+    def get_current_block_height(self) -> Optional[int]:
+        try:
+            return int(self.eth_rpc('eth_blockNumber', [], timeout=10), 16)
+        except Exception as e:
+            bt.logging.debug(f'{self.env_prefix} get_current_block_height failed: {e}')
+            return None
+
+    def normalize_address(self, address: str) -> str:
+        return address.lower() if isinstance(address, str) else address
+
+    def is_valid_address(self, address: str) -> bool:
+        """0x + 40 hex, and if mixed-case the EIP-55 checksum must verify (typo protection,
+        no RPC). Done by hand: eth_utils 5+ ``is_address`` accepts unprefixed hex and stopped
+        validating checksums, which would wave through exactly the typos EIP-55 exists to catch."""
+        if not isinstance(address, str) or not _HEX_ADDR_RE.match(address):
+            return False
+        body = address[2:]
+        if body == body.lower() or body == body.upper():
+            return True
+        return is_checksum_address(address)
+
+    def _account(self, key: Optional[Any] = None):
+        raw = key if isinstance(key, str) and key else os.environ.get(self._key_env)
+        if not raw:
+            return None
+        try:
+            return Account.from_key(raw)
+        except Exception as e:
+            bt.logging.error(f'{self.env_prefix} private key unusable: {e}')
+            return None
+
+    def sign_from_proof(self, address: str, message: str, key: Optional[Any] = None) -> str:
+        """EIP-191 personal_sign over ``message``. key: hex private key; None → {PREFIX}_PRIVATE_KEY."""
+        acct = self._account(key)
+        if acct is None:
+            bt.logging.error(f'{self.env_prefix} signing requires the {self._key_env} env var (or an explicit key)')
+            return ''
+        if self.normalize_address(acct.address) != self.normalize_address(address):
+            bt.logging.error(
+                f'{self.env_prefix} key derives {acct.address} but the proof address is {address} — key mismatch'
+            )
+            return ''
+        try:
+            signed = Account.sign_message(encode_defunct(text=message), acct.key)
+            return signed.signature.hex()
+        except Exception as e:
+            bt.logging.error(f'{self.env_prefix} sign_from_proof failed: {e}')
+            return ''
+
+    def verify_from_proof(self, address: str, message: str, signature: str) -> bool:
+        """Recover the EIP-191 signer and compare case-insensitively. No RPC dependency."""
+        try:
+            sig = signature if signature.startswith('0x') else f'0x{signature}'
+            recovered = Account.recover_message(encode_defunct(text=message), signature=sig)
+            return self.normalize_address(recovered) == self.normalize_address(address)
+        except Exception as e:
+            bt.logging.error(f'{self.env_prefix} verify_from_proof failed: {e}')
+            return False
+
+
+class EvmAsset(Asset):
+    """Base for assets on EVM chains: key handling, send dedup ladder, deposit-scan
+    cursors, the settled-tx cache, and the connection check scaffold.
+
+    Chain questions route through ``self.chain`` (seam rule): a fused native coin is its
+    own chain; a token binds ``self._chain`` to its host network's `EvmChain` at
+    construction. Env vars key off the asset's ``chain_def.env_prefix``.
+    """
+
+    # Settled-tx cache bound — comfortably above any realistic concurrent-leg count.
+    # Deliberately NOT cleared per pass: entries are keyed by immutable block hash
+    # (reorg-safe), and cross-pass reuse is the cache's whole point.
+    _SETTLED_CACHE_MAX = 512
+    _MAX_SCAN_CURSORS = 64
+
+    def __init__(self):
+        self.last_send_error: Optional[str] = None
+        # Settled-tx cache, keyed tx_hash → immutable per-block facts. A mined tx's receipt
+        # and its block's timestamp are immutable per block hash, so the validator's 12s
+        # re-verify pays 1 RPC instead of 3 — parity with BTC's single /tx. Reorg-safe: an
+        # entry is served only while the fresh tx fetch reports the SAME blockHash; a reorg
+        # changes it → miss → full refetch. Only fully-settled entries are cached.
+        self._settled_cache: OrderedDict[str, dict] = OrderedDict()
+        # Own broadcasts, tx_hash → (to, amount, head at broadcast): send dedup scoped to this
+        # process and to SCAN_LOOKBACK_BLOCKS (#461 class — a later same-amount swap must never
+        # resolve to an earlier swap's consumed tx).
+        self.broadcasted_txids: dict[str, Tuple[str, int, int]] = {}
+        # Deposit-scanner head cursors, keyed per (from, to, amount) — see find_recent_outgoing.
+        self.scan_cursors: dict[Tuple[str, str, int], int] = {}
+        self.SCAN_LOOKBACK_BLOCKS = max(1, SCAN_LOOKBACK_SECS // self.chain_def.seconds_per_block)
+
+    @property
+    def _key_env(self) -> str:
+        return f'{self.chain_def.env_prefix}_PRIVATE_KEY'
+
+    def _send_error(self, msg: str) -> None:
+        self.last_send_error = msg
+        bt.logging.error(msg)
+
+    def describe(self) -> str:
+        chain = self.chain
+        hosts = ', '.join(urlparse(base).netloc or base for base in chain.rpc_bases)
+        return f'{chain.network_def.label} JSON-RPC ({chain.network}): {hosts}'
+
+    def can_send_from(self, address: str) -> bool:
+        acct = self.chain._account()
+        norm = self.chain.normalize_address
+        return acct is not None and norm(acct.address) == norm(address)
+
+    def check_connection(self, require_send: bool = True) -> None:
+        if require_send:
+            key = os.environ.get(self._key_env)
+            if not key:
+                raise ConnectionError(f'{self.chain_def.env_prefix} signing requires the {self._key_env} env var')
+            try:
+                Account.from_key(key)
+            except Exception as e:
+                raise ConnectionError(f'{self._key_env} is not a valid 32-byte hex key: {e}') from e
+        chain_id, tip = self.chain.connect_network()
+        bt.logging.success(
+            f'[{self.chain.network_def.label}Rpc] connected: '
+            f'network={self.chain.network}, chain_id={chain_id}, tip={tip}'
+        )
+
+    def _prior_broadcast(self, want: Tuple[str, int], head: int) -> Optional[str]:
+        """Reusable tx hash from a prior own broadcast to (to, amount); None when a fresh send is
+        provably safe; raises when an in-flight duplicate can't be ruled out. Reuse requires the
+        tx to be in the mempool or settled (status 1) — a reverted tx moved no funds and clears.
+        Entries age out after SCAN_LOOKBACK_BLOCKS (the old mined-scan bound), so a later
+        same-amount swap can never resolve to an earlier swap's consumed tx."""
+        for txid, (to_norm, amt, seen) in list(self.broadcasted_txids.items()):
+            if head - seen > self.SCAN_LOOKBACK_BLOCKS:
+                del self.broadcasted_txids[txid]
+                continue
+            if (to_norm, amt) != want:
+                continue
+            tx = self.chain.eth_rpc('eth_getTransactionByHash', [txid], null_needs_quorum=True)
+            if tx is None:
+                continue
+            if tx.get('blockNumber') is None:
+                return txid
+            receipt = self.chain.eth_rpc('eth_getTransactionReceipt', [txid])
+            if receipt is None:
+                raise RuntimeError(f'prior tx {txid[:16]}... mined but its receipt is unavailable')
+            if int(receipt.get('status') or '0x0', 16) == 1:
+                return txid
+            del self.broadcasted_txids[txid]
+        return None
+
+    def _set_cursor(self, key: Tuple[str, str, int], height: int) -> None:
+        self.scan_cursors[key] = height
+        if len(self.scan_cursors) > self._MAX_SCAN_CURSORS:
+            self.scan_cursors.pop(next(iter(self.scan_cursors)))

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -26,6 +26,12 @@ class ChainDefinition:
     # Default 0 (at-or-after the floor; only a tx that predates it is a replay). Absorbs honest miner
     # clock skew; MUST stay well under reservation_ttl_secs — the replay window is exactly this wide (B2).
     replay_grace_secs: int = 0
+    # Layered-asset fields: the wire id stays flat, the layering lives here. None for
+    # assets that are their own network (btc/tao/sol/eth).
+    host_chain: str | None = None  # network whose txs carry this asset (assets/evm.py EVM_NETWORKS key)
+    # Canonical MAINNET contract of a hosted asset. Testnet deployments + env overrides
+    # resolve in the provider (assets/erc20.py) — each address lives exactly once.
+    asset_locator: str | None = None
 
 
 # ─── Supported Chains ────────────────────────────────────
@@ -88,11 +94,36 @@ CHAIN_ETH = ChainDefinition(
     replay_grace_secs=0,
 )
 
+CHAIN_ARBUSDC = ChainDefinition(
+    id='arbusdc',
+    name='USDC (Arbitrum)',
+    native_unit='µUSDC',
+    decimals=6,
+    env_prefix='ARBUSDC',
+    # ~4 blocks/s real; 1s is the integer floor. 90 confs ≈ 25s real (~90s in extension
+    # math) — both far inside the 600s default program grace, so no grace-table arm.
+    seconds_per_block=1,
+    min_confirmations=90,
+    # F1 pin — DO NOT raise until the is_executable_rate orientation fix lands: the gate
+    # consumes the canonical arbusdc-per-SOL rate as if it were SOL-per-arbusdc on the
+    # arbusdc->sol side, so a real dust floor can demand a source above max_swap and
+    # silently burn the direction's pool. ERC-20 transfers have no protocol minimum, so
+    # 1 is also honest.
+    min_onchain_amount=1,
+    # Sequencer-stamped timestamps vs the hub clock — modest skew allowance (Arbitrum
+    # timestamps are non-decreasing, but monotonicity says nothing about hub-spoke skew).
+    replay_grace_secs=60,
+    host_chain='arbitrum',
+    # Circle-verified native USDC on Arbitrum One (developers.circle.com, 2026-08-07).
+    asset_locator='0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+)
+
 SUPPORTED_CHAINS = {
     'btc': CHAIN_BTC,
     'tao': CHAIN_TAO,
     'sol': CHAIN_SOL,
     'eth': CHAIN_ETH,
+    'arbusdc': CHAIN_ARBUSDC,
 }
 
 

--- a/allways/cli/main.py
+++ b/allways/cli/main.py
@@ -53,11 +53,13 @@ load_dotenv(Path.home() / '.allways' / '.env', override=False)
 from allways.cli.help import StyledAliasGroup, StyledGroup  # noqa: E402
 from allways.cli.swap_commands.helpers import (  # noqa: E402
     ALLWAYS_DIR,
+    ARBUSDC_NETWORKS,
     BTC_NETWORKS,
     CONFIG_FILE,
     ENV_BUNDLES,
     ETH_NETWORKS,
     SOLANA_NETWORKS,
+    apply_arbusdc_network_env,
     apply_btc_network_env,
     apply_eth_network_env,
     apply_global_flags,
@@ -67,9 +69,10 @@ from allways.cli.swap_commands.helpers import (  # noqa: E402
 )
 from allways.constants import NETUID_FINNEY  # noqa: E402
 
-# Feed configured chain networks into the providers (which read {BTC,ETH}_NETWORK from env; a real env wins).
+# Feed configured chain networks into the providers (which read {BTC,ETH,ARBUSDC}_NETWORK from env; a real env wins).
 apply_btc_network_env(get_effective_config())
 apply_eth_network_env(get_effective_config())
+apply_arbusdc_network_env(get_effective_config())
 
 # Restore original argv now that bittensor has been imported
 _sys.argv = _saved_argv
@@ -163,6 +166,7 @@ def _effective_settings(config: dict) -> list:
 
     btc_env = os.environ.get('BTC_NETWORK')
     eth_env = os.environ.get('ETH_NETWORK')
+    arbusdc_env = os.environ.get('ARBUSDC_NETWORK')
     return [
         row('network', default='finney'),
         row('netuid', default=NETUID_FINNEY),
@@ -180,6 +184,11 @@ def _effective_settings(config: dict) -> list:
             'eth-network',
             config.get('eth-network') or eth_env or 'mainnet',
             'config' if config.get('eth-network') else 'env' if eth_env else 'default',
+        ),
+        (
+            'arbusdc-network',
+            config.get('arbusdc-network') or arbusdc_env or 'mainnet',
+            'config' if config.get('arbusdc-network') else 'env' if arbusdc_env else 'default',
         ),
         row('router'),
         ('program-id', program_id, program_src),
@@ -217,6 +226,7 @@ VALID_CONFIG_KEYS = (
     'solana-keypair',
     'btc-network',
     'eth-network',
+    'arbusdc-network',
     'router',
     'env',
 )
@@ -229,7 +239,7 @@ def config_set(key: str, value: str):
     """Set a configuration value.
 
     [dim]Valid keys:
-        env                 One-liner bundle: sets network + solana-network + btc-network + eth-network + netuid + router
+        env                 One-liner bundle: sets every chain's network + netuid + router
         wallet              Bittensor wallet name
         hotkey              Bittensor hotkey name
         network             Bittensor network name (test/finney/local) or ws:// endpoint
@@ -239,6 +249,7 @@ def config_set(key: str, value: str):
         solana-keypair      Path to the Solana keypair that signs miner/admin ops (SOLANA_KEYPAIR_PATH env wins)
         btc-network         Bitcoin network name (mainnet/testnet4/testnet/signet)
         eth-network         Ethereum network name (mainnet/sepolia)
+        arbusdc-network     Arbitrum USDC network name (mainnet/sepolia)
         router              Validator hotkey (ss58) to route reservations through; "" = self-represent
         program-id          Solana program ID (miner/admin commands)[/dim]
 
@@ -247,10 +258,11 @@ def config_set(key: str, value: str):
         network:        finney | test | local | ws://...
         solana-network: devnet | mainnet | localnet   (or set a custom solana-rpc URL)
         btc-network:    mainnet | testnet4 | testnet | signet
-        eth-network:    mainnet | sepolia[/dim]
+        eth-network:    mainnet | sepolia
+        arbusdc-network: mainnet | sepolia (Arbitrum Sepolia)[/dim]
 
     [dim]Examples:
-        $ alw config set env testnet          # bittensor test + solana devnet + btc testnet4 + eth sepolia + netuid 19
+        $ alw config set env testnet          # bittensor test + solana devnet + btc testnet4 + eth/arbusdc sepolia + netuid 19
         $ alw config set wallet alice
         $ alw config set solana-network devnet
         $ alw config set solana-keypair ~/.config/solana/dev.json
@@ -265,7 +277,7 @@ def config_set(key: str, value: str):
         except json.JSONDecodeError:
             console.print('[yellow]Warning: Existing config was invalid, starting fresh[/yellow]')
 
-    # env bundle: expand one name into all three chains' networks + netuid in a single write.
+    # env bundle: expand one name into every chain's network + netuid in a single write.
     if key == 'env':
         bundle = ENV_BUNDLES.get(value)
         if not bundle:
@@ -287,6 +299,9 @@ def config_set(key: str, value: str):
         return
     if key == 'eth-network' and value not in ETH_NETWORKS:
         console.print(f'[red]Unknown eth-network {value!r}; expected {list(ETH_NETWORKS)}.[/red]')
+        return
+    if key == 'arbusdc-network' and value not in ARBUSDC_NETWORKS:
+        console.print(f'[red]Unknown arbusdc-network {value!r}; expected {list(ARBUSDC_NETWORKS)}.[/red]')
         return
 
     # Validate the keypair at set time and echo its pubkey, so a typo'd path or wrong file

--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -38,7 +38,9 @@ SOLANA_NETWORKS = {
 BTC_NETWORKS = ('mainnet', 'testnet', 'testnet4', 'signet')
 # Names the ETH provider (ETH_NETWORK env) accepts; endpoints default to public JSON-RPC per network.
 ETH_NETWORKS = ('mainnet', 'sepolia')
-# One-liner env bundle: `alw config set env testnet|mainnet` sets all three chains' networks + netuid
+# Names the arbusdc provider (ARBUSDC_NETWORK env) accepts; sepolia = Arbitrum Sepolia.
+ARBUSDC_NETWORKS = ('mainnet', 'sepolia')
+# One-liner env bundle: `alw config set env testnet|mainnet` sets every chain's network + netuid
 # + the default router. Testnet routes through the Ventura Labs validator; mainnet self-represents
 # (no routing validator live yet). `alw config set router <ss58>` opts into routing on mainnet.
 ENV_BUNDLES = {
@@ -47,6 +49,7 @@ ENV_BUNDLES = {
         'solana-network': 'devnet',
         'btc-network': 'testnet4',
         'eth-network': 'sepolia',
+        'arbusdc-network': 'sepolia',
         'netuid': '19',
         'router': '5HicmHG7fjbxrtx8FZNdv4xxS5jSN84KGpMnTHsKtKv9peao',
     },
@@ -55,6 +58,7 @@ ENV_BUNDLES = {
         'solana-network': 'mainnet',
         'btc-network': 'mainnet',
         'eth-network': 'mainnet',
+        'arbusdc-network': 'mainnet',
         'netuid': '7',
         # No routing validator on mainnet yet — bid self-represented until one ships a routing
         # product. Explicit '' (not omitted) so re-running `env mainnet` CLEARS a stale router.
@@ -116,6 +120,13 @@ def apply_eth_network_env(config: dict) -> None:
     A real ETH_NETWORK env wins (explicit override); otherwise the configured name is applied."""
     if not os.environ.get('ETH_NETWORK') and config.get('eth-network'):
         os.environ['ETH_NETWORK'] = config['eth-network']
+
+
+def apply_arbusdc_network_env(config: dict) -> None:
+    """Feed arbusdc-network config into the arbusdc provider, which reads ARBUSDC_NETWORK from the
+    env. A real ARBUSDC_NETWORK env wins (explicit override); otherwise the configured name is applied."""
+    if not os.environ.get('ARBUSDC_NETWORK') and config.get('arbusdc-network'):
+        os.environ['ARBUSDC_NETWORK'] = config['arbusdc-network']
 
 
 # Quote-update churn fee tiers — mirror smart-contracts/…/constants.rs quote_update_fee().

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -426,6 +426,9 @@ def swap_now_command(
             fail('No miner can fund an executable swap for that amount within bounds.')
         cand, amts = best
 
+    # Deliverability screens — before the fee-charging entry AND before sending into a doomed swap.
+    _screen_deliverability(client, config, cand, from_chain, to_chain, receive_address_opt, user_from_addr, from_amount)
+
     # Resume a seat this taker already holds rather than paying for a second bid: a prior run may have
     # bid + drawn (or even finalized) but crashed on a transient RPC before instructing the send. The
     # reused per-miner reservation makes `swap now` idempotent for THIS taker — recover it, don't re-bid.
@@ -595,6 +598,61 @@ def _deadline_lines(reserved_until: int, want_send: bool, now: Optional[int] = N
     if not want_send:
         lines.append('  [dim]`alw swap now --send` does the send, the relay and the watch in one step.[/dim]')
     return lines
+
+
+def _gate_provider(chain: str, client, config):
+    """Read-only provider for deliverability screens (no send creds, no startup check).
+    None when it can't be built — the screens fail open; routed flows are re-gated by the
+    validator either way."""
+    from allways.assets import ASSET_REGISTRY
+
+    spec = next((s for s in ASSET_REGISTRY if s.chain_id == chain), None)
+    if spec is None:
+        return None
+    avail = {'solana_rpc_url': client.rpc.url, 'solana_keypair': client.keypair}
+    try:
+        return spec.cls(**{k: avail[k] for k in spec.kwarg_names if k in avail})
+    except Exception:  # noqa: BLE001 - unbuildable provider (missing env) → screens fail open
+        return None
+
+
+def _screen_deliverability(client, config, cand, from_chain, to_chain, receive_addr, user_from_addr, from_amount):
+    """Pre-reserve deliverability screens — bounce BEFORE any fee is spent.
+
+    Self-represented flows have no validator to gate for them (F7), so mirror the
+    validator's reserve gates locally: the taker's receive address must be well-formed and
+    accept the dest asset, and the miner's receive address must accept the source funds
+    (T18). The source-address probe is a courtesy warning only — a frozen source just means
+    the deposit fails and the reservation lapses unclaimed."""
+    spoke = to_chain if from_chain == NUMERAIRE_CHAIN else from_chain
+    provider = _gate_provider(spoke, client, config)
+    if provider is None:
+        return
+    if spoke == to_chain:
+        # Format first — offline, and a malformed address can never be delivered to.
+        if not provider.chain.is_valid_address(receive_addr):
+            fail(f'  {receive_addr!r} is not a valid {to_chain.upper()} address. No funds moved.')
+        amts = compute_intake_amounts(from_chain, to_chain, from_amount, cand.rate_display)
+        if not provider.can_deliver_to(receive_addr, amts.to_amount):
+            fail(
+                f'  Your receive address cannot accept {to_chain.upper()} right now '
+                '(frozen or transfers paused). No funds moved.'
+            )
+        return
+    quote = client.get_quote(cand.miner, from_chain, to_chain)
+    miner_addr = getattr(quote, 'miner_from_addr', '') if quote else ''
+    if miner_addr and (
+        not provider.chain.is_valid_address(miner_addr) or not provider.can_deliver_to(miner_addr, from_amount)
+    ):
+        fail(
+            f"  This miner's {from_chain.upper()} receive address cannot accept the source funds "
+            '— pick another miner (--miner). No funds moved.'
+        )
+    if user_from_addr and not provider.can_deliver_to(user_from_addr, from_amount):
+        console.print(
+            f'  [yellow]Heads-up: your {from_chain.upper()} source address looks unable to move funds '
+            '(frozen?). If the deposit fails, the reservation lapses unclaimed.[/yellow]'
+        )
 
 
 def _source_provider(from_chain: str, client, config):

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -68,7 +68,7 @@ REWARD_MINER_STATES: frozenset[MinerActivity] = frozenset({MinerActivity.AVAILAB
 # uniformly as 'dest per 1 hub'. SOL by construction (the contract lives on Solana: collateral, fee, and the
 # collateral_amount notional are all SOL). Referenced wherever code needs "is this the hub", instead of a literal.
 NUMERAIRE_CHAIN = 'sol'
-LAUNCH_SPOKES = ('btc', 'tao', 'eth')  # chains paired against the hub; add a chain here to launch its pair
+LAUNCH_SPOKES = ('btc', 'tao', 'eth', 'arbusdc')  # chains paired against the hub; add a chain here to launch its pair
 # Fixed burn: pools sum to MINER_POOL_SHARE instead of 1.0, so at least
 # BURN_RATE of every round recycles to RECYCLE_UID before any shortfall.
 BURN_RATE = 0.90

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -14,6 +14,7 @@ from bittensor import Keypair
 from solders.pubkey import Pubkey
 
 from allways.assets.base import ProviderUnreachableError
+from allways.chains import SUPPORTED_CHAINS
 from allways.cli.swap_commands.swap_intake import (
     candidate_miners,
     compute_intake_amounts,
@@ -73,6 +74,11 @@ def reserve_on_behalf(
     pool is open (so joiners stay rate-consistent for D1) else the miner's live quote (which the
     contract pins at open). Validates eligibility + bounds before paying the fee.
     """
+    # Chain ids are lowercase everywhere (the program enforces it at intake); reject a
+    # cased/unknown id here too so it can't derive a mismatched quote PDA or pool first.
+    if from_chain not in SUPPORTED_CHAINS or to_chain not in SUPPORTED_CHAINS:
+        return ReserveResult(False, f'unsupported chain pair {from_chain}->{to_chain} (chain ids are lowercase)')
+
     client = validator.solana_client
     miner_pk = resolve_miner_pubkey(validator, miner_hotkey)
     if miner_pk is None:
@@ -83,6 +89,7 @@ def reserve_on_behalf(
         return ReserveResult(False, 'miner is not active')
 
     now = int(time.time())
+    quote = None
     pool = client.get_pool(miner_pk)
     joining = (
         pool is not None
@@ -116,11 +123,27 @@ def reserve_on_behalf(
     if not ok:
         return ReserveResult(False, reason)
 
-    # Deliverability gate — BEFORE any funds move: a dest that provably refuses transfers
-    # (e.g. a reverting contract wallet) must bounce here, not strand a paid swap later.
-    provider = getattr(validator, 'axon_assets', {}).get(to_chain)
-    if provider is not None and not provider.can_deliver_to(user_to_addr, amts.to_amount):
-        return ReserveResult(False, 'destination address rejects incoming transfers')
+    # Deliverability gates — BEFORE any funds move: a dest that can't take delivery (malformed
+    # address, or one that provably refuses transfers) must bounce here, not strand a paid swap
+    # later. Format first: it's offline and a malformed address can never be delivered to.
+    providers = getattr(validator, 'axon_assets', {})
+    provider = providers.get(to_chain)
+    if provider is not None:
+        if not provider.chain.is_valid_address(user_to_addr):
+            return ReserveResult(False, f'destination is not a valid {to_chain} address')
+        if not provider.can_deliver_to(user_to_addr, amts.to_amount):
+            return ReserveResult(False, 'destination address rejects incoming transfers')
+    # Same gate, source side (T18): the miner's receive address must accept the user's funds —
+    # a miner quoting a malformed/rejecting/blacklisted address griefs takers into a burned fee.
+    src_provider = providers.get(from_chain)
+    if src_provider is not None:
+        miner_quote = quote or client.get_quote(miner_pk, from_chain, to_chain)
+        miner_from_addr = getattr(miner_quote, 'miner_from_addr', '') if miner_quote else ''
+        if miner_from_addr and (
+            not src_provider.chain.is_valid_address(miner_from_addr)
+            or not src_provider.can_deliver_to(miner_from_addr, from_amount)
+        ):
+            return ReserveResult(False, 'miner receive address cannot accept the source funds')
 
     try:
         user_pk = Pubkey.from_string(user_pubkey)

--- a/tests/test_arbusdc_provider.py
+++ b/tests/test_arbusdc_provider.py
@@ -277,10 +277,19 @@ class TestDeliveryGates:
         rpc_stub(provider, {'eth_blockNumber': hex(1000), 'eth_call': eth_call_views(blacklisted=[RECIPIENT])})
         assert provider.delivery_refused(RECIPIENT, since_unix=0) is True
 
+    def test_slash_gate_paused_token(self, provider):
+        # A pause makes delivery impossible for EVERYONE through no fault of the miner —
+        # the slash gate must defer exactly like the reserve gate refuses.
+        rpc_stub(provider, {'eth_blockNumber': hex(1000), 'eth_call': eth_call_views(paused=True)})
+        assert provider.delivery_refused(RECIPIENT, since_unix=0) is True
+
     def test_slash_gate_samples_history(self, provider):
         # Clean at latest, blacklisted at a sampled historical block (freeze lifted mid-window).
         def call(params):
-            if params[0]['data'].startswith(SEL_IS_BLACKLISTED):
+            data = params[0]['data']
+            if data.startswith(SEL_PAUSED):
+                return '0x0'
+            if data.startswith(SEL_IS_BLACKLISTED):
                 return hex(int(params[1] != 'latest'))
             raise AssertionError(params)
 
@@ -346,6 +355,20 @@ class TestSendGuards:
         rpc_stub(provider, self._send_responses(gas_balance=10))
         assert provider.send_amount(RECIPIENT, AMOUNT) is None
         assert 'Insufficient gas balance' in provider.last_send_error
+
+    def test_insufficient_balance_diagnosed_before_estimator_revert(self, provider, monkeypatch):
+        # An underfunded transfer reverts in the estimator too — the balance check runs first
+        # so a token-poor miner reads "Insufficient", not "destination refuses".
+        monkeypatch.setenv('ARBUSDC_PRIVATE_KEY', TEST_KEY)
+        responses = self._send_responses(token_balance=AMOUNT - 1)
+
+        def revert(params):
+            raise RuntimeError('execution reverted: transfer amount exceeds balance')
+
+        responses['eth_estimateGas'] = revert
+        rpc_stub(provider, responses)
+        assert provider.send_amount(RECIPIENT, AMOUNT) is None
+        assert 'Insufficient ARBUSDC' in provider.last_send_error
 
     def test_reverting_transfer_refused(self, provider, monkeypatch):
         monkeypatch.setenv('ARBUSDC_PRIVATE_KEY', TEST_KEY)
@@ -479,6 +502,18 @@ class TestCheckConnection:
     def test_missing_key_fails_when_send_required(self, provider):
         with pytest.raises(ConnectionError, match='ARBUSDC_PRIVATE_KEY'):
             provider.check_connection(require_send=True)
+
+    def test_wrong_network_endpoint_deeper_in_ladder_fails_boot(self, provider):
+        # Every configured endpoint is probed at startup — a wrong-network URL at position 2
+        # would otherwise surface only mid-outage, quietly serving wrong-chain verifications.
+        def fake_rpc(method, params, timeout=15, bases=None, **kw):
+            if method == 'eth_chainId':
+                return '0x1' if bases and 'drpc' in bases[0] else hex(421_614)
+            return '0x10'
+
+        provider.chain.eth_rpc = fake_rpc
+        with pytest.raises(ConnectionError, match='drpc serves chain id 1'):
+            provider.check_connection(require_send=False)
 
     def test_codeless_contract_fails(self, provider):
         rpc_stub(provider, {'eth_chainId': hex(421_614), 'eth_blockNumber': '0x10', 'eth_getCode': '0x'})

--- a/tests/test_arbusdc_provider.py
+++ b/tests/test_arbusdc_provider.py
@@ -1,0 +1,498 @@
+"""Erc20/ArbUsdc unit tests — all offline (RPC layer mocked, signing is pure crypto).
+
+Covers the token-specific hazards: settlement truth is the Transfer log of the PINNED
+contract (never tx.value — F2), the provable payer is the log's `from` topic (F5),
+dual-balance sends (F6), and the Circle-shaped delivery gates (blacklist + pause, no
+getCode — F3). Shared EVM plumbing (failover, proofs, casing) is covered by the ETH suite.
+"""
+
+from typing import Optional
+
+import pytest
+
+from allways.assets.base import ProviderUnreachableError
+from allways.assets.erc20 import (
+    SEL_BALANCE_OF,
+    SEL_IS_BLACKLISTED,
+    SEL_PAUSED,
+    SEL_TRANSFER,
+    TRANSFER_TOPIC0,
+    ArbUsdc,
+)
+from allways.chains import CHAIN_ARBUSDC
+
+# Well-known dev key (hardhat account #0) — never funded on mainnet, deterministic address.
+TEST_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+TEST_ADDR = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+
+CONTRACT = '0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d'  # Circle USDC, Arbitrum Sepolia
+SENDER = '0x' + '11' * 20
+RECIPIENT = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+TX = '0x' + 'ab' * 32
+BLOCK_HASH = '0x' + 'cd' * 32
+AMOUNT = 150_000_000  # 150 USDC in µUSDC
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    monkeypatch.setenv('ARBUSDC_NETWORK', 'sepolia')
+    for var in ('ARBUSDC_RPC_URLS', 'ARBUSDC_PRIVATE_KEY', 'ARBUSDC_TOKEN_CONTRACT'):
+        monkeypatch.delenv(var, raising=False)
+    return ArbUsdc()
+
+
+def rpc_stub(provider, responses: dict):
+    """Replace eth_rpc with a method→response map. A callable value is invoked with params."""
+
+    def fake_rpc(method, params, timeout=15, **kw):
+        value = responses[method]
+        return value(params) if callable(value) else value
+
+    provider.chain.eth_rpc = fake_rpc  # the asset talks through its chain (composed seam)
+    return provider
+
+
+def topic(address: str) -> str:
+    return '0x' + '00' * 12 + address.lower().removeprefix('0x')
+
+
+def transfer_log(contract=CONTRACT, sender=SENDER, recipient=RECIPIENT, amount=AMOUNT) -> dict:
+    return {'address': contract, 'topics': [TRANSFER_TOPIC0, topic(sender), topic(recipient)], 'data': hex(amount)}
+
+
+def mined_tx_responses(logs=None, status='0x1', tip=1_000_100, receipt: Optional[dict] = ...):
+    if logs is None:
+        logs = [transfer_log()]
+    if receipt is ...:
+        receipt = {'status': status, 'blockNumber': '0xf4240', 'blockHash': BLOCK_HASH, 'logs': logs}
+    return {
+        'eth_getTransactionByHash': {
+            'hash': TX,
+            'from': SENDER,
+            'to': CONTRACT,
+            'blockNumber': '0xf4240',  # 1_000_000
+            'blockHash': BLOCK_HASH,
+        },
+        'eth_getTransactionReceipt': receipt,
+        'eth_blockNumber': hex(tip),
+        'eth_getBlockByNumber': {'hash': BLOCK_HASH, 'timestamp': '0x64'},
+    }
+
+
+def eth_call_views(blacklisted=(), paused=False, balances=None):
+    """eth_call dispatcher over the token's views, keyed by selector."""
+
+    def call(params):
+        data = params[0]['data']
+        if data.startswith(SEL_PAUSED):
+            return hex(int(paused))
+        addr = '0x' + data[-40:]
+        if data.startswith(SEL_IS_BLACKLISTED):
+            return hex(int(addr in {a.lower() for a in blacklisted}))
+        if data.startswith(SEL_BALANCE_OF):
+            return hex((balances or {}).get(addr, 0))
+        raise AssertionError(f'unexpected eth_call {data[:10]}')
+
+    return call
+
+
+class TestTransferLogVerification:
+    def test_settled_transfer_matches(self, provider):
+        rpc_stub(provider, mined_tx_responses())
+        info = provider.verify_transaction(TX, RECIPIENT, AMOUNT)
+        assert info is not None
+        assert info.amount == AMOUNT
+        assert info.sender == SENDER
+        assert info.confirmed  # 101 confs >= 90
+        assert info.block_time == 100
+
+    def test_unconfirmed_below_min_confs(self, provider):
+        rpc_stub(provider, mined_tx_responses(tip=1_000_010))
+        info = provider.verify_transaction(TX, RECIPIENT, AMOUNT)
+        assert info is not None and not info.confirmed
+
+    def test_wrong_contract_log_rejected(self, provider):
+        # F2: a Transfer of USDC.e / a fake token must never satisfy a native-USDC leg.
+        fake = transfer_log(contract='0x' + '99' * 20)
+        rpc_stub(provider, mined_tx_responses(logs=[fake]))
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT) is None
+
+    def test_wrong_recipient_rejected(self, provider):
+        rpc_stub(provider, mined_tx_responses(logs=[transfer_log(recipient='0x' + '22' * 20)]))
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT) is None
+
+    def test_underpay_rejected_overpay_accepted(self, provider):
+        rpc_stub(provider, mined_tx_responses(logs=[transfer_log(amount=AMOUNT - 1)]))
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT) is None
+        rpc_stub(provider, mined_tx_responses(logs=[transfer_log(amount=AMOUNT + 5)]))
+        info = provider.verify_transaction(TX, RECIPIENT, AMOUNT)
+        assert info is not None and info.amount == AMOUNT + 5
+
+    def test_multi_log_tx_scans_all_logs(self, provider):
+        noise = [
+            transfer_log(contract='0x' + '99' * 20),  # other token
+            transfer_log(recipient='0x' + '22' * 20),  # other recipient
+            transfer_log(),  # the real leg
+        ]
+        rpc_stub(provider, mined_tx_responses(logs=noise))
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT) is not None
+
+    def test_reverted_rejected(self, provider):
+        rpc_stub(provider, mined_tx_responses(status='0x0'))
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT) is None
+
+    def test_receipt_unavailable_raises(self, provider):
+        rpc_stub(provider, mined_tx_responses(receipt=None))
+        with pytest.raises(ProviderUnreachableError):
+            provider.verify_transaction(TX, RECIPIENT, AMOUNT)
+
+    def test_rpc_unreachable_raises(self, provider):
+        def boom(params):
+            raise ConnectionError('down')
+
+        rpc_stub(provider, {'eth_getTransactionByHash': boom})
+        with pytest.raises(ProviderUnreachableError):
+            provider.verify_transaction(TX, RECIPIENT, AMOUNT)
+
+    def test_missing_block_timestamp_raises(self, provider):
+        responses = mined_tx_responses()
+        responses['eth_getBlockByNumber'] = {'hash': BLOCK_HASH, 'timestamp': '0x0'}
+        rpc_stub(provider, responses)
+        with pytest.raises(ProviderUnreachableError):
+            provider.verify_transaction(TX, RECIPIENT, AMOUNT)
+
+    def test_not_found_returns_none(self, provider):
+        rpc_stub(provider, {'eth_getTransactionByHash': None})
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT) is None
+
+    def test_checksummed_recipient_matches_lowercase_topic(self, provider):
+        rpc_stub(provider, mined_tx_responses())
+        assert provider.verify_transaction(TX, RECIPIENT.lower(), AMOUNT) is not None
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT) is not None  # EIP-55 form
+
+    def test_settled_cache_skips_receipt_refetch(self, provider):
+        calls: dict = {}
+        responses = mined_tx_responses()
+
+        def fake_rpc(method, params, timeout=15, **kw):
+            calls[method] = calls.get(method, 0) + 1
+            return responses[method]
+
+        provider.chain.eth_rpc = fake_rpc
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT) is not None
+        provider.chain.clear_pass_tip()
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT) is not None
+        assert calls['eth_getTransactionReceipt'] == 1  # second pass served from the cache
+
+    def test_settled_cache_never_vouches_for_a_different_leg(self, provider):
+        # Caught live (2026-08-07): the match lives in the receipt logs the cache skips, so a
+        # cached settled read must re-check recipient + amount or any claim on the tx passes.
+        rpc_stub(provider, mined_tx_responses())
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT) is not None
+        provider.chain.clear_pass_tip()
+        assert provider.verify_transaction(TX, '0x' + '22' * 20, AMOUNT) is None
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT + 1) is None
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT - 5) is not None  # overpay still fine
+
+
+class TestSenderPin:
+    def test_sender_from_log_topic_any_casing(self, provider):
+        rpc_stub(provider, mined_tx_responses())
+        checksummed = '0x' + SENDER.removeprefix('0x').upper()
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT, expected_sender=checksummed) is not None
+
+    def test_sender_mismatch_rejected(self, provider):
+        rpc_stub(provider, mined_tx_responses())
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT, expected_sender=TEST_ADDR) is None
+
+    def test_tx_from_is_not_the_pin(self, provider):
+        # The tx envelope sender (router/sponsor) differs from the log party — the log wins.
+        responses = mined_tx_responses()
+        responses['eth_getTransactionByHash'] = dict(responses['eth_getTransactionByHash'], **{'from': TEST_ADDR})
+        rpc_stub(provider, responses)
+        info = provider.verify_transaction(TX, RECIPIENT, AMOUNT, expected_sender=SENDER)
+        assert info is not None and info.sender == SENDER
+
+    def test_malformed_sender_topic_fails_closed(self, provider):
+        bad = transfer_log()
+        bad['topics'][1] = '0x' + 'ff' * 32  # nonzero prefix — not an address topic
+        rpc_stub(provider, mined_tx_responses(logs=[bad]))
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT) is None
+
+    def test_self_transfer_rejected(self, provider):
+        rpc_stub(provider, mined_tx_responses(logs=[transfer_log(sender=RECIPIENT)]))
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT) is None
+
+
+class TestPendingCalldata:
+    def _pending(self, to=CONTRACT, recipient=RECIPIENT, amount=AMOUNT, sender=SENDER):
+        return {
+            'hash': TX,
+            'from': sender,
+            'to': to,
+            'input': SEL_TRANSFER + topic(recipient).removeprefix('0x') + f'{amount:064x}',
+            'blockNumber': None,
+        }
+
+    def test_pending_transfer_matches(self, provider):
+        rpc_stub(provider, {'eth_getTransactionByHash': self._pending()})
+        info = provider.verify_transaction(TX, RECIPIENT, AMOUNT)
+        assert info is not None and not info.confirmed
+        assert info.sender == SENDER and info.amount == AMOUNT
+
+    def test_pending_to_other_contract_rejected(self, provider):
+        rpc_stub(provider, {'eth_getTransactionByHash': self._pending(to='0x' + '99' * 20)})
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT) is None
+
+    def test_pending_underpay_rejected(self, provider):
+        rpc_stub(provider, {'eth_getTransactionByHash': self._pending(amount=AMOUNT - 1)})
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT) is None
+
+    def test_pending_wrong_recipient_rejected(self, provider):
+        rpc_stub(provider, {'eth_getTransactionByHash': self._pending(recipient='0x' + '22' * 20)})
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT) is None
+
+
+class TestDeliveryGates:
+    def test_clean_dest_passes(self, provider):
+        rpc_stub(provider, {'eth_call': eth_call_views()})
+        assert provider.can_deliver_to(RECIPIENT, AMOUNT) is True
+
+    def test_blacklisted_dest_blocks_reserve(self, provider):
+        rpc_stub(provider, {'eth_call': eth_call_views(blacklisted=[RECIPIENT])})
+        assert provider.can_deliver_to(RECIPIENT, AMOUNT) is False
+
+    def test_paused_token_blocks_reserve(self, provider):
+        rpc_stub(provider, {'eth_call': eth_call_views(paused=True)})
+        assert provider.can_deliver_to(RECIPIENT, AMOUNT) is False
+
+    def test_reserve_gate_fails_open_on_rpc_trouble(self, provider):
+        def boom(params):
+            raise ConnectionError('down')
+
+        rpc_stub(provider, {'eth_call': boom})
+        assert provider.can_deliver_to(RECIPIENT, AMOUNT) is True
+
+    def test_slash_gate_blacklisted_now(self, provider):
+        rpc_stub(provider, {'eth_blockNumber': hex(1000), 'eth_call': eth_call_views(blacklisted=[RECIPIENT])})
+        assert provider.delivery_refused(RECIPIENT, since_unix=0) is True
+
+    def test_slash_gate_samples_history(self, provider):
+        # Clean at latest, blacklisted at a sampled historical block (freeze lifted mid-window).
+        def call(params):
+            if params[0]['data'].startswith(SEL_IS_BLACKLISTED):
+                return hex(int(params[1] != 'latest'))
+            raise AssertionError(params)
+
+        rpc_stub(provider, {'eth_blockNumber': hex(1000), 'eth_call': call})
+        assert provider.delivery_refused(RECIPIENT, since_unix=0) is True
+
+    def test_slash_gate_clean_is_false(self, provider):
+        rpc_stub(provider, {'eth_blockNumber': hex(1000), 'eth_call': eth_call_views()})
+        assert provider.delivery_refused(RECIPIENT, since_unix=0) is False
+
+    def test_slash_gate_raises_on_rpc_trouble(self, provider):
+        # The caller defers the slash — a flaky RPC postpones, never falsifies.
+        def boom(params):
+            raise ConnectionError('down')
+
+        rpc_stub(provider, {'eth_blockNumber': hex(1000), 'eth_call': boom})
+        with pytest.raises(Exception):
+            provider.delivery_refused(RECIPIENT, since_unix=0)
+
+    def test_slash_gate_survives_historical_probe_failure(self, provider):
+        # Public nodes serve historical eth_call only ~a minute deep (verified live) — a failing
+        # sample is skipped so a shallow endpoint can't defer every slash on the pair forever.
+        def call(params):
+            if params[1] == 'latest':
+                return '0x0'
+            raise ConnectionError('pruned state')
+
+        rpc_stub(provider, {'eth_blockNumber': hex(1000), 'eth_call': call})
+        assert provider.delivery_refused(RECIPIENT, since_unix=0) is False
+
+
+class TestSendGuards:
+    def _send_responses(self, token_balance=10 * AMOUNT, gas_balance=10**18, est='0xfde8'):  # est 65k
+        return {
+            'eth_blockNumber': hex(1000),
+            'eth_getBlockByNumber': {'baseFeePerGas': hex(10**8)},
+            'eth_maxPriorityFeePerGas': hex(10**7),
+            'eth_estimateGas': est,
+            'eth_call': eth_call_views(balances={TEST_ADDR.lower(): token_balance}),
+            'eth_getBalance': hex(gas_balance),
+            'eth_getTransactionCount': '0x0',
+            'eth_sendRawTransaction': '0x' + 'ee' * 32,
+        }
+
+    def test_no_key_refused(self, provider):
+        assert provider.send_amount(RECIPIENT, AMOUNT) is None
+        assert 'ARBUSDC_PRIVATE_KEY' in provider.last_send_error
+
+    def test_key_mismatch_refused(self, provider, monkeypatch):
+        monkeypatch.setenv('ARBUSDC_PRIVATE_KEY', TEST_KEY)
+        assert provider.send_amount(RECIPIENT, AMOUNT, from_address=RECIPIENT) is None
+        assert 'key mismatch' in provider.last_send_error
+
+    def test_insufficient_token_balance_refused(self, provider, monkeypatch):
+        monkeypatch.setenv('ARBUSDC_PRIVATE_KEY', TEST_KEY)
+        rpc_stub(provider, self._send_responses(token_balance=AMOUNT - 1))
+        assert provider.send_amount(RECIPIENT, AMOUNT) is None
+        assert 'Insufficient ARBUSDC' in provider.last_send_error
+
+    def test_insufficient_gas_balance_refused(self, provider, monkeypatch):
+        # F6: token-rich but gas-poor must refuse BEFORE broadcasting a doomed transfer.
+        monkeypatch.setenv('ARBUSDC_PRIVATE_KEY', TEST_KEY)
+        rpc_stub(provider, self._send_responses(gas_balance=10))
+        assert provider.send_amount(RECIPIENT, AMOUNT) is None
+        assert 'Insufficient gas balance' in provider.last_send_error
+
+    def test_reverting_transfer_refused(self, provider, monkeypatch):
+        monkeypatch.setenv('ARBUSDC_PRIVATE_KEY', TEST_KEY)
+        responses = self._send_responses()
+
+        def revert(params):
+            raise RuntimeError('execution reverted: Blacklistable: account is blacklisted')
+
+        responses['eth_estimateGas'] = revert
+        rpc_stub(provider, responses)
+        assert provider.send_amount(RECIPIENT, AMOUNT) is None
+        assert 'refuses' in provider.last_send_error
+
+    def test_absurd_gas_estimate_refused(self, provider, monkeypatch):
+        monkeypatch.setenv('ARBUSDC_PRIVATE_KEY', TEST_KEY)
+        rpc_stub(provider, self._send_responses(est=hex(200_000)))  # ×1.2 > 150k cap
+        assert provider.send_amount(RECIPIENT, AMOUNT) is None
+
+    def test_happy_path_broadcasts_transfer_calldata(self, provider, monkeypatch):
+        monkeypatch.setenv('ARBUSDC_PRIVATE_KEY', TEST_KEY)
+        sent = {}
+        responses = self._send_responses()
+
+        def capture(params):
+            sent['raw'] = params[0]
+            return '0x' + 'ee' * 32
+
+        responses['eth_sendRawTransaction'] = capture
+        rpc_stub(provider, responses)
+        result = provider.send_amount(RECIPIENT, AMOUNT, from_address=TEST_ADDR)
+        assert result == ('0x' + 'ee' * 32, 0)
+        # Dedup ledger keys by the PRE-broadcast precomputed txid, recorded before the send.
+        assert list(provider.broadcasted_txids.values()) == [(RECIPIENT.lower(), AMOUNT, 1000)]
+        # The signed payload carries transfer() calldata addressed to the token contract.
+        assert SEL_TRANSFER.removeprefix('0x') in sent['raw']
+        assert RECIPIENT.lower().removeprefix('0x') in sent['raw']
+
+    def test_prior_broadcast_reused_not_resent(self, provider, monkeypatch):
+        monkeypatch.setenv('ARBUSDC_PRIVATE_KEY', TEST_KEY)
+        prior_tx = '0x' + 'aa' * 32
+        provider.broadcasted_txids[prior_tx] = (RECIPIENT.lower(), AMOUNT, 990)
+        responses = self._send_responses()
+        responses['eth_getTransactionByHash'] = {'hash': prior_tx, 'blockNumber': None}  # still in mempool
+
+        def never(params):
+            raise AssertionError('must not rebroadcast')
+
+        responses['eth_sendRawTransaction'] = never
+        rpc_stub(provider, responses)
+        assert provider.send_amount(RECIPIENT, AMOUNT) == (prior_tx, 0)
+
+    def test_stale_dedup_entry_expires(self, provider, monkeypatch):
+        # An entry older than the lookback window is dropped, not reused (#461 class).
+        monkeypatch.setenv('ARBUSDC_PRIVATE_KEY', TEST_KEY)
+        prior_tx = '0x' + 'aa' * 32
+        provider.broadcasted_txids[prior_tx] = (RECIPIENT.lower(), AMOUNT, 1000 - provider.SCAN_LOOKBACK_BLOCKS - 1)
+        rpc_stub(provider, self._send_responses())
+        result = provider.send_amount(RECIPIENT, AMOUNT)
+        assert result is not None and result[0] != prior_tx
+        assert prior_tx not in provider.broadcasted_txids
+
+
+class TestScanner:
+    def test_getlogs_hit_returns_hash(self, provider):
+        found = '0x' + 'bb' * 32
+
+        def logs(params):
+            f = params[0]
+            assert f['address'] == CONTRACT
+            assert f['topics'] == [TRANSFER_TOPIC0, topic(TEST_ADDR), topic(RECIPIENT)]
+            return [{'data': hex(AMOUNT), 'transactionHash': found}]
+
+        rpc_stub(provider, {'eth_blockNumber': hex(1000), 'eth_getLogs': logs})
+        assert provider.find_recent_outgoing(TEST_ADDR, RECIPIENT, AMOUNT) == found
+
+    def test_underpaying_log_ignored_cursor_advances(self, provider):
+        rpc_stub(provider, {'eth_blockNumber': hex(1000), 'eth_getLogs': [{'data': hex(1), 'transactionHash': TX}]})
+        assert provider.find_recent_outgoing(TEST_ADDR, RECIPIENT, AMOUNT) is None
+        key = (TEST_ADDR.lower(), RECIPIENT.lower(), AMOUNT)
+        assert provider.scan_cursors[key] == 1000
+
+    def test_failed_range_parks_cursor(self, provider):
+        def boom(params):
+            raise ConnectionError('range too large')
+
+        rpc_stub(provider, {'eth_blockNumber': hex(1000), 'eth_getLogs': boom})
+        assert provider.find_recent_outgoing(TEST_ADDR, RECIPIENT, AMOUNT) is None
+        key = (TEST_ADDR.lower(), RECIPIENT.lower(), AMOUNT)
+        # Parked just below the failed range start — the same span is retried next call.
+        assert provider.scan_cursors[key] == 1000 - provider.SCAN_LOOKBACK_BLOCKS
+
+
+class TestNetworkAndContract:
+    def test_unknown_network_raises(self, monkeypatch):
+        monkeypatch.setenv('ARBUSDC_NETWORK', 'seplia')
+        with pytest.raises(ValueError, match='ARBUSDC_NETWORK'):
+            ArbUsdc()
+
+    def test_unset_defaults_to_mainnet_with_registry_contract(self, monkeypatch):
+        for var in ('ARBUSDC_NETWORK', 'ARBUSDC_RPC_URLS', 'ARBUSDC_TOKEN_CONTRACT'):
+            monkeypatch.delenv(var, raising=False)
+        p = ArbUsdc()
+        assert p.chain.network == 'mainnet'
+        assert p.token_contract == CHAIN_ARBUSDC.asset_locator
+
+    def test_sepolia_uses_testnet_deployment(self, provider):
+        assert provider.token_contract == CONTRACT
+
+    def test_env_override_wins(self, monkeypatch):
+        monkeypatch.setenv('ARBUSDC_NETWORK', 'sepolia')
+        monkeypatch.setenv('ARBUSDC_TOKEN_CONTRACT', '0x' + '42' * 20)
+        assert ArbUsdc().token_contract == '0x' + '42' * 20
+
+    def test_lookback_window_is_time_based(self, provider):
+        # 1s blocks → the ≈5 min dedup/scan window is 300 blocks, not ETH's 25.
+        assert provider.SCAN_LOOKBACK_BLOCKS == 300
+
+    def test_chain_binding(self, provider):
+        assert provider.chain_def is CHAIN_ARBUSDC
+        assert provider.chain.chain_id == 421_614
+        # Composed, not fused: the first non-fused asset — a second Arbitrum token shares the chain.
+        assert provider.chain is not provider
+
+
+class TestCheckConnection:
+    def test_chain_id_mismatch_fails(self, provider):
+        rpc_stub(provider, {'eth_chainId': '0x1', 'eth_blockNumber': '0x10'})
+        with pytest.raises(ConnectionError, match='chain id'):
+            provider.check_connection(require_send=False)
+
+    def test_missing_key_fails_when_send_required(self, provider):
+        with pytest.raises(ConnectionError, match='ARBUSDC_PRIVATE_KEY'):
+            provider.check_connection(require_send=True)
+
+    def test_codeless_contract_fails(self, provider):
+        rpc_stub(provider, {'eth_chainId': hex(421_614), 'eth_blockNumber': '0x10', 'eth_getCode': '0x'})
+        with pytest.raises(ConnectionError, match='no code'):
+            provider.check_connection(require_send=False)
+
+    def test_happy_path_paused_only_warns(self, provider):
+        rpc_stub(
+            provider,
+            {
+                'eth_chainId': hex(421_614),
+                'eth_blockNumber': '0x10',
+                'eth_getCode': '0x6080',
+                'eth_call': eth_call_views(paused=True),
+            },
+        )
+        provider.check_connection(require_send=False)  # paused is a warning, not a failure

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -1,12 +1,16 @@
 """Tests for allways.chains — chain registry, canonical pairing, and the seconds-based extension target."""
 
+import re
+
 import pytest
 
 from allways.chains import (
+    CHAIN_ARBUSDC,
     CHAIN_BTC,
     CHAIN_ETH,
     CHAIN_TAO,
     EXTENSION_BUCKET_SECONDS,
+    SUPPORTED_CHAINS,
     canonical_pair,
     compute_extension_target_secs,
     get_chain_def,
@@ -23,9 +27,27 @@ class TestGetChain:
     def test_eth(self):
         assert get_chain_def('eth') is CHAIN_ETH
 
+    def test_arbusdc(self):
+        assert get_chain_def('arbusdc') is CHAIN_ARBUSDC
+
     def test_unsupported_raises(self):
         with pytest.raises(KeyError):
             get_chain_def('doge')
+
+    def test_ids_are_lowercase_and_fit_the_wire(self):
+        """Every registry id must be lowercase (the program rejects cased ids at intake, PDAs
+        and the grace table key off exact strings) AND <=10 chars (every chain column across
+        the DB is VARCHAR(10) — an 11-16 char id passes on-chain then errors on insert)."""
+        for chain_id, chain in SUPPORTED_CHAINS.items():
+            assert re.fullmatch(r'[a-z0-9]{1,10}', chain_id), chain_id
+            assert chain.id == chain_id
+
+    def test_layered_fields_default_none_for_native_assets(self):
+        for chain_id in ('btc', 'tao', 'sol', 'eth'):
+            assert get_chain_def(chain_id).host_chain is None
+            assert get_chain_def(chain_id).asset_locator is None
+        assert CHAIN_ARBUSDC.host_chain == 'arbitrum'
+        assert CHAIN_ARBUSDC.asset_locator.startswith('0x')
 
 
 class TestCanonicalPair:
@@ -98,6 +120,10 @@ class TestComputeExtensionTargetSecs:
     def test_eth_remaining_confs(self):
         # ETH needs 32 confs, 12s each: remaining=32, raw = 10000 + 384 + 120 = 10504, bucket up to 10800.
         assert compute_extension_target_secs('eth', 0, self.NOW, self.CEILING) == 10_800
+
+    def test_arbusdc_remaining_confs(self):
+        # arbusdc needs 90 confs, 1s each: remaining=90, raw = 10000 + 90 + 120 = 10210, bucket up to 10800.
+        assert compute_extension_target_secs('arbusdc', 0, self.NOW, self.CEILING) == 10_800
 
     def test_unsupported_chain_raises(self):
         with pytest.raises(KeyError):

--- a/tests/test_network_config.py
+++ b/tests/test_network_config.py
@@ -12,10 +12,12 @@ from pathlib import Path
 import pytest
 
 from allways.cli.swap_commands.helpers import (
+    ARBUSDC_NETWORKS,
     BTC_NETWORKS,
     ENV_BUNDLES,
     ETH_NETWORKS,
     SOLANA_NETWORKS,
+    apply_arbusdc_network_env,
     apply_btc_network_env,
     apply_eth_network_env,
     load_cli_keypair,
@@ -83,10 +85,19 @@ def test_api_key_composes_onto_network_name(monkeypatch):
 def test_env_bundles_cover_all_chains():
     for name in ('testnet', 'mainnet'):
         b = ENV_BUNDLES[name]
-        assert set(b) == {'network', 'solana-network', 'btc-network', 'eth-network', 'netuid', 'router'}
+        assert set(b) == {
+            'network',
+            'solana-network',
+            'btc-network',
+            'eth-network',
+            'arbusdc-network',
+            'netuid',
+            'router',
+        }
         assert b['solana-network'] in SOLANA_NETWORKS
         assert b['btc-network'] in BTC_NETWORKS
         assert b['eth-network'] in ETH_NETWORKS
+        assert b['arbusdc-network'] in ARBUSDC_NETWORKS
 
 
 def test_btc_shim_sets_env_when_unset(monkeypatch):
@@ -119,6 +130,22 @@ def test_eth_shim_respects_real_env(monkeypatch):
     import os
 
     assert os.environ['ETH_NETWORK'] == 'mainnet'  # explicit env wins
+
+
+def test_arbusdc_shim_sets_env_when_unset(monkeypatch):
+    monkeypatch.delenv('ARBUSDC_NETWORK', raising=False)
+    apply_arbusdc_network_env({'arbusdc-network': 'sepolia'})
+    import os
+
+    assert os.environ.get('ARBUSDC_NETWORK') == 'sepolia'
+
+
+def test_arbusdc_shim_respects_real_env(monkeypatch):
+    monkeypatch.setenv('ARBUSDC_NETWORK', 'mainnet')
+    apply_arbusdc_network_env({'arbusdc-network': 'sepolia'})
+    import os
+
+    assert os.environ['ARBUSDC_NETWORK'] == 'mainnet'  # explicit env wins
 
 
 def test_keypair_env_wins_over_config(monkeypatch):

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -18,6 +18,8 @@ from allways.utils.rate import (
 TAO_DEC = 9
 BTC_DEC = 8
 ETH_DEC = 18
+SOL_DEC = 9
+USDC_DEC = 6
 
 
 class TestBtcToTao:
@@ -132,6 +134,33 @@ class TestFutureEth:
         tao_rao = calculate_to_amount(source_wei, '2000', is_reverse=False, to_decimals=TAO_DEC, from_decimals=ETH_DEC)
         back_wei = calculate_to_amount(tao_rao, '2000', is_reverse=True, to_decimals=TAO_DEC, from_decimals=ETH_DEC)
         assert back_wei == source_wei
+
+
+class TestSolArbusdc:
+    """sol ↔ arbusdc: the first spoke with FEWER decimals than the hub (6 vs 9) whose
+    canonical dest is the spoke — decimal_diff = 6 - 9 = -3, integer-exact both branches."""
+
+    def test_sol_to_arbusdc(self):
+        # 1 SOL @ 150 USDC/SOL → 150 USDC
+        result = calculate_to_amount(10**SOL_DEC, '150', is_reverse=False, to_decimals=USDC_DEC, from_decimals=SOL_DEC)
+        assert result == 150 * 10**USDC_DEC
+
+    def test_arbusdc_to_sol(self):
+        # 150 USDC @ 150 USDC/SOL → 1 SOL
+        source = 150 * 10**USDC_DEC
+        result = calculate_to_amount(source, '150', is_reverse=True, to_decimals=USDC_DEC, from_decimals=SOL_DEC)
+        assert result == 10**SOL_DEC
+
+    def test_round_trip_exact(self):
+        source = 10**SOL_DEC
+        usdc = calculate_to_amount(source, '150', is_reverse=False, to_decimals=USDC_DEC, from_decimals=SOL_DEC)
+        back = calculate_to_amount(usdc, '150', is_reverse=True, to_decimals=USDC_DEC, from_decimals=SOL_DEC)
+        assert back == source
+
+    def test_single_microusdc_granularity(self):
+        # 1 µUSDC @ 150 USDC/SOL → 1000/150 lamports, floored: the coarsest step of the pair.
+        result = calculate_to_amount(1, '150', is_reverse=True, to_decimals=USDC_DEC, from_decimals=SOL_DEC)
+        assert result == 6
 
 
 class TestEdgeCases:
@@ -417,6 +446,17 @@ class TestIsExecutableRate:
         source maps in-bounds — just executable."""
         rate = (10 * self.DUST) / self.MAX
         assert is_executable_rate(rate, 'sol', 'btc', self.MIN, self.MAX) is True
+
+    def test_arbusdc_rates_executable_at_unit_floor(self):
+        """F1 regression guard — arbusdc must stay routable BOTH ways while its
+        min_onchain_amount stays pinned at 1. The gate consumes the canonical USDC-per-SOL
+        rate as if it were SOL-per-USDC on the arbusdc→sol side (the PR-E orientation
+        defect), so a real dust floor (e.g. 0.01 USDC = 10_000) pushes the implied minimum
+        source above max_swap and silently burns the direction's pool. If this test fails
+        because the floor was raised: revert the floor — it is load-bearing until PR-E."""
+        assert get_chain_def('arbusdc').min_onchain_amount == 1
+        assert is_executable_rate(150.0, 'arbusdc', 'sol', self.MIN, self.MAX) is True
+        assert is_executable_rate(150.0, 'sol', 'arbusdc', self.MIN, self.MAX) is True
 
     def test_sol_to_btc_sentinel_unset_bounds_still_permissive(self):
         """Unset bounds disable the gate in both directions — keeps the

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -95,15 +95,76 @@ def test_open_happy_path_persists_routed_request():
     store.close()
 
 
+def _gate_asset(can_deliver, valid=lambda addr: True):
+    """Duck-typed asset for the reserve deliverability gates (can_deliver_to + chain format check)."""
+    return SimpleNamespace(can_deliver_to=can_deliver, chain=SimpleNamespace(is_valid_address=valid))
+
+
 def test_undeliverable_destination_rejects_before_any_bid():
     # B-lite reserve gate: a dest that provably refuses transfers bounces before funds move.
     client = FakeClient()
     validator = _validator(client)
-    validator.axon_assets = {'btc': SimpleNamespace(can_deliver_to=lambda addr, amt: False)}
+    validator.axon_assets = {'btc': _gate_asset(lambda addr, amt: False)}
     result = reserve_on_behalf(validator, HOTKEY, 'sol', 'btc', USER_PK, str(USER_PK), 'userBTCaddr', 10**9)
     assert not result.ok
     assert 'rejects incoming transfers' in result.reason
     assert client.calls == []  # bounced before the on-chain bid
+
+
+def test_malformed_destination_address_rejects_before_any_bid():
+    # F4: address FORMAT is screened first — offline, and a malformed dest can never deliver.
+    client = FakeClient()
+    validator = _validator(client)
+    validator.axon_assets = {'btc': _gate_asset(lambda addr, amt: True, valid=lambda addr: False)}
+    result = reserve_on_behalf(validator, HOTKEY, 'sol', 'btc', USER_PK, str(USER_PK), 'not-an-addr', 10**9)
+    assert not result.ok
+    assert 'not a valid btc address' in result.reason
+    assert client.calls == []
+
+
+def test_malformed_miner_receive_address_rejects():
+    client = FakeClient()
+    client.quote.miner_from_addr = 'minerSOLaddr'
+    validator = _validator(client)
+    validator.axon_assets = {'sol': _gate_asset(lambda addr, amt: True, valid=lambda addr: addr != 'minerSOLaddr')}
+    result = reserve_on_behalf(validator, HOTKEY, 'sol', 'btc', USER_PK, str(USER_PK), 'userBTCaddr', 10**9)
+    assert not result.ok
+    assert 'miner receive address' in result.reason
+    assert client.calls == []
+
+
+def test_cased_chain_id_rejects_at_intake():
+    # F4: chain ids are lowercase everywhere — a cased id must bounce before it can derive
+    # a mismatched quote PDA (the program enforces the same at its own intake).
+    client = FakeClient()
+    validator = _validator(client)
+    result = reserve_on_behalf(validator, HOTKEY, 'SOL', 'btc', USER_PK, str(USER_PK), 'userBTCaddr', 10**9)
+    assert not result.ok
+    assert 'lowercase' in result.reason
+    assert client.calls == []
+
+
+def test_miner_receive_address_screened_on_source_chain():
+    # T18: a miner quoting a rejecting/blacklisted receive address griefs takers into a
+    # burned entry fee — the reserve gate screens the SOURCE side too, before any bid.
+    client = FakeClient()
+    client.quote.miner_from_addr = 'minerSOLaddr'
+    validator = _validator(client)
+    validator.axon_assets = {'sol': _gate_asset(lambda addr, amt: addr != 'minerSOLaddr')}
+    result = reserve_on_behalf(validator, HOTKEY, 'sol', 'btc', USER_PK, str(USER_PK), 'userBTCaddr', 10**9)
+    assert not result.ok
+    assert 'miner receive address' in result.reason
+    assert client.calls == []
+
+
+def test_miner_receive_address_clean_still_bids():
+    client = FakeClient()
+    client.quote.miner_from_addr = 'minerSOLaddr'
+    validator = _validator(client)
+    validator.axon_assets = {'sol': _gate_asset(lambda addr, amt: True)}
+    result = reserve_on_behalf(validator, HOTKEY, 'sol', 'btc', USER_PK, str(USER_PK), 'userBTCaddr', 10**9)
+    assert result.ok
+    assert client.calls == [('open_or_request', 'sol', 'btc')]
 
 
 def test_inactive_miner_rejects():

--- a/tests/test_swap_now_reservation.py
+++ b/tests/test_swap_now_reservation.py
@@ -131,6 +131,7 @@ def _run_swap_now(reserved_until, from_chain='btc'):
 
     with (
         patch('allways.cli.swap_commands.swap.get_solana_cli_context', return_value=(None, client)),
+        patch('allways.cli.swap_commands.swap._gate_provider', return_value=None),
         patch('allways.cli.swap_commands.swap.candidate_miners', return_value=[cand]),
         patch('allways.cli.swap_commands.swap.select_best_miner', return_value=(cand, amts)),
         patch('allways.cli.swap_commands.swap._poll_drawn', return_value=drawn),
@@ -315,6 +316,7 @@ def _run_resume(existing, poll_resv):
     ]
     with (
         patch('allways.cli.swap_commands.swap.get_solana_cli_context', return_value=(None, client)),
+        patch('allways.cli.swap_commands.swap._gate_provider', return_value=None),
         patch('allways.cli.swap_commands.swap.candidate_miners', return_value=[cand]),
         patch('allways.cli.swap_commands.swap.select_best_miner', return_value=(cand, amts)),
         patch(
@@ -438,3 +440,73 @@ def test_deadline_notice_never_shows_negative_runway():
     now = 1_700_000_000
     body = ' '.join(_deadline_lines(now - 50, want_send=False, now=now))
     assert '0s' in body and '-50' not in body
+
+
+# ─── Pre-reserve deliverability screens (F7/T18 — the CLI mirror of the validator gate) ───
+
+
+class _Gate:
+    def __init__(self, reject=(), malformed=()):
+        self.reject = set(reject)
+        self.checked = []
+        self.chain = types.SimpleNamespace(is_valid_address=lambda addr: addr not in set(malformed))
+
+    def can_deliver_to(self, addr, amount):
+        self.checked.append(addr)
+        return addr not in self.reject
+
+
+def _screen(gate, from_chain, to_chain, client=None):
+    from allways.cli.swap_commands.swap import _screen_deliverability
+
+    cand = types.SimpleNamespace(miner='miner-pk', rate_display='150')
+    with patch('allways.cli.swap_commands.swap._gate_provider', return_value=gate):
+        _screen_deliverability(client or MagicMock(), {}, cand, from_chain, to_chain, 'recvaddr', 'useraddr', 10**6)
+    return gate
+
+
+def test_screen_blocks_undeliverable_receive_address():
+    # F7: self-represented takers have no validator to bounce a blacklisted dest for them.
+    import pytest
+
+    with pytest.raises(SystemExit):
+        _screen(_Gate(reject={'recvaddr'}), 'sol', 'arbusdc')
+
+
+def test_screen_blocks_rejecting_miner_receive_address():
+    # T18 mirror: don't bid (and burn the entry fee) toward a miner whose receive address rejects.
+    import pytest
+
+    client = MagicMock()
+    client.get_quote.return_value = types.SimpleNamespace(miner_from_addr='mineraddr')
+    with pytest.raises(SystemExit):
+        _screen(_Gate(reject={'mineraddr'}), 'arbusdc', 'sol', client)
+
+
+def test_screen_only_warns_on_frozen_source_address():
+    # F13c courtesy: a frozen SOURCE is benign (deposit fails, reservation lapses) — warn, never block.
+    client = MagicMock()
+    client.get_quote.return_value = types.SimpleNamespace(miner_from_addr='mineraddr')
+    gate = _screen(_Gate(reject={'useraddr'}), 'arbusdc', 'sol', client)
+    assert 'useraddr' in gate.checked
+
+
+def test_screen_fails_open_without_a_provider():
+    _screen(None, 'sol', 'arbusdc')  # no provider buildable → no screen, no crash
+
+
+def test_screen_blocks_malformed_receive_address():
+    # F4: format is screened before any RPC-backed gate — offline and always authoritative.
+    import pytest
+
+    with pytest.raises(SystemExit):
+        _screen(_Gate(malformed={'recvaddr'}), 'sol', 'arbusdc')
+
+
+def test_screen_blocks_malformed_miner_receive_address():
+    import pytest
+
+    client = MagicMock()
+    client.get_quote.return_value = types.SimpleNamespace(miner_from_addr='mineraddr')
+    with pytest.raises(SystemExit):
+        _screen(_Gate(malformed={'mineraddr'}), 'arbusdc', 'sol', client)

--- a/tests/test_swap_now_reservation.py
+++ b/tests/test_swap_now_reservation.py
@@ -510,3 +510,33 @@ def test_screen_blocks_malformed_miner_receive_address():
     client.get_quote.return_value = types.SimpleNamespace(miner_from_addr='mineraddr')
     with pytest.raises(SystemExit):
         _screen(_Gate(malformed={'mineraddr'}), 'arbusdc', 'sol', client)
+
+
+def test_screen_rejection_aborts_swap_now_before_any_bid():
+    # Placement guard: the screen fires inside `swap now` BEFORE the resume/bid machinery —
+    # a doomed dest aborts the flow with no bid placed and no reservation touched.
+    from click.testing import CliRunner
+
+    from allways.cli.swap_commands.swap import swap_now_command
+
+    user = '68ToGUYjjYpqi7Atx7QyhbybR2RCfo2tkmgcoNR3DxYF'
+    client = MagicMock()
+    client.keypair.pubkey.return_value = user
+    client.get_config.return_value = types.SimpleNamespace(
+        min_swap_amount=1, max_swap_amount=10**18, pool_window_secs=60
+    )
+    amts = types.SimpleNamespace(collateral_amount=10**9, from_amount=5000, to_amount=10**9)
+    cand = types.SimpleNamespace(miner='miner-pk', rate_display='0.0021', collateral=10**10)
+    argv = ['--from', 'sol', '--to', 'btc', '--amount', '0.001', '--receive-address', 'userBTCaddr', '--yes']
+    with (
+        patch('allways.cli.swap_commands.swap.get_solana_cli_context', return_value=(None, client)),
+        patch('allways.cli.swap_commands.swap._gate_provider', return_value=_Gate(reject={'userBTCaddr'})),
+        patch('allways.cli.swap_commands.swap.candidate_miners', return_value=[cand]),
+        patch('allways.cli.swap_commands.swap.select_best_miner', return_value=(cand, amts)),
+        patch('allways.cli.swap_commands.swap._save_pending'),
+    ):
+        result = CliRunner().invoke(swap_now_command, argv)
+    assert result.exit_code != 0
+    assert 'cannot accept' in result.output
+    client.open_or_request.assert_not_called()
+    client.get_reservation.assert_not_called()

--- a/tests/test_swap_routed.py
+++ b/tests/test_swap_routed.py
@@ -60,6 +60,7 @@ def _run(client, *, argv_extra=(), responses=None, axon=AXON, config=None, confi
     info = types.SimpleNamespace(headline='router unreachable', accepted=0)
     with (
         patch('allways.cli.swap_commands.swap.get_solana_cli_context', return_value=(config, client)),
+        patch('allways.cli.swap_commands.swap._gate_provider', return_value=None),
         patch('allways.cli.swap_commands.swap.candidate_miners', return_value=[cand]),
         patch('allways.cli.swap_commands.swap.select_best_miner', return_value=(cand, amts)),
         patch('allways.cli.swap_commands.swap.find_validator_axon', return_value=axon) as find_axon,
@@ -260,6 +261,7 @@ def test_stale_cached_axon_refreshes_once_then_succeeds():
     info = types.SimpleNamespace(headline='no response', accepted=0)
     with (
         patch('allways.cli.swap_commands.swap.get_solana_cli_context', return_value=(None, client)),
+        patch('allways.cli.swap_commands.swap._gate_provider', return_value=None),
         patch('allways.cli.swap_commands.swap.candidate_miners', return_value=[cand]),
         patch('allways.cli.swap_commands.swap.select_best_miner', return_value=(cand, amts)),
         patch('allways.cli.swap_commands.swap.find_validator_axon', side_effect=[stale, fresh]) as find_axon,


### PR DESCRIPTION
**TLDR: the subnet gets its first token asset — Circle's USDC on Arbitrum, swapping against SOL both ways. Tokens live on someone else's chain and settle through contract logs instead of plain transfers, so this PR builds the generic ERC-20 machinery once (`Erc20` + a shared `EvmChain` family); the next token is a registry row, not a rewrite.**

## What a token changes

A plain ETH payment is verified off the transaction itself: to, value, from. A USDC payment moves nothing in `tx.value` — the truth is the token contract's `Transfer` log. So verification here accepts a tx only when its status-1 receipt carries a Transfer **from the pinned Circle contract** paying the expected recipient (fake tokens and bridged USDC.e can never match), and the provable payer is the log's `from` topic, not the envelope sender. Pending txs match on `transfer()` calldata addressed to the contract. Anything unreadable (missing receipt, missing timestamp) stays "unknown" and defers — never a slash verdict.

Sending changes shape too: the miner now needs **two balances** — USDC to pay the leg and ETH-on-Arbitrum to pay gas — and both are checked before anything broadcasts. Gas comes from `eth_estimateGas` (a revert here means the transfer cannot land — blacklisted party or paused token — so the miner declines instead of burning gas). The double-send dedup ladder is the same one ETH hardened in #618, with the lookback window converted to wall time (300 one-second Arbitrum blocks ≈ ETH's 25 twelve-second ones).

## Circle-shaped delivery gates

USDC's failure modes aren't ETH's. Any address can be frozen by Circle, and the whole token can be paused — both make delivery impossible through no fault of the miner. And unlike ETH, a contract-wallet destination receives ERC-20 fine, so there is deliberately **no getCode check** (one would hand every smart-wallet user permanent slash immunity):

- **Reserve gate**: `!isBlacklisted(dest) && !paused()` — a doomed swap bounces before any fee is spent. Fails open on RPC noise.
- **Reserve gate, source side** (new, all chains): the *miner's* receive address is screened the same way, killing a griefing vector where a miner quotes a frozen address and takers burn entry fees on deposits that can't land.
- **Slash gate**: a blacklisted destination or a paused token — now, or sampled across the swap window — exempts the miner. RPC failure on the load-bearing latest probe defers the slash (postpones, never falsifies).
- The self-represented CLI path now runs the same screens locally before bidding (it has no validator to bounce for it), plus a courtesy warning when the taker's own source address looks frozen.

## One floor you must not "fix"

`min_onchain_amount=1` on the arbusdc row is load-bearing. The executable-rate gate currently consumes the canonical USDC-per-SOL rate with the wrong orientation on the arbusdc→sol side; with a floor of 1 the gate stays correct-by-vacuity, but any real dust floor (0.01 USDC) makes the direction unroutable and silently burns its pool share. A regression test pins the floor and fails if it's raised. The orientation root fix is the follow-up PR (all-pairs blast radius, its own review).

## Structure

`ChainProvider`-era plumbing that ETH built (endpoint failover, null quorum, EIP-55/EIP-191 handling, dedup, cursors) moved into `assets/evm.py` as `EvmChain`/`EvmAsset` — Ethereum and Arbitrum are config rows (`EvmNetwork` instances), never subclasses, and the ETH suite passes unchanged on top of the extraction. `chains.py` grows two optional fields (`host_chain`, `asset_locator`, None for every existing chain); the wire keeps flat lowercase ids, and the on-behalf reserve op now rejects cased/unknown ids at intake, mirroring the program guard from #621.

Dwellir has no keyless Arbitrum endpoint, so committed defaults are publicnode+drpc and the Dwellir key rides in via `ARBUSDC_RPC_URLS` (key-in-URL, already supported).

## Launch notes

- **Validators must reach Arbitrum RPCs at boot** — deploy env docs land before this merges; CI auto-redeploys validators on merge.
- Direction pools re-slice /6 → /8: each existing leg's zero-volume floor drops 25%, and the arbusdc share burns until miners quote the pair. Miners: fund USDC inventory + ETH-on-Arbitrum gas, then `alw miner quotes --arbusdc-price <usdc-per-sol> --arbusdc-address <addr>` (flags already derive).
- Slash compensation stays SOL-denominated; a stablecoin leg makes rate drift between reserve and slash slightly sharper — pre-existing model, no code change.
- A broken blacklist RPC postpones (never falsifies) slashes on this pair; historical blacklist samples are best-effort because public nodes serve historical `eth_call` only ~a minute deep (verified live).
- 90 confs × 1s ≈ 25s real settlement — comfortably inside the program's 600s default grace; no grace-table arm.

Tests: 1026 passed (72 new). Live read-only verification against Arbitrum One + Sepolia: connection/chain-id/contract-code checks, a real 22 USDC transfer verified through the cased-recipient + sender-pin path, wrong-recipient and over-claim rejected, balance and both gates exercised. The live pass also caught a settled-cache bug (a cached verify could vouch for a different recipient's claim on the same tx hash) — fixed with a regression test.

## Rebased onto #624 + #625 (chain seam + naming)

The EVM family now sits on the sealed seam: `EvmChain` absorbed the members #624 moved to Chain (addresses, proofs, tip, plus the JSON-RPC ladder — the family's transport, as the Chain docstring anticipated), and `EvmAsset` kept the asset side (keys, dedup ladder, caches). **`Erc20` is the first non-fused asset**: it composes its host network's `EvmChain` via the `_chain` hook rather than being its own chain — a second Arbitrum token shares the instance from day one. `Ether` stays fused per the fused-until-second-asset rule. Expecteds arrive canonicalized per #624; the token fetchers (including the settled-cache leg check) only normalize on-chain values. #625's `chain_def`/`get_chain_def`/`AssetSpec`/`SendResult` are applied throughout.

Also lands here (from the #624 review): `is_valid_address` gets its first production callers — both reserve gates (validator + CLI) now format-screen the taker's receive address and the miner's receive address, offline, before any fee is spent. A malformed dest previously sailed to the miner's failed send with the taker's reservation fee burned.

1036 tests; live mainnet/sepolia re-verification repeated post-rebase (cased-recipient + sender-pin verify, cross-leg cache rejection, gates, format screens).


## Review pass (2026-08-07)

Three tightenings out of the completion review, folded in as one commit:

- The token-balance check now precedes the gas estimate: an underfunded transfer reverts in the estimator too, which previously misread as the destination refusing.
- `paused()` joined the slash gate. The reserve gates already refused a paused token; a pause landing mid-swap then rode to a slash the miner could do nothing about. Both issuer refusals now defer identically.
- Startup probes every configured RPC endpoint's chainId, not just the first responsive one — a wrong-network URL deeper in the failover ladder used to surface only during a primary outage, quietly serving wrong-chain verifications.

Plus a flow-placement test pinning that a rejecting deliverability screen aborts `swap now` before any bid or reservation touch. 1040 tests; live mainnet/sepolia read-only pass repeated after the changes (the mainnet run also exercised the failover ladder for real — publicnode 403s receipt fetches, drpc serves them).