### PR TITLE
Drop ink-era rejection rules the Solana stack never emits

### DIFF
--- a/allways/cli/validator_rejections.py
+++ b/allways/cli/validator_rejections.py
@@ -73,27 +73,6 @@ _RULES: list[_Rule] = [
         ),
     ),
     (
-        'invalid_source_proof',
-        'invalid source address proof',
-        True,
-        lambda ctx: (
-            f'Signature for [yellow]{_ctx_get(ctx, "from_address", "<your source address>")}[/yellow] '
-            'did not verify. The signing key (BTC_PRIVATE_KEY/WIF or coldkey) does not match '
-            'the source address.'
-        ),
-    ),
-    (
-        'address_cooldown',
-        'address on cooldown',
-        True,
-        lambda ctx: (
-            f'Source address [yellow]{_ctx_get(ctx, "from_address", "<your source address>")}[/yellow] '
-            f'is cooling down — {_ctx_get(ctx, "raw_reason", "").removeprefix("Address on cooldown: ")}. '
-            f'Each failed reservation doubles the next cooldown; wait it out or reserve from a different '
-            'address.'
-        ),
-    ),
-    (
         'wrong_direction',
         'miner does not support this swap direction',
         True,

--- a/tests/test_validator_rejections.py
+++ b/tests/test_validator_rejections.py
@@ -80,22 +80,6 @@ def test_insufficient_source_balance_translates():
     assert '0.0008' in info.headline
 
 
-def test_address_cooldown_includes_raw_reason():
-    raw = 'Address on cooldown: ~50 blocks remaining (strike 2, 300-block window)'
-    info = render_and_aggregate(
-        _silent_console(),
-        [FakeResp(accepted=False, rejection_reason=raw)],
-        context={'from_address': 'tb1qabc'},
-    )
-    assert info.category == 'address_cooldown'
-    assert info.deterministic is True
-    assert '50 blocks remaining' in info.headline
-    assert 'strike 2' in info.headline
-    assert 'doubles' in info.headline
-    # No double-wrapped 'Address on cooldown: Address on cooldown'
-    assert info.headline.lower().count('address on cooldown') == 0
-
-
 def test_miner_busy_is_not_deterministic():
     info = render_and_aggregate(
         _silent_console(),


### PR DESCRIPTION
Two rejection rules in the CLI's message formatter describe the retired ink! contract, not the Solana program. Nothing in the current stack emits either reason string (grepped repo-wide; the only matches were the rules themselves and `smart-contracts/ink/`, untouched since #48).

- `invalid_source_proof` — there is no server-side source-address signature check. `SwapReserveSynapse` carries no signature field, and `reserve_on_behalf` verifies none. The binding is sender pinning: `Reservation.from_addr` is stored on-chain (`state.rs:133` — "kept so initiate can verify the initiating user matches the reserver") and enforced as `expected_sender` at `reserve_engine.py:339`. The protection is real; this message describes a mechanism that isn't the one doing the work.
- `address_cooldown` — the per-address strike map lives only in `smart-contracts/ink/lib.rs:139`. The Solana program has no equivalent. The message tells users "Each failed reservation doubles the next cooldown; wait it out or reserve from a different address", which is advice about a system that no longer exists.

`sign_from_proof` / `verify_from_proof` stay: the BTC external-signature paste flow (`cli/swap_commands/helpers.py:501`) is a real caller and a genuine client-side typo guard.

Also drops the test that asserted the cooldown rendering, and corrects the workspace CLAUDE.md sentence that attributed sender verification to a proof rather than to pinning (that file lives outside this repo, noted here for the record).

`1041 passed`, ruff clean.
