### PR TITLE
Unify EVM log tags and single-source the key env var

### DIFF
--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -68,11 +68,14 @@ class Erc20(EvmAsset):
     """A generic ERC-20 asset on an EVM chain, bound by its registry row.
 
     Not fused: the token composes its host network's `EvmChain` (``self._chain``) — the
-    first non-fused asset, and the shape a second same-network token shares a chain
-    instance through. Settlement truth is the token contract's Transfer log, never
-    tx.value: verification accepts a tx iff its status-1 receipt carries a Transfer from
-    the PINNED contract paying the expected recipient, and the provable payer is the
-    log's `from` topic. Delivery gates are issuer-shaped: blacklist + pause, and
+    first non-fused asset. Each token builds its own chain instance today; a second token
+    on the same network would want them pooled (one ladder, one tip fetch per pass) — a
+    construction change here, not a shape change.
+
+    Settlement truth is the token contract's Transfer log, never tx.value: verification
+    accepts a tx iff its status-1 receipt carries a Transfer from the PINNED contract
+    paying the expected recipient, and the provable payer is the log's `from` topic.
+    Delivery gates are issuer-shaped: blacklist + pause, and
     deliberately NO getCode — contract wallets receive ERC-20 fine, and a code probe
     would hand them slash immunity.
     """
@@ -82,7 +85,6 @@ class Erc20(EvmAsset):
         self._chain = EvmChain(EVM_NETWORKS[chain_def.host_chain], chain_def.env_prefix)
         EvmAsset.__init__(self)
         self.token_contract = _token_contract(chain_def, self.chain.network)
-        self._log = f'[{chain_def.id}]'
 
     @property
     def chain_def(self) -> ChainDefinition:
@@ -308,7 +310,7 @@ class Erc20(EvmAsset):
         norm = self.chain.normalize_address
         acct = self.chain._account()
         if acct is None:
-            self._send_error(f'{self._key_env} not set or unusable')
+            self._send_error(f'{self.chain._key_env} not set or unusable')
             return None
         if from_address and norm(acct.address) != norm(from_address):
             self._send_error(

--- a/allways/assets/ethereum.py
+++ b/allways/assets/ethereum.py
@@ -9,8 +9,6 @@ from allways.assets.base import ProviderUnreachableError, SendResult, Transactio
 from allways.assets.evm import ETHEREUM, FALLBACK_PRIORITY_FEE_WEI, EvmAsset, EvmChain
 from allways.chains import CHAIN_ETH, ChainDefinition
 
-LOG_ETH = '[EthRpc]'
-
 TRANSFER_GAS = 21_000
 # Refuse destinations whose receive hook wants more than this — bounds the miner's gas
 # spend against a hostile contract; the slash gate exempts code-bearing dests anyway.
@@ -30,7 +28,7 @@ class Ether(EvmAsset, EvmChain):
     """
 
     def __init__(self):
-        EvmChain.__init__(self, ETHEREUM, 'ETH')
+        EvmChain.__init__(self, ETHEREUM, CHAIN_ETH.env_prefix)
         EvmAsset.__init__(self)
 
     @property
@@ -59,7 +57,7 @@ class Ether(EvmAsset, EvmChain):
         except Exception as e:
             raise ProviderUnreachableError(f'ETH RPC unreachable: {e}') from e
         if tx is None:
-            bt.logging.debug(f'{LOG_ETH} tx {tx_hash[:16]}... not found')
+            bt.logging.debug(f'{self._log} tx {tx_hash[:16]}... not found')
             return None
 
         to = self.chain.normalize_address(tx.get('to') or '')  # null for contract creation
@@ -67,7 +65,7 @@ class Ether(EvmAsset, EvmChain):
         amount = int(tx.get('value') or '0x0', 16)
         if to != self.chain.normalize_address(expected_recipient) or amount < expected_amount:
             bt.logging.warning(
-                f'{LOG_ETH} tx {tx_hash[:16]}... does not pay {expected_recipient} >= {expected_amount} wei '
+                f'{self._log} tx {tx_hash[:16]}... does not pay {expected_recipient} >= {expected_amount} wei '
                 f'(to={tx.get("to")}, value={amount})'
             )
             return None
@@ -105,7 +103,7 @@ class Ether(EvmAsset, EvmChain):
             if receipt is None:
                 raise ProviderUnreachableError(f'ETH tx {tx_hash[:16]}... is mined but its receipt is unavailable')
             if int(receipt.get('status') or '0x0', 16) != 1:
-                bt.logging.warning(f'{LOG_ETH} tx {tx_hash[:16]}... reverted (status 0) — moved no funds, rejecting')
+                bt.logging.warning(f'{self._log} tx {tx_hash[:16]}... reverted (status 0) — moved no funds, rejecting')
                 return None
 
             block_number = int(receipt['blockNumber'], 16)
@@ -125,7 +123,7 @@ class Ether(EvmAsset, EvmChain):
                     f'ETH tx {tx_hash[:16]}... is mined but block {block_number} has no readable timestamp'
                 )
             if is_confirmed and block.get('hash') and block['hash'] != receipt.get('blockHash'):
-                bt.logging.warning(f'{LOG_ETH} tx {tx_hash[:16]}... block was reorged out — rejecting')
+                bt.logging.warning(f'{self._log} tx {tx_hash[:16]}... block was reorged out — rejecting')
                 return None
 
             # Cache only a fully-settled, internally-consistent read (status 1, timestamped,

--- a/allways/assets/evm.py
+++ b/allways/assets/evm.py
@@ -287,6 +287,9 @@ class EvmAsset(Asset):
     _MAX_SCAN_CURSORS = 64
 
     def __init__(self):
+        # Asset-scoped log tag (the wire id). Transport lines carry the CHAIN's tag instead —
+        # one Arbitrum ladder serves every Arbitrum asset, so the two must stay distinguishable.
+        self._log = f'[{self.chain_def.id}]'
         self.last_send_error: Optional[str] = None
         # Settled-tx cache, keyed tx_hash → immutable per-block facts. A mined tx's receipt
         # and its block's timestamp are immutable per block hash, so the validator's 12s
@@ -301,10 +304,6 @@ class EvmAsset(Asset):
         # Deposit-scanner head cursors, keyed per (from, to, amount) — see find_recent_outgoing.
         self.scan_cursors: dict[Tuple[str, str, int], int] = {}
         self.SCAN_LOOKBACK_BLOCKS = max(1, SCAN_LOOKBACK_SECS // self.chain_def.seconds_per_block)
-
-    @property
-    def _key_env(self) -> str:
-        return f'{self.chain_def.env_prefix}_PRIVATE_KEY'
 
     def _send_error(self, msg: str) -> None:
         self.last_send_error = msg
@@ -322,13 +321,14 @@ class EvmAsset(Asset):
 
     def check_connection(self, require_send: bool = True) -> None:
         if require_send:
-            key = os.environ.get(self._key_env)
+            key_env = self.chain._key_env
+            key = os.environ.get(key_env)
             if not key:
-                raise ConnectionError(f'{self.chain_def.env_prefix} signing requires the {self._key_env} env var')
+                raise ConnectionError(f'{self.chain_def.env_prefix} signing requires the {key_env} env var')
             try:
                 Account.from_key(key)
             except Exception as e:
-                raise ConnectionError(f'{self._key_env} is not a valid 32-byte hex key: {e}') from e
+                raise ConnectionError(f'{key_env} is not a valid 32-byte hex key: {e}') from e
         chain_id, tip = self.chain.connect_network()
         bt.logging.success(
             f'[{self.chain.network_def.label}Rpc] connected: '


### PR DESCRIPTION
Follow-up cleanup to #623. No behavior change — log strings and one env-var lookup path.

**Log tags.** #623 replaced the hardcoded `EthRpc` ladder tag with `f'{network_def.label}Rpc'`, which reads `EthereumRpc`, but left `LOG_ETH = '[EthRpc]'` stamping four tx-level warnings in `ethereum.py`. ETH emitted two tags for one provider. `Erc20` already had the split right (`ArbitrumRpc` for transport, `[arbusdc]` for legs), so `_log = f'[{chain_def.id}]'` moves to `EvmAsset` and both families share it. ETH leg lines are now `[eth]`; transport stays `EthereumRpc`. The distinction is load-bearing: one Arbitrum ladder serves every Arbitrum asset.

**`_key_env`.** Defined on both `EvmChain` and `EvmAsset`; the MRO silently shadowed `EvmChain`'s on the fused `Ether`. They agreed only because `Ether.__init__` passed the literal `'ETH'` and `CHAIN_ETH.env_prefix` also happens to be `'ETH'`. Now defined once on `EvmChain` (it owns `env_prefix` and `_account`), reached through `self.chain._key_env` from both shapes.

**`Ether.__init__`.** Takes `CHAIN_ETH.env_prefix` instead of a hardcoded `'ETH'` — the coincidence above was the only thing making the duplication benign.

**`Erc20` docstring.** Claimed the class is "the shape a second same-network token shares a chain instance through". It isn't — `__init__` unconditionally builds its own `EvmChain`. Corrected to say what's true and what pooling would take.

Verified: `1042 passed`, ruff clean. No test asserts on log strings; nothing outside the assets package reads `_key_env`.
