### PR TITLE
Reject the zero address as an EVM destination

### DIFF
--- a/allways/assets/evm.py
+++ b/allways/assets/evm.py
@@ -227,6 +227,10 @@ class EvmChain(Chain):
         validating checksums, which would wave through exactly the typos EIP-55 exists to catch."""
         if not isinstance(address, str) or not _HEX_ADDR_RE.match(address):
             return False
+        # The zero address is never a real destination: ETH burns to it, and an ERC-20 transfer()
+        # reverts on it — a dest no delivery gate catches, so an honest miner would be slashed.
+        if int(address, 16) == 0:
+            return False
         body = address[2:]
         if body == body.lower() or body == body.upper():
             return True

--- a/tests/test_arbusdc_provider.py
+++ b/tests/test_arbusdc_provider.py
@@ -258,6 +258,11 @@ class TestDeliveryGates:
         rpc_stub(provider, {'eth_call': eth_call_views()})
         assert provider.can_deliver_to(RECIPIENT, AMOUNT) is True
 
+    def test_zero_address_is_not_a_valid_dest(self, provider):
+        # USDC transfer() reverts to the zero address (no blacklist/pause gate would catch it), so a
+        # reservation aimed there would strand the miner into a slash. The format gate must reject it.
+        assert provider.chain.is_valid_address('0x' + '00' * 20) is False
+
     def test_blacklisted_dest_blocks_reserve(self, provider):
         rpc_stub(provider, {'eth_call': eth_call_views(blacklisted=[RECIPIENT])})
         assert provider.can_deliver_to(RECIPIENT, AMOUNT) is False

--- a/tests/test_ethereum_provider.py
+++ b/tests/test_ethereum_provider.py
@@ -96,6 +96,12 @@ class TestAddresses:
         assert not provider.is_valid_address(None)
         assert not provider.is_valid_address('f39Fd6e51aad88F6F4ce6aB8827279cffFb92266')  # no 0x
 
+    def test_zero_address_rejected(self, provider):
+        # ERC-20 transfer() reverts to the zero address (no blacklist/pause gate catches it), so an
+        # honest miner reserved for it would be forced into a slash. Reject at the format gate.
+        assert not provider.is_valid_address('0x' + '00' * 20)
+        assert not provider.is_valid_address('0x' + '0' * 40)
+
     def test_normalize_lowercases(self, provider):
         assert provider.normalize_address(TEST_ADDR) == TEST_ADDR.lower()
 


### PR DESCRIPTION
## What
Reject `0x0000…0000` in `EvmChain.is_valid_address` so it can never be a swap destination (or a miner receive address).

## Why
USDC's `transfer()` reverts unconditionally to the zero address — a revert condition **no delivery gate catches**: `can_deliver_to` / `delivery_refused` only check `isBlacklisted` + `paused()`, and the zero address is neither. A user could reserve a SOL→arbusdc swap with `to = 0x0`, fund the source leg, and the miner's delivery would revert on every attempt → overdue → **forced slash of an honest miner** on fully attacker-controlled input.

`getCode` was (correctly) dropped for ERC-20 because a contract recipient receives USDC fine; the zero-recipient revert is the one case that reasoning missed. Native ETH burns to zero rather than reverting, so it was never a slash vector there — but zero is never a legitimate destination on either, so the guard lives once in the shared `EvmChain`.

## Change
- One format-level check (offline, no RPC): `int(address, 16) == 0` → invalid. Runs ahead of `can_deliver_to` in both the dest and source reserve gates, fully closing the reservation path.

## Tests
- `test_ethereum_provider.py::TestAddresses::test_zero_address_rejected`
- `test_arbusdc_provider.py::TestDeliveryGates::test_zero_address_is_not_a_valid_dest`
- Full ETH + arbusdc + reserve-engine + input-validation suites green (216 passed).