### PR TITLE
Classify EVM execution reverts by JSON-RPC code, not message text

### DIFF
--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -412,7 +412,7 @@ class Erc20(EvmAsset):
         try:
             est = int(self.chain.eth_rpc('eth_estimateGas', [params]), 16)
         except Exception as e:
-            return None if 'revert' in str(e).lower() else DEFAULT_TOKEN_TRANSFER_GAS
+            return None if getattr(e, 'is_execution_revert', False) else DEFAULT_TOKEN_TRANSFER_GAS
         gas = est + est // 5
         return None if gas > MAX_TOKEN_TRANSFER_GAS else gas
 

--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -445,6 +445,8 @@ class Erc20(EvmAsset):
         if self._refused_at(address):
             return True
         tip = int(self.chain.eth_rpc('eth_blockNumber', []), 16)
+        # Span is in blocks; seconds_per_block floors to 1 on sub-second chains, so this reaches
+        # ~4× fewer wall-seconds than it reads. Fine here — the latest probe above is load-bearing.
         span = min(60, max(0, int(time.time()) - int(since_unix)) // self.chain_def.seconds_per_block)
         for probe in dict.fromkeys(hex(max(0, tip - span // d)) for d in (1, 2)):
             try:

--- a/allways/assets/evm.py
+++ b/allways/assets/evm.py
@@ -36,8 +36,10 @@ class EvmRpcError(RuntimeError):
 # comfortably in normal conditions without meaningfully overpaying a transfer).
 FALLBACK_PRIORITY_FEE_WEI = 1_000_000_000
 
-# Send-dedup / deposit-scan window in wall seconds (≈5 min); each chain derives its
-# block-count bound from its own block time so the window means the same everywhere.
+# Send-dedup / deposit-scan window in wall seconds (≈5 min); each chain derives its block
+# bound from its own block time. Note seconds_per_block is an integer floor, so on sub-second
+# chains (Arbitrum ~0.25s → floored to 1) the bound covers ~4× fewer wall-seconds than this.
+# Harmless: the scanner only surfaces a hash the confirm path re-verifies by exact tx hash.
 SCAN_LOOKBACK_SECS = 300
 
 

--- a/allways/assets/evm.py
+++ b/allways/assets/evm.py
@@ -16,6 +16,22 @@ from allways.assets.chain import Chain
 
 _HEX_ADDR_RE = re.compile(r'^0x[0-9a-fA-F]{40}$')
 
+
+class EvmRpcError(RuntimeError):
+    """A JSON-RPC ``error`` object from an endpoint (an execution/method result), distinct from a
+    transport failure. Carries the structured error so callers branch on the code, not the message
+    wording (which varies by provider). ``is_execution_revert`` is a deterministic on-chain verdict."""
+
+    def __init__(self, message: str, error: Any):
+        super().__init__(message)
+        self.error = error if isinstance(error, dict) else {}
+
+    @property
+    def is_execution_revert(self) -> bool:
+        # Geth: code 3 + 'execution reverted'; others: -32000 with 'revert' in the message.
+        return self.error.get('code') == 3 or 'revert' in str(self.error.get('message') or '').lower()
+
+
 # eth_maxPriorityFeePerGas fallback when an endpoint doesn't serve it (1 gwei clears
 # comfortably in normal conditions without meaningfully overpaying a transfer).
 FALLBACK_PRIORITY_FEE_WEI = 1_000_000_000
@@ -138,6 +154,7 @@ class EvmChain(Chain):
         log = f'{self.network_def.label}Rpc'
         payload = {'jsonrpc': '2.0', 'id': 1, 'method': method, 'params': params}
         last_err: Optional[Exception] = None
+        revert_err: Optional[EvmRpcError] = None
         saw_null = False
         for i, base in enumerate(rpc_bases):
             pos = f'[{i + 1}/{len(rpc_bases)}]'
@@ -165,7 +182,11 @@ class EvmChain(Chain):
 
             if 'error' in body:
                 err = body['error']
-                last_err = RuntimeError(f'{base} {method}: rpc error {err}')
+                last_err = EvmRpcError(f'{base} {method}: rpc error {err}', err)
+                # A revert is a deterministic execution verdict — remember it so it outranks any
+                # transport error from a later endpoint (else a flaky node masks a real refusal).
+                if last_err.is_execution_revert:
+                    revert_err = last_err
                 bt.logging.warning(f'{log} {pos} {tag} {method} → rpc error {err}; {tail}')
                 continue
 
@@ -179,6 +200,8 @@ class EvmChain(Chain):
             else:
                 bt.logging.debug(f'{log} {pos} {tag} {method} → ok')
             return result
+        if revert_err is not None:
+            raise revert_err
         if saw_null and last_err is None:
             return None
         if saw_null:

--- a/tests/test_arbusdc_provider.py
+++ b/tests/test_arbusdc_provider.py
@@ -11,7 +11,6 @@ from typing import Optional
 import pytest
 
 from allways.assets.base import ProviderUnreachableError
-from allways.assets.evm import EvmRpcError
 from allways.assets.erc20 import (
     SEL_BALANCE_OF,
     SEL_IS_BLACKLISTED,
@@ -20,6 +19,7 @@ from allways.assets.erc20 import (
     TRANSFER_TOPIC0,
     ArbUsdc,
 )
+from allways.assets.evm import EvmRpcError
 from allways.chains import CHAIN_ARBUSDC
 
 # Well-known dev key (hardhat account #0) — never funded on mainnet, deterministic address.

--- a/tests/test_arbusdc_provider.py
+++ b/tests/test_arbusdc_provider.py
@@ -11,6 +11,7 @@ from typing import Optional
 import pytest
 
 from allways.assets.base import ProviderUnreachableError
+from allways.assets.evm import EvmRpcError
 from allways.assets.erc20 import (
     SEL_BALANCE_OF,
     SEL_IS_BLACKLISTED,
@@ -375,7 +376,21 @@ class TestSendGuards:
         responses = self._send_responses()
 
         def revert(params):
-            raise RuntimeError('execution reverted: Blacklistable: account is blacklisted')
+            raise EvmRpcError('rpc error', {'code': 3, 'message': 'execution reverted: account is blacklisted'})
+
+        responses['eth_estimateGas'] = revert
+        rpc_stub(provider, responses)
+        assert provider.send_amount(RECIPIENT, AMOUNT) is None
+        assert 'refuses' in provider.last_send_error
+
+    def test_revert_detected_by_code_when_message_lacks_the_word(self, provider, monkeypatch):
+        # The old string-match missed a code-3 revert phrased without "revert" and would have
+        # broadcast a doomed tx (gas burned, no delivery). The typed verdict catches it.
+        monkeypatch.setenv('ARBUSDC_PRIVATE_KEY', TEST_KEY)
+        responses = self._send_responses()
+
+        def revert(params):
+            raise EvmRpcError('rpc error', {'code': 3, 'message': 'gas required exceeds allowance'})
 
         responses['eth_estimateGas'] = revert
         rpc_stub(provider, responses)

--- a/tests/test_ethereum_provider.py
+++ b/tests/test_ethereum_provider.py
@@ -11,6 +11,7 @@ import pytest
 
 from allways.assets.base import ProviderUnreachableError
 from allways.assets.ethereum import Ether
+from allways.assets.evm import EvmRpcError
 
 # Well-known dev key (hardhat account #0) — never funded on mainnet, deterministic address.
 TEST_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
@@ -341,6 +342,28 @@ class TestRpcFailover:
         provider.rpc_bases = ['https://a.example']
         with pytest.raises(Exception):
             provider.eth_rpc('eth_blockNumber', [])
+
+    def test_execution_revert_raises_typed_verdict(self, provider):
+        body = {'error': {'code': 3, 'message': 'execution reverted', 'data': '0x'}}
+        provider.http.post = lambda url, json=None, timeout=15: self._Resp(body=body)
+        provider.rpc_bases = ['https://a.example']
+        with pytest.raises(EvmRpcError) as exc:
+            provider.eth_rpc('eth_estimateGas', [{}])
+        assert exc.value.is_execution_revert
+
+    def test_revert_outranks_later_transport_failure(self, provider):
+        # A deterministic revert on endpoint A must not be masked by endpoint B being down —
+        # else the caller reads "transient" and broadcasts a doomed tx.
+        def post(url, json=None, timeout=15):
+            if 'a.example' in url:
+                return self._Resp(body={'error': {'code': 3, 'message': 'execution reverted'}})
+            raise ConnectionError('down')
+
+        provider.http.post = post
+        provider.rpc_bases = ['https://a.example', 'https://b.example']
+        with pytest.raises(EvmRpcError) as exc:
+            provider.eth_rpc('eth_estimateGas', [{}])
+        assert exc.value.is_execution_revert
 
 
 class TestCheckConnection:


### PR DESCRIPTION
## What
`eth_rpc` now surfaces a JSON-RPC `error` as a typed `EvmRpcError` carrying the structured error, with an `is_execution_revert` verdict (Geth code 3, or `revert` in the message for other nodes). The ERC-20 send path branches on that verdict instead of grepping the error string.

## Why (A5 from the arbusdc review)
`_transfer_gas` decided "did the transfer revert?" with `'revert' in str(e).lower()`. Two brittle failures:
- A real revert phrased **without** the word "revert" (e.g. a bare `code 3` / "gas required exceeds allowance") was misread as transient → the miner **broadcast a doomed tx** (gas burned, no delivery, still slash-exposed).
- A definitive revert on endpoint A could be **masked** by endpoint B being down: the loop kept only the last (transport) error, so the caller read "transient" and fell back to a default-gas broadcast.

## Change
- `EvmRpcError(RuntimeError)` in `evm.py` — holds the JSON-RPC error dict; `is_execution_revert` reads the **code**, not prose.
- `eth_rpc` records a revert and **raises it in preference** to a later transport error (a deterministic on-chain verdict outranks a flaky endpoint).
- `erc20._transfer_gas` → `getattr(e, 'is_execution_revert', False)`.
- Native ETH gates are unaffected (they still classify via the message, which the typed error's `str()` preserves) — they can adopt the verdict later.

## Tests
- `test_ethereum_provider.py`: typed-verdict raise; **revert outranks a later down endpoint**.
- `test_arbusdc_provider.py`: revert refused; **code-3 revert whose message lacks "revert"** is now caught.
- 399 passed across the EVM/reserve/rate/swap surface.