### PR TITLE
Fix executable-rate gate orientation to canonical rates

### DIFF
--- a/allways/chains.py
+++ b/allways/chains.py
@@ -104,11 +104,9 @@ CHAIN_ARBUSDC = ChainDefinition(
     # math) — both far inside the 600s default program grace, so no grace-table arm.
     seconds_per_block=1,
     min_confirmations=90,
-    # F1 pin — DO NOT raise until the is_executable_rate orientation fix lands: the gate
-    # consumes the canonical arbusdc-per-SOL rate as if it were SOL-per-arbusdc on the
-    # arbusdc->sol side, so a real dust floor can demand a source above max_swap and
-    # silently burn the direction's pool. ERC-20 transfers have no protocol minimum, so
-    # 1 is also honest.
+    # ERC-20 transfers have no protocol minimum, so 1 is the honest floor. (The old
+    # F1 orientation defect that made this value load-bearing is fixed in utils/rate.py;
+    # raising it to an economic floor is now safe if ever wanted.)
     min_onchain_amount=1,
     # Sequencer-stamped timestamps vs the hub clock — modest skew allowance (Arbitrum
     # timestamps are non-decreasing, but monotonicity says nothing about hub-spoke skew).

--- a/allways/utils/rate.py
+++ b/allways/utils/rate.py
@@ -171,55 +171,54 @@ def is_executable_rate(
 ) -> bool:
     """True iff the rate is fundably routable in its declared direction.
 
-    Crown-eligibility gate against rates that no user can route. The on-chain swap bounds
-    (``min_swap_amount``/``max_swap_amount``) constrain the **SOL leg** (``collateral_amount``), so SOL is the
-    bounded asset and ``min_swap_lamports``/``max_swap_lamports`` are SOL lamports. Routable means a source >= the
-    source chain's ``min_onchain_amount`` maps a SOL leg into ``[min, max]``.
+    Crown-eligibility gate against rates that no user can route. ``rate`` is the CANONICAL
+    number every caller stores and feeds — spoke per 1 SOL — in BOTH directions. The on-chain
+    swap bounds (``min_swap_amount``/``max_swap_amount``) constrain the **SOL leg**
+    (``collateral_amount``), so SOL is the bounded asset and ``min_swap_lamports``/
+    ``max_swap_lamports`` are SOL lamports. Routable means a spoke source >= the spoke's
+    ``min_onchain_amount`` maps a SOL leg into ``[min, max]``.
 
-    * X→SOL: high-side rates — even the smallest fundable source maps above ``max``, so no fundable
-      source produces an in-bounds SOL leg.
-    * SOL→X: the SOL leg IS the source, so it trivially fits any bounds, but absurd rates imply absurd
-      destinations. Caught by the symmetric check on ``1/rate``: if the inverse direction has no fundable
-      source, the original rate is at an extreme of the executable spectrum.
+    Both directions reduce to the same spoke-side question. X→SOL: an absurdly LOW canonical
+    rate (the crown-squat — lowest wins that sort) makes even 1 smallest-unit of spoke
+    overshoot ``max``, so nothing routes. SOL→X: the SOL leg is the source and trivially fits,
+    but the symmetric spoke-side check keeps the executable spectrum bounded.
 
-    A bound at ``0`` is the contract's "unset" sentinel and disables that side; both at 0 → permissive.
-    Non-SOL pairs (no SOL leg) have no bound to enforce → permissive.
+    A bound at ``0`` is the contract's "unset" sentinel and disables that side; both at 0 →
+    permissive. Non-SOL pairs (no SOL leg) have no bound to enforce → permissive.
     """
     if not math.isfinite(rate) or rate <= 0:
         return False
     if min_swap_lamports <= 0 and max_swap_lamports <= 0:
         return True
 
-    def _has_integer_routable_source(forward_rate: float, src_chain: str) -> bool:
-        # For a "src → sol" direction at ``forward_rate`` (sol per src), is there an src amount that is
-        # fundable on-chain (>= the chain's min_onchain_amount) whose SOL leg lands in bounds?
+    def _has_integer_routable_source(sol_per_source: float, src_chain: str) -> bool:
+        # For a "src → sol" leg: is there a src amount that is fundable on-chain (>= the
+        # chain's min_onchain_amount) whose SOL leg lands in bounds?
+        # sol_lamports = source_units × sol_per_source × 10**(sol_dec - src_dec).
         src = get_chain_def(src_chain)
         decimal_factor = 10 ** (get_chain_def(NUMERAIRE_CHAIN).decimals - src.decimals)
-        denom = forward_rate * decimal_factor
+        denom = sol_per_source * decimal_factor
         if not math.isfinite(denom) or denom <= 0:
-            # rate × decimal_factor overflowed → smallest positive integer source already maps above max.
             return False
         # Floor at the source chain's dust/existential minimum: a rate whose only in-bounds source is
         # below it (e.g. 1 sat) is unfundable, so unexecutable.
-        min_source = max(src.min_onchain_amount, math.ceil(max(1, min_swap_lamports) / denom))
+        lo = max(1, min_swap_lamports) / denom
+        if not math.isfinite(lo):
+            # The rate is beyond float routing math (e.g. float-max canonical) — sentinel.
+            return False
+        min_source = max(src.min_onchain_amount, math.ceil(lo))
         if max_swap_lamports <= 0:
             return True
         max_source = math.floor(max_swap_lamports / denom)
         return min_source <= max_source
 
+    # Callers feed canonical spoke-per-SOL; the source-side check wants SOL-per-spoke — invert.
+    # (The X→SOL branch used to pass the canonical rate through uninverted: the F1 orientation
+    # defect, which made any real spoke dust floor unroutable at rate² error.)
     if to_chain == NUMERAIRE_CHAIN:
-        # Forward into SOL: sol_lamports = source_units × rate × 10**(sol_dec - src_dec).
-        return _has_integer_routable_source(rate, from_chain)
-
+        return _has_integer_routable_source(1.0 / rate, from_chain)
     if from_chain == NUMERAIRE_CHAIN and to_chain != NUMERAIRE_CHAIN:
-        # Reverse out of SOL: the SOL leg is the source itself, so any positive lamport in [min, max] is
-        # trivially in bounds — but absurd rates imply destinations so large no rational user would route,
-        # and the miner can post them just to win the lowest-rate-wins crown. Treat ``1/rate`` as a
-        # ``to_chain → sol`` rate and apply the same integer-routability check by symmetry.
-        inverse = 1.0 / rate
-        if not math.isfinite(inverse) or inverse <= 0:
-            return False
-        return _has_integer_routable_source(inverse, to_chain)
+        return _has_integer_routable_source(1.0 / rate, to_chain)
 
     # Non-SOL pairs have no SOL-leg bound to enforce.
     return True
@@ -244,7 +243,8 @@ def min_executable_sol_leg(
     if to_chain == NUMERAIRE_CHAIN:
         src = get_chain_def(from_chain)
         decimal_factor = 10 ** (get_chain_def(NUMERAIRE_CHAIN).decimals - src.decimals)
-        denom = rate * decimal_factor
+        # Same orientation as the gate: canonical spoke-per-SOL in, SOL-per-spoke for the math.
+        denom = (1.0 / rate) * decimal_factor
         if not math.isfinite(denom) or denom <= 0:
             return 0
         min_source = max(src.min_onchain_amount, math.ceil(max(1, min_swap_lamports) / denom))

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -1,6 +1,8 @@
 """Tests for allways.utils.rate — to_amount calculation and fee deduction math."""
 
+from dataclasses import replace
 from decimal import Decimal
+from unittest.mock import patch
 
 from allways.chains import get_chain_def
 from allways.constants import BTC_TO_SAT, RATE_PRECISION, TAO_TO_RAO
@@ -333,29 +335,41 @@ class TestDirectionalRate:
 class TestIsExecutableRate:
     """Crown-eligibility gate against sentinel quotes that no user can route.
 
-    SOL is the bounded asset (``collateral_amount``): the contract's ``min_swap_amount``/``max_swap_amount``
-    constrain the SOL leg, in lamports. Bounds: ``min_swap=0.1 SOL``, ``max_swap=0.5 SOL``. (BTC decimals
-    8, SOL/TAO 9 → btc↔sol decimal_factor 10, same boundary arithmetic as the retired btc↔tao gate.)
+    ``rate`` is the CANONICAL number the chain stores — spoke per 1 SOL — in BOTH
+    directions (what every production caller feeds). SOL is the bounded asset
+    (``collateral_amount``): the contract's ``min_swap_amount``/``max_swap_amount``
+    constrain the SOL leg, in lamports. Bounds here: ``min_swap=0.1 SOL``, ``max_swap=0.5 SOL``.
+
+    The crown-relevant sentinel is a LOW canonical rate on the spoke→sol direction
+    (lowest wins that sort): it maps even 1 smallest-unit of spoke above ``max_swap``,
+    so nothing routes. A huge canonical rate is routable in principle and simply loses
+    the sort — permissive by design.
     """
 
     MIN = 100_000_000  # 0.1 SOL
     MAX = 500_000_000  # 0.5 SOL
 
-    def test_sane_btc_to_sol_rate_executable(self):
-        assert is_executable_rate(326.0, 'btc', 'sol', self.MIN, self.MAX) is True
+    def test_sane_btc_rates_executable_both_directions(self):
+        # ~0.0021 BTC per SOL: 0.1 SOL needs ~21_000 sats — comfortably fundable.
+        assert is_executable_rate(0.0021, 'btc', 'sol', self.MIN, self.MAX) is True
+        assert is_executable_rate(0.0021, 'sol', 'btc', self.MIN, self.MAX) is True
 
-    def test_sane_sol_to_btc_rate_executable(self):
-        assert is_executable_rate(326.0, 'sol', 'btc', self.MIN, self.MAX) is True
+    def test_crown_squat_low_btc_rate_rejected(self):
+        # 1e-12 BTC/SOL wins the btc→sol sort but maps 1 sat to 5e12 lamports —
+        # far above max_swap; no positive integer source routes.
+        assert is_executable_rate(1e-12, 'btc', 'sol', self.MIN, self.MAX) is False
+        assert is_executable_rate(1e-12, 'sol', 'btc', self.MIN, self.MAX) is False
 
-    def test_huge_btc_to_sol_rate_rejected(self):
-        """1e10 SOL/BTC: 1 sat → 1e11 lamports = 100 SOL, far above 0.5 SOL max.
-        No positive integer sat lands in [0.1, 0.5] SOL."""
-        assert is_executable_rate(1e10, 'btc', 'sol', self.MIN, self.MAX) is False
-
-    def test_float_max_btc_to_sol_rate_rejected(self):
-        """The other sentinel miners post: float-max wins the rate sort but
-        overflows the conversion math entirely."""
+    def test_float_max_rate_rejected(self):
+        """Sentinel miners post float-max: its inverse is subnormal and the band math
+        leaves float range entirely — rejected, never crashes."""
         assert is_executable_rate(1.797e308, 'btc', 'sol', self.MIN, self.MAX) is False
+        assert is_executable_rate(1.797e308, 'sol', 'btc', self.MIN, self.MAX) is False
+
+    def test_huge_rate_loses_the_sort_but_is_routable(self):
+        # 1e10 BTC/SOL is a terrible offer that can never win the crown; a (huge)
+        # source does route an in-bounds SOL leg, so the gate stays permissive.
+        assert is_executable_rate(1e10, 'btc', 'sol', self.MIN, self.MAX) is True
 
     def test_zero_rate_rejected(self):
         assert is_executable_rate(0.0, 'btc', 'sol', self.MIN, self.MAX) is False
@@ -370,31 +384,33 @@ class TestIsExecutableRate:
     def test_bounds_unset_is_permissive(self):
         """Both bounds at 0 → no on-chain limit configured → don't filter.
         Matches the contract's unset-bounds sentinel."""
-        assert is_executable_rate(1e10, 'btc', 'sol', 0, 0) is True
-        assert is_executable_rate(1e-10, 'sol', 'btc', 0, 0) is True
-
-    def test_sane_eth_rates_executable(self):
-        """ETH is the first spoke with MORE decimals than the hub (18 vs 9), so the eth↔sol
-        decimal_factor is fractional (1e-9) — the gate math must survive that regime.
-        ~20 SOL per ETH: 0.1 SOL ÷ (20 × 1e-9) = 5e6 wei min source, comfortably fundable."""
-        assert is_executable_rate(20.0, 'eth', 'sol', self.MIN, self.MAX) is True
-        assert is_executable_rate(20.0, 'sol', 'eth', self.MIN, self.MAX) is True
-
-    def test_huge_eth_to_sol_rate_rejected(self):
-        """1e20 SOL/ETH: even the min_onchain_amount source (5e13 wei) maps to
-        5e13 × 1e20 × 1e-9 = 5e24 lamports — absurdly above max. No fundable source fits."""
-        assert is_executable_rate(1e20, 'eth', 'sol', self.MIN, self.MAX) is False
+        assert is_executable_rate(1e-12, 'btc', 'sol', 0, 0) is True
+        assert is_executable_rate(1e-12, 'sol', 'btc', 0, 0) is True
 
     def test_max_unset_only_lower_bound_enforced(self):
-        """If only min_swap is set, every rate above the floor is executable."""
-        assert is_executable_rate(1e10, 'btc', 'sol', self.MIN, 0) is True
+        """If only min_swap is set, every fundable-source rate is executable."""
+        assert is_executable_rate(1e-12, 'btc', 'sol', self.MIN, 0) is True
+        assert is_executable_rate(1e-12, 'sol', 'btc', self.MIN, 0) is True
 
-    def test_sol_to_btc_lowball_rate_rejected(self):
-        """sol→btc with rate=1e-8 implies 0.1 SOL buys 1e7 BTC — destination
-        absurdity, not a granularity miss. Caught by the symmetric check:
-        treating 1/r = 1e8 as a btc→sol rate, 1 sat already overshoots
-        max_swap on the SOL leg, so the original rate is sentinel-low."""
-        assert is_executable_rate(1e-8, 'sol', 'btc', self.MIN, self.MAX) is False
+    def test_sane_eth_rates_executable(self):
+        """ETH has MORE decimals than the hub (18 vs 9) → fractional decimal_factor (1e-9).
+        ~0.05 ETH per SOL: 0.1 SOL needs 5e15 wei (0.005 ETH), comfortably fundable."""
+        assert is_executable_rate(0.05, 'eth', 'sol', self.MIN, self.MAX) is True
+        assert is_executable_rate(0.05, 'sol', 'eth', self.MIN, self.MAX) is True
+
+    def test_crown_squat_low_eth_rate_rejected(self):
+        """1e-20 ETH/SOL: 1 wei maps to 1e11 lamports — above max_swap; unroutable."""
+        assert is_executable_rate(1e-20, 'eth', 'sol', self.MIN, self.MAX) is False
+
+    def test_sane_tao_sol_rates_executable(self):
+        """tao↔sol: both 9-decimal, decimal_factor 1. ~2 TAO per SOL routes."""
+        assert is_executable_rate(2.0, 'tao', 'sol', self.MIN, self.MAX) is True
+        assert is_executable_rate(2.0, 'sol', 'tao', self.MIN, self.MAX) is True
+
+    def test_crown_squat_low_tao_rate_rejected(self):
+        """1e-10 TAO/SOL: 1 rao overshoots max_swap on the SOL leg — unroutable."""
+        assert is_executable_rate(1e-10, 'tao', 'sol', self.MIN, self.MAX) is False
+        assert is_executable_rate(1e-10, 'sol', 'tao', self.MIN, self.MAX) is False
 
     def test_non_sol_pair_is_permissive(self):
         """A pair with no SOL leg (e.g. legacy btc↔tao) has no SOL bound to
@@ -402,71 +418,44 @@ class TestIsExecutableRate:
         assert is_executable_rate(1e10, 'btc', 'tao', self.MIN, self.MAX) is True
         assert is_executable_rate(1e-8, 'tao', 'btc', self.MIN, self.MAX) is True
 
-    def test_sane_tao_sol_rates_executable(self):
-        """tao↔sol: both 9-decimal, decimal_factor 1. A ~1:1 rate routes."""
-        assert is_executable_rate(1.0, 'tao', 'sol', self.MIN, self.MAX) is True
-        assert is_executable_rate(1.0, 'sol', 'tao', self.MIN, self.MAX) is True
-
-    def test_huge_tao_to_sol_rate_rejected(self):
-        """1e10 SOL/TAO: the smallest fundable TAO source maps far above max_swap."""
-        assert is_executable_rate(1e10, 'tao', 'sol', self.MIN, self.MAX) is False
-
-    def test_lowball_sol_to_tao_rate_rejected(self):
-        """Symmetric out of SOL: 1e-10 TAO/SOL → inverse 1e10 overshoots on the SOL leg."""
-        assert is_executable_rate(1e-10, 'sol', 'tao', self.MIN, self.MAX) is False
-
     DUST = get_chain_def('btc').min_onchain_amount  # smallest fundable BTC source
 
-    def test_sub_dust_boundary_rate_rejected(self):
-        """At max_swap/10, the only in-bounds source is 1 sat — below the BTC
-        dust floor, so unfundable. Rejected (the crown-squat rate)."""
-        rate = self.MAX / 10  # SOL leg at 1 sat == max_swap; 1 sat < dust
+    def test_one_sat_boundary_rate_rejected(self):
+        """At r = 10/max_swap the only in-bounds source is 1 sat — below the BTC
+        dust floor, so unfundable. Rejected (the boundary of the squat regime)."""
+        rate = 10 / self.MAX  # 1 sat → exactly max_swap on the SOL leg
         assert is_executable_rate(rate, 'btc', 'sol', self.MIN, self.MAX) is False
-
-    def test_dust_floor_boundary_rate_executable(self):
-        """At the rate where the dust floor maps exactly to max_swap, the
-        smallest fundable source is in-bounds — just executable."""
-        rate = self.MAX / (10 * self.DUST)  # DUST sat → max_swap on the SOL leg
-        assert is_executable_rate(rate, 'btc', 'sol', self.MIN, self.MAX) is True
-
-    def test_just_past_dust_floor_boundary_rejected(self):
-        """Just above the boundary, even the dust floor overshoots max_swap →
-        no fundable source routes."""
-        rate = (self.MAX / (10 * self.DUST)) * 1.0001
-        assert is_executable_rate(rate, 'btc', 'sol', self.MIN, self.MAX) is False
-
-    def test_sol_to_btc_sub_dust_boundary_rate_rejected(self):
-        """Symmetric: r = 10/max_swap maps 1 sat (sub-dust) to max_swap on the
-        inverse leg — rejected (the crown-squat rate)."""
-        rate = 10 / self.MAX
         assert is_executable_rate(rate, 'sol', 'btc', self.MIN, self.MAX) is False
 
-    def test_sol_to_btc_dust_floor_boundary_executable(self):
-        """Symmetric boundary at the dust floor: the dust-clearing inverse
-        source maps in-bounds — just executable."""
-        rate = (10 * self.DUST) / self.MAX
+    def test_dust_floor_boundary_rate_executable(self):
+        """At the rate where the dust floor maps exactly to max_swap, the smallest
+        fundable source is in-bounds — just executable."""
+        rate = (10 * self.DUST) / self.MAX  # DUST sats → max_swap on the SOL leg
+        assert is_executable_rate(rate, 'btc', 'sol', self.MIN, self.MAX) is True
         assert is_executable_rate(rate, 'sol', 'btc', self.MIN, self.MAX) is True
 
+    def test_just_past_dust_floor_boundary_rejected(self):
+        """Just below the boundary, even the dust floor overshoots max_swap →
+        no fundable source routes."""
+        rate = ((10 * self.DUST) / self.MAX) * 0.999
+        assert is_executable_rate(rate, 'btc', 'sol', self.MIN, self.MAX) is False
+
     def test_arbusdc_rates_executable_at_unit_floor(self):
-        """F1 regression guard — arbusdc must stay routable BOTH ways while its
-        min_onchain_amount stays pinned at 1. The gate consumes the canonical USDC-per-SOL
-        rate as if it were SOL-per-USDC on the arbusdc→sol side (the PR-E orientation
-        defect), so a real dust floor (e.g. 0.01 USDC = 10_000) pushes the implied minimum
-        source above max_swap and silently burns the direction's pool. If this test fails
-        because the floor was raised: revert the floor — it is load-bearing until PR-E."""
+        """arbusdc regression guard (the F1 pin, kept): the pair must stay routable
+        BOTH ways at the honest unit floor. The orientation defect this guarded
+        against is fixed — the gate now inverts the canonical rate correctly."""
         assert get_chain_def('arbusdc').min_onchain_amount == 1
         assert is_executable_rate(150.0, 'arbusdc', 'sol', self.MIN, self.MAX) is True
         assert is_executable_rate(150.0, 'sol', 'arbusdc', self.MIN, self.MAX) is True
 
-    def test_sol_to_btc_sentinel_unset_bounds_still_permissive(self):
-        """Unset bounds disable the gate in both directions — keeps the
-        legacy "no on-chain bounds yet" path permissive."""
-        assert is_executable_rate(1e-8, 'sol', 'btc', 0, 0) is True
-
-    def test_sol_to_btc_zero_max_only_min_set_is_permissive(self):
-        """If only min_swap is set (max_swap=0), any rate above the floor
-        symmetry still passes. Mirrors test_max_unset_only_lower_bound_enforced."""
-        assert is_executable_rate(1e-8, 'sol', 'btc', self.MIN, 0) is True
+    def test_arbusdc_survives_a_real_dust_floor(self):
+        """What PR-E unlocks: with the orientation fixed, a real economic floor
+        (0.01 USDC = 10_000 µUSDC) no longer kills the arbusdc→sol direction —
+        0.1 SOL needs ~15 USDC at 150 USDC/SOL, far above any dust floor."""
+        floor = replace(get_chain_def('arbusdc'), min_onchain_amount=10_000)
+        with patch.dict('allways.chains.SUPPORTED_CHAINS', {'arbusdc': floor}):
+            assert is_executable_rate(150.0, 'arbusdc', 'sol', self.MIN, self.MAX) is True
+            assert is_executable_rate(150.0, 'sol', 'arbusdc', self.MIN, self.MAX) is True
 
 
 class TestQuantizeRate:

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -618,17 +618,18 @@ class TestReplayCrownTime:
         store.close()
 
     def test_boundary_squat_dropped_per_block(self, tmp_path: Path):
-        """Squatter posts a live, executable rate (50000 TAO/BTC) whose smallest
-        in-band leg (0.5 TAO at 1000 sats) exceeds their 0.15 TAO collateral.
-        Survives is_executable_rate but the per-block gate drops them — entire
-        window unfilled (no other holders)."""
+        """Squatter posts a live, executable canonical rate (2.2e-5 BTC/SOL —
+        best in the lowest-wins sort) whose smallest in-band
+        leg (~0.45 SOL at the 1000-sat dust floor) exceeds their 0.15 SOL collateral. Survives
+        is_executable_rate but the per-block gate drops them — entire window
+        unfilled (no other holders)."""
         store = ValidatorStateStore(db_path=tmp_path / 'state.db')
         watcher = make_watcher(store, active={'hk_squat'})
         seed_collateral(watcher, 'hk_squat', 150_000_000, block=0)
         conn = store.require_connection()
         conn.execute(
             'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
-            ('hk_squat', 'btc', 'sol', 50000.0, 0),
+            ('hk_squat', 'btc', 'sol', 2.2e-5, 0),
         )
         conn.commit()
 
@@ -655,7 +656,7 @@ class TestReplayCrownTime:
         seed_collateral(watcher, 'hk_funded', 500_000_000, block=0)
         conn = store.require_connection()
         for row in (
-            ('hk_squat', 'btc', 'sol', 50000.0, 0),  # best rate, can't fund
+            ('hk_squat', 'btc', 'sol', 2.2e-5, 0),  # best rate, can't fund
             ('hk_funded', 'btc', 'sol', 326.0, 0),  # runner-up, can fund
         ):
             conn.execute(
@@ -710,12 +711,12 @@ class TestReplayCrownTime:
         store = ValidatorStateStore(db_path=tmp_path / 'state.db')
         watcher = make_watcher(store, active={'hk_squat'})
         seed_collateral(watcher, 'hk_squat', 150_000_000, block=0)
-        # Top-up mid-window — collateral clears the 1.10× requirement on the 0.5 TAO leg.
+        # Top-up mid-window — collateral clears the 1.10× requirement on the ~0.45 SOL leg.
         watcher.apply_event(600, 'CollateralPosted', {'miner': 'hk_squat', 'amount': 400_000_000, 'total': 550_000_000})
         conn = store.require_connection()
         conn.execute(
             'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
-            ('hk_squat', 'btc', 'sol', 50000.0, 0),
+            ('hk_squat', 'btc', 'sol', 2.2e-5, 0),
         )
         conn.commit()
 
@@ -730,8 +731,8 @@ class TestReplayCrownTime:
             min_swap_lamports=100_000_000,
             max_swap_lamports=500_000_000,
         )
-        # Blocks (100, 600] dropped (collateral 0.15 < 0.5 TAO leg).
-        # Blocks (600, 1100] credited (collateral 0.5 TAO).
+        # Blocks (100, 600] dropped (collateral 0.15 SOL < the 0.5 SOL requirement).
+        # Blocks (600, 1100] credited (0.55 SOL clears it).
         assert crown == {'hk_squat': 500.0}
         store.close()
 
@@ -1152,7 +1153,7 @@ class TestSnapshotCurrentCrownHolders:
 
     def test_boundary_squat_excluded_from_live_table(self, tmp_path: Path):
         """The squatter posts the best, executable rate but their 0.15 TAO
-        collateral can't fund the 0.5 TAO leg it forces. The live table must
+        collateral can't fund the ~0.45 SOL leg it forces. The live table must
         drop them to the funded runner-up, matching the ledger."""
         v = make_validator(
             tmp_path,
@@ -1161,8 +1162,8 @@ class TestSnapshotCurrentCrownHolders:
             max_swap_amount=500_000_000,
             collaterals={'hk_squat': 150_000_000, 'hk_funded': 500_000_000},
         )
-        # btc→sol (into the bounded SOL leg): the squat rate forces a 0.5-SOL leg the squatter can't fund.
-        self._seed_rate(v.state_store, 'hk_squat', 50000.0, 'btc', 'sol')  # best rate, can't fund
+        # btc→sol (into the bounded SOL leg): the squat rate forces a ~0.45-SOL leg the squatter can't fund.
+        self._seed_rate(v.state_store, 'hk_squat', 2.2e-5, 'btc', 'sol')  # best rate, can't fund
         self._seed_rate(v.state_store, 'hk_funded', 326.0, 'btc', 'sol')  # runner-up, can fund
 
         rows = snapshot_current_crown_holders(v, v.block)
@@ -1191,7 +1192,7 @@ class TestLedgerSnapshotAgreement:
             collaterals={'hk_squat': 150_000_000, 'hk_funded': 500_000_000},
         )
         conn = v.state_store.require_connection()
-        for hk, rate in (('hk_squat', 50000.0), ('hk_funded', 326.0)):
+        for hk, rate in (('hk_squat', 2.2e-5), ('hk_funded', 326.0)):
             conn.execute(
                 'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
                 (hk, 'btc', 'sol', rate, 0),
@@ -2609,10 +2610,10 @@ class TestCrownCanFund:
 
     def test_unexecutable_rate_is_unconstrained(self):
         # min_leg 0 = "no in-band fundable swap" — executability is policed by
-        # is_executable_rate, not this gate (the #392 sentinel rate, btc→sol).
+        # is_executable_rate, not this gate (the crown-squat low canonical, btc→sol).
         assert crown_can_fund(
             'hk',
-            1e10,
+            1e-12,
             from_chain='btc',
             to_chain='sol',
             min_swap_lamports=100_000_000,


### PR DESCRIPTION
**DO NOT MERGE until the arbusdc pair has soaked** (T16 rollout order) — this changes crown eligibility on every live pair the moment it deploys.

## The defect (F1 root cause)

`is_executable_rate`/`min_executable_sol_leg` consumed their `rate` argument as SOL-per-source on the spoke→sol side, while every production caller (`swap_intake`, `quote`, scoring's crown predicates) feeds the canonical spoke-per-SOL number the chain stores. The error factor is rate² — harmless at BTC/TAO/ETH magnitudes, pair-killing at USDC's (~150² = 22,500×), which is why arbusdc shipped with `min_onchain_amount=1` pinned and a tripwire test.

## The fix

- The gate now **pins the canonical convention in both directions** and inverts exactly once (the SOL→spoke branch already did; the spoke→sol branch now matches).
- Float-range guard: a float-max sentinel rate's subnormal inverse used to be able to reach `math.ceil(inf)` — now rejected cleanly.
- `min_executable_sol_leg` gets the same single inversion.
- arbusdc's `min_onchain_amount=1` stops being load-bearing (comment updated); a new regression test proves a real dust floor (0.01 USDC) survives both directions.

## Blast radius, made explicit

Under lowest-canonical-wins (spoke→sol), the crown-relevant squat is a **LOW** canonical rate — the gate now rejects exactly that (it used to reject the harmless high side). Squat-rate scoring tests re-derived in the canonical convention: the btc→sol squat fixture is now 2.2e-5 BTC/SOL (best-in-sort, forces a ~0.45 SOL leg vs 0.15 SOL collateral) instead of the old inverted 50000.0. A huge canonical rate is routable-in-principle and simply loses the sort — permissive by design.

1037 tests, ruff clean.