### PR TITLE
Skip the coldkey prompt when the keyfile is unencrypted

### DIFF
--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -128,6 +128,10 @@ class Miner(BaseMinerNeuron):
         detached miner reads garbage from stdin, producing spurious
         "password invalid" errors mid-swap.
 
+        An unencrypted keyfile has no password to cache, and prompting for one
+        hands a detached miner an EOFError at boot instead of a running neuron
+        — so that case unlocks directly.
+
         Reads ``MINER_BITTENSOR_COLDKEY_PASSWORD`` if set, otherwise prompts
         once at startup. Uses ``save_password_to_env`` (not direct
         ``os.environ`` assignment) because bittensor-wallet 4.0.1 stores the
@@ -135,6 +139,11 @@ class Miner(BaseMinerNeuron):
         ``BT_PW__...`` env var is rejected as malformed base64.
         """
         from getpass import getpass
+
+        if not self.wallet.coldkey_file.is_encrypted():
+            self.wallet.unlock_coldkey()
+            bt.logging.info('Bittensor coldkey unlocked (keyfile is not encrypted)')
+            return
 
         password = os.environ.get('MINER_BITTENSOR_COLDKEY_PASSWORD')
         if not password:

--- a/tests/test_miner_coldkey_unlock.py
+++ b/tests/test_miner_coldkey_unlock.py
@@ -1,0 +1,63 @@
+"""Miner.unlock_coldkey: headless startup across encrypted and plaintext keyfiles.
+
+A miner created without a coldkey password has nothing to prompt for; prompting
+anyway kills a detached neuron with EOFError before it ever polls a swap.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from neurons.miner import Miner
+
+
+def _wallet(encrypted: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        name='miner',
+        coldkey_file=SimpleNamespace(is_encrypted=lambda: encrypted, save_password_to_env=MagicMock()),
+        unlock_coldkey=MagicMock(),
+    )
+
+
+def _no_prompt(monkeypatch):
+    """Make any getpass() call an error — a headless miner has no stdin to read."""
+    import getpass as getpass_module
+
+    def _boom(_prompt=''):
+        raise EOFError('getpass called with no tty')
+
+    monkeypatch.setattr(getpass_module, 'getpass', _boom)
+
+
+def test_plaintext_keyfile_unlocks_without_prompting(monkeypatch):
+    monkeypatch.delenv('MINER_BITTENSOR_COLDKEY_PASSWORD', raising=False)
+    _no_prompt(monkeypatch)
+    wallet = _wallet(encrypted=False)
+
+    Miner.unlock_coldkey(SimpleNamespace(wallet=wallet))
+
+    wallet.unlock_coldkey.assert_called_once()
+    # Nothing to cache: a password env var written for a plaintext keyfile is noise.
+    wallet.coldkey_file.save_password_to_env.assert_not_called()
+
+
+def test_encrypted_keyfile_caches_password_from_env(monkeypatch):
+    monkeypatch.setenv('MINER_BITTENSOR_COLDKEY_PASSWORD', 'hunter2')
+    _no_prompt(monkeypatch)
+    wallet = _wallet(encrypted=True)
+
+    Miner.unlock_coldkey(SimpleNamespace(wallet=wallet))
+
+    wallet.coldkey_file.save_password_to_env.assert_called_once_with('hunter2')
+    wallet.unlock_coldkey.assert_called_once()
+
+
+def test_encrypted_keyfile_without_env_still_prompts(monkeypatch):
+    """The guard must not swallow the real prompt path — an encrypted keyfile
+    with no env var is exactly when a human is expected to type one in."""
+    monkeypatch.delenv('MINER_BITTENSOR_COLDKEY_PASSWORD', raising=False)
+    _no_prompt(monkeypatch)
+
+    with pytest.raises(EOFError):
+        Miner.unlock_coldkey(SimpleNamespace(wallet=_wallet(encrypted=True)))


### PR DESCRIPTION
## Problem

`Miner.unlock_coldkey` prompts for a password unconditionally when `MINER_BITTENSOR_COLDKEY_PASSWORD` is unset. A coldkey created without a password has none to give, so a detached miner dies at boot:

```
Enter password to unlock coldkey (alw-testnet-miner): Traceback (most recent call last):
  File "neurons/miner.py", line 44, in __init__
    self.unlock_coldkey()
  File "neurons/miner.py", line 141, in unlock_coldkey
    password = getpass(f'Enter password to unlock coldkey ({self.wallet.name}): ')
EOFError
```

systemd restarts it into the same crash forever. Hit while standing up a testnet miner for the arbusdc spoke.

## Fix

Unlock directly when `coldkey_file.is_encrypted()` is false. An unencrypted keyfile has no password to cache, so both the prompt and the `save_password_to_env` round-trip are skipped.

The encrypted paths are untouched: env var still caches through the keyfile, and an encrypted keyfile with no env var still prompts.

## Tests

`tests/test_miner_coldkey_unlock.py` covers all three branches, with `getpass` patched to raise `EOFError` so a headless environment is what is actually being asserted. The plaintext test fails on `test` and passes here.

Full suite: 1057 passed.