### PR TITLE
Collapse chain naming to chain_def/chain; tighten asset typing

### DIFF
--- a/allways/assets/__init__.py
+++ b/allways/assets/__init__.py
@@ -1,8 +1,8 @@
-from typing import Dict, Optional, Set, Tuple, Type
+from typing import Dict, NamedTuple, Optional, Set, Tuple, Type
 
 import bittensor as bt
 
-from allways.assets.base import Asset, TransactionInfo
+from allways.assets.base import Asset, SendResult, TransactionInfo
 from allways.assets.bitcoin import Bitcoin
 from allways.assets.chain import Chain
 from allways.assets.ethereum import Ether
@@ -11,7 +11,9 @@ from allways.assets.subtensor import Tao
 
 __all__ = [
     'Asset',
+    'AssetSpec',
     'Chain',
+    'SendResult',
     'TransactionInfo',
     'Bitcoin',
     'Tao',
@@ -20,13 +22,21 @@ __all__ = [
     'create_assets',
 ]
 
-# Registry: (chain_id, asset class, kwarg names to forward). The wire id is a "chain"
-# (program strings, DB columns, /chains); in code it resolves to an Asset.
-ASSET_REGISTRY: Tuple[Tuple[str, Type[Asset], Tuple[str, ...]], ...] = (
-    ('btc', Bitcoin, ()),
-    ('tao', Tao, ('subtensor', 'wallet')),
-    ('sol', Sol, ('solana_rpc_url', 'solana_keypair')),
-    ('eth', Ether, ()),
+
+class AssetSpec(NamedTuple):
+    """One registry row. The wire id is a "chain" (program strings, DB columns, /chains);
+    in code it resolves to an Asset built as ``cls(**forwarded create_assets kwargs)``."""
+
+    chain_id: str
+    cls: Type[Asset]
+    kwarg_names: Tuple[str, ...]  # create_assets kwargs this asset's constructor takes
+
+
+ASSET_REGISTRY: Tuple[AssetSpec, ...] = (
+    AssetSpec('btc', Bitcoin, ()),
+    AssetSpec('tao', Tao, ('subtensor', 'wallet')),
+    AssetSpec('sol', Sol, ('solana_rpc_url', 'solana_keypair')),
+    AssetSpec('eth', Ether, ()),
 )
 
 

--- a/allways/assets/base.py
+++ b/allways/assets/base.py
@@ -12,14 +12,19 @@ class ProviderUnreachableError(Exception):
     """Raised when a chain provider cannot reach its backend during verification."""
 
 
+# What ``send_amount`` resolves to: (tx_hash, block_number) on success — block_number is 0 when
+# the chain reports inclusion asynchronously — or None when the send was refused/failed.
+SendResult = Optional[Tuple[str, int]]
+
+
 @dataclass
 class TransactionInfo:
     tx_hash: str
-    confirmed: bool
-    sender: str
+    confirmed: bool  # True once the tx has the chain's min_confirmations
+    sender: str  # provable payer (first input / from / Transfer-log party); '' = unprovable
     recipient: str
-    amount: int  # Smallest unit (satoshis / rao)
-    block_number: Optional[int] = None
+    amount: int  # Smallest unit (satoshis / rao / wei / µUSDC)
+    block_number: Optional[int] = None  # None while in the mempool
     confirmations: int = 0
     block_time: Optional[int] = None  # Block's mined time, unix seconds (replay-freshness floor; B2)
 
@@ -44,8 +49,15 @@ class Asset(ABC):
     # Non-fused assets (tokens on a multi-asset chain) set this at construction.
     _chain: Optional[Chain] = None
 
+    @property
     @abstractmethod
-    def get_chain(self) -> ChainDefinition: ...
+    def chain_def(self) -> ChainDefinition:
+        """This asset's registry row (chains.py): wire id, decimals, confirmations, env prefix.
+
+        Three chain-ish names, three meanings — keep them straight:
+        ``chain_def`` (this property) = the asset's static registry FACTS;
+        ``chain`` = the live network OBJECT the asset talks through (`Chain`);
+        ``chains.get_chain(id)`` = registry LOOKUP from a wire id."""
 
     @property
     def chain(self) -> Chain:
@@ -58,7 +70,7 @@ class Asset(ABC):
 
     def describe(self) -> str:
         """One-line summary of the backend/API this provider talks to, for startup logs."""
-        return self.get_chain().name
+        return self.chain_def.name
 
     def clear_cache(self) -> None:
         """Reset per-asset scratch caches at the start of a validator pass. No-op by default."""
@@ -149,7 +161,7 @@ class Asset(ABC):
         if require_confirmed and not tx_info.confirmed:
             bt.logging.debug(
                 f'verify_transaction: tx {tx_hash[:16]}... not yet confirmed '
-                f'({tx_info.confirmations}/{self.get_chain().min_confirmations})'
+                f'({tx_info.confirmations}/{self.chain_def.min_confirmations})'
             )
             return None
 
@@ -184,9 +196,7 @@ class Asset(ABC):
         return False
 
     @abstractmethod
-    def send_amount(
-        self, to_address: str, amount: int, from_address: Optional[str] = None
-    ) -> Optional[Tuple[str, int]]:
+    def send_amount(self, to_address: str, amount: int, from_address: Optional[str] = None) -> SendResult:
         """Send funds to an address. Returns (tx_hash, block_number) or None.
 
         Providers own their own signing credentials — TAO uses the ``bt.Wallet``

--- a/allways/assets/base.py
+++ b/allways/assets/base.py
@@ -57,7 +57,7 @@ class Asset(ABC):
         Three chain-ish names, three meanings — keep them straight:
         ``chain_def`` (this property) = the asset's static registry FACTS;
         ``chain`` = the live network OBJECT the asset talks through (`Chain`);
-        ``chains.get_chain(id)`` = registry LOOKUP from a wire id."""
+        ``chains.get_chain_def(id)`` = registry LOOKUP from a wire id."""
 
     @property
     def chain(self) -> Chain:

--- a/allways/assets/base.py
+++ b/allways/assets/base.py
@@ -54,10 +54,8 @@ class Asset(ABC):
     def chain_def(self) -> ChainDefinition:
         """This asset's registry row (chains.py): wire id, decimals, confirmations, env prefix.
 
-        Three chain-ish names, three meanings — keep them straight:
-        ``chain_def`` (this property) = the asset's static registry FACTS;
-        ``chain`` = the live network OBJECT the asset talks through (`Chain`);
-        ``chains.get_chain_def(id)`` = registry LOOKUP from a wire id."""
+        ``chain_def`` is the asset's static registry FACTS (``chains.get_chain_def(id)`` reaches
+        the same row from a wire id); ``chain`` is the live network OBJECT it talks through."""
 
     @property
     def chain(self) -> Chain:

--- a/allways/assets/bitcoin.py
+++ b/allways/assets/bitcoin.py
@@ -10,7 +10,7 @@ from bitcoin_message_tool.bmt import sign_message, verify_message
 from embit.networks import NETWORKS
 from embit.script import address_to_scriptpubkey
 
-from allways.assets.base import Asset, ProviderUnreachableError, TransactionInfo
+from allways.assets.base import Asset, ProviderUnreachableError, SendResult, TransactionInfo
 from allways.assets.chain import Chain
 from allways.chains import CHAIN_BTC, ChainDefinition
 
@@ -143,7 +143,8 @@ class Bitcoin(Asset, Chain):
         self.last_send_error = msg
         bt.logging.error(msg)
 
-    def get_chain(self) -> ChainDefinition:
+    @property
+    def chain_def(self) -> ChainDefinition:
         return CHAIN_BTC
 
     def describe(self) -> str:
@@ -240,7 +241,7 @@ class Bitcoin(Asset, Chain):
             if confirmed and block_number:
                 confirmations = self.api_calc_confirmations(block_number)
 
-            min_confs = self.get_chain().min_confirmations
+            min_confs = self.chain_def.min_confirmations
             is_confirmed = confirmations >= min_confs if confirmed else False
 
             if is_confirmed:
@@ -504,7 +505,7 @@ class Bitcoin(Asset, Chain):
         amount: int,
         from_address: Optional[str] = None,
         fee_rate_override: Optional[int] = None,
-    ) -> Optional[Tuple[str, int]]:
+    ) -> SendResult:
         """Send BTC via embit + Blockstream API (no full node required). Amount in satoshis.
 
         Uses BTC_PRIVATE_KEY env var (WIF format). Supports all address types:
@@ -646,8 +647,12 @@ class Bitcoin(Asset, Chain):
             self._send_error(f'embit send failed: {type(e).__name__}: {e}')
             return None
 
-    def resolve_sender_utxos(self, from_address, type_to_script):
-        """Match from_address to address type and fetch UTXOs, or probe all types."""
+    def resolve_sender_utxos(
+        self, from_address: Optional[str], type_to_script: dict
+    ) -> Optional[Tuple[bytes, str, list, str]]:
+        """(script, address, utxos, address_type) for the funding address, or None.
+
+        Matches ``from_address`` to its address type when given, else probes all types."""
         if from_address:
             detected = detect_address_type(from_address)
             if detected not in type_to_script:
@@ -683,7 +688,9 @@ class Bitcoin(Asset, Chain):
         self._send_error('No UTXOs found for any address type')
         return None
 
-    def select_utxos(self, utxos, amount: int, is_segwit: bool, fee_rate_override: Optional[int] = None):
+    def select_utxos(
+        self, utxos: list, amount: int, is_segwit: bool, fee_rate_override: Optional[int] = None
+    ) -> Optional[Tuple[list, int, int]]:
         """Greedy UTXO selection. Returns (selected, total_in, fee) or None."""
         fee_rate = self.estimate_fee_rate(override=fee_rate_override)
         input_vsize = 68 if is_segwit else 148
@@ -769,9 +776,7 @@ class Bitcoin(Asset, Chain):
                 time.sleep(3)
         return BTC_MIN_FEE_RATE
 
-    def send_amount(
-        self, to_address: str, amount: int, from_address: Optional[str] = None
-    ) -> Optional[Tuple[str, int]]:
+    def send_amount(self, to_address: str, amount: int, from_address: Optional[str] = None) -> SendResult:
         """Send BTC via embit + Esplora. Returns (tx_hash, block_number) or None.
 
         Signing credentials come from ``BTC_PRIVATE_KEY``, not from the caller.

--- a/allways/assets/ethereum.py
+++ b/allways/assets/ethereum.py
@@ -2,7 +2,7 @@ import os
 import re
 import time
 from collections import OrderedDict
-from typing import Any, Dict, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 from urllib.parse import urlparse
 
 import bittensor as bt
@@ -11,7 +11,10 @@ from eth_account import Account
 from eth_account.messages import encode_defunct
 from eth_utils import is_checksum_address
 
-from allways.assets.base import Asset, ProviderUnreachableError, TransactionInfo
+if TYPE_CHECKING:
+    from eth_account.signers.local import LocalAccount
+
+from allways.assets.base import Asset, ProviderUnreachableError, SendResult, TransactionInfo
 from allways.assets.chain import Chain
 from allways.chains import CHAIN_ETH, ChainDefinition
 
@@ -100,7 +103,8 @@ class Ether(Asset, Chain):
         self.last_send_error = msg
         bt.logging.error(msg)
 
-    def get_chain(self) -> ChainDefinition:
+    @property
+    def chain_def(self) -> ChainDefinition:
         return CHAIN_ETH
 
     def describe(self) -> str:
@@ -253,7 +257,7 @@ class Ether(Asset, Chain):
             block_time = cached['block_time']
             tip = self.chain.cached_block_height()
             confirmations = max(0, tip - block_number + 1) if tip is not None else 0
-            is_confirmed = confirmations >= self.get_chain().min_confirmations
+            is_confirmed = confirmations >= self.chain_def.min_confirmations
         else:
             try:
                 receipt = self.eth_rpc('eth_getTransactionReceipt', [tx_hash])
@@ -268,7 +272,7 @@ class Ether(Asset, Chain):
             block_number = int(receipt['blockNumber'], 16)
             tip = self.chain.cached_block_height()
             confirmations = max(0, tip - block_number + 1) if tip is not None else 0
-            is_confirmed = confirmations >= self.get_chain().min_confirmations
+            is_confirmed = confirmations >= self.chain_def.min_confirmations
 
             # The freshness gate fails closed on a missing block_time, so an unreadable
             # timestamp must be 'unknown' (raise), never a verdict — same as the receipt above.
@@ -334,7 +338,7 @@ class Ether(Asset, Chain):
             return True
         return is_checksum_address(address)
 
-    def _account(self, key: Optional[Any] = None):
+    def _account(self, key: Optional[Any] = None) -> Optional['LocalAccount']:
         raw = key if isinstance(key, str) and key else os.environ.get('ETH_PRIVATE_KEY')
         if not raw:
             return None
@@ -376,9 +380,7 @@ class Ether(Asset, Chain):
 
     # --- Sending ---
 
-    def send_amount(
-        self, to_address: str, amount: int, from_address: Optional[str] = None
-    ) -> Optional[Tuple[str, int]]:
+    def send_amount(self, to_address: str, amount: int, from_address: Optional[str] = None) -> SendResult:
         """Send ETH via a type-2 (EIP-1559) transfer signed with ETH_PRIVATE_KEY. Amount in wei.
 
         ``from_address`` (the miner's committed address) must match the key — validators
@@ -527,7 +529,7 @@ class Ether(Asset, Chain):
         either side. Raises when the chain view is unavailable (caller defers)."""
         tip = int(self.eth_rpc('eth_blockNumber', []), 16)
         # Probe depth clamped to what non-archive public nodes serve (~128 blocks).
-        span = min(120, max(0, int(time.time()) - int(since_unix)) // self.get_chain().seconds_per_block)
+        span = min(120, max(0, int(time.time()) - int(since_unix)) // self.chain_def.seconds_per_block)
         probes = ['latest'] + [hex(max(0, tip - span // d)) for d in (1, 2)]
         return any((self.eth_rpc('eth_getCode', [address, b]) or '0x') != '0x' for b in probes)
 

--- a/allways/assets/ethereum.py
+++ b/allways/assets/ethereum.py
@@ -2,7 +2,7 @@ import os
 import re
 import time
 from collections import OrderedDict
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 from urllib.parse import urlparse
 
 import bittensor as bt
@@ -10,9 +10,6 @@ import requests
 from eth_account import Account
 from eth_account.messages import encode_defunct
 from eth_utils import is_checksum_address
-
-if TYPE_CHECKING:
-    from eth_account.signers.local import LocalAccount
 
 from allways.assets.base import Asset, ProviderUnreachableError, SendResult, TransactionInfo
 from allways.assets.chain import Chain
@@ -338,7 +335,7 @@ class Ether(Asset, Chain):
             return True
         return is_checksum_address(address)
 
-    def _account(self, key: Optional[Any] = None) -> Optional['LocalAccount']:
+    def _account(self, key: Optional[Any] = None):
         raw = key if isinstance(key, str) and key else os.environ.get('ETH_PRIVATE_KEY')
         if not raw:
             return None

--- a/allways/assets/solana.py
+++ b/allways/assets/solana.py
@@ -1,6 +1,6 @@
 import base64
 import time
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional
 
 import bittensor as bt
 import requests
@@ -8,7 +8,7 @@ from solders.keypair import Keypair
 from solders.pubkey import Pubkey
 from solders.signature import Signature
 
-from allways.assets.base import Asset, ProviderUnreachableError, TransactionInfo
+from allways.assets.base import Asset, ProviderUnreachableError, SendResult, TransactionInfo
 from allways.assets.chain import Chain
 from allways.chains import CHAIN_SOL, ChainDefinition
 from allways.solana.rpc import SolanaRpc, resolve_rpc_url
@@ -40,7 +40,8 @@ class Sol(Asset, Chain):
         self.rpc = SolanaRpc(self.rpc_url, timeout=timeout)
         self.keypair = solana_keypair
 
-    def get_chain(self) -> ChainDefinition:
+    @property
+    def chain_def(self) -> ChainDefinition:
         return CHAIN_SOL
 
     def describe(self) -> str:
@@ -109,7 +110,7 @@ class Sol(Asset, Chain):
         sender = keys[0] if keys else ''  # fee payer / first signer == the transfer source
         return TransactionInfo(
             tx_hash=tx_hash,
-            confirmed=confirmations >= self.get_chain().min_confirmations,
+            confirmed=confirmations >= self.chain_def.min_confirmations,
             sender=sender,
             recipient=expected_recipient,
             amount=credit,
@@ -238,9 +239,7 @@ class Sol(Asset, Chain):
             bt.logging.error(f'{LOG_SOL} verify_from_proof failed: {e}')
             return False
 
-    def send_amount(
-        self, to_address: str, amount: int, from_address: Optional[str] = None
-    ) -> Optional[Tuple[str, int]]:
+    def send_amount(self, to_address: str, amount: int, from_address: Optional[str] = None) -> SendResult:
         """Send ``amount`` lamports to ``to_address`` via SystemProgram transfer.
 
         Signs with the provider's own keypair (callers pass no key material). Returns

--- a/allways/assets/subtensor.py
+++ b/allways/assets/subtensor.py
@@ -5,7 +5,7 @@ import bittensor as bt
 from bittensor import Keypair
 from bittensor.utils import is_valid_ss58_address, ss58_encode
 
-from allways.assets.base import Asset, ProviderUnreachableError, TransactionInfo
+from allways.assets.base import Asset, ProviderUnreachableError, SendResult, TransactionInfo
 from allways.assets.chain import Chain
 from allways.chains import CHAIN_TAO, ChainDefinition
 
@@ -34,7 +34,8 @@ class Tao(Asset, Chain):
         # Deposit-scanner head cursors, keyed per (from, to, amount) triple — see find_recent_outgoing.
         self.scan_cursors: Dict[Tuple[str, str, int], int] = {}
 
-    def get_chain(self) -> ChainDefinition:
+    @property
+    def chain_def(self) -> ChainDefinition:
         return CHAIN_TAO
 
     def describe(self) -> str:
@@ -50,7 +51,7 @@ class Tao(Asset, Chain):
         except Exception as e:
             raise ConnectionError(f'Cannot reach Subtensor: {e}') from e
 
-    def clear_cache(self):
+    def clear_cache(self) -> None:
         """Clear the block cache. Call at the start of each poll cycle."""
         self.block_cache.clear()
         self.block_hash_cache.clear()
@@ -446,7 +447,7 @@ class Tao(Asset, Chain):
 
                     return TransactionInfo(
                         tx_hash=tx_hash,
-                        confirmed=confs >= self.get_chain().min_confirmations,
+                        confirmed=confs >= self.chain_def.min_confirmations,
                         sender=settled_sender,
                         recipient=expected_recipient,
                         amount=settled_amount,
@@ -624,9 +625,7 @@ class Tao(Asset, Chain):
             bt.logging.error(f'TAO verify_from_proof failed: {e}')
             return False
 
-    def send_amount(
-        self, to_address: str, amount: int, from_address: Optional[str] = None
-    ) -> Optional[Tuple[str, int]]:
+    def send_amount(self, to_address: str, amount: int, from_address: Optional[str] = None) -> SendResult:
         """Send TAO via subtensor transfer. Amount is in rao."""
         if self.wallet is None:
             bt.logging.error('TAO send_amount called on a read-only Tao (no wallet)')

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -96,8 +96,10 @@ SUPPORTED_CHAINS = {
 }
 
 
-def get_chain(chain_id: str) -> ChainDefinition:
-    """Lookup chain by ID. Raises KeyError if unsupported."""
+def get_chain_def(chain_id: str) -> ChainDefinition:
+    """Registry lookup: wire id → its ChainDefinition. Raises KeyError if unsupported.
+
+    Same facts as ``Asset.chain_def``, reached from an id instead of an asset."""
     return SUPPORTED_CHAINS[chain_id]
 
 
@@ -129,7 +131,7 @@ def compute_extension_target_secs(chain_id: str, confirmations: int, now_unix: i
     Covers the leg's remaining confirmations plus a padding buffer, bucket-rounded (in seconds) so
     validators converge, then clamped to the contract ceiling (``max_extend_at``).
     """
-    chain = get_chain(chain_id)
+    chain = get_chain_def(chain_id)
     remaining = max(0, chain.min_confirmations - confirmations)
     target = now_unix + remaining * chain.seconds_per_block + EXTENSION_PADDING_SECONDS
     target = math.ceil(target / EXTENSION_BUCKET_SECONDS) * EXTENSION_BUCKET_SECONDS

--- a/allways/cli/swap_commands/quote.py
+++ b/allways/cli/swap_commands/quote.py
@@ -10,7 +10,7 @@ import click
 from rich.table import Table
 from rich.text import Text
 
-from allways.chains import SUPPORTED_CHAINS, get_chain
+from allways.chains import SUPPORTED_CHAINS, get_chain_def
 from allways.cli.swap_commands.helpers import (
     FINITE_FLOAT,
     console,
@@ -81,7 +81,7 @@ def quote_command(from_chain: str, to_chain: str, amount: float, as_json: bool):
     max_swap = int(getattr(cfg, 'max_swap_amount', 0)) if cfg else 0
 
     from_amount = to_smallest_units(amount, from_chain)
-    to_dec = get_chain(to_chain).decimals
+    to_dec = get_chain_def(to_chain).decimals
 
     book = load_miner_book(client, with_reservation=False)
     candidates = []

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -604,10 +604,9 @@ def _source_provider(from_chain: str, client, config):
     (→ manual fallback) if the provider can't be built with send credentials."""
     from allways.assets import ASSET_REGISTRY
 
-    entry = next((e for e in ASSET_REGISTRY if e[0] == from_chain), None)
-    if entry is None:
+    spec = next((s for s in ASSET_REGISTRY if s.chain_id == from_chain), None)
+    if spec is None:
         return None
-    _id, cls, kwarg_names = entry
 
     avail = {'solana_rpc_url': client.rpc.url, 'solana_keypair': client.keypair}
     if from_chain == 'tao':
@@ -616,7 +615,7 @@ def _source_provider(from_chain: str, client, config):
         _cfg, wallet, subtensor, _ = get_cli_context(need_wallet=True)
         avail.update(subtensor=subtensor, wallet=wallet)
     try:
-        provider = cls(**{k: avail[k] for k in kwarg_names if k in avail})
+        provider = spec.cls(**{k: avail[k] for k in spec.kwarg_names if k in avail})
         provider.check_connection(require_send=True)
     except Exception as e:  # noqa: BLE001 - missing creds (e.g. no BTC_PRIVATE_KEY) → manual fallback
         console.print(f'[dim]  Auto-send unavailable for {from_chain.upper()} ({e}); use the manual flow.[/dim]')

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -15,7 +15,7 @@ from typing import List, NamedTuple, Optional
 
 import click
 
-from allways.chains import SUPPORTED_CHAINS, get_chain
+from allways.chains import SUPPORTED_CHAINS, get_chain_def
 from allways.cli.dendrite_lite import (
     broadcast_synapse,
     discover_validators,
@@ -188,7 +188,7 @@ MINER_RATE_WARN_FRACTION = 0.5
 
 
 def _net_receive(to_amount: int, to_chain: str) -> float:
-    return apply_fee_deduction(to_amount, FEE_DIVISOR) / 10 ** get_chain(to_chain).decimals
+    return apply_fee_deduction(to_amount, FEE_DIVISOR) / 10 ** get_chain_def(to_chain).decimals
 
 
 def _named_intake(miner_opt, candidates, viable, from_chain, to_chain, from_amount, min_swap, max_swap):
@@ -210,7 +210,7 @@ def _pick_intake(viable, from_chain, to_chain):
     if not sys.stdin.isatty():
         fail('Bare --miner needs a terminal; pass --miner <pubkey> when scripting.')
     ranked = sorted(viable, key=lambda p: p[1].to_amount, reverse=True)
-    sol_decimals = get_chain(NUMERAIRE_CHAIN).decimals
+    sol_decimals = get_chain_def(NUMERAIRE_CHAIN).decimals
     console.print(f'\n  Miners quoting {from_chain.upper()}->{to_chain.upper()} (best first):')
     for i, (c, amts) in enumerate(ranked, 1):
         rate_disp = directional_rate(from_chain, to_chain, c.rate_display)
@@ -456,7 +456,7 @@ def swap_now_command(
         f'{to_chain.upper()}/{from_chain.upper()}{pinned_note})\n'
     )
     if contention.is_open and not resuming:
-        fee_sol = int(getattr(cfg, 'reservation_fee_lamports', 0)) / 10 ** get_chain(NUMERAIRE_CHAIN).decimals
+        fee_sol = int(getattr(cfg, 'reservation_fee_lamports', 0)) / 10 ** get_chain_def(NUMERAIRE_CHAIN).decimals
         if contention.weighted_rivals > 0:
             hopeless = '' if routed else ', so a self-represented taker is very unlikely to win this draw'
             console.print(
@@ -541,7 +541,7 @@ def swap_now_command(
             pool_window,
             drawn=existing if resume_drawn else None,
         )
-    recv = apply_fee_deduction(int(resv.to_amount), FEE_DIVISOR) / 10 ** get_chain(to_chain).decimals
+    recv = apply_fee_deduction(int(resv.to_amount), FEE_DIVISOR) / 10 ** get_chain_def(to_chain).decimals
     console.print(f'[green]  Seat filled[/green] — receiving ~[cyan]{recv:.8g} {to_chain.upper()}[/cyan].')
     # Never instruct a send the reservation can't outlive: a deposit that lands after reserved_until
     # yields no claim, and the funds are stranded (straight to the miner — no escrow, no Swap, no
@@ -660,7 +660,7 @@ def _auto_send_wizard(client, config, resv, miner_pk, from_chain, to_chain, from
         )
         return False
 
-    amount_disp = int(resv.from_amount) / 10 ** get_chain(from_chain).decimals
+    amount_disp = int(resv.from_amount) / 10 ** get_chain_def(from_chain).decimals
     to_addr = resv.miner_from_addr
     wallet_label = {
         'sol': 'Solana keypair',

--- a/allways/cli/swap_commands/swap_intake.py
+++ b/allways/cli/swap_commands/swap_intake.py
@@ -10,7 +10,7 @@ CLI taker path and the validator reserve engine build the same candidate set fro
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
-from allways.chains import canonical_pair, get_chain
+from allways.chains import canonical_pair, get_chain_def
 from allways.constants import COLLATERAL_REQUIREMENT_BPS, NUMERAIRE_CHAIN, RATE_PRECISION, required_collateral
 from allways.utils.rate import (
     calculate_to_amount,
@@ -37,7 +37,7 @@ class MinerCandidate:
 
 def to_smallest_units(amount: float, chain: str) -> int:
     """Display amount (e.g. 0.1 BTC) → smallest units (sat/lamport/rao)."""
-    return int(round(amount * 10 ** get_chain(chain).decimals))
+    return int(round(amount * 10 ** get_chain_def(chain).decimals))
 
 
 def rate_display_from_fixed(rate_fixed: int) -> str:
@@ -82,7 +82,7 @@ def compute_intake_amounts(from_chain: str, to_chain: str, from_amount: int, rat
     canon_from, canon_to = canonical_pair(from_chain, to_chain)
     is_reverse = from_chain != canon_from
     to_amount = calculate_to_amount(
-        from_amount, rate_display, is_reverse, get_chain(canon_to).decimals, get_chain(canon_from).decimals
+        from_amount, rate_display, is_reverse, get_chain_def(canon_to).decimals, get_chain_def(canon_from).decimals
     )
     collateral_amount = from_amount if from_chain == NUMERAIRE_CHAIN else to_amount
     return IntakeAmounts(collateral_amount=collateral_amount, from_amount=from_amount, to_amount=to_amount)
@@ -171,7 +171,7 @@ def max_intake_from_amount(
         return cap
     canon_from, canon_to = canonical_pair(from_chain, to_chain)
     return max_from_for_to_cap(
-        cap, candidate.rate_display, True, get_chain(canon_to).decimals, get_chain(canon_from).decimals
+        cap, candidate.rate_display, True, get_chain_def(canon_to).decimals, get_chain_def(canon_from).decimals
     )
 
 

--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -14,7 +14,7 @@ from rich.table import Table
 from rich.text import Text
 from solders.pubkey import Pubkey
 
-from allways.chains import SUPPORTED_CHAINS, get_chain
+from allways.chains import SUPPORTED_CHAINS, get_chain_def
 from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
     FINITE_FLOAT,
@@ -355,8 +355,8 @@ def view_active_swaps(status_filter, as_json):
 
 
 def _render_swap_detail(s):
-    to_dec = get_chain(s.to_chain).decimals
-    from_dec = get_chain(s.from_chain).decimals
+    to_dec = get_chain_def(s.to_chain).decimals
+    from_dec = get_chain_def(s.from_chain).decimals
     console.print(f'\n[bold]Swap {s.key_hex[:16]}[/bold]\n')
     console.print(f'  Status:      [bold]{s.status}[/bold]')
     console.print(f'  Pair:        {s.from_chain.upper()} → {s.to_chain.upper()}')
@@ -567,8 +567,8 @@ def view_reservation(miner_pk, as_json):
     now = int(time.time())
     remaining = max(0, int(resv.reserved_until) - now)
     claimed = bytes(resv.claimed_swap_key) != ZERO_SWAP_KEY
-    to_dec = get_chain(resv.to_chain).decimals
-    from_dec = get_chain(resv.from_chain).decimals
+    to_dec = get_chain_def(resv.to_chain).decimals
+    from_dec = get_chain_def(resv.from_chain).decimals
 
     if as_json:
         print_json(

--- a/allways/utils/rate.py
+++ b/allways/utils/rate.py
@@ -4,7 +4,7 @@ import math
 from decimal import Decimal
 from typing import TYPE_CHECKING, Tuple
 
-from allways.chains import canonical_pair, get_chain
+from allways.chains import canonical_pair, get_chain_def
 from allways.constants import NUMERAIRE_CHAIN, RATE_PRECISION, RATE_SIG_FIGS
 
 if TYPE_CHECKING:
@@ -140,8 +140,8 @@ def expected_swap_amounts(swap: 'SolanaSwap', fee_divisor: int) -> Tuple[int, in
         swap.from_amount,
         swap.rate,
         is_reverse,
-        get_chain(canon_to).decimals,
-        get_chain(canon_from).decimals,
+        get_chain_def(canon_to).decimals,
+        get_chain_def(canon_from).decimals,
     )
     if to_amount == 0:
         return 0, 0
@@ -193,8 +193,8 @@ def is_executable_rate(
     def _has_integer_routable_source(forward_rate: float, src_chain: str) -> bool:
         # For a "src → sol" direction at ``forward_rate`` (sol per src), is there an src amount that is
         # fundable on-chain (>= the chain's min_onchain_amount) whose SOL leg lands in bounds?
-        src = get_chain(src_chain)
-        decimal_factor = 10 ** (get_chain(NUMERAIRE_CHAIN).decimals - src.decimals)
+        src = get_chain_def(src_chain)
+        decimal_factor = 10 ** (get_chain_def(NUMERAIRE_CHAIN).decimals - src.decimals)
         denom = forward_rate * decimal_factor
         if not math.isfinite(denom) or denom <= 0:
             # rate × decimal_factor overflowed → smallest positive integer source already maps above max.
@@ -240,10 +240,10 @@ def min_executable_sol_leg(
     if not is_executable_rate(rate, from_chain, to_chain, min_swap_lamports, max_swap_lamports):
         return 0
     if from_chain == NUMERAIRE_CHAIN:
-        return max(get_chain(NUMERAIRE_CHAIN).min_onchain_amount, max(0, min_swap_lamports))
+        return max(get_chain_def(NUMERAIRE_CHAIN).min_onchain_amount, max(0, min_swap_lamports))
     if to_chain == NUMERAIRE_CHAIN:
-        src = get_chain(from_chain)
-        decimal_factor = 10 ** (get_chain(NUMERAIRE_CHAIN).decimals - src.decimals)
+        src = get_chain_def(from_chain)
+        decimal_factor = 10 ** (get_chain_def(NUMERAIRE_CHAIN).decimals - src.decimals)
         denom = rate * decimal_factor
         if not math.isfinite(denom) or denom <= 0:
             return 0

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -325,7 +325,7 @@ def confirm_deposit(validator, miner_hotkey: str, from_tx_hash: str, from_tx_blo
     # confirms (source 'pending'->extend, 'ok'+fresh->attest). A 0-conf mempool tx has no block_time, so its
     # freshness is deferred too; only a mined tx is freshness-checked here (fast-fail a stale mined deposit).
     if tx_info.block_time is not None:
-        grace = getattr(provider.get_chain(), 'replay_grace_secs', 0)
+        grace = getattr(provider.chain_def, 'replay_grace_secs', 0)
         if not is_tx_fresh(tx_info, int(reservation.created_at), grace):
             return ConfirmResult(False, 'Source tx fails freshness — stale/replayed deposit')
 

--- a/allways/validator/solana_swap_loop.py
+++ b/allways/validator/solana_swap_loop.py
@@ -165,7 +165,7 @@ class SolanaSwapLoop:
         would silently always-pass). Fresh iff block_time >= floor - grace; a per-chain GRACE (default 0)
         absorbs honest clock skew. Fails closed if block_time is missing."""
         provider = self.providers.get(chain)
-        grace = getattr(provider.get_chain(), 'replay_grace_secs', 0) if provider else 0
+        grace = getattr(provider.chain_def, 'replay_grace_secs', 0) if provider else 0
         if not is_tx_fresh(info, floor_unix, grace):
             bt.logging.warning(
                 f'{label}: {chain} tx block_time {getattr(info, "block_time", None)} predates floor '

--- a/allways/validator/solana_swap_loop.py
+++ b/allways/validator/solana_swap_loop.py
@@ -18,7 +18,7 @@ from solders.pubkey import Pubkey
 
 from allways import dev_signal
 from allways.assets.base import ProviderUnreachableError
-from allways.chains import compute_extension_target_secs, get_chain
+from allways.chains import compute_extension_target_secs, get_chain_def
 from allways.constants import EXTENSION_PADDING_SECONDS
 from allways.solana import pdas
 from allways.solana.client import benign_marker, swap_from_solana, swap_key_from_tx_hash
@@ -84,7 +84,7 @@ def _status_name(swap: Any) -> str:
 def _confs(chain_id: str, info: Any) -> str:
     """Confirmation progress of a leg, e.g. '1/2 confs'. Unmined or absent legs read 0."""
     have = int(getattr(info, 'confirmations', 0) or 0)
-    return f'{have}/{get_chain(chain_id).min_confirmations} confs'
+    return f'{have}/{get_chain_def(chain_id).min_confirmations} confs'
 
 
 def _swap_key_hex(key: Any) -> str:

--- a/tests/test_axon_solana_handlers.py
+++ b/tests/test_axon_solana_handlers.py
@@ -64,7 +64,8 @@ class FakeProvider:
         self.tx_info = tx_info
         self.grace = grace
 
-    def get_chain(self):
+    @property
+    def chain_def(self):
         return SimpleNamespace(replay_grace_secs=self.grace)
 
     def verify_transaction(self, **kw):

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -9,23 +9,23 @@ from allways.chains import (
     EXTENSION_BUCKET_SECONDS,
     canonical_pair,
     compute_extension_target_secs,
-    get_chain,
+    get_chain_def,
 )
 
 
 class TestGetChain:
     def test_btc(self):
-        assert get_chain('btc') is CHAIN_BTC
+        assert get_chain_def('btc') is CHAIN_BTC
 
     def test_tao(self):
-        assert get_chain('tao') is CHAIN_TAO
+        assert get_chain_def('tao') is CHAIN_TAO
 
     def test_eth(self):
-        assert get_chain('eth') is CHAIN_ETH
+        assert get_chain_def('eth') is CHAIN_ETH
 
     def test_unsupported_raises(self):
         with pytest.raises(KeyError):
-            get_chain('doge')
+            get_chain_def('doge')
 
 
 class TestCanonicalPair:

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -2,7 +2,7 @@
 
 from decimal import Decimal
 
-from allways.chains import get_chain
+from allways.chains import get_chain_def
 from allways.constants import BTC_TO_SAT, RATE_PRECISION, TAO_TO_RAO
 from allways.utils.rate import (
     apply_fee_deduction,
@@ -386,7 +386,7 @@ class TestIsExecutableRate:
         """Symmetric out of SOL: 1e-10 TAO/SOL → inverse 1e10 overshoots on the SOL leg."""
         assert is_executable_rate(1e-10, 'sol', 'tao', self.MIN, self.MAX) is False
 
-    DUST = get_chain('btc').min_onchain_amount  # smallest fundable BTC source
+    DUST = get_chain_def('btc').min_onchain_amount  # smallest fundable BTC source
 
     def test_sub_dust_boundary_rate_rejected(self):
         """At max_swap/10, the only in-bounds source is 1 sat — below the BTC

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -420,7 +420,8 @@ class _FakeProvider:
             raise ProviderUnreachableError('down')
         return self._tx
 
-    def get_chain(self):
+    @property
+    def chain_def(self):
         return SimpleNamespace(replay_grace_secs=self._grace)
 
 

--- a/tests/test_self_transfer_guard.py
+++ b/tests/test_self_transfer_guard.py
@@ -21,7 +21,8 @@ class FakeProvider(Asset, Chain):
     def __init__(self, tx: TransactionInfo):
         self._tx = tx
 
-    def get_chain(self) -> ChainDefinition:
+    @property
+    def chain_def(self) -> ChainDefinition:
         return CHAIN_TAO
 
     def check_connection(self, **kwargs) -> None: ...

--- a/tests/test_solana_provider.py
+++ b/tests/test_solana_provider.py
@@ -238,7 +238,7 @@ class TestSend:
 
 def test_chain_metadata():
     p = provider_with(FakeRpc())
-    chain = p.get_chain()
+    chain = p.chain_def
     assert chain is CHAIN_SOL
     assert chain.id == 'sol' and chain.native_unit == 'lamport' and chain.decimals == 9
     assert chain.min_onchain_amount == 890880  # rent-exempt floor (0-data System account)

--- a/tests/test_solana_swap_loop.py
+++ b/tests/test_solana_swap_loop.py
@@ -74,7 +74,8 @@ class RecordingProvider:
             raise ProviderUnreachableError('down')
         return self.refuses
 
-    def get_chain(self):
+    @property
+    def chain_def(self):
         return SimpleNamespace(replay_grace_secs=self.grace)
 
     def verify_transaction(self, tx_hash, expected_recipient, expected_amount, block_hint=0, expected_sender=None):

--- a/tests/test_swap_now_reservation.py
+++ b/tests/test_swap_now_reservation.py
@@ -70,9 +70,9 @@ def test_send_margin_does_not_scale_with_confirmation_depth():
     """The margin covers relaying the claim on-chain, not waiting for confirmations. It must therefore
     fit inside a freshly-won reservation (ttl 480s, minus the ~60-80s pool draw) for EVERY chain —
     including BTC, whose 2 x 600s confirmation wait alone exceeds the whole TTL."""
-    from allways.chains import get_chain
+    from allways.chains import get_chain_def
 
-    btc = get_chain('btc')
+    btc = get_chain_def('btc')
     assert btc.min_confirmations * btc.seconds_per_block > _SEND_MARGIN_SECS
     assert _SEND_MARGIN_SECS < 480 - 80  # clears a fresh reservation post-draw, on any source chain
 


### PR DESCRIPTION
**TLDR: after #624, three chain-ish spellings meant three different things — `chains.get_chain(id)` (registry lookup), `Asset.get_chain()` (this asset's registry row), `Asset.chain` (the live network object). This PR collapses them to two concepts with two names: `chain_def` = the registry FACTS (as `asset.chain_def` from an asset, `chains.get_chain_def(id)` from a wire id — same noun, same return type), and `chain` = the network OBJECT. Plus a typing pass over the asset layer. Zero behavior change — stacked on #624, merges right after it.**

## The renames

- `Asset.get_chain()` → **`asset.chain_def`** (property) — the asset's static registry row (id, decimals, confirmations, env prefix)
- `chains.get_chain(id)` → **`chains.get_chain_def(id)`** — the same facts, looked up by wire id
- `asset.chain` — unchanged (#624's network object)

Every fact-accessor now shares the `chain_def` noun and returns `ChainDefinition`; `chain` alone always means the network. The distinction is documented once on the `chain_def` property, where readers land. Registry symbols (`SUPPORTED_CHAINS`, `CHAIN_*`, `ChainDefinition`) are untouched — the das drift gate parses `ChainDefinition(` blocks and `': CHAIN_'` rows only (verified against `check-chain-drift.mjs`), and `chain_def` stays within chain vocabulary, so the #622 wire-vocab rule holds. alw-utils has zero `get_chain` callers (verified).

## The typing

- `SendResult = Optional[Tuple[str, int]]` — `send_amount`'s return shape was the least self-evident in the codebase; the alias carries its meaning (tx_hash, block_number; block 0 = async inclusion) everywhere it's used.
- `ASSET_REGISTRY` rows are now `AssetSpec` NamedTuples — call sites read `spec.chain_id`/`spec.cls` instead of `e[0]`/`e[1]` index guessing.
- `TransactionInfo` fields annotated with their semantics (provable-sender rule, mempool sentinel, smallest units).
- Remaining un-annotated returns in `assets/` filled in (`resolve_sender_utxos`, `select_utxos`, `_account`, `clear_cache`).

Mechanical throughout; the full suite (960, including #624's review-fix tests) passes unchanged and is the review gate.