### PR TITLE
Collapse repeat seam reads behind a TTL bucket

### DIFF
--- a/allways/validator/seam_http.py
+++ b/allways/validator/seam_http.py
@@ -11,6 +11,8 @@ publishing no port.
 import json
 import os
 import threading
+import time
+from functools import lru_cache
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import parse_qs, urlparse
 
@@ -26,8 +28,40 @@ from allways.validator.reserve_engine import (
 
 SEAM_HOST = os.environ.get('ALLWAYS_SEAM_HOST', '127.0.0.1')
 
+# The offering polls /status and /deposit-scan per active swap on a tight loop, and its
+# list view reconciles every live row per poll — so identical reads arrive from many tabs and
+# many rows at once, each costing uncached getAccountInfo. Sustained hard enough that earns the
+# validator an RPC 429, and a validator that cannot read the chain cannot verify a swap: the
+# miner holding the reservation is the one who eats the timeout. A chatty consumer must not be
+# able to price the validator out of its own RPC budget.
+#
+# Sized to the consumer's fastest poll, not longer: past that the TTL — not the caller's
+# cadence — sets how fast a stage transition surfaces, buying no extra dedup (a burst of tabs
+# and reconciled rows lands within ~1s) at the cost of latency on every transition. Cadence is
+# the lever for fewer reads; this one only collapses simultaneous ones.
+SEAM_READ_TTL_SECS = 3.0
+
+
+def _ttl_bucket() -> int:
+    """Cache key component that rolls every TTL — a new bucket is a miss, old ones age out of
+    the LRU. Far shorter than any transition the offering reacts to (reservations live minutes,
+    dest legs need tens of seconds of confirmations), so a read this stale changes no decision."""
+    return int(time.monotonic() / SEAM_READ_TTL_SECS)
+
 
 def _make_handler(validator, secret: str):
+    # Memos are per server, closing over this validator rather than keying on it: the validator
+    # is not required to be hashable, and no module-level table pins it alive. lru_cache does not
+    # store exceptions, so a transient RPC fault is retried rather than pinned for the bucket;
+    # maxsize caps the table so a long-lived seam can't grow an entry per swap ever polled.
+    @lru_cache(maxsize=512)
+    def cached_status(miner_hotkey: str, swap_key: str, _bucket: int):
+        return swap_status(validator, miner_hotkey, swap_key)
+
+    @lru_cache(maxsize=512)
+    def cached_deposit_scan(miner_hotkey: str, _bucket: int):
+        return scan_deposit(validator, miner_hotkey)
+
     class SeamHandler(BaseHTTPRequestHandler):
         def log_message(self, *args):  # silence default stderr access log
             pass
@@ -67,10 +101,12 @@ def _make_handler(validator, secret: str):
                     # Optional swap_key (hex, persisted by the consumer at claim time) resolves the
                     # swap directly — the only route to post-attestation stages, since vote_initiate
                     # consumes the reservation at quorum.
-                    return self._send(200, swap_status(validator, q['miner_hotkey'], q.get('swap_key', '')).__dict__)
+                    status = cached_status(q['miner_hotkey'], q.get('swap_key', ''), _ttl_bucket())
+                    return self._send(200, status.__dict__)
                 if url.path == '/deposit-scan':
                     # Hash-finder for the offering's deposit watcher — /confirm stays the verifier.
-                    return self._send(200, {'tx_hash': scan_deposit(validator, q['miner_hotkey'])})
+                    tx_hash = cached_deposit_scan(q['miner_hotkey'], _ttl_bucket())
+                    return self._send(200, {'tx_hash': tx_hash})
                 if url.path == '/health':
                     return self._send(200, {'ok': True})
             except (KeyError, ValueError) as e:

--- a/tests/test_seam_read_cache.py
+++ b/tests/test_seam_read_cache.py
@@ -1,0 +1,120 @@
+"""The seam's read memo: repeat polls must not each cost a chain read.
+
+The offering polls /status per active swap on a tight loop and reconciles every live row per
+poll, so identical reads arrive from many tabs and many rows at once — each one uncached
+`getAccountInfo` before this. Driven through the HTTP surface, the same way the offering hits it.
+"""
+
+import json
+import urllib.error
+import urllib.request
+from types import SimpleNamespace
+
+import pytest
+
+from allways.validator import seam_http
+from allways.validator.reserve_engine import SwapStatus
+
+SECRET = 'test-secret'
+
+
+def _get(server, path):
+    host, port = server.server_address
+    r = urllib.request.Request(f'http://127.0.0.1:{port}{path}', method='GET')
+    r.add_header('X-Seam-Secret', SECRET)
+    with urllib.request.urlopen(r) as resp:
+        return json.loads(resp.read())
+
+
+@pytest.fixture
+def counted(monkeypatch):
+    """A seam whose chain reads are counted — each fixture builds a fresh memo."""
+    calls = {'status': 0, 'scan': 0}
+
+    def fake_status(_validator, miner_hotkey, swap_key=''):
+        calls['status'] += 1
+        return SwapStatus('reserved', 999, f'user-{calls["status"]}', swap_key)
+
+    def fake_scan(_validator, _miner_hotkey):
+        calls['scan'] += 1
+        return f'hash-{calls["scan"]}'
+
+    monkeypatch.setattr(seam_http, 'swap_status', fake_status)
+    monkeypatch.setattr(seam_http, 'scan_deposit', fake_scan)
+    srv = seam_http.start_seam(SimpleNamespace(), 0, SECRET)
+    yield srv, calls
+    srv.shutdown()
+
+
+def test_bucket_is_stable_within_the_ttl_and_rolls_after(monkeypatch):
+    ttl = seam_http.SEAM_READ_TTL_SECS
+    base = ttl * 1000  # start on a bucket boundary, so the assertions hold for any TTL
+    monkeypatch.setattr(seam_http.time, 'monotonic', lambda: base)
+    first = seam_http._ttl_bucket()
+    monkeypatch.setattr(seam_http.time, 'monotonic', lambda: base + ttl * 0.9)
+    assert seam_http._ttl_bucket() == first  # same window → cache hit
+    monkeypatch.setattr(seam_http.time, 'monotonic', lambda: base + ttl * 1.1)
+    assert seam_http._ttl_bucket() != first  # rolled → refresh
+
+
+def test_ttl_stays_under_the_transitions_the_offering_reacts_to():
+    """Reservations live minutes and dest legs need tens of seconds of confirmations — a read
+    this stale changes no decision. A TTL that crept up would start hiding real transitions."""
+    assert 0 < seam_http.SEAM_READ_TTL_SECS <= 5
+
+
+def test_repeat_polls_cost_one_chain_read(counted):
+    """The whole point: N identical polls inside one bucket, one read."""
+    server, calls = counted
+    payloads = [_get(server, '/status?miner_hotkey=hk') for _ in range(25)]
+
+    assert calls['status'] == 1
+    assert {p['user'] for p in payloads} == {'user-1'}  # every caller saw the same answer
+
+
+def test_distinct_swaps_do_not_share_an_entry(counted):
+    """A per-swap key must never serve another swap's status."""
+    server, calls = counted
+    a = _get(server, '/status?miner_hotkey=hkA')
+    b = _get(server, '/status?miner_hotkey=hkB')
+    c = _get(server, f'/status?miner_hotkey=hkA&swap_key={"ab" * 32}')
+
+    assert calls['status'] == 3
+    assert len({a['user'], b['user'], c['user']}) == 3
+
+
+def test_a_new_bucket_refreshes(counted, monkeypatch):
+    server, calls = counted
+    monkeypatch.setattr(seam_http, '_ttl_bucket', lambda: 7)
+    _get(server, '/status?miner_hotkey=hk')
+    _get(server, '/status?miner_hotkey=hk')
+    assert calls['status'] == 1
+    monkeypatch.setattr(seam_http, '_ttl_bucket', lambda: 8)
+    _get(server, '/status?miner_hotkey=hk')
+    assert calls['status'] == 2
+
+
+def test_deposit_scan_is_memoized_too(counted):
+    server, calls = counted
+    hashes = [_get(server, '/deposit-scan?miner_hotkey=hk')['tx_hash'] for _ in range(10)]
+    assert calls['scan'] == 1
+    assert hashes == ['hash-1'] * 10
+
+
+def test_failures_are_not_cached(counted, monkeypatch):
+    """A transient RPC fault must not pin an error for the whole bucket."""
+    server, calls = counted
+    state = {'fail': True}
+
+    def flaky(_validator, _miner_hotkey, swap_key=''):
+        if state['fail']:
+            raise RuntimeError('getAccountInfo: HTTP 429')
+        calls['status'] += 1
+        return SwapStatus('reserved', 999, 'recovered', swap_key)
+
+    monkeypatch.setattr(seam_http, 'swap_status', flaky)
+    with pytest.raises(urllib.error.HTTPError):
+        _get(server, '/status?miner_hotkey=hk')
+    state['fail'] = False
+    # Same bucket: the retry reaches the producer instead of replaying the failure.
+    assert _get(server, '/status?miner_hotkey=hk')['user'] == 'recovered'


### PR DESCRIPTION
## Problem

`/status` and `/deposit-scan` do uncached `getAccountInfo` reads on **every request** (`reserve_engine.py:492,511` — reservation, then swap). The offering polls `/status` per active swap, and its `list()` reconciles *every* live row per poll, so identical reads arrive from many tabs and many rows at once.

Observed on devnet 2026-08-10 during the first arbusdc swap:

```
21:00:30 ERROR validator.py:118  Step 17973 error (1 consecutive): getProgramAccounts: HTTP 429
21:01:50 ERROR validator.py:118  Step 17976 error (4 consecutive): getProgramAccounts: HTTP 429
         ERROR seam_http.py:79   seam GET /status failed: getAccountInfo: HTTP 429   (40+ in 90s)
```

The seam was ~15x noisier than the forward loop and starved it. **A validator that cannot read the chain cannot verify a swap, and the miner holding the reservation is the one who eats the timeout** — so a chatty consumer must not be able to price the validator out of its own RPC budget.

Measured for scale: the entire program is ~10 KB across all account types. This is call *frequency*, not payload — `dataSlice` would buy nothing.

## Fix

A time bucket in the cache key: `int(monotonic() / 2.0)`. The bucket rolls every TTL, so a new bucket is a miss and stale entries age out of the LRU. Two `lru_cache`d closures — no cache class, no lock, no eviction bookkeeping. **+35 lines in the file that already owns these routes.**

Bounds cost at one chain read per key per TTL regardless of poll rate. The TTL is far shorter than any transition the offering reacts to (reservations live minutes; dest legs need tens of seconds of confirmations), so a read this stale changes no decision.

Why closures rather than module-level memos keyed on `validator`: keying on it would require the validator to be hashable (`SimpleNamespace` is not — it defines `__eq__` without `__hash__`) and would pin it alive in a module-level table. Closing over it costs nothing and avoids both.

Free from `lru_cache`: exceptions are not stored, so a transient RPC fault is retried rather than pinned for the bucket; `maxsize` caps the table so a long-lived seam can't grow an entry per swap ever polled.

## Scope

This is the defensive half — it bounds the worst case across many pollers and `list()` fanout. A single well-behaved poller still costs ~one read per TTL; the client's cadence is the other half, in ventura #75 (adaptive interval: slow while awaiting a human deposit, fast near the deadline and through the confirmation stages). Independent and complementary: #75 removes the waste, this bounds the worst case.

Not touched: the forward loop's 2 `getProgramAccounts` per step. Those are justified by protocol timing (30s pool window, 600s fulfillment timeout) and are a rounding error next to the seam.

## Tests

`tests/test_seam_read_cache.py` — 7 cases driven through the HTTP surface, the same way the offering hits it: repeat polls cost one read, per-swap key isolation, bucket rollover refreshes, deposit-scan memoized, failures uncached, and TTL bounds. Full suite 1064 passed.
