### PR TITLE
Add HYPE (Hyperliquid) as a launch spoke

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,14 @@ ARBUSDC_NETWORK=mainnet             # mainnet | sepolia (Arbitrum Sepolia)
 # optional local signing for `alw swap`
 ARBUSDC_PRIVATE_KEY=
 
+# ─── Chain: Hyperliquid (HYPE pairs) ───────────────────────
+HYPE_NETWORK=mainnet                # mainnet | testnet
+# OPTIONAL ordered JSON-RPC endpoints (keyed providers embed the key in the URL);
+# unset = public (rpc.hyperliquid.xyz, drpc) — those are capped at 100 req/min per IP
+# HYPE_RPC_URLS=https://api-hyperliquid-mainnet-evm.n.dwellir.com/your_key,https://rpc.hyperliquid.xyz/evm
+# 32-byte hex key — required for miners; optional local signing for `alw swap`
+HYPE_PRIVATE_KEY=
+
 # ─── Miner-only ────────────────────────────────────────────
 # headless miners: unlocks the coldkey at startup for TAO sends; unset = prompt at launch
 MINER_BITTENSOR_COLDKEY_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Native transactions across independent assets — no wrapped tokens, no bridges,
 
 Allways creates a verification layer above independent systems. Assets move natively. Miners complete transactions, validators independently verify the results, and a smart contract enforces outcomes through collateral and slashing.
 
-Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, and SOL ↔ USDC-on-Arbitrum (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
+Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, and SOL ↔ HYPE (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
 
 ## Miner Risk Disclaimer
 
@@ -69,7 +69,7 @@ needs to persist across restarts.
 
 ## Miner Environment Variables
 
-- `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARBUSDC_PRIVATE_KEY`, `{ETH,ARBUSDC}_RPC_URLS`, etc. — see `.env.example`.
+- `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARBUSDC_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `{ETH,ARBUSDC,HYPE}_RPC_URLS`, etc. — see `.env.example`.
 
 ## Running a Local Subtensor Lite Node (Validators)
 

--- a/allways/assets/__init__.py
+++ b/allways/assets/__init__.py
@@ -8,6 +8,7 @@ from allways.assets.chain import Chain
 from allways.assets.erc20 import ArbUsdc, Erc20
 from allways.assets.ethereum import Ether
 from allways.assets.evm_coin import EvmCoin
+from allways.assets.hyperliquid import Hype
 from allways.assets.solana import Sol
 from allways.assets.subtensor import Tao
 
@@ -22,6 +23,7 @@ __all__ = [
     'Sol',
     'EvmCoin',
     'Ether',
+    'Hype',
     'Erc20',
     'ArbUsdc',
     'create_assets',
@@ -43,6 +45,7 @@ ASSET_REGISTRY: Tuple[AssetSpec, ...] = (
     AssetSpec('sol', Sol, ('solana_rpc_url', 'solana_keypair')),
     AssetSpec('eth', Ether, ()),
     AssetSpec('arbusdc', ArbUsdc, ()),
+    AssetSpec('hype', Hype, ()),
 )
 
 

--- a/allways/assets/evm.py
+++ b/allways/assets/evm.py
@@ -82,9 +82,19 @@ ARBITRUM = EvmNetwork(
         'sepolia': ('https://arbitrum-sepolia-rpc.publicnode.com', 'https://arbitrum-sepolia.drpc.org'),
     },
 )
+HYPERLIQUID = EvmNetwork(
+    label='Hyperliquid',
+    chain_ids={'mainnet': 999, 'testnet': 998},
+    rpc_urls={
+        # The official gateways are rate-limited to 100 req/min per IP — fine as the keyless
+        # default, but operators should point {PREFIX}_RPC_URLS at a keyed endpoint.
+        'mainnet': ('https://rpc.hyperliquid.xyz/evm', 'https://hyperliquid.drpc.org'),
+        'testnet': ('https://rpc.hyperliquid-testnet.xyz/evm', 'https://hyperliquid-testnet.drpc.org'),
+    },
+)
 
 # ChainDefinition.host_chain → the EvmNetwork that hosts the asset.
-EVM_NETWORKS: Mapping[str, EvmNetwork] = {'ethereum': ETHEREUM, 'arbitrum': ARBITRUM}
+EVM_NETWORKS: Mapping[str, EvmNetwork] = {'ethereum': ETHEREUM, 'arbitrum': ARBITRUM, 'hyperliquid': HYPERLIQUID}
 
 
 class EvmChain(Chain):

--- a/allways/assets/evm_coin.py
+++ b/allways/assets/evm_coin.py
@@ -18,10 +18,6 @@ ZERO_ADDRESS = '0x' + '00' * 20
 # RPC per block, and sub-second chains would otherwise turn SCAN_LOOKBACK_BLOCKS into hundreds of
 # calls per pass (HyperEVM's public RPC allows 100/min). Never binds on ~12s chains (25 blocks).
 MAX_WALK_BLOCKS = 32
-# Hard ceiling on the deposit scanner's block walk, independent of block time: the walk costs one
-# RPC per block, and sub-second chains would otherwise turn SCAN_LOOKBACK_BLOCKS into hundreds of
-# calls per pass (HyperEVM's public RPC allows 100/min). Never binds on ~12s chains (25 blocks).
-MAX_WALK_BLOCKS = 32
 
 
 class EvmCoin(EvmAsset, EvmChain):

--- a/allways/assets/evm_coin.py
+++ b/allways/assets/evm_coin.py
@@ -14,6 +14,14 @@ TRANSFER_GAS = 21_000
 # spend against a hostile contract; the slash gate exempts code-bearing dests anyway.
 MAX_TRANSFER_GAS = 100_000
 ZERO_ADDRESS = '0x' + '00' * 20
+# Hard ceiling on the deposit scanner's block walk, independent of block time: the walk costs one
+# RPC per block, and sub-second chains would otherwise turn SCAN_LOOKBACK_BLOCKS into hundreds of
+# calls per pass (HyperEVM's public RPC allows 100/min). Never binds on ~12s chains (25 blocks).
+MAX_WALK_BLOCKS = 32
+# Hard ceiling on the deposit scanner's block walk, independent of block time: the walk costs one
+# RPC per block, and sub-second chains would otherwise turn SCAN_LOOKBACK_BLOCKS into hundreds of
+# calls per pass (HyperEVM's public RPC allows 100/min). Never binds on ~12s chains (25 blocks).
+MAX_WALK_BLOCKS = 32
 
 
 class EvmCoin(EvmAsset, EvmChain):
@@ -317,7 +325,7 @@ class EvmCoin(EvmAsset, EvmChain):
         want_from = norm(from_addr)
         want_to = norm(to_addr)
         key = (want_from, want_to, int(amount))
-        floor = max(head - self.SCAN_LOOKBACK_BLOCKS, 0)
+        floor = max(head - min(self.SCAN_LOOKBACK_BLOCKS, MAX_WALK_BLOCKS), 0)
         last = self.scan_cursors.get(key, floor)
         for block_num in range(max(last, floor) + 1, head + 1):
             try:

--- a/allways/assets/hyperliquid.py
+++ b/allways/assets/hyperliquid.py
@@ -1,0 +1,12 @@
+from allways.assets.evm import HYPERLIQUID
+from allways.assets.evm_coin import EvmCoin
+from allways.chains import CHAIN_HYPE
+
+
+class Hype(EvmCoin):
+    """HYPE on HyperEVM — a config-row binding of the generic EvmCoin (see chains.CHAIN_HYPE).
+
+    HyperEVM speaks plain JSON-RPC, so nothing here is chain-specific beyond the pairing."""
+
+    def __init__(self):
+        super().__init__(CHAIN_HYPE, HYPERLIQUID)

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -129,12 +129,33 @@ CHAIN_ARBUSDC = ChainDefinition(
     asset_locator='0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
 )
 
+CHAIN_HYPE = ChainDefinition(
+    id='hype',
+    name='Hyperliquid',
+    native_unit='wei',
+    decimals=18,
+    env_prefix='HYPE',
+    networks=('mainnet', 'testnet'),
+    testnet_network='testnet',
+    # ~1s small blocks (transfers never need the 60s big blocks — those carry >2M gas).
+    seconds_per_block=1,
+    # HyperBFT finalizes the block sequence on inclusion — no reorgs to outrun. 2 is a
+    # one-block margin against an endpoint serving a head its consensus hasn't sealed yet.
+    min_confirmations=2,
+    # Rate sanity floor, not an economic guarantee: 0.0001 HYPE covers a 21k-gas transfer
+    # below ~4.7 gwei — miners price real gas into their quotes.
+    min_onchain_amount=100_000_000_000_000,
+    # Consensus-stamped timestamps vs the hub clock — modest skew allowance, as on Arbitrum.
+    replay_grace_secs=60,
+)
+
 SUPPORTED_CHAINS = {
     'btc': CHAIN_BTC,
     'tao': CHAIN_TAO,
     'sol': CHAIN_SOL,
     'eth': CHAIN_ETH,
     'arbusdc': CHAIN_ARBUSDC,
+    'hype': CHAIN_HYPE,
 }
 
 

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -68,7 +68,8 @@ REWARD_MINER_STATES: frozenset[MinerActivity] = frozenset({MinerActivity.AVAILAB
 # uniformly as 'dest per 1 hub'. SOL by construction (the contract lives on Solana: collateral, fee, and the
 # collateral_amount notional are all SOL). Referenced wherever code needs "is this the hub", instead of a literal.
 NUMERAIRE_CHAIN = 'sol'
-LAUNCH_SPOKES = ('btc', 'tao', 'eth', 'arbusdc')  # chains paired against the hub; add a chain here to launch its pair
+# Chains paired against the hub; add a chain here to launch its pair.
+LAUNCH_SPOKES = ('btc', 'tao', 'eth', 'arbusdc', 'hype')
 # Fixed burn: pools sum to MINER_POOL_SHARE instead of 1.0, so at least
 # BURN_RATE of every round recycles to RECYCLE_UID before any shortfall.
 BURN_RATE = 0.90

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -8,6 +8,7 @@ from allways.chains import (
     CHAIN_ARBUSDC,
     CHAIN_BTC,
     CHAIN_ETH,
+    CHAIN_HYPE,
     CHAIN_TAO,
     EXTENSION_BUCKET_SECONDS,
     SUPPORTED_CHAINS,
@@ -30,6 +31,9 @@ class TestGetChain:
     def test_arbusdc(self):
         assert get_chain_def('arbusdc') is CHAIN_ARBUSDC
 
+    def test_hype(self):
+        assert get_chain_def('hype') is CHAIN_HYPE
+
     def test_unsupported_raises(self):
         with pytest.raises(KeyError):
             get_chain_def('doge')
@@ -43,7 +47,7 @@ class TestGetChain:
             assert chain.id == chain_id
 
     def test_layered_fields_default_none_for_native_assets(self):
-        for chain_id in ('btc', 'tao', 'sol', 'eth'):
+        for chain_id in ('btc', 'tao', 'sol', 'eth', 'hype'):
             assert get_chain_def(chain_id).host_chain is None
             assert get_chain_def(chain_id).asset_locator is None
         assert CHAIN_ARBUSDC.host_chain == 'arbitrum'
@@ -124,6 +128,10 @@ class TestComputeExtensionTargetSecs:
     def test_arbusdc_remaining_confs(self):
         # arbusdc needs 90 confs, 1s each: remaining=90, raw = 10000 + 90 + 120 = 10210, bucket up to 10800.
         assert compute_extension_target_secs('arbusdc', 0, self.NOW, self.CEILING) == 10_800
+
+    def test_hype_remaining_confs(self):
+        # hype needs 2 confs, 1s each: remaining=2, raw = 10000 + 2 + 120 = 10122, bucket up to 10200.
+        assert compute_extension_target_secs('hype', 0, self.NOW, self.CEILING) == 10_200
 
     def test_unsupported_chain_raises(self):
         with pytest.raises(KeyError):

--- a/tests/test_cli_chain_networks.py
+++ b/tests/test_cli_chain_networks.py
@@ -52,12 +52,13 @@ class TestPinnedContract:
             'btc-network',
             'eth-network',
             'arbusdc-network',
+            'hype-network',
             'router',
             'env',
         )
 
     def test_chain_network_keys(self):
-        assert CHAIN_NETWORK_KEYS == ('btc-network', 'eth-network', 'arbusdc-network')
+        assert CHAIN_NETWORK_KEYS == ('btc-network', 'eth-network', 'arbusdc-network', 'hype-network')
 
     def test_testnet_bundle(self):
         assert ENV_BUNDLES['testnet'] == {
@@ -66,6 +67,7 @@ class TestPinnedContract:
             'btc-network': 'testnet4',
             'eth-network': 'sepolia',
             'arbusdc-network': 'sepolia',
+            'hype-network': 'testnet',
             'netuid': '19',
             'router': '5HicmHG7fjbxrtx8FZNdv4xxS5jSN84KGpMnTHsKtKv9peao',
         }
@@ -77,6 +79,7 @@ class TestPinnedContract:
             'btc-network': 'mainnet',
             'eth-network': 'mainnet',
             'arbusdc-network': 'mainnet',
+            'hype-network': 'mainnet',
             'netuid': '7',
             'router': '',
         }
@@ -98,6 +101,7 @@ class TestPinnedContract:
             'btc': ('mainnet', 'testnet', 'testnet4', 'signet'),
             'eth': ('mainnet', 'sepolia'),
             'arbusdc': ('mainnet', 'sepolia'),
+            'hype': ('mainnet', 'testnet'),
         }
 
 

--- a/tests/test_hype_provider.py
+++ b/tests/test_hype_provider.py
@@ -1,0 +1,234 @@
+"""Hype unit tests — all offline (RPC layer mocked, signing is pure crypto).
+
+The EVM behaviour itself is `EvmCoin`, proven by the Ether suite. What is HYPE-specific — and
+what a wrong value here would cost — lives in the binding: which network the env selects, the
+chain id every signed tx commits to, and the sub-second block time that drives the scanner.
+"""
+
+import pytest
+from eth_account import Account
+
+from allways.assets.base import ProviderUnreachableError
+from allways.assets.evm import HYPERLIQUID
+from allways.assets.evm_coin import MAX_WALK_BLOCKS
+from allways.assets.hyperliquid import Hype
+from allways.chains import CHAIN_HYPE, get_chain_def
+from allways.constants import LAUNCH_SPOKES
+
+TEST_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'  # hardhat account #0
+RECIPIENT = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+TX = '0x' + 'ab' * 32
+BLOCK_HASH = '0x' + 'cd' * 32
+
+SEND_RESPONSES = {
+    'eth_blockNumber': hex(100),
+    'eth_getBlockByNumber': {'baseFeePerGas': hex(10**9)},
+    'eth_maxPriorityFeePerGas': hex(10**9),
+    'eth_getTransactionCount': '0x0',
+    'eth_getBalance': hex(10**19),
+    'eth_estimateGas': hex(21_000),
+}
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    monkeypatch.setenv('HYPE_NETWORK', 'mainnet')
+    monkeypatch.delenv('HYPE_RPC_URLS', raising=False)
+    monkeypatch.delenv('HYPE_PRIVATE_KEY', raising=False)
+    return Hype()
+
+
+def rpc_stub(provider, responses: dict):
+    """Replace eth_rpc with a method→response map. A callable value is invoked with params."""
+
+    def fake_rpc(method, params, timeout=15, **kw):
+        value = responses[method]
+        return value(params) if callable(value) else value
+
+    provider.eth_rpc = fake_rpc
+    return provider
+
+
+def mined_responses(status='0x1', tip=1_000_002, value_hex=hex(10**18)):
+    return {
+        'eth_getTransactionByHash': {
+            'hash': TX,
+            'from': '0x' + '11' * 20,
+            'to': RECIPIENT,
+            'value': value_hex,
+            'blockNumber': '0xf4240',
+            'blockHash': BLOCK_HASH,
+        },
+        'eth_getTransactionReceipt': {'status': status, 'blockNumber': '0xf4240', 'blockHash': BLOCK_HASH},
+        'eth_blockNumber': hex(tip),
+        'eth_getBlockByNumber': {'hash': BLOCK_HASH, 'timestamp': '0x64'},
+    }
+
+
+class TestRegistryRow:
+    def test_is_a_launch_spoke_bound_to_its_registry_row(self, provider):
+        assert provider.chain_def is CHAIN_HYPE is get_chain_def('hype')
+        assert 'hype' in LAUNCH_SPOKES
+
+    def test_native_coin_is_fused_with_its_chain(self, provider):
+        assert provider.chain is provider
+
+    def test_decimals_and_prefix(self):
+        assert (CHAIN_HYPE.decimals, CHAIN_HYPE.env_prefix, CHAIN_HYPE.native_unit) == (18, 'HYPE', 'wei')
+
+    def test_confirmations_stay_inside_the_program_fulfillment_grace(self):
+        # An unlisted chain gets the program's 600s default grace; 2 × 1s blocks is far inside it.
+        assert CHAIN_HYPE.min_confirmations * CHAIN_HYPE.seconds_per_block < 600
+
+
+class TestNetworkSelection:
+    def test_mainnet_chain_id(self, provider):
+        assert provider.chain_id == 999
+
+    def test_testnet_chain_id(self, monkeypatch):
+        monkeypatch.setenv('HYPE_NETWORK', 'testnet')
+        assert Hype().chain_id == 998
+
+    def test_unknown_network_raises(self, monkeypatch):
+        # A typo must never fall back to mainnet — that spends real HYPE against test swaps.
+        monkeypatch.setenv('HYPE_NETWORK', 'testnett')
+        with pytest.raises(ValueError, match='HYPE_NETWORK'):
+            Hype()
+
+    def test_unset_network_defaults_to_mainnet(self, monkeypatch):
+        monkeypatch.delenv('HYPE_NETWORK', raising=False)
+        assert Hype().network == 'mainnet'
+
+    @pytest.mark.parametrize('network', tuple(HYPERLIQUID.chain_ids))
+    def test_every_network_has_a_keyless_default_ladder(self, monkeypatch, network):
+        monkeypatch.setenv('HYPE_NETWORK', network)
+        assert Hype().rpc_bases == list(HYPERLIQUID.rpc_urls[network])
+
+    def test_rpc_urls_env_overrides_the_public_ladder(self, monkeypatch):
+        monkeypatch.setenv('HYPE_RPC_URLS', 'https://paid.example/key/,https://backup.example')
+        assert Hype().rpc_bases == ['https://paid.example/key', 'https://backup.example']
+
+    def test_wrong_network_endpoint_fails_startup(self, monkeypatch):
+        # Testnet configured, a mainnet endpoint answering: the ladder must be rejected outright,
+        # never quietly used to verify legs against the wrong chain.
+        monkeypatch.setenv('HYPE_NETWORK', 'testnet')
+        p = rpc_stub(Hype(), {'eth_chainId': hex(999)})
+        with pytest.raises(ConnectionError, match='expected 998'):
+            p.check_connection(require_send=False)
+
+
+class TestVerification:
+    def test_settled_transfer_matches(self, provider):
+        rpc_stub(provider, mined_responses())
+        info = provider.fetch_matching_tx(TX, RECIPIENT, 10**18)
+        assert info is not None and info.confirmed and info.amount == 10**18
+        assert info.block_time == 0x64
+
+    def test_two_confirmations_are_enough(self, provider):
+        rpc_stub(provider, mined_responses(tip=1_000_001))  # mined block + 1
+        assert provider.fetch_matching_tx(TX, RECIPIENT, 10**18).confirmed
+
+    def test_one_confirmation_is_not(self, provider):
+        rpc_stub(provider, mined_responses(tip=1_000_000))
+        assert provider.fetch_matching_tx(TX, RECIPIENT, 10**18).confirmed is False
+
+    def test_reverted_tx_rejected(self, provider):
+        # Inclusion is not settlement: a reverted tx still carries intact to/value fields.
+        rpc_stub(provider, mined_responses(status='0x0'))
+        assert provider.fetch_matching_tx(TX, RECIPIENT, 10**18) is None
+
+    def test_underpayment_rejected(self, provider):
+        rpc_stub(provider, mined_responses(value_hex=hex(10**17)))
+        assert provider.fetch_matching_tx(TX, RECIPIENT, 10**18) is None
+
+    def test_absent_tx_is_absent(self, provider):
+        rpc_stub(provider, {'eth_getTransactionByHash': None})
+        assert provider.fetch_matching_tx(TX, RECIPIENT, 10**18) is None
+
+    def test_unreadable_receipt_is_unknown_not_absent(self, provider):
+        # 'unknown' must never read as 'no such payment' — that verdict slashes a paying miner.
+        responses = mined_responses()
+        responses['eth_getTransactionReceipt'] = None
+        with pytest.raises(ProviderUnreachableError):
+            rpc_stub(provider, responses).fetch_matching_tx(TX, RECIPIENT, 10**18)
+
+    def test_unreadable_block_timestamp_is_unknown_not_absent(self, provider):
+        # is_tx_fresh fails closed on a missing block_time, so a stale-looking dest leg
+        # would ride to a TIMEOUT slash. Raise instead and let the caller retry.
+        responses = mined_responses()
+        responses['eth_getBlockByNumber'] = {'hash': BLOCK_HASH}
+        with pytest.raises(ProviderUnreachableError):
+            rpc_stub(provider, responses).fetch_matching_tx(TX, RECIPIENT, 10**18)
+
+
+class TestSending:
+    @pytest.fixture(autouse=True)
+    def _key(self, provider, monkeypatch):
+        monkeypatch.setenv('HYPE_PRIVATE_KEY', TEST_KEY)
+
+    def test_broadcasts_a_hyperevm_signed_transfer(self, provider):
+        # Pins the whole signed payload: chain id 999 (a tx signed for any other chain is simply
+        # invalid here), EIP-1559 fees off the stubbed base fee, and the estimated gas + 20%.
+        broadcast = {}
+
+        def capture(params):
+            broadcast['raw'] = params[0]
+            return TX
+
+        rpc_stub(provider, dict(SEND_RESPONSES, eth_sendRawTransaction=capture))
+        assert provider.send_amount(RECIPIENT, 10**16) == (TX, 0)
+
+        expected = Account.sign_transaction(
+            {
+                'chainId': 999,
+                'nonce': 0,
+                'to': RECIPIENT,
+                'value': 10**16,
+                'gas': 25_200,
+                'maxFeePerGas': 3 * 10**9,
+                'maxPriorityFeePerGas': 10**9,
+            },
+            TEST_KEY,
+        )
+        raw = getattr(expected, 'raw_transaction', None) or getattr(expected, 'rawTransaction')
+        assert broadcast['raw'].removeprefix('0x') == raw.hex().removeprefix('0x')
+
+    def test_no_key_refused(self, provider, monkeypatch):
+        monkeypatch.delenv('HYPE_PRIVATE_KEY', raising=False)
+        assert provider.send_amount(RECIPIENT, 10**16) is None
+        assert 'HYPE_PRIVATE_KEY' in provider.last_send_error
+
+    def test_key_mismatch_refused(self, provider):
+        assert provider.send_amount(RECIPIENT, 10**16, from_address=RECIPIENT) is None
+        assert 'key mismatch' in provider.last_send_error
+
+    def test_insufficient_balance_refused(self, provider):
+        rpc_stub(provider, dict(SEND_RESPONSES, eth_getBalance=hex(10**12)))
+        assert provider.send_amount(RECIPIENT, 10**18) is None
+        assert 'Insufficient HYPE' in provider.last_send_error
+
+
+class TestDepositScanner:
+    def test_walk_is_bounded_for_a_sub_second_chain(self, provider):
+        # 5 min of 1s blocks would be ~300 sequential eth_getBlockByNumber calls per first scan —
+        # past HyperEVM's public 100 req/min budget. The walk bound is what keeps it sane.
+        assert provider.SCAN_LOOKBACK_BLOCKS > MAX_WALK_BLOCKS
+
+        scanned = []
+
+        def block(params):
+            scanned.append(int(params[0], 16))
+            return {'transactions': []}
+
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getBlockByNumber': block})
+        assert provider.find_recent_outgoing(RECIPIENT, RECIPIENT, 1) is None
+        assert len(scanned) == MAX_WALK_BLOCKS
+
+    def test_cursor_parks_below_an_unreadable_block(self, provider):
+        def boom(params):
+            raise ConnectionError('down')
+
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getBlockByNumber': boom})
+        assert provider.find_recent_outgoing(RECIPIENT, RECIPIENT, 1) is None
+        # Never leap a block the scan could not read — the deposit in it must stay reachable.
+        assert provider.scan_cursors[(RECIPIENT.lower(), RECIPIENT.lower(), 1)] == 10_000 - MAX_WALK_BLOCKS

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -402,6 +402,15 @@ class TestIsExecutableRate:
         """1e-20 ETH/SOL: 1 wei maps to 1e11 lamports — above max_swap; unroutable."""
         assert is_executable_rate(1e-20, 'eth', 'sol', self.MIN, self.MAX) is False
 
+    def test_sane_hype_rates_executable(self):
+        # ~0.2 SOL per HYPE, canonical 'HYPE per 1 SOL' — same 18 decimals as ETH but twice
+        # the on-chain floor, which is the input this gate actually reads.
+        assert is_executable_rate(5.0, 'hype', 'sol', self.MIN, self.MAX) is True
+        assert is_executable_rate(5.0, 'sol', 'hype', self.MIN, self.MAX) is True
+
+    def test_absurd_hype_rate_unexecutable(self):
+        assert is_executable_rate(1e-20, 'hype', 'sol', self.MIN, self.MAX) is False
+
     def test_sane_tao_sol_rates_executable(self):
         """tao↔sol: both 9-decimal, decimal_factor 1. ~2 TAO per SOL routes."""
         assert is_executable_rate(2.0, 'tao', 'sol', self.MIN, self.MAX) is True


### PR DESCRIPTION
Adds SOL ↔ HYPE. Stacked on entrius/allways#637 — **merge that first**; this PR's diff is only the chain itself.

HyperEVM is a plain EVM JSON-RPC chain, so the pair is a registry row plus a binding of the shared `EvmCoin`. No contract, DB, or consumer changes.

```
allways/chains.py              CHAIN_HYPE row                       + 21
allways/assets/evm.py          HYPERLIQUID network (chain ids, RPC)  + 12
allways/assets/hyperliquid.py  class Hype(EvmCoin)                   + 12
allways/assets/__init__.py     registry row                          +  3
allways/constants.py           LAUNCH_SPOKES                         +  1
```

Everything else in the diff is `.env.example`, README, and tests.

## Chain parameters

| Field | Value | Why |
|---|---|---|
| `decimals` | 18 | Native gas coin on HyperEVM |
| `seconds_per_block` | 1 | ~1s small blocks; transfers never need the 60s big blocks (those carry >2M gas) |
| `min_confirmations` | 2 | HyperBFT finalizes the block sequence on inclusion — no reorgs. 2 is a one-block margin against an endpoint serving an unsealed head |
| `min_onchain_amount` | 1e14 wei | Rate-sanity floor: 0.0001 HYPE covers a 21k-gas transfer below ~4.7 gwei |
| `replay_grace_secs` | 60 | Hub-clock vs spoke-clock skew allowance, as on Arbitrum |
| `networks` / `testnet_network` | mainnet, testnet / testnet | chain id 999 / 998, checked against `HYPE_NETWORK` at startup |

Default keyless RPC ladders ship for both networks (`rpc.hyperliquid.xyz`, `drpc`); those are capped at 100 req/min per IP, so `HYPE_RPC_URLS` should point at a keyed endpoint (e.g. Dwellir) in production.

The one shared-code change: `evm_coin.py` gains a hard ceiling on the deposit scanner's block walk. At 1s blocks the existing 5-minute lookback would be ~300 sequential `eth_getBlockByNumber` calls on a first scan. The bound never binds on ~12s chains, so ETH behaviour is unchanged.

## Verification

- `uv run pytest tests/ -q` → **1108 passed**; ruff format + check clean.
- `tests/test_hype_provider.py` (26 cases) covers network selection, the wrong-network startup rejection, inclusion vs settlement, receipt/timestamp unavailability raising rather than reading as absent, the full signed payload (chain id, EIP-1559 fees, estimated gas), send guards, and the scanner's bound + cursor parking.
- The pinned CLI contract from #637 (`tests/test_cli_chain_networks.py`) required a conscious update here — `hype-network` in the settable keys, `hype: testnet` in the testnet bundle, `hype: mainnet` in the mainnet bundle. A new chain cannot slip into the CLI unnoticed.
- Live read-only pass on **both** networks: startup chain-id check, tip, a real settled transfer verified through an UPPERCASED recipient with the sender pinned, underpayment / wrong-sender / unknown-tx all rejected, balance read.
- `alw miner quotes --help` shows `--hype-price/--hype-address`; `alw config` shows the `hype-network` row; `alw config set --help` lists `mainnet | testnet` — all derived, none hand-written.

## Notes

- The program needs nothing: chains are opaque strings, and an unlisted chain gets the 600s default fulfillment grace, far above 2 × 1s confirmations.
- A fifth spoke dilutes the zero-volume emission floor to (1−α)/pairs, as with every added pair.
- das-allways companion: entrius/das-allways#86. Its CI drift gate stays red until this merges (it reads `chains.py` from `test`); verified green against this branch with `ALLWAYS_BRANCH=feat/hype-spoke`.