### PR TITLE
Never slash a miner for a malformed destination address

### DIFF
--- a/allways/validator/solana_swap_loop.py
+++ b/allways/validator/solana_swap_loop.py
@@ -175,10 +175,17 @@ class SolanaSwapLoop:
         return True
 
     def _dest_refuses(self, swap: Any) -> bool:
-        """Evidence the dest can't receive (or the check is unavailable) — either way, never slash on it."""
+        """Evidence the dest can't receive (or the check is unavailable) — either way, never slash on it.
+
+        Beyond issuer refusal (blacklist/pause), a malformed dest address is undeliverable by
+        construction and never the miner's fault. A self-represented taker reserves on-chain directly,
+        bypassing the reserve-time address gate, so this slash-side check is the miner's only guard
+        against a poisoned (e.g. zero-address) reservation."""
         provider = self.providers.get(swap.to_chain)
         if provider is None:
             return False
+        if not provider.chain.is_valid_address(swap.user_to_addr):
+            return True
         try:
             return provider.delivery_refused(swap.user_to_addr, int(swap.initiated_at))
         except Exception as e:

--- a/tests/test_solana_swap_loop.py
+++ b/tests/test_solana_swap_loop.py
@@ -61,18 +61,26 @@ class RecordingProvider:
     True=confirmed, False=matched-but-unconfirmed (extendable), None=absent. block_time, confirmations and a
     per-chain replay_grace_secs feed the freshness + extension-target math."""
 
-    def __init__(self, result=True, block_time=FRESH, grace=0, confirmations=0):
+    def __init__(self, result=True, block_time=FRESH, grace=0, confirmations=0, valid_addr=True):
         self.result = result
         self.block_time = block_time
         self.grace = grace
         self.confirmations = confirmations
         self.refuses = False
+        self.valid_addr = valid_addr
         self.calls = []
 
     def delivery_refused(self, address, since_unix):
         if self.refuses == 'unreachable':
             raise ProviderUnreachableError('down')
         return self.refuses
+
+    @property
+    def chain(self):
+        return self  # fused-provider shape: the asset is its own chain
+
+    def is_valid_address(self, address):
+        return self.valid_addr
 
     @property
     def chain_def(self):
@@ -178,6 +186,14 @@ def test_fulfilled_overdue_refusal_check_down_defers():
 def test_active_overdue_refusing_dest_waits_no_slash():
     loop, providers = loop_with(result=None)
     providers['sol'].refuses = True
+    assert loop.decide(make_swap(status='Active', timeout_at=1000), now=1500).decision == SwapDecision.WAIT
+
+
+def test_overdue_malformed_dest_addr_waits_no_slash():
+    # A self-represented taker can reserve with a poison dest (e.g. 0x0) the reserve gate never saw.
+    # A malformed dest is undeliverable through no fault of the miner — the slash gate must not fire.
+    loop, providers = loop_with(result=None)
+    providers['sol'].valid_addr = False
     assert loop.decide(make_swap(status='Active', timeout_at=1000), now=1500).decision == SwapDecision.WAIT
 
 


### PR DESCRIPTION
## What
`_dest_refuses` (the validator's slash gate) now returns "don't slash" when the swap's destination address is malformed — the same "undeliverable through no fault of the miner" class it already honors for blacklist/pause.

## Why (completes the A1 seal for the self-represented path)
A1 (#629) rejected the zero address in `is_valid_address`, but that gate runs inside `reserve_on_behalf` — the **routed** path. A **self-represented** taker (the live mainnet path) reserves on-chain directly and bypasses it, so a malicious taker could still reserve a miner with `user_to_addr = 0x0` (or any garbage). The miner then can't deliver (USDC `transfer(0)` reverts), goes overdue, and `_dest_refuses` — which only checked blacklist/pause — let it ride to a **slash**. This closes that bypass for every chain: a dest the miner could never deliver to is never the miner's fault.

## Deliberately NOT included: an amount floor
I explored also refusing-to-slash when the delivered amount is below the dest chain's `min_onchain_amount` (the "keep-alive floor"). Rejected, because that field means two different things: a **hard delivery-failure** on TAO (existential deposit) / BTC (dust relay), but only a **rate-sanity floor** on ETH, where a sub-floor transfer *succeeds*. A blanket "don't slash below floor" would let a miner **skip delivering** small sol→eth swaps and dodge the slash — a net-negative. The genuine hard-fail cases (TAO/BTC sub-floor) require an absurd miner rate that `is_executable_rate` already filters, so they're not reachable in practice; sealing them safely would need chain-specific hard-fail modeling, tracked separately.

## Change
- `_dest_refuses`: `if not provider.chain.is_valid_address(swap.user_to_addr): return True` before the blacklist/pause probe. A miner can't game it (the dest is fixed at reserve; a valid address always falls through to the normal check).

## Tests
- `test_overdue_malformed_dest_addr_waits_no_slash` — an overdue swap to a malformed dest WAITs, never TIMEOUTs.
- 170 passed across swap-loop/reserve/seam/axon/fulfillment.