### PR TITLE
Never slash a miner for a reserved-key Solana destination

### DIFF
--- a/allways/assets/solana.py
+++ b/allways/assets/solana.py
@@ -15,12 +15,48 @@ from allways.solana.rpc import SolanaRpc, resolve_rpc_url
 
 LOG_SOL = '[Solana]'
 
-# Accounts these programs own are readonly-enforced: the runtime rejects any lamport change,
-# so a transfer to one ALWAYS fails (ReadonlyLamportChange). Covers every builtin (System,
-# Vote, Stake, ComputeBudget, the loaders) and every sysvar. Deployed BPF programs are owned
-# by a loader instead and receive SOL fine — executability is not the test, ownership is.
-READONLY_OWNERS = frozenset(
+# Solana's reserved account keys: the runtime demotes these to read-only in EVERY transaction, so
+# a transfer to one always fails (ReadonlyLamportChange) and no miner could ever deliver to it.
+# Mirrors agave-reserved-account-keys' RESERVED_ACCOUNTS verbatim (v3.1.14, includes the pending
+# feature-gated entries — never a legitimate destination either way). The set is consensus-critical
+# and append-only, so a stale copy under-blocks but never over-blocks; re-sync when agave adds a key.
+# Not derivable from account ownership: post-Core-BPF, Stake/Config/AddressLookupTable are owned by
+# the upgradeable loader, StakeConfig has no account at all, and the SPL Token program is executable
+# yet receives SOL fine. Membership is the only sound test, and it needs no RPC.
+RESERVED_ACCOUNTS = frozenset(
     {
+        # builtin programs
+        'AddressLookupTab1e1111111111111111111111111',
+        'BPFLoader1111111111111111111111111111111111',
+        'BPFLoader2111111111111111111111111111111111',
+        'BPFLoaderUpgradeab1e11111111111111111111111',
+        'ComputeBudget111111111111111111111111111111',
+        'Config1111111111111111111111111111111111111',
+        'Ed25519SigVerify111111111111111111111111111',
+        'Feature111111111111111111111111111111111111',
+        'KeccakSecp256k11111111111111111111111111111',
+        'LoaderV411111111111111111111111111111111111',
+        'Secp256r1SigVerify1111111111111111111111111',
+        'Stake11111111111111111111111111111111111111',
+        'StakeConfig11111111111111111111111111111111',
+        'Vote111111111111111111111111111111111111111',
+        'ZkE1Gama1Proof11111111111111111111111111111',
+        'ZkTokenProof1111111111111111111111111111111',
+        '11111111111111111111111111111111',
+        # sysvars
+        'Sysvar1nstructions1111111111111111111111111',
+        'SysvarC1ock11111111111111111111111111111111',
+        'SysvarEpochRewards1111111111111111111111111',
+        'SysvarEpochSchedu1e111111111111111111111111',
+        'SysvarFees111111111111111111111111111111111',
+        'SysvarLastRestartS1ot1111111111111111111111',
+        'SysvarRecentB1ockHashes11111111111111111111',
+        'SysvarRent111111111111111111111111111111111',
+        'SysvarRewards111111111111111111111111111111',
+        'SysvarS1otHashes111111111111111111111111111',
+        'SysvarS1otHistory11111111111111111111111111',
+        'SysvarStakeHistory1111111111111111111111111',
+        # other
         'NativeLoader1111111111111111111111111111111',
         'Sysvar1111111111111111111111111111111111111',
     }
@@ -215,24 +251,15 @@ class Sol(Asset, Chain):
             bt.logging.error(f'SOL get_balance failed for {address}: {e}')
             return 0
 
-    def _is_readonly_account(self, address: str) -> bool:
-        """Whether the runtime forbids crediting ``address`` (ownership is immutable, so one
-        read at latest is definitive — no historical sampling, unlike the EVM code probe)."""
-        return self.rpc.get_account_owner(address) in READONLY_OWNERS
-
     def can_deliver_to(self, address: str, amount: int) -> bool:
-        """Reserve-time gate. Fails open — only a positive readonly-owner read blocks a reservation."""
-        try:
-            return not self._is_readonly_account(address)
-        except Exception as e:
-            bt.logging.warning(f'{LOG_SOL} owner probe failed for {address}: {e} — allowing')
-            return True
+        """Reserve-time gate: bounce a reserved-key destination before any funds move."""
+        return address not in RESERVED_ACCOUNTS
 
     def delivery_refused(self, address: str, since_unix: int) -> bool:
-        """Slash gate: a builtin/sysvar destination is undeliverable by construction — the runtime
-        rejects the lamport credit outright, so the miner could never have paid. Raises when the
-        chain view is unavailable (caller defers rather than slashing on a blind spot)."""
-        return self._is_readonly_account(address)
+        """Slash gate: a reserved-key destination is undeliverable by construction — the runtime
+        rejects the lamport credit outright, so the miner could never have paid. Offline and
+        exact, so unlike the EVM probes there is no RPC to fail and no window to sample."""
+        return address in RESERVED_ACCOUNTS
 
     def is_valid_address(self, address: str) -> bool:
         """Validate a base58 ed25519 pubkey (32 bytes) without RPC."""

--- a/allways/assets/solana.py
+++ b/allways/assets/solana.py
@@ -15,6 +15,17 @@ from allways.solana.rpc import SolanaRpc, resolve_rpc_url
 
 LOG_SOL = '[Solana]'
 
+# Accounts these programs own are readonly-enforced: the runtime rejects any lamport change,
+# so a transfer to one ALWAYS fails (ReadonlyLamportChange). Covers every builtin (System,
+# Vote, Stake, ComputeBudget, the loaders) and every sysvar. Deployed BPF programs are owned
+# by a loader instead and receive SOL fine — executability is not the test, ownership is.
+READONLY_OWNERS = frozenset(
+    {
+        'NativeLoader1111111111111111111111111111111',
+        'Sysvar1111111111111111111111111111111111111',
+    }
+)
+
 
 class Sol(Asset, Chain):
     """Solana swap-leg provider for native SOL transfers.
@@ -203,6 +214,25 @@ class Sol(Asset, Chain):
         except Exception as e:
             bt.logging.error(f'SOL get_balance failed for {address}: {e}')
             return 0
+
+    def _is_readonly_account(self, address: str) -> bool:
+        """Whether the runtime forbids crediting ``address`` (ownership is immutable, so one
+        read at latest is definitive — no historical sampling, unlike the EVM code probe)."""
+        return self.rpc.get_account_owner(address) in READONLY_OWNERS
+
+    def can_deliver_to(self, address: str, amount: int) -> bool:
+        """Reserve-time gate. Fails open — only a positive readonly-owner read blocks a reservation."""
+        try:
+            return not self._is_readonly_account(address)
+        except Exception as e:
+            bt.logging.warning(f'{LOG_SOL} owner probe failed for {address}: {e} — allowing')
+            return True
+
+    def delivery_refused(self, address: str, since_unix: int) -> bool:
+        """Slash gate: a builtin/sysvar destination is undeliverable by construction — the runtime
+        rejects the lamport credit outright, so the miner could never have paid. Raises when the
+        chain view is unavailable (caller defers rather than slashing on a blind spot)."""
+        return self._is_readonly_account(address)
 
     def is_valid_address(self, address: str) -> bool:
         """Validate a base58 ed25519 pubkey (32 bytes) without RPC."""

--- a/allways/solana/rpc.py
+++ b/allways/solana/rpc.py
@@ -124,6 +124,11 @@ class SolanaRpc:
         val = res.get('value')
         return None if val is None else int(val['lamports'])
 
+    def get_account_owner(self, pubkey, commitment: str = 'confirmed') -> Optional[str]:
+        res = self._call('getAccountInfo', [str(pubkey), {'encoding': 'base64', 'commitment': commitment}])
+        val = res.get('value')
+        return None if val is None else str(val['owner'])
+
     def get_program_accounts(
         self,
         program_id,

--- a/allways/solana/rpc.py
+++ b/allways/solana/rpc.py
@@ -124,11 +124,6 @@ class SolanaRpc:
         val = res.get('value')
         return None if val is None else int(val['lamports'])
 
-    def get_account_owner(self, pubkey, commitment: str = 'confirmed') -> Optional[str]:
-        res = self._call('getAccountInfo', [str(pubkey), {'encoding': 'base64', 'commitment': commitment}])
-        val = res.get('value')
-        return None if val is None else str(val['owner'])
-
     def get_program_accounts(
         self,
         program_id,

--- a/tests/test_solana_provider.py
+++ b/tests/test_solana_provider.py
@@ -158,6 +158,55 @@ class TestAddressValidity:
         assert p.is_valid_address(None) is False
 
 
+class TestDeliveryGates:
+    """Builtin/sysvar destinations are readonly-enforced: the runtime rejects the lamport credit,
+    so an honest miner can never deliver and must never be slashed for it. Verified against LiteSVM
+    (2026-08-10): System Program and every sysvar fail with ReadonlyLamportChange; the SPL Token
+    Program — executable, but loader-owned — receives SOL fine, so ownership is the test."""
+
+    SYSTEM_PROGRAM = '11111111111111111111111111111111'
+    CLOCK_SYSVAR = 'SysvarC1ock11111111111111111111111111111111'
+
+    def owner_rpc(self, owner):
+        rpc = FakeRpc()
+        rpc.get_account_owner = lambda pubkey, commitment='confirmed': owner
+        return rpc
+
+    def failing_rpc(self):
+        rpc = FakeRpc()
+
+        def boom(pubkey, commitment='confirmed'):
+            raise requests.ConnectionError('down')
+
+        rpc.get_account_owner = boom
+        return rpc
+
+    @pytest.mark.parametrize(
+        'owner', ['NativeLoader1111111111111111111111111111111', 'Sysvar1111111111111111111111111111111111111']
+    )
+    def test_readonly_owner_blocks_reservation_and_exempts_slash(self, owner):
+        p = provider_with(self.owner_rpc(owner))
+        assert p.can_deliver_to(self.SYSTEM_PROGRAM, 10**9) is False
+        assert p.delivery_refused(self.SYSTEM_PROGRAM, 0) is True
+
+    @pytest.mark.parametrize(
+        'owner', ['11111111111111111111111111111111', 'BPFLoader2111111111111111111111111111111111', None]
+    )
+    def test_ordinary_and_deployed_program_dests_pass(self, owner):
+        """System-owned wallets and loader-owned (executable) programs both take a credit."""
+        p = provider_with(self.owner_rpc(owner))
+        assert p.can_deliver_to(str(Keypair().pubkey()), 10**9) is True
+        assert p.delivery_refused(str(Keypair().pubkey()), 0) is False
+
+    def test_reserve_gate_fails_open_on_rpc_trouble(self):
+        assert provider_with(self.failing_rpc()).can_deliver_to(self.CLOCK_SYSVAR, 10**9) is True
+
+    def test_slash_gate_raises_on_rpc_trouble(self):
+        """A blind chain view must defer the slash, never falsify one — the caller catches and WAITs."""
+        with pytest.raises(requests.ConnectionError):
+            provider_with(self.failing_rpc()).delivery_refused(self.CLOCK_SYSVAR, 0)
+
+
 class TestProofRoundtrip:
     def test_sign_then_verify(self):
         kp = Keypair()

--- a/tests/test_solana_provider.py
+++ b/tests/test_solana_provider.py
@@ -10,7 +10,7 @@ import requests
 from solders.keypair import Keypair
 
 from allways.assets.base import ProviderUnreachableError
-from allways.assets.solana import Sol
+from allways.assets.solana import RESERVED_ACCOUNTS, Sol
 from allways.chains import CHAIN_SOL
 
 
@@ -159,52 +159,58 @@ class TestAddressValidity:
 
 
 class TestDeliveryGates:
-    """Builtin/sysvar destinations are readonly-enforced: the runtime rejects the lamport credit,
-    so an honest miner can never deliver and must never be slashed for it. Verified against LiteSVM
-    (2026-08-10): System Program and every sysvar fail with ReadonlyLamportChange; the SPL Token
-    Program — executable, but loader-owned — receives SOL fine, so ownership is the test."""
+    """Solana's reserved account keys are read-only in every transaction, so a transfer to one
+    always fails and an honest miner must never be slashed for missing it. Verified against LiteSVM
+    (2026-08-10): all 31 reserved keys reject the credit; the incinerator and ordinary/PDA/program
+    addresses accept it. Ownership is NOT the test — Stake/Config/AddressLookupTable are owned by
+    the upgradeable loader, StakeConfig has no account, and the SPL Token program is executable
+    yet fundable."""
 
-    SYSTEM_PROGRAM = '11111111111111111111111111111111'
-    CLOCK_SYSVAR = 'SysvarC1ock11111111111111111111111111111111'
+    # One per shape the account-owner heuristic got wrong, plus the obvious burn target.
+    RESERVED = [
+        '11111111111111111111111111111111',  # System Program — owner NativeLoader
+        'SysvarC1ock11111111111111111111111111111111',  # sysvar — owner Sysvar
+        'StakeConfig11111111111111111111111111111111',  # no account exists at all
+        'Stake11111111111111111111111111111111111111',  # Core BPF: owner is the upgradeable loader
+        'Config1111111111111111111111111111111111111',  # ditto
+        'AddressLookupTab1e1111111111111111111111111',  # ditto
+        'Feature111111111111111111111111111111111111',  # no account exists
+    ]
+    DELIVERABLE = [
+        '1nc1nerator11111111111111111111111111111111',  # deliberately not reserved — a burn must land
+        'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',  # executable, loader-owned, receives SOL fine
+    ]
 
-    def owner_rpc(self, owner):
-        rpc = FakeRpc()
-        rpc.get_account_owner = lambda pubkey, commitment='confirmed': owner
-        return rpc
+    @pytest.mark.parametrize('address', RESERVED)
+    def test_reserved_key_blocks_reservation_and_exempts_slash(self, address):
+        p = provider_with(FakeRpc())
+        assert p.can_deliver_to(address, 10**9) is False
+        assert p.delivery_refused(address, 0) is True
 
-    def failing_rpc(self):
-        rpc = FakeRpc()
+    @pytest.mark.parametrize('address', DELIVERABLE)
+    def test_fundable_special_addresses_pass(self, address):
+        p = provider_with(FakeRpc())
+        assert p.can_deliver_to(address, 10**9) is True
+        assert p.delivery_refused(address, 0) is False
 
-        def boom(pubkey, commitment='confirmed'):
-            raise requests.ConnectionError('down')
+    def test_ordinary_wallet_passes(self):
+        p = provider_with(FakeRpc())
+        addr = str(Keypair().pubkey())
+        assert p.can_deliver_to(addr, 10**9) is True
+        assert p.delivery_refused(addr, 0) is False
 
-        rpc.get_account_owner = boom
-        return rpc
+    def test_gates_need_no_rpc(self):
+        """Offline by construction — a dead RPC can neither block a reservation nor defer a slash."""
+        p = provider_with(FakeRpc(raise_conn=True))
+        assert p.can_deliver_to(self.RESERVED[0], 10**9) is False
+        assert p.delivery_refused(self.RESERVED[0], 0) is True
 
-    @pytest.mark.parametrize(
-        'owner', ['NativeLoader1111111111111111111111111111111', 'Sysvar1111111111111111111111111111111111111']
-    )
-    def test_readonly_owner_blocks_reservation_and_exempts_slash(self, owner):
-        p = provider_with(self.owner_rpc(owner))
-        assert p.can_deliver_to(self.SYSTEM_PROGRAM, 10**9) is False
-        assert p.delivery_refused(self.SYSTEM_PROGRAM, 0) is True
-
-    @pytest.mark.parametrize(
-        'owner', ['11111111111111111111111111111111', 'BPFLoader2111111111111111111111111111111111', None]
-    )
-    def test_ordinary_and_deployed_program_dests_pass(self, owner):
-        """System-owned wallets and loader-owned (executable) programs both take a credit."""
-        p = provider_with(self.owner_rpc(owner))
-        assert p.can_deliver_to(str(Keypair().pubkey()), 10**9) is True
-        assert p.delivery_refused(str(Keypair().pubkey()), 0) is False
-
-    def test_reserve_gate_fails_open_on_rpc_trouble(self):
-        assert provider_with(self.failing_rpc()).can_deliver_to(self.CLOCK_SYSVAR, 10**9) is True
-
-    def test_slash_gate_raises_on_rpc_trouble(self):
-        """A blind chain view must defer the slash, never falsify one — the caller catches and WAITs."""
-        with pytest.raises(requests.ConnectionError):
-            provider_with(self.failing_rpc()).delivery_refused(self.CLOCK_SYSVAR, 0)
+    def test_reserved_set_matches_agave(self):
+        """Guards against a typo silently un-blocking a key: agave v3.1.14 lists exactly 31."""
+        assert len(RESERVED_ACCOUNTS) == 31
+        assert all(32 <= len(a) <= 44 for a in RESERVED_ACCOUNTS)
+        p = provider_with(FakeRpc())
+        assert all(p.is_valid_address(a) for a in RESERVED_ACCOUNTS)
 
 
 class TestProofRoundtrip:


### PR DESCRIPTION
## What
`Sol` now implements the two delivery gates: a destination in Solana's **reserved account key set** bounces at reserve time and never slashes at timeout.

## Why
The runtime demotes every reserved key to read-only in **every** transaction, so a transfer to one always fails with `ReadonlyLamportChange`. That's 31 addresses: every builtin (System, Vote, Stake, ComputeBudget, the loaders, …) and every sysvar.

`Sol` had no gate override, so both fell through to the base defaults (`can_deliver_to` → True, `delivery_refused` → False). A taker who self-represents (bypassing `reserve_on_behalf`, the live mainnet path) could pin `user_to_addr = 11111111111111111111111111111111`, fund the source leg, and the miner's delivery would fail on every attempt → overdue → **slash of an honest miner** on attacker-controlled input. Same shape as the arbusdc zero-address hole (#629), on the hub receive direction.

#631 doesn't catch it: these are well-formed pubkeys, so `is_valid_address` passes them.

## Why set membership, and not an account probe
Neither `executable` nor `owner` is a sound predicate. Verified against LiteSVM (2026-08-10) with a bare `system_instruction::transfer` to each:

| Destination | Owner | Executable | Transfer |
|---|---|---|---|
| System Program, Vote, ComputeBudget | NativeLoader | yes | FAIL |
| Clock, Rent, … sysvars | Sysvar | no | FAIL |
| Stake, Config, AddressLookupTable | **BPFLoaderUpgradeab1e** (Core BPF migration) | yes | FAIL |
| StakeConfig, Feature | **no account exists** | — | FAIL |
| **SPL Token Program** | BPFLoader2 | **yes** | **OK** |
| Incinerator, PDA, token account, wallet | — | no | OK |

An `executable` test wrongly blocks the Token Program. An `owner ∈ {NativeLoader, Sysvar}` test misses Stake, Config, AddressLookupTable, StakeConfig and Feature — all trivially discoverable addresses that would still slash an honest miner. Only membership in the reserved set is exact.

It is also *better*: the set is static, so the gates are pure offline lookups. No RPC means no `getAccountInfo` payload fetch on the synchronous reserve path (a ProgramData destination would have pulled megabytes), no retry stall, and no failure mode where a dead RPC pins a swap in `WAIT` forever.

`RESERVED_ACCOUNTS` mirrors `agave-reserved-account-keys` v3.1.14 verbatim, including the feature-gated pending entries. The list is consensus-critical and append-only, so a stale copy under-blocks but never over-blocks; a length assertion in the tests catches a typo silently un-blocking a key.

## Audit of the other spokes
Checked every asset for a well-formed destination that is structurally undeliverable. `sol` was the only one left:

- **eth** — zero address rejected in `is_valid_address` (#629); code-bearing dests are blanket slash-exempt via the `getCode` probe; precompiles accept value transfers.
- **arbusdc** — USDC's `transfer` only reverts on `to == address(0)` (invalid since #629), blacklisted party, or paused token. The latter two are already the `delivery_refused` predicate.
- **btc** — every embit-parseable address maps to a relayable scriptPubKey.
- **tao** — any `AccountId32` can receive.

Amount floors were checked the same way and are all clear: BTC 1000 sat vs a 546 worst-case dust line, TAO 500 rao == the existential deposit, SOL sub-rent-exempt credits land fine (confirmed in the same LiteSVM run), ETH/arbusdc have no protocol minimum.

## Change
- `RESERVED_ACCOUNTS` in `assets/solana.py` + `Sol.can_deliver_to` + `Sol.delivery_refused`. No RPC, no new dependency.

No new call sites — both slash paths (`solana_swap_loop.py:275`, `:355`) already funnel through `_dest_refuses`, and the reserve gates already call `can_deliver_to`.

## Tests
- `TestDeliveryGates` in `test_solana_provider.py` — one case per shape an owner heuristic gets wrong (NativeLoader-owned, Sysvar-owned, loader-owned, no-account-at-all); the incinerator and the SPL Token program stay deliverable; ordinary wallets pass; the gates work with a dead RPC; the set matches agave's count.
- 1054 passed, ruff clean.
