### PR TITLE
Move chain-level members from Asset to Chain

### DIFF
--- a/allways/assets/__init__.py
+++ b/allways/assets/__init__.py
@@ -59,6 +59,7 @@ def create_assets(
         try:
             provider_kwargs = {k: kwargs[k] for k in kwarg_names if k in kwargs}
             provider = cls(**provider_kwargs)
+            provider.chain  # a missing Chain binding fails here at boot, not mid-pass
             if check:
                 provider.check_connection(require_send=require_send)
             providers[chain_id] = provider

--- a/allways/assets/__init__.py
+++ b/allways/assets/__init__.py
@@ -5,7 +5,7 @@ import bittensor as bt
 from allways.assets.base import Asset, TransactionInfo
 from allways.assets.bitcoin import Bitcoin
 from allways.assets.chain import Chain
-from allways.assets.ethereum import EvmCoin
+from allways.assets.ethereum import Ether
 from allways.assets.solana import Sol
 from allways.assets.subtensor import Tao
 
@@ -16,7 +16,7 @@ __all__ = [
     'Bitcoin',
     'Tao',
     'Sol',
-    'EvmCoin',
+    'Ether',
     'create_assets',
 ]
 
@@ -26,7 +26,7 @@ ASSET_REGISTRY: Tuple[Tuple[str, Type[Asset], Tuple[str, ...]], ...] = (
     ('btc', Bitcoin, ()),
     ('tao', Tao, ('subtensor', 'wallet')),
     ('sol', Sol, ('solana_rpc_url', 'solana_keypair')),
-    ('eth', EvmCoin, ()),
+    ('eth', Ether, ()),
 )
 
 

--- a/allways/assets/base.py
+++ b/allways/assets/base.py
@@ -38,19 +38,27 @@ class Asset(ABC):
     3. Register it in ASSET_REGISTRY; add {ENV_PREFIX}_* vars to .env
     """
 
+    # Non-fused assets (tokens on a multi-asset chain) set this at construction.
+    _chain: Optional[Chain] = None
+
     @abstractmethod
     def get_chain(self) -> ChainDefinition: ...
 
     @property
     def chain(self) -> Chain:
         """The network this asset lives on. Fused single-asset classes are their own chain."""
+        if self._chain is not None:
+            return self._chain
         if isinstance(self, Chain):
             return self
-        raise NotImplementedError(f'{type(self).__name__} must bind a Chain')
+        raise NotImplementedError(f'{type(self).__name__} must bind a Chain (set self._chain)')
 
     def describe(self) -> str:
         """One-line summary of the backend/API this provider talks to, for startup logs."""
         return self.get_chain().name
+
+    def clear_cache(self) -> None:
+        """Reset per-asset scratch caches at the start of a validator pass. No-op by default."""
 
     def can_send_from(self, address: str) -> bool:
         """True iff this provider's signing credentials control ``address`` — i.e. a ``send_amount``

--- a/allways/assets/base.py
+++ b/allways/assets/base.py
@@ -32,6 +32,9 @@ class Asset(ABC):
     `.chain` returns itself. The registry row stays a `ChainDefinition` in chains.py —
     the wire says chain; in code an id resolves to an Asset.
 
+    Seam rule: asset-side code asks chain questions through ``self.chain``; chain
+    members calling each other keep plain ``self`` (they move together on a split).
+
     Adding a new asset:
     1. Add its ChainDefinition to chains.py
     2. Implement this interface (or reuse a family class, e.g. an ERC-20)
@@ -128,6 +131,11 @@ class Asset(ABC):
         Rejections are logged once in the base so observability for the defense
         is in one place instead of duplicated at every call site.
         """
+        # Canonicalize expecteds once here so every fetcher compares in canonical form.
+        chain = self.chain
+        expected_recipient = chain.normalize_address(expected_recipient)
+        expected_sender = chain.normalize_address(expected_sender) if expected_sender else expected_sender
+
         tx_info = self.fetch_matching_tx(
             tx_hash=tx_hash,
             expected_recipient=expected_recipient,
@@ -145,8 +153,7 @@ class Asset(ABC):
             )
             return None
 
-        chain = self.chain
-        if expected_sender and chain.normalize_address(tx_info.sender) != chain.normalize_address(expected_sender):
+        if expected_sender and chain.normalize_address(tx_info.sender) != expected_sender:
             bt.logging.warning(
                 f'verify_transaction: sender mismatch on tx {tx_hash[:16]}... '
                 f'(expected {expected_sender}, got {tx_info.sender!r})'
@@ -156,7 +163,7 @@ class Asset(ABC):
         # A self-transfer (sender == recipient) is never a real swap leg: the
         # paying and receiving parties are always distinct. Rejecting it blocks
         # same-wallet A->A volume fakes; A->B self-flow is bounded economically.
-        if tx_info.sender and chain.normalize_address(tx_info.sender) == chain.normalize_address(expected_recipient):
+        if tx_info.sender and chain.normalize_address(tx_info.sender) == expected_recipient:
             bt.logging.warning(
                 f'verify_transaction: self-transfer on tx {tx_hash[:16]}... '
                 f'(sender == recipient {expected_recipient}) — rejecting'

--- a/allways/assets/base.py
+++ b/allways/assets/base.py
@@ -1,7 +1,6 @@
-import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Optional, Tuple
+from typing import Optional, Tuple
 
 import bittensor as bt
 
@@ -39,11 +38,6 @@ class Asset(ABC):
     3. Register it in ASSET_REGISTRY; add {ENV_PREFIX}_* vars to .env
     """
 
-    # True if this provider's RPCs hit the shared substrate websocket, so
-    # callers must serialise them under axon_lock. HTTP-backed providers leave
-    # this False and stay lock-free.
-    uses_substrate: bool = False
-
     @abstractmethod
     def get_chain(self) -> ChainDefinition: ...
 
@@ -57,14 +51,6 @@ class Asset(ABC):
     def describe(self) -> str:
         """One-line summary of the backend/API this provider talks to, for startup logs."""
         return self.get_chain().name
-
-    def normalize_address(self, address: str) -> str:
-        """Canonical comparison form for this chain's addresses (identity by default).
-
-        Chains whose address encoding is case-insensitive (ETH hex / EIP-55 checksum casing)
-        override this so equality checks never fail on casing alone. Comparison only — never
-        feed the normalized form back on-chain or into display."""
-        return address
 
     def can_send_from(self, address: str) -> bool:
         """True iff this provider's signing credentials control ``address`` — i.e. a ``send_amount``
@@ -151,7 +137,8 @@ class Asset(ABC):
             )
             return None
 
-        if expected_sender and self.normalize_address(tx_info.sender) != self.normalize_address(expected_sender):
+        chain = self.chain
+        if expected_sender and chain.normalize_address(tx_info.sender) != chain.normalize_address(expected_sender):
             bt.logging.warning(
                 f'verify_transaction: sender mismatch on tx {tx_hash[:16]}... '
                 f'(expected {expected_sender}, got {tx_info.sender!r})'
@@ -161,7 +148,7 @@ class Asset(ABC):
         # A self-transfer (sender == recipient) is never a real swap leg: the
         # paying and receiving parties are always distinct. Rejecting it blocks
         # same-wallet A->A volume fakes; A->B self-flow is bounded economically.
-        if tx_info.sender and self.normalize_address(tx_info.sender) == self.normalize_address(expected_recipient):
+        if tx_info.sender and chain.normalize_address(tx_info.sender) == chain.normalize_address(expected_recipient):
             bt.logging.warning(
                 f'verify_transaction: self-transfer on tx {tx_hash[:16]}... '
                 f'(sender == recipient {expected_recipient}) — rejecting'
@@ -170,42 +157,8 @@ class Asset(ABC):
 
         return tx_info
 
-    # A cached tip is reused for at most this long. The validator clears it each forward pass (one
-    # getSlot/pass); this TTL is the safety net for callers that never clear (e.g. the miner), so the
-    # tip can never freeze — it self-refreshes at least this often. Slightly longer than a subtensor
-    # block so a validator pass stays on one fetch.
-    _TIP_TTL_SECONDS = 15.0
-
-    def cached_block_height(self) -> Optional[int]:
-        """Chain tip, cached so per-tx confirmation math shares one lookup instead of one per leg.
-
-        The validator clears this each pass (``clear_pass_tip``) → one ``getSlot`` per pass. The TTL
-        caps staleness for callers that never clear (the miner), so the tip can never freeze. A start-
-        of-pass/slightly-stale tip biases confirmations low — conservative, never a false confirm. A
-        failed fetch (None) is not cached, so it retries."""
-        tip = getattr(self, '_pass_tip', None)
-        if tip is not None and time.monotonic() - getattr(self, '_pass_tip_ts', 0.0) < self._TIP_TTL_SECONDS:
-            return tip
-        tip = self.get_current_block_height()
-        if tip is not None:
-            self._pass_tip = tip
-            self._pass_tip_ts = time.monotonic()
-        return tip
-
-    def clear_pass_tip(self) -> None:
-        """Expire the cached tip — the validator calls this once per pass for a fresh start-of-pass tip."""
-        self._pass_tip = None
-
-    @abstractmethod
-    def get_current_block_height(self) -> Optional[int]:
-        """Chain tip block height. None on transient backend failure."""
-        ...
-
     @abstractmethod
     def get_balance(self, address: str) -> int: ...
-
-    @abstractmethod
-    def is_valid_address(self, address: str) -> bool: ...
 
     def can_deliver_to(self, address: str, amount: int) -> bool:
         """Reserve-time gate: False only on positive evidence the destination cannot receive."""
@@ -214,16 +167,6 @@ class Asset(ABC):
     def delivery_refused(self, address: str, since_unix: int) -> bool:
         """Slash gate: True only on positive evidence delivery was refusable since ``since_unix``."""
         return False
-
-    @abstractmethod
-    def sign_from_proof(self, address: str, message: str, key: Optional[Any] = None) -> str:
-        """Sign a source proof message with the given key. Returns hex signature."""
-        ...
-
-    @abstractmethod
-    def verify_from_proof(self, address: str, message: str, signature: str) -> bool:
-        """Verify a source proof signature from the given address."""
-        ...
 
     @abstractmethod
     def send_amount(

--- a/allways/assets/bitcoin.py
+++ b/allways/assets/bitcoin.py
@@ -150,6 +150,10 @@ class Bitcoin(Asset, Chain):
         hosts = ', '.join(urlparse(base).netloc or base for base, _ in self.btc_api_bases())
         return f'Esplora API ({self.network}): {hosts}'
 
+    def normalize_address(self, address: str) -> str:
+        """bech32 is case-insensitive (BIP-173); base58 legacy addresses are not — lowercase bech32 only."""
+        return address.lower() if address.lower().startswith(('bc1', 'tb1', 'bcrt1')) else address
+
     def can_send_from(self, address: str) -> bool:
         """True iff BTC_PRIVATE_KEY derives ``address`` (any of its p2wpkh / p2sh-p2wpkh / p2pkh
         forms) — i.e. this WIF can broadcast the source deposit from the pinned sender."""

--- a/allways/assets/bitcoin.py
+++ b/allways/assets/bitcoin.py
@@ -152,7 +152,8 @@ class Bitcoin(Asset, Chain):
 
     def normalize_address(self, address: str) -> str:
         """bech32 is case-insensitive (BIP-173); base58 legacy addresses are not — lowercase bech32 only."""
-        return address.lower() if address.lower().startswith(('bc1', 'tb1', 'bcrt1')) else address
+        lowered = address.lower()
+        return lowered if detect_address_type(lowered) in (ADDR_TYPE_P2WPKH, ADDR_TYPE_P2TR) else address
 
     def can_send_from(self, address: str) -> bool:
         """True iff BTC_PRIVATE_KEY derives ``address`` (any of its p2wpkh / p2sh-p2wpkh / p2pkh

--- a/allways/assets/bitcoin.py
+++ b/allways/assets/bitcoin.py
@@ -204,7 +204,7 @@ class Bitcoin(Asset, Chain):
         15s TTL caps staleness for callers that never clear (miner fulfillment, axon-reserve), so the
         tip can never freeze. A stale-low tip biases confirmations low — conservative, never a false
         confirm. A failed tip fetch (None) is not cached and yields 0, so it retries next call."""
-        tip_height = self.cached_block_height()
+        tip_height = self.chain.cached_block_height()
         if tip_height is None:
             return 0
         return max(0, tip_height - block_number + 1)

--- a/allways/assets/bitcoin.py
+++ b/allways/assets/bitcoin.py
@@ -152,6 +152,8 @@ class Bitcoin(Asset, Chain):
 
     def normalize_address(self, address: str) -> str:
         """bech32 is case-insensitive (BIP-173); base58 legacy addresses are not — lowercase bech32 only."""
+        if not isinstance(address, str):
+            return address
         lowered = address.lower()
         return lowered if detect_address_type(lowered) in (ADDR_TYPE_P2WPKH, ADDR_TYPE_P2TR) else address
 
@@ -169,7 +171,11 @@ class Bitcoin(Asset, Chain):
             net = NETWORKS['test'] if self.network in ('testnet', 'testnet4') else NETWORKS['main']
             pub = EmbitPrivateKey.from_wif(wif).get_public_key()
             seg = p2wpkh(pub)
-            return address in {seg.address(net), p2sh(seg).address(net), p2pkh(pub).address(net)}
+            return self.normalize_address(address) in {
+                seg.address(net),
+                p2sh(seg).address(net),
+                p2pkh(pub).address(net),
+            }
         except Exception:
             return False
 
@@ -447,6 +453,7 @@ class Bitcoin(Asset, Chain):
         Supports P2PKH, P2WPKH, and P2SH-P2WPKH addresses via BIP-137.
         key: WIF private key string. If None, falls back to get_wif (BTC_PRIVATE_KEY).
         """
+        address = self.normalize_address(address)
         addr_type = detect_address_type(address)
         if addr_type == ADDR_TYPE_P2TR:
             bt.logging.error('Taproot (P2TR) addresses are not yet supported for message signing')
@@ -475,6 +482,7 @@ class Bitcoin(Asset, Chain):
         Supports P2PKH, P2WPKH, and P2SH-P2WPKH addresses via BIP-137.
         No RPC dependency — pure cryptographic verification.
         """
+        address = self.normalize_address(address)
         addr_type = detect_address_type(address)
         if addr_type == ADDR_TYPE_P2TR:
             bt.logging.warning('Taproot (P2TR) addresses are not yet supported for message verification')

--- a/allways/assets/chain.py
+++ b/allways/assets/chain.py
@@ -20,6 +20,8 @@ class Chain(ABC):
     # tip can never freeze — it self-refreshes at least this often. Slightly longer than a subtensor
     # block so a validator pass stays on one fetch.
     _TIP_TTL_SECONDS = 15.0
+    _pass_tip: Optional[int] = None
+    _pass_tip_ts: float = 0.0
 
     @abstractmethod
     def get_current_block_height(self) -> Optional[int]:
@@ -33,9 +35,8 @@ class Chain(ABC):
         caps staleness for callers that never clear (the miner), so the tip can never freeze. A start-
         of-pass/slightly-stale tip biases confirmations low — conservative, never a false confirm. A
         failed fetch (None) is not cached, so it retries."""
-        tip = getattr(self, '_pass_tip', None)
-        if tip is not None and time.monotonic() - getattr(self, '_pass_tip_ts', 0.0) < self._TIP_TTL_SECONDS:
-            return tip
+        if self._pass_tip is not None and time.monotonic() - self._pass_tip_ts < self._TIP_TTL_SECONDS:
+            return self._pass_tip
         tip = self.get_current_block_height()
         if tip is not None:
             self._pass_tip = tip

--- a/allways/assets/chain.py
+++ b/allways/assets/chain.py
@@ -15,11 +15,6 @@ class Chain(ABC):
     the address format, the ownership-proof signature scheme, the transport.
     """
 
-    # True if this chain's RPCs hit the shared substrate websocket, so
-    # callers must serialise them under axon_lock. HTTP-backed chains leave
-    # this False and stay lock-free.
-    uses_substrate: bool = False
-
     # A cached tip is reused for at most this long. The validator clears it each forward pass (one
     # getSlot/pass); this TTL is the safety net for callers that never clear (e.g. the miner), so the
     # tip can never freeze — it self-refreshes at least this often. Slightly longer than a subtensor

--- a/allways/assets/chain.py
+++ b/allways/assets/chain.py
@@ -12,7 +12,8 @@ class Chain(ABC):
     config-driven Chain instance per network instead of a class per chain.
 
     Everything here is a fact of the network, shared by every asset on it: the tip,
-    the address format, the ownership-proof signature scheme, the transport.
+    the address format, the ownership-proof signature scheme. Transport (sessions,
+    RPC ladders) moves here when the first split lands.
     """
 
     # A cached tip is reused for at most this long. The validator clears it each forward pass (one

--- a/allways/assets/chain.py
+++ b/allways/assets/chain.py
@@ -1,17 +1,73 @@
+import time
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Any, Optional
 
 
 class Chain(ABC):
-    """A network you can talk to: reach it, read blocks/txs, know its id.
+    """A network you can talk to: reach it, read blocks/txs, know its address and proof rules.
 
     Assets live on chains (`Asset.chain`). Single-asset networks fuse the two — the
     asset class also implements Chain and `.chain` returns itself — and split the day
     the chain hosts its second asset. Multi-asset families (EVM) bind a shared,
     config-driven Chain instance per network instead of a class per chain.
+
+    Everything here is a fact of the network, shared by every asset on it: the tip,
+    the address format, the ownership-proof signature scheme, the transport.
     """
+
+    # True if this chain's RPCs hit the shared substrate websocket, so
+    # callers must serialise them under axon_lock. HTTP-backed chains leave
+    # this False and stay lock-free.
+    uses_substrate: bool = False
+
+    # A cached tip is reused for at most this long. The validator clears it each forward pass (one
+    # getSlot/pass); this TTL is the safety net for callers that never clear (e.g. the miner), so the
+    # tip can never freeze — it self-refreshes at least this often. Slightly longer than a subtensor
+    # block so a validator pass stays on one fetch.
+    _TIP_TTL_SECONDS = 15.0
 
     @abstractmethod
     def get_current_block_height(self) -> Optional[int]:
         """Chain tip block height. None on transient backend failure."""
+        ...
+
+    def cached_block_height(self) -> Optional[int]:
+        """Chain tip, cached so per-tx confirmation math shares one lookup instead of one per leg.
+
+        The validator clears this each pass (``clear_pass_tip``) → one ``getSlot`` per pass. The TTL
+        caps staleness for callers that never clear (the miner), so the tip can never freeze. A start-
+        of-pass/slightly-stale tip biases confirmations low — conservative, never a false confirm. A
+        failed fetch (None) is not cached, so it retries."""
+        tip = getattr(self, '_pass_tip', None)
+        if tip is not None and time.monotonic() - getattr(self, '_pass_tip_ts', 0.0) < self._TIP_TTL_SECONDS:
+            return tip
+        tip = self.get_current_block_height()
+        if tip is not None:
+            self._pass_tip = tip
+            self._pass_tip_ts = time.monotonic()
+        return tip
+
+    def clear_pass_tip(self) -> None:
+        """Expire the cached tip — the validator calls this once per pass for a fresh start-of-pass tip."""
+        self._pass_tip = None
+
+    @abstractmethod
+    def is_valid_address(self, address: str) -> bool: ...
+
+    def normalize_address(self, address: str) -> str:
+        """Canonical comparison form for this chain's addresses (identity by default).
+
+        Chains whose address encoding is case-insensitive (ETH hex / EIP-55 checksum casing)
+        override this so equality checks never fail on casing alone. Comparison only — never
+        feed the normalized form back on-chain or into display."""
+        return address
+
+    @abstractmethod
+    def sign_from_proof(self, address: str, message: str, key: Optional[Any] = None) -> str:
+        """Sign a source proof message with the given key. Returns hex signature."""
+        ...
+
+    @abstractmethod
+    def verify_from_proof(self, address: str, message: str, signature: str) -> bool:
+        """Verify a source proof signature from the given address."""
         ...

--- a/allways/assets/ethereum.py
+++ b/allways/assets/ethereum.py
@@ -50,7 +50,7 @@ def rpc_tag(base: str) -> str:
     return parts[-2] if len(parts) >= 2 else host
 
 
-class EvmCoin(Asset, Chain):
+class Ether(Asset, Chain):
     """Ethereum chain provider: eth-account + public JSON-RPC (no local node required).
 
     Plain EOA value transfers only, by design: a swap leg is verified off the transaction's

--- a/allways/assets/ethereum.py
+++ b/allways/assets/ethereum.py
@@ -219,10 +219,10 @@ class Ether(Asset, Chain):
             bt.logging.debug(f'{LOG_ETH} tx {tx_hash[:16]}... not found')
             return None
 
-        to = self.normalize_address(tx.get('to') or '')  # null for contract creation
-        sender = self.normalize_address(tx.get('from') or '')
+        to = self.chain.normalize_address(tx.get('to') or '')  # null for contract creation
+        sender = self.chain.normalize_address(tx.get('from') or '')
         amount = int(tx.get('value') or '0x0', 16)
-        if to != self.normalize_address(expected_recipient) or amount < expected_amount:
+        if to != self.chain.normalize_address(expected_recipient) or amount < expected_amount:
             bt.logging.warning(
                 f'{LOG_ETH} tx {tx_hash[:16]}... does not pay {expected_recipient} >= {expected_amount} wei '
                 f'(to={tx.get("to")}, value={amount})'
@@ -251,7 +251,7 @@ class Ether(Asset, Chain):
         if cached is not None and tx_block_hash and cached['block_hash'] == tx_block_hash:
             block_number = cached['block_number']
             block_time = cached['block_time']
-            tip = self.cached_block_height()
+            tip = self.chain.cached_block_height()
             confirmations = max(0, tip - block_number + 1) if tip is not None else 0
             is_confirmed = confirmations >= self.get_chain().min_confirmations
         else:
@@ -266,7 +266,7 @@ class Ether(Asset, Chain):
                 return None
 
             block_number = int(receipt['blockNumber'], 16)
-            tip = self.cached_block_height()
+            tip = self.chain.cached_block_height()
             confirmations = max(0, tip - block_number + 1) if tip is not None else 0
             is_confirmed = confirmations >= self.get_chain().min_confirmations
 
@@ -346,7 +346,7 @@ class Ether(Asset, Chain):
 
     def can_send_from(self, address: str) -> bool:
         acct = self._account()
-        return acct is not None and self.normalize_address(acct.address) == self.normalize_address(address)
+        return acct is not None and self.chain.normalize_address(acct.address) == self.chain.normalize_address(address)
 
     def sign_from_proof(self, address: str, message: str, key: Optional[Any] = None) -> str:
         """EIP-191 personal_sign over ``message``. key: hex private key; None → ETH_PRIVATE_KEY."""
@@ -390,11 +390,11 @@ class Ether(Asset, Chain):
         if acct is None:
             self._send_error('ETH_PRIVATE_KEY not set or unusable')
             return None
-        if from_address and self.normalize_address(acct.address) != self.normalize_address(from_address):
+        if from_address and self.chain.normalize_address(acct.address) != self.chain.normalize_address(from_address):
             self._send_error(f'ETH key derives {acct.address} but committed address is {from_address} — key mismatch')
             return None
 
-        head = self.get_current_block_height()
+        head = self.chain.get_current_block_height()
         if head is None:
             self._send_error('cannot read the chain head to scope send dedup — not sending')
             return None
@@ -402,7 +402,7 @@ class Ether(Asset, Chain):
         try:
             # A prior own broadcast to this dest blocks a fresh send unless provably absent
             # from every endpoint — probing by hash sees the mempool; never risk paying twice.
-            want = (self.normalize_address(to_address), int(amount))
+            want = (self.chain.normalize_address(to_address), int(amount))
             try:
                 prior = self._prior_broadcast(want, head)
             except Exception as e:
@@ -545,11 +545,11 @@ class Ether(Asset, Chain):
         else None. A hash-finder only — the seam's confirm re-verifies everything by hash, so a
         miss just means the manual rescue paths. Mined blocks only (plain JSON-RPC exposes no
         mempool filter), so it lags a broadcast by up to one block."""
-        head = self.get_current_block_height()
+        head = self.chain.get_current_block_height()
         if head is None:
             return None
-        want_from = self.normalize_address(from_addr)
-        want_to = self.normalize_address(to_addr)
+        want_from = self.chain.normalize_address(from_addr)
+        want_to = self.chain.normalize_address(to_addr)
         key = (want_from, want_to, int(amount))
         floor = max(head - self.SCAN_LOOKBACK_BLOCKS, 0)
         last = self.scan_cursors.get(key, floor)
@@ -561,9 +561,9 @@ class Ether(Asset, Chain):
                 self._set_cursor(key, block_num - 1)
                 return None
             for tx in (block or {}).get('transactions', []):
-                if self.normalize_address(tx.get('from') or '') != want_from:
+                if self.chain.normalize_address(tx.get('from') or '') != want_from:
                     continue
-                if self.normalize_address(tx.get('to') or '') != want_to:
+                if self.chain.normalize_address(tx.get('to') or '') != want_to:
                     continue
                 if int(tx.get('value') or '0x0', 16) < int(amount):
                     continue

--- a/allways/assets/ethereum.py
+++ b/allways/assets/ethereum.py
@@ -548,8 +548,9 @@ class Ether(Asset, Chain):
         head = self.chain.get_current_block_height()
         if head is None:
             return None
-        want_from = self.chain.normalize_address(from_addr)
-        want_to = self.chain.normalize_address(to_addr)
+        norm = self.chain.normalize_address
+        want_from = norm(from_addr)
+        want_to = norm(to_addr)
         key = (want_from, want_to, int(amount))
         floor = max(head - self.SCAN_LOOKBACK_BLOCKS, 0)
         last = self.scan_cursors.get(key, floor)
@@ -561,9 +562,9 @@ class Ether(Asset, Chain):
                 self._set_cursor(key, block_num - 1)
                 return None
             for tx in (block or {}).get('transactions', []):
-                if self.chain.normalize_address(tx.get('from') or '') != want_from:
+                if norm(tx.get('from') or '') != want_from:
                     continue
-                if self.chain.normalize_address(tx.get('to') or '') != want_to:
+                if norm(tx.get('to') or '') != want_to:
                     continue
                 if int(tx.get('value') or '0x0', 16) < int(amount):
                     continue

--- a/allways/assets/solana.py
+++ b/allways/assets/solana.py
@@ -182,7 +182,7 @@ class Sol(Asset, Chain):
         of one each — the getSlot count drops from per-leg to per-pass."""
         if slot is None:
             return 0
-        tip = self.cached_block_height()
+        tip = self.chain.cached_block_height()
         if tip is None:
             return 0
         return max(0, tip - int(slot) + 1)

--- a/allways/assets/subtensor.py
+++ b/allways/assets/subtensor.py
@@ -21,9 +21,6 @@ class Tao(Asset, Chain):
     clear error if they attempt to send.
     """
 
-    # RPCs run on the shared substrate websocket — callers serialise via axon_lock.
-    uses_substrate = True
-
     # Balances pallet index and transfer call indices on Subtensor
     _BALANCES_PALLET = 5
     _TRANSFER_CALLS = {0: 'transfer_allow_death', 3: 'transfer_keep_alive', 7: 'transfer_all'}

--- a/allways/assets/subtensor.py
+++ b/allways/assets/subtensor.py
@@ -548,7 +548,7 @@ class Tao(Asset, Chain):
         else None. The TAO sibling of the BTC/SOL deposit scanners: a hash-finder only — the
         seam's confirm re-verifies everything by hash, so a miss here just means the manual
         rescue paths. An unretrievable block is skipped and not revisited (the cursor moves on)."""
-        head = self.get_current_block_height()
+        head = self.chain.get_current_block_height()
         if head is None:
             return None
         key = (from_addr, to_addr, int(amount))

--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -462,7 +462,7 @@ def sign_or_prompt_external(
     Returns an empty string when no valid signature is obtained.
     """
     try:
-        signature = provider.sign_from_proof(address, message, key)
+        signature = provider.chain.sign_from_proof(address, message, key)
     except Exception as e:
         bt.logging.warning(f'Internal signing failed ({type(e).__name__}): {e}')
         signature = ''
@@ -487,7 +487,7 @@ def sign_or_prompt_external(
         return ''
 
     try:
-        verified = provider.verify_from_proof(address, message, pasted)
+        verified = provider.chain.verify_from_proof(address, message, pasted)
     except Exception as e:
         console.print(f'[red]Signature verification errored: {e}[/red]')
         return ''

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -100,7 +100,7 @@ def clear_provider_caches(self: Validator) -> None:
     for provider in self.assets.values():
         if hasattr(provider, 'clear_cache'):
             provider.clear_cache()
-        provider.clear_pass_tip()  # reset the per-pass hoisted chain tip (one getSlot/pass, not per-leg)
+        provider.chain.clear_pass_tip()  # reset the per-pass hoisted chain tip (one getSlot/pass, not per-leg)
 
 
 def ingest_solana_events(self: Validator) -> None:

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -98,12 +98,8 @@ async def forward(self: Validator) -> None:
 
 def clear_provider_caches(self: Validator) -> None:
     for provider in self.assets.values():
-        try:
-            provider.clear_cache()
-            provider.chain.clear_pass_tip()  # reset the per-pass hoisted chain tip (one getSlot/pass, not per-leg)
-        except Exception as e:
-            # One broken asset must not leave every other chain serving stale tips.
-            bt.logging.warning(f'{type(provider).__name__}: cache clear failed: {e}')
+        provider.clear_cache()
+        provider.chain.clear_pass_tip()  # reset the per-pass hoisted chain tip (one getSlot/pass, not per-leg)
 
 
 def ingest_solana_events(self: Validator) -> None:

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -98,9 +98,12 @@ async def forward(self: Validator) -> None:
 
 def clear_provider_caches(self: Validator) -> None:
     for provider in self.assets.values():
-        if hasattr(provider, 'clear_cache'):
+        try:
             provider.clear_cache()
-        provider.chain.clear_pass_tip()  # reset the per-pass hoisted chain tip (one getSlot/pass, not per-leg)
+            provider.chain.clear_pass_tip()  # reset the per-pass hoisted chain tip (one getSlot/pass, not per-leg)
+        except Exception as e:
+            # One broken asset must not leave every other chain serving stale tips.
+            bt.logging.warning(f'{type(provider).__name__}: cache clear failed: {e}')
 
 
 def ingest_solana_events(self: Validator) -> None:

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -149,11 +149,13 @@ class Validator(BaseValidatorNeuron):
 
         # Separate subtensor + chain providers for the axon handlers (thread safety).
         # axon_lock serialises every call on axon_subtensor's websocket so two handler
-        # threads can't both land in recv. The miner-activate / swap-confirm handlers
-        # read registration + source chains off these; scoring bounds come off Solana.
+        # threads can't both land in recv. The TAO provider gets its own dedicated
+        # connection instead of sharing that websocket: a TAO source verify can scan
+        # blocks for seconds, so holding axon_lock across it would stall every other
+        # handler, and running it unlocked would race the locked reads' recv (#456).
         self.axon_lock = threading.RLock()
         self.axon_subtensor = bt.Subtensor(config=self.config)
-        self.axon_assets = create_assets(subtensor=self.axon_subtensor, solana_rpc_url=solana_rpc_url)
+        self.axon_assets = create_assets(subtensor=bt.Subtensor(config=self.config), solana_rpc_url=solana_rpc_url)
         bt.logging.debug(f'Validator components: fee_divisor={self.fee_divisor}')
 
         # Attach synapse handlers to axon

--- a/tests/test_assets_optional.py
+++ b/tests/test_assets_optional.py
@@ -12,6 +12,10 @@ class _Boom:
 
 
 class _Ok:
+    @property
+    def chain(self):
+        return self
+
     def check_connection(self, require_send=True):
         pass
 

--- a/tests/test_bitcoin_signing.py
+++ b/tests/test_bitcoin_signing.py
@@ -145,6 +145,16 @@ class TestBitcoinSignFromProof:
         assert signature != ''
         assert provider.verify_from_proof(addr, TEST_MESSAGE, signature)
 
+    def test_uppercase_bech32_signs_and_verifies(self):
+        """BIP-173: uppercase bech32 (QR form) is the same address — sign and verify must accept it."""
+        provider = make_lightweight_provider()
+        addr, _, _ = sign_message(TEST_WIF, 'p2wpkh', 'x', deterministic=True)
+
+        signature = provider.sign_from_proof(addr.upper(), TEST_MESSAGE, key=TEST_WIF)
+
+        assert signature != ''
+        assert provider.verify_from_proof(addr.upper(), TEST_MESSAGE, signature)
+
     def test_p2tr_address_rejected(self):
         """P2TR isn't supported for BIP-137 signing — must return '' cleanly."""
         provider = make_lightweight_provider()
@@ -373,3 +383,14 @@ class TestNormalizeAddress:
         btc = Bitcoin()
         legacy = '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2'
         assert btc.normalize_address(legacy) == legacy
+
+    def test_non_string_passes_through(self):
+        assert Bitcoin().normalize_address(None) is None
+
+
+class TestCanSendFromCase:
+    def test_uppercase_bech32_matches_derived_address(self):
+        provider = make_lightweight_provider()
+        addr, _, _ = sign_message(TEST_WIF, 'p2wpkh', 'x', deterministic=True)
+        with patch.dict(os.environ, {'BTC_PRIVATE_KEY': TEST_WIF}, clear=False):
+            assert provider.can_send_from(addr.upper())

--- a/tests/test_bitcoin_signing.py
+++ b/tests/test_bitcoin_signing.py
@@ -353,3 +353,23 @@ class TestToMainnetAddress:
 
     def test_unparseable_returns_unchanged(self):
         assert to_mainnet_address('notanaddress') == 'notanaddress'
+
+
+class TestNormalizeAddress:
+    """bech32 is case-insensitive per BIP-173 (uppercase is standard in QR codes);
+    base58 legacy addresses are case-sensitive and must pass through untouched."""
+
+    def test_uppercase_bech32_matches_lowercase(self):
+        btc = Bitcoin()
+        upper = 'BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4'
+        assert btc.normalize_address(upper) == upper.lower()
+
+    def test_testnet_and_regtest_prefixes(self):
+        btc = Bitcoin()
+        assert btc.normalize_address('TB1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KXPJZSX').startswith('tb1q')
+        assert btc.normalize_address('BCRT1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KYGT080').startswith('bcrt1q')
+
+    def test_base58_passes_through_case_sensitive(self):
+        btc = Bitcoin()
+        legacy = '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2'
+        assert btc.normalize_address(legacy) == legacy

--- a/tests/test_ethereum_provider.py
+++ b/tests/test_ethereum_provider.py
@@ -1,4 +1,4 @@
-"""EvmCoin unit tests — all offline (RPC layer mocked, signing is pure crypto).
+"""Ether unit tests — all offline (RPC layer mocked, signing is pure crypto).
 
 Covers the ETH-specific hazards: EIP-55 casing at every comparison boundary, inclusion≠settlement
 (reverted txs carry intact to/value fields), receipt-unavailable must read as 'unknown' not
@@ -10,7 +10,7 @@ from typing import Optional
 import pytest
 
 from allways.assets.base import ProviderUnreachableError
-from allways.assets.ethereum import EvmCoin
+from allways.assets.ethereum import Ether
 
 # Well-known dev key (hardhat account #0) — never funded on mainnet, deterministic address.
 TEST_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
@@ -25,7 +25,7 @@ def provider(monkeypatch):
     monkeypatch.setenv('ETH_NETWORK', 'mainnet')
     monkeypatch.delenv('ETH_RPC_URLS', raising=False)
     monkeypatch.delenv('ETH_PRIVATE_KEY', raising=False)
-    return EvmCoin()
+    return Ether()
 
 
 def rpc_stub(provider, responses: dict):
@@ -427,12 +427,12 @@ class TestNetworkGuard:
         # A typo ('seplia') silently becoming mainnet would pay real ETH against test swaps.
         monkeypatch.setenv('ETH_NETWORK', 'seplia')
         with pytest.raises(ValueError, match='ETH_NETWORK'):
-            EvmCoin()
+            Ether()
 
     def test_unset_defaults_to_mainnet(self, monkeypatch):
         monkeypatch.delenv('ETH_NETWORK', raising=False)
         monkeypatch.delenv('ETH_RPC_URLS', raising=False)
-        assert EvmCoin().network == 'mainnet'
+        assert Ether().network == 'mainnet'
 
 
 class TestAbsenceQuorum:

--- a/tests/test_self_transfer_guard.py
+++ b/tests/test_self_transfer_guard.py
@@ -11,10 +11,11 @@ reward-side limits, so it still passes here.
 from typing import Optional
 
 from allways.assets.base import Asset, TransactionInfo
+from allways.assets.chain import Chain
 from allways.chains import CHAIN_TAO, ChainDefinition
 
 
-class FakeProvider(Asset):
+class FakeProvider(Asset, Chain):
     """Returns a single canned tx; only the base post-checks are exercised."""
 
     def __init__(self, tx: TransactionInfo):


### PR DESCRIPTION
## Summary
Seals the Asset/Chain seam opened by #622. The Chain ABC shipped holding only the tip read while ~8 network-level members stayed on Asset; the first token asset would have inherited that blur. This moves every member that is a fact of the network — shared by all assets on it — onto Chain, so the two ABCs read as the model states: Asset = a thing you can swap; Chain = a network you can talk to.

## Changes
- Moved Asset -> Chain: uses_substrate, tip surface (get_current_block_height + cached_block_height/clear_pass_tip/_TIP_TTL_SECONDS), is_valid_address, normalize_address, sign_from_proof, verify_from_proof. The duplicate get_current_block_height abstract on Asset is gone.
- can_send_from and check_connection stay on Asset (genuinely mixed: credentials + asset config).
- Chain questions now route through .chain at every seam crossing: verify_transaction normalizes via self.chain, forward.py clears the pass tip via provider.chain, CLI proof helpers sign/verify via provider.chain. A no-op today (fused classes are their own chain) but split-safe.
- EvmCoin -> Ether: the native coin of every EVM network IS ether (Arbitrum included), and the name joins Bitcoin/Tao/Sol instead of family jargon.

Zero behavior change: 954 passed, unchanged from baseline; test churn is the Ether rename plus one fake provider becoming honestly fused (FakeProvider(Asset, Chain)).

Note for feat/arbusdc-spoke (#623): rebase onto this — EvmChain absorbs the moved members and EvmAsset thins accordingly.