### PR TITLE
Checksum the send dest before signing EVM transactions

### DIFF
--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple
 
 import bittensor as bt
 from eth_account import Account
-from eth_utils import keccak
+from eth_utils import keccak, to_checksum_address
 
 from allways.assets.base import ProviderUnreachableError, SendResult, TransactionInfo
 from allways.assets.evm import EVM_NETWORKS, FALLBACK_PRIORITY_FEE_WEI, EvmAsset, EvmChain
@@ -365,7 +365,9 @@ class Erc20(EvmAsset):
                 {
                     'chainId': self.chain.chain_id,
                     'nonce': nonce,
-                    'to': self.token_contract,
+                    # eth-account refuses a non-checksummed `to` — a lowercase contract override
+                    # (env repoint, e2e fake) must not brick every send.
+                    'to': to_checksum_address(self.token_contract),
                     'value': 0,
                     'data': '0x' + calldata,
                     'gas': gas,

--- a/allways/assets/ethereum.py
+++ b/allways/assets/ethereum.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import bittensor as bt
 from eth_account import Account
+from eth_utils import to_checksum_address
 
 from allways.assets.base import ProviderUnreachableError, SendResult, TransactionInfo
 from allways.assets.evm import ETHEREUM, FALLBACK_PRIORITY_FEE_WEI, EvmAsset, EvmChain
@@ -221,7 +222,10 @@ class Ether(EvmAsset, EvmChain):
                 {
                     'chainId': self.chain.chain_id,
                     'nonce': nonce,
-                    'to': to_address,
+                    # eth-account refuses a non-checksummed `to`, but an ALL-LOWERCASE committed
+                    # dest is legal (EIP-55 is optional) — checksum here or the send crashes and
+                    # the miner rides to a slash on an address it could never pay.
+                    'to': to_checksum_address(to_address),
                     'value': amount,
                     'gas': gas,
                     'maxFeePerGas': max_fee,

--- a/tests/test_arbusdc_provider.py
+++ b/tests/test_arbusdc_provider.py
@@ -406,6 +406,14 @@ class TestSendGuards:
         assert SEL_TRANSFER.removeprefix('0x') in sent['raw']
         assert RECIPIENT.lower().removeprefix('0x') in sent['raw']
 
+    def test_lowercase_contract_override_still_sends(self, provider, monkeypatch):
+        # eth-account refuses a non-checksummed `to`; the sign path checksums it, so a
+        # lowercase ARBUSDC_TOKEN_CONTRACT (env repoint, e2e fake) must not brick sends.
+        monkeypatch.setenv('ARBUSDC_PRIVATE_KEY', TEST_KEY)
+        provider.token_contract = provider.token_contract.lower()
+        rpc_stub(provider, self._send_responses())
+        assert provider.send_amount(RECIPIENT, AMOUNT, from_address=TEST_ADDR) is not None
+
     def test_prior_broadcast_reused_not_resent(self, provider, monkeypatch):
         monkeypatch.setenv('ARBUSDC_PRIVATE_KEY', TEST_KEY)
         prior_tx = '0x' + 'aa' * 32

--- a/tests/test_ethereum_provider.py
+++ b/tests/test_ethereum_provider.py
@@ -512,6 +512,13 @@ class TestSendResilience:
         # After `provider`, whose fixture delenvs the key.
         monkeypatch.setenv('ETH_PRIVATE_KEY', TEST_KEY)
 
+    def test_all_lowercase_committed_dest_still_sends(self, provider):
+        # An all-lowercase dest is legal (EIP-55 is optional) and passes is_valid_address, but
+        # eth-account refuses a non-checksummed `to` — the sign path checksums it, or the miner
+        # could never pay this dest and would ride to a slash.
+        rpc_stub(provider, dict(SEND_RESPONSES, eth_sendRawTransaction='0x' + 'ee' * 32))
+        assert provider.send_amount(RECIPIENT.lower(), 10**15) is not None
+
     def test_null_broadcast_response_still_returns_the_local_hash(self, provider):
         # The hash is computed locally from the signed tx — a quirky 'result: null' from the
         # broadcast must never become a blank hash in the miner's persisted send record.


### PR DESCRIPTION
eth-account refuses a non-checksummed `to` field. An all-lowercase committed dest is legal (EIP-55 is a display checksum, optional by spec) and passes `is_valid_address` — so an ETH miner asked to pay one crashed at signing (`TypeError: Transaction had invalid fields`) on every pass, could never deliver, and rode the swap to a timeout slash on an address it had no way to pay. The getCode-based slash gate can't exempt a plain EOA, so the slash lands.

`Erc20` hits the same wall through a lowercase `ARBUSDC_TOKEN_CONTRACT` override (env repoint, e2e fake) — every send refuses.

Fix: `to_checksum_address` at the two signing sites (Ether dest, Erc20 contract). Comparison/display strings stay untouched; only the signed field is canonicalized. Found by driving the real `Erc20` provider against the e2e fake's lowercase contract address.

1042 tests (2 new: lowercase committed dest sends; lowercase contract override sends).