### PR TITLE
Compose EVM chains and key their env by network

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,16 +42,17 @@ ETH_NETWORK=mainnet                 # mainnet | sepolia
 # 32-byte hex key — required for miners; optional local signing for `alw swap`
 ETH_PRIVATE_KEY=
 
-# ─── Chain: Arbitrum USDC (arbusdc pairs) ──────────────────
-ARBUSDC_NETWORK=mainnet             # mainnet | sepolia (Arbitrum Sepolia)
+# ─── Network: Arbitrum (arbusdc pairs) ─────────────────────
+# Vars are per NETWORK, shared by every asset on it (ARB_ here, not ARBUSDC_).
+ARB_NETWORK=mainnet                 # mainnet | sepolia (Arbitrum Sepolia)
 # OPTIONAL ordered JSON-RPC endpoints (keyed providers embed the key in the URL);
 # unset = public (publicnode, drpc)
-# ARBUSDC_RPC_URLS=https://api-arbitrum-mainnet-archive.n.dwellir.com/your_key,https://arbitrum-one-rpc.publicnode.com
-# OPTIONAL token contract override (dev/e2e fakes) — unset = Circle's canonical USDC deployment
-# ARBUSDC_TOKEN_CONTRACT=
+# ARB_RPC_URLS=https://api-arbitrum-mainnet-archive.n.dwellir.com/your_key,https://arbitrum-one-rpc.publicnode.com
 # 32-byte hex key — required for miners (fund USDC for legs + ETH-on-Arbitrum for gas);
 # optional local signing for `alw swap`
-ARBUSDC_PRIVATE_KEY=
+ARB_PRIVATE_KEY=
+# OPTIONAL token contract override (dev/e2e fakes) — per ASSET, unset = Circle's canonical deployment
+# ARBUSDC_TOKEN_CONTRACT=
 
 # ─── Chain: Hyperliquid (HYPE pairs) ───────────────────────
 HYPE_NETWORK=mainnet                # mainnet | testnet

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ needs to persist across restarts.
 
 ## Miner Environment Variables
 
-- `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARBUSDC_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `{ETH,ARBUSDC,HYPE}_RPC_URLS`, etc. — see `.env.example`.
+- `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `{ETH,ARB,HYPE}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config. See `.env.example`.
 
 ## Running a Local Subtensor Lite Node (Validators)
 

--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -29,8 +29,9 @@ MAX_TOKEN_TRANSFER_GAS = 150_000
 DEFAULT_TOKEN_TRANSFER_GAS = 120_000
 
 # Testnet deployments per (asset id, network). The canonical mainnet deployment is the
-# registry row's asset_locator; {PREFIX}_TOKEN_CONTRACT overrides either (e2e fakes,
-# emergency repoint) — each address lives exactly once.
+# registry row's asset_locator; {ASSET_ID}_TOKEN_CONTRACT overrides either (e2e fakes,
+# emergency repoint) — each address lives exactly once. Keyed by asset, not by network
+# prefix: one network can host several tokens, and each pins its own contract.
 TESTNET_TOKEN_CONTRACTS = {
     # Circle-verified native USDC on Arbitrum Sepolia (developers.circle.com, 2026-08-07).
     'arbusdc': {'sepolia': '0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d'},
@@ -38,16 +39,15 @@ TESTNET_TOKEN_CONTRACTS = {
 
 
 def _token_contract(chain_def: ChainDefinition, network: str) -> str:
-    override = os.environ.get(f'{chain_def.env_prefix}_TOKEN_CONTRACT')
+    var = f'{chain_def.id.upper()}_TOKEN_CONTRACT'
+    override = os.environ.get(var)
     if override:
         return override
     contract = (
         chain_def.asset_locator if network == 'mainnet' else TESTNET_TOKEN_CONTRACTS.get(chain_def.id, {}).get(network)
     )
     if not contract:
-        raise ValueError(
-            f'No {chain_def.id} token contract for network {network!r} — set {chain_def.env_prefix}_TOKEN_CONTRACT'
-        )
+        raise ValueError(f'No {chain_def.id} token contract for network {network!r} — set {var}')
     return contract
 
 
@@ -67,10 +67,9 @@ def _topic_addr(topic: str) -> str:
 class Erc20(EvmAsset):
     """A generic ERC-20 asset on an EVM chain, bound by its registry row.
 
-    Not fused: the token composes its host network's `EvmChain` (``self._chain``) — the
-    first non-fused asset. Each token builds its own chain instance today; a second token
-    on the same network would want them pooled (one ladder, one tip fetch per pass) — a
-    construction change here, not a shape change.
+    Composes its host network's `EvmChain` (``self._chain``), as every EVM asset does.
+    Assets on one network share its env prefix, so they can never disagree about which
+    network they are on; they still build an instance each (one extra tip fetch per pass).
 
     Settlement truth is the token contract's Transfer log, never tx.value: verification
     accepts a tx iff its status-1 receipt carries a Transfer from the PINNED contract
@@ -109,7 +108,7 @@ class Erc20(EvmAsset):
         if code == '0x':
             # A typo'd override or wrong network would otherwise surface as every send failing.
             raise ConnectionError(
-                f'{self.chain_def.env_prefix} token contract {self.token_contract} has no code on {self.chain.network}'
+                f'{self.chain_def.id} token contract {self.token_contract} has no code on {self.chain.network}'
             )
         try:
             if self._eth_call(SEL_PAUSED):
@@ -306,7 +305,8 @@ class Erc20(EvmAsset):
         Returns (tx_hash, 0) or None; dedup/rescue ladder mirrors the native EVM send.
         """
         self.last_send_error = None
-        prefix = self.chain_def.env_prefix
+        # prefix names the NETWORK (its key/RPC env); token names the ASSET being moved.
+        prefix, token = self.chain_def.env_prefix, self.chain_def.id.upper()
         norm = self.chain.normalize_address
         acct = self.chain._account()
         if acct is None:
@@ -348,13 +348,13 @@ class Erc20(EvmAsset):
             # estimator too, which would misread as the destination refusing.
             token_balance = self.get_balance(acct.address)
             if token_balance < amount:
-                self._send_error(f'Insufficient {prefix}: have {token_balance} units, need {amount}')
+                self._send_error(f'Insufficient {token}: have {token_balance} units, need {amount}')
                 return None
 
             calldata = SEL_TRANSFER[2:] + _pad_addr(to_address) + f'{int(amount):064x}'
             gas = self._transfer_gas(acct.address, calldata)
             if gas is None:
-                self._send_error(f'destination {to_address} refuses {prefix} transfers — not sending')
+                self._send_error(f'destination {to_address} refuses {token} transfers — not sending')
                 return None
 
             gas_balance = int(self.chain.eth_rpc('eth_getBalance', [acct.address, 'latest']), 16)
@@ -399,7 +399,7 @@ class Erc20(EvmAsset):
                 self._send_error(f'{prefix} broadcast failed: {broadcast_err}')
                 return None
 
-            bt.logging.info(f'Sent {amount} {prefix} units to {to_address} (tx: {tx_hash}, maxFee: {max_fee})')
+            bt.logging.info(f'Sent {amount} {token} units to {to_address} (tx: {tx_hash}, maxFee: {max_fee})')
             # A quirky null broadcast reply must never persist as a blank tx hash.
             return (tx_hash or expected_txid, 0)
         except Exception as e:

--- a/allways/assets/evm.py
+++ b/allways/assets/evm.py
@@ -104,8 +104,8 @@ class EvmChain(Chain):
     addresses, EIP-191 ownership proofs, tip reads.
 
     One behavior class for the whole family; per-network facts come from the `EvmNetwork`
-    config row, env wiring from ``env_prefix`` (the hosted asset's prefix until a second
-    asset shares the instance — the chain then earns its own env identity).
+    config row, env wiring from ``env_prefix`` — the NETWORK's identity, so every asset on
+    a network reads one {PREFIX}_NETWORK and one ladder and they cannot disagree.
 
     Addresses are hex and case-insensitive (EIP-55 is a display checksum), so every
     comparison goes through ``normalize_address`` (lowercase) — on-chain strings keep

--- a/allways/assets/evm_coin.py
+++ b/allways/assets/evm_coin.py
@@ -20,22 +20,21 @@ ZERO_ADDRESS = '0x' + '00' * 20
 MAX_WALK_BLOCKS = 32
 
 
-class EvmCoin(EvmAsset, EvmChain):
+class EvmCoin(EvmAsset):
     """An EVM network's native coin: eth-account + public JSON-RPC (no local node required).
 
     Plain EOA value transfers only, by design: a swap leg is verified off the transaction's
     own from/to/value, which internal (contract-mediated) transfers don't populate — and the
     sender-pinning defense needs a provable EOA sender anyway.
 
-    Fused with its chain (a native coin is its network's first asset); the shared EVM
-    plumbing lives in `EvmChain`/`EvmAsset` and splits out the day a second asset lands on
-    the network. The `Erc20` twin for tokens; both are bound by a registry row, never
-    subclassed per chain.
+    Composes its network's `EvmChain` exactly as the `Erc20` twin does — a native coin is
+    an asset ON a network, not the network itself, and fusing the two stops being true the
+    moment a token lands beside it. Both are bound by a registry row, never subclassed.
     """
 
     def __init__(self, chain_def: ChainDefinition, network_def: EvmNetwork):
         self._chain_def = chain_def
-        EvmChain.__init__(self, network_def, chain_def.env_prefix)
+        self._chain = EvmChain(network_def, chain_def.env_prefix)
         EvmAsset.__init__(self)
 
     @property

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -16,9 +16,12 @@ class ChainDefinition:
     name: str  # Display name (e.g. 'Bitcoin')
     native_unit: str  # Smallest unit name (e.g. 'satoshi')
     decimals: int  # Precision (e.g. 8 for BTC, 9 for TAO)
-    env_prefix: str  # .env variable prefix (e.g. 'BTC' -> BTC_NETWORK)
+    # .env variable prefix — the NETWORK's, not the asset's ('ARB' -> ARB_NETWORK), so assets
+    # sharing a network share its config. Only {id}_TOKEN_CONTRACT keys off the asset.
+    env_prefix: str
     # Network names the provider accepts in {env_prefix}_NETWORK; [0] is the default (mainnet).
-    # Empty = the network isn't picked by name (sol/tao resolve by RPC URL / bittensor network).
+    # Empty = the network isn't picked by name here — either it resolves another way (sol/tao,
+    # by RPC URL / bittensor network) or another asset on the same network owns the setting.
     networks: tuple[str, ...] = ()
     # Which of ``networks`` the `alw config set env testnet` bundle selects. Named, not
     # positional: a chain can offer several testnets (BTC has three) and only one is the
@@ -110,7 +113,7 @@ CHAIN_ARBUSDC = ChainDefinition(
     name='USDC (Arbitrum)',
     native_unit='µUSDC',
     decimals=6,
-    env_prefix='ARBUSDC',
+    env_prefix='ARB',
     networks=('mainnet', 'sepolia'),  # sepolia = Arbitrum Sepolia
     testnet_network='sepolia',
     # ~4 blocks/s real; 1s is the integer floor. 90 confs ≈ 25s real (~90s in extension

--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -42,8 +42,11 @@ NAME_SELECTED_CHAINS = tuple(c for c in SUPPORTED_CHAINS.values() if c.networks)
 
 
 def network_key(chain: ChainDefinition) -> str:
-    """CLI config key that sets this chain's network (e.g. 'btc-network')."""
-    return f'{chain.id}-network'
+    """CLI config key that sets this NETWORK's name (e.g. 'btc-network', 'arb-network').
+
+    Keyed off env_prefix, not the asset id, so it names the same thing the env var does —
+    assets sharing a network get one row between them, never one each."""
+    return f'{chain.env_prefix.lower()}-network'
 
 
 def testnet_name(chain: ChainDefinition) -> str:

--- a/tests/test_arbusdc_provider.py
+++ b/tests/test_arbusdc_provider.py
@@ -36,8 +36,8 @@ AMOUNT = 150_000_000  # 150 USDC in µUSDC
 
 @pytest.fixture
 def provider(monkeypatch):
-    monkeypatch.setenv('ARBUSDC_NETWORK', 'sepolia')
-    for var in ('ARBUSDC_RPC_URLS', 'ARBUSDC_PRIVATE_KEY', 'ARBUSDC_TOKEN_CONTRACT'):
+    monkeypatch.setenv('ARB_NETWORK', 'sepolia')
+    for var in ('ARB_RPC_URLS', 'ARB_PRIVATE_KEY', 'ARBUSDC_TOKEN_CONTRACT'):
         monkeypatch.delenv(var, raising=False)
     return ArbUsdc()
 
@@ -342,22 +342,22 @@ class TestSendGuards:
 
     def test_no_key_refused(self, provider):
         assert provider.send_amount(RECIPIENT, AMOUNT) is None
-        assert 'ARBUSDC_PRIVATE_KEY' in provider.last_send_error
+        assert 'ARB_PRIVATE_KEY' in provider.last_send_error
 
     def test_key_mismatch_refused(self, provider, monkeypatch):
-        monkeypatch.setenv('ARBUSDC_PRIVATE_KEY', TEST_KEY)
+        monkeypatch.setenv('ARB_PRIVATE_KEY', TEST_KEY)
         assert provider.send_amount(RECIPIENT, AMOUNT, from_address=RECIPIENT) is None
         assert 'key mismatch' in provider.last_send_error
 
     def test_insufficient_token_balance_refused(self, provider, monkeypatch):
-        monkeypatch.setenv('ARBUSDC_PRIVATE_KEY', TEST_KEY)
+        monkeypatch.setenv('ARB_PRIVATE_KEY', TEST_KEY)
         rpc_stub(provider, self._send_responses(token_balance=AMOUNT - 1))
         assert provider.send_amount(RECIPIENT, AMOUNT) is None
         assert 'Insufficient ARBUSDC' in provider.last_send_error
 
     def test_insufficient_gas_balance_refused(self, provider, monkeypatch):
         # F6: token-rich but gas-poor must refuse BEFORE broadcasting a doomed transfer.
-        monkeypatch.setenv('ARBUSDC_PRIVATE_KEY', TEST_KEY)
+        monkeypatch.setenv('ARB_PRIVATE_KEY', TEST_KEY)
         rpc_stub(provider, self._send_responses(gas_balance=10))
         assert provider.send_amount(RECIPIENT, AMOUNT) is None
         assert 'Insufficient gas balance' in provider.last_send_error
@@ -365,7 +365,7 @@ class TestSendGuards:
     def test_insufficient_balance_diagnosed_before_estimator_revert(self, provider, monkeypatch):
         # An underfunded transfer reverts in the estimator too — the balance check runs first
         # so a token-poor miner reads "Insufficient", not "destination refuses".
-        monkeypatch.setenv('ARBUSDC_PRIVATE_KEY', TEST_KEY)
+        monkeypatch.setenv('ARB_PRIVATE_KEY', TEST_KEY)
         responses = self._send_responses(token_balance=AMOUNT - 1)
 
         def revert(params):
@@ -377,7 +377,7 @@ class TestSendGuards:
         assert 'Insufficient ARBUSDC' in provider.last_send_error
 
     def test_reverting_transfer_refused(self, provider, monkeypatch):
-        monkeypatch.setenv('ARBUSDC_PRIVATE_KEY', TEST_KEY)
+        monkeypatch.setenv('ARB_PRIVATE_KEY', TEST_KEY)
         responses = self._send_responses()
 
         def revert(params):
@@ -391,7 +391,7 @@ class TestSendGuards:
     def test_revert_detected_by_code_when_message_lacks_the_word(self, provider, monkeypatch):
         # The old string-match missed a code-3 revert phrased without "revert" and would have
         # broadcast a doomed tx (gas burned, no delivery). The typed verdict catches it.
-        monkeypatch.setenv('ARBUSDC_PRIVATE_KEY', TEST_KEY)
+        monkeypatch.setenv('ARB_PRIVATE_KEY', TEST_KEY)
         responses = self._send_responses()
 
         def revert(params):
@@ -403,12 +403,12 @@ class TestSendGuards:
         assert 'refuses' in provider.last_send_error
 
     def test_absurd_gas_estimate_refused(self, provider, monkeypatch):
-        monkeypatch.setenv('ARBUSDC_PRIVATE_KEY', TEST_KEY)
+        monkeypatch.setenv('ARB_PRIVATE_KEY', TEST_KEY)
         rpc_stub(provider, self._send_responses(est=hex(200_000)))  # ×1.2 > 150k cap
         assert provider.send_amount(RECIPIENT, AMOUNT) is None
 
     def test_happy_path_broadcasts_transfer_calldata(self, provider, monkeypatch):
-        monkeypatch.setenv('ARBUSDC_PRIVATE_KEY', TEST_KEY)
+        monkeypatch.setenv('ARB_PRIVATE_KEY', TEST_KEY)
         sent = {}
         responses = self._send_responses()
 
@@ -429,13 +429,13 @@ class TestSendGuards:
     def test_lowercase_contract_override_still_sends(self, provider, monkeypatch):
         # eth-account refuses a non-checksummed `to`; the sign path checksums it, so a
         # lowercase ARBUSDC_TOKEN_CONTRACT (env repoint, e2e fake) must not brick sends.
-        monkeypatch.setenv('ARBUSDC_PRIVATE_KEY', TEST_KEY)
+        monkeypatch.setenv('ARB_PRIVATE_KEY', TEST_KEY)
         provider.token_contract = provider.token_contract.lower()
         rpc_stub(provider, self._send_responses())
         assert provider.send_amount(RECIPIENT, AMOUNT, from_address=TEST_ADDR) is not None
 
     def test_prior_broadcast_reused_not_resent(self, provider, monkeypatch):
-        monkeypatch.setenv('ARBUSDC_PRIVATE_KEY', TEST_KEY)
+        monkeypatch.setenv('ARB_PRIVATE_KEY', TEST_KEY)
         prior_tx = '0x' + 'aa' * 32
         provider.broadcasted_txids[prior_tx] = (RECIPIENT.lower(), AMOUNT, 990)
         responses = self._send_responses()
@@ -450,7 +450,7 @@ class TestSendGuards:
 
     def test_stale_dedup_entry_expires(self, provider, monkeypatch):
         # An entry older than the lookback window is dropped, not reused (#461 class).
-        monkeypatch.setenv('ARBUSDC_PRIVATE_KEY', TEST_KEY)
+        monkeypatch.setenv('ARB_PRIVATE_KEY', TEST_KEY)
         prior_tx = '0x' + 'aa' * 32
         provider.broadcasted_txids[prior_tx] = (RECIPIENT.lower(), AMOUNT, 1000 - provider.SCAN_LOOKBACK_BLOCKS - 1)
         rpc_stub(provider, self._send_responses())
@@ -491,12 +491,12 @@ class TestScanner:
 
 class TestNetworkAndContract:
     def test_unknown_network_raises(self, monkeypatch):
-        monkeypatch.setenv('ARBUSDC_NETWORK', 'seplia')
-        with pytest.raises(ValueError, match='ARBUSDC_NETWORK'):
+        monkeypatch.setenv('ARB_NETWORK', 'seplia')
+        with pytest.raises(ValueError, match='ARB_NETWORK'):
             ArbUsdc()
 
     def test_unset_defaults_to_mainnet_with_registry_contract(self, monkeypatch):
-        for var in ('ARBUSDC_NETWORK', 'ARBUSDC_RPC_URLS', 'ARBUSDC_TOKEN_CONTRACT'):
+        for var in ('ARB_NETWORK', 'ARB_RPC_URLS', 'ARBUSDC_TOKEN_CONTRACT'):
             monkeypatch.delenv(var, raising=False)
         p = ArbUsdc()
         assert p.chain.network == 'mainnet'
@@ -506,7 +506,7 @@ class TestNetworkAndContract:
         assert provider.token_contract == CONTRACT
 
     def test_env_override_wins(self, monkeypatch):
-        monkeypatch.setenv('ARBUSDC_NETWORK', 'sepolia')
+        monkeypatch.setenv('ARB_NETWORK', 'sepolia')
         monkeypatch.setenv('ARBUSDC_TOKEN_CONTRACT', '0x' + '42' * 20)
         assert ArbUsdc().token_contract == '0x' + '42' * 20
 
@@ -528,7 +528,7 @@ class TestCheckConnection:
             provider.check_connection(require_send=False)
 
     def test_missing_key_fails_when_send_required(self, provider):
-        with pytest.raises(ConnectionError, match='ARBUSDC_PRIVATE_KEY'):
+        with pytest.raises(ConnectionError, match='ARB_PRIVATE_KEY'):
             provider.check_connection(require_send=True)
 
     def test_wrong_network_endpoint_deeper_in_ladder_fails_boot(self, provider):

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -46,6 +46,17 @@ class TestGetChain:
             assert re.fullmatch(r'[a-z0-9]{1,10}', chain_id), chain_id
             assert chain.id == chain_id
 
+    def test_one_row_per_env_prefix_owns_the_network_setting(self):
+        """env_prefix names the NETWORK, so assets sharing one share its {PREFIX}_NETWORK.
+        Exactly one of them may declare ``networks`` — two would render duplicate CLI rows
+        writing the same env var, and a second asset on a network must carry networks=()."""
+        owners: dict[str, list[str]] = {}
+        for chain in SUPPORTED_CHAINS.values():
+            if chain.networks:
+                owners.setdefault(chain.env_prefix, []).append(chain.id)
+        for prefix, ids in owners.items():
+            assert len(ids) == 1, f'{prefix}_NETWORK is declared by more than one row: {ids}'
+
     def test_layered_fields_default_none_for_native_assets(self):
         for chain_id in ('btc', 'tao', 'sol', 'eth', 'hype'):
             assert get_chain_def(chain_id).host_chain is None

--- a/tests/test_cli_chain_networks.py
+++ b/tests/test_cli_chain_networks.py
@@ -51,14 +51,14 @@ class TestPinnedContract:
             'solana-keypair',
             'btc-network',
             'eth-network',
-            'arbusdc-network',
+            'arb-network',
             'hype-network',
             'router',
             'env',
         )
 
     def test_chain_network_keys(self):
-        assert CHAIN_NETWORK_KEYS == ('btc-network', 'eth-network', 'arbusdc-network', 'hype-network')
+        assert CHAIN_NETWORK_KEYS == ('btc-network', 'eth-network', 'arb-network', 'hype-network')
 
     def test_testnet_bundle(self):
         assert ENV_BUNDLES['testnet'] == {
@@ -66,7 +66,7 @@ class TestPinnedContract:
             'solana-network': 'devnet',
             'btc-network': 'testnet4',
             'eth-network': 'sepolia',
-            'arbusdc-network': 'sepolia',
+            'arb-network': 'sepolia',
             'hype-network': 'testnet',
             'netuid': '19',
             'router': '5HicmHG7fjbxrtx8FZNdv4xxS5jSN84KGpMnTHsKtKv9peao',
@@ -78,7 +78,7 @@ class TestPinnedContract:
             'solana-network': 'mainnet',
             'btc-network': 'mainnet',
             'eth-network': 'mainnet',
-            'arbusdc-network': 'mainnet',
+            'arb-network': 'mainnet',
             'hype-network': 'mainnet',
             'netuid': '7',
             'router': '',

--- a/tests/test_ethereum_provider.py
+++ b/tests/test_ethereum_provider.py
@@ -36,7 +36,7 @@ def rpc_stub(provider, responses: dict):
         value = responses[method]
         return value(params) if callable(value) else value
 
-    provider.eth_rpc = fake_rpc
+    provider.chain.eth_rpc = fake_rpc
     return provider
 
 
@@ -75,71 +75,71 @@ def counting_rpc_stub(provider, responses: dict):
         value = responses[method]
         return value(params) if callable(value) else value
 
-    provider.eth_rpc = fake_rpc
+    provider.chain.eth_rpc = fake_rpc
     return calls
 
 
 class TestAddresses:
     def test_valid_lowercase(self, provider):
-        assert provider.is_valid_address(TEST_ADDR.lower())
+        assert provider.chain.is_valid_address(TEST_ADDR.lower())
 
     def test_valid_checksummed(self, provider):
-        assert provider.is_valid_address(TEST_ADDR)
+        assert provider.chain.is_valid_address(TEST_ADDR)
 
     def test_bad_checksum_mixed_case_rejected(self, provider):
         # Flip one letter's case: mixed-case implies EIP-55, and the checksum no longer verifies.
         bad = TEST_ADDR.replace('aad', 'aaD')
-        assert not provider.is_valid_address(bad)
+        assert not provider.chain.is_valid_address(bad)
 
     def test_wrong_length_and_junk(self, provider):
-        assert not provider.is_valid_address('0x1234')
-        assert not provider.is_valid_address('')
-        assert not provider.is_valid_address(None)
-        assert not provider.is_valid_address('f39Fd6e51aad88F6F4ce6aB8827279cffFb92266')  # no 0x
+        assert not provider.chain.is_valid_address('0x1234')
+        assert not provider.chain.is_valid_address('')
+        assert not provider.chain.is_valid_address(None)
+        assert not provider.chain.is_valid_address('f39Fd6e51aad88F6F4ce6aB8827279cffFb92266')  # no 0x
 
     def test_zero_address_rejected(self, provider):
         # ERC-20 transfer() reverts to the zero address (no blacklist/pause gate catches it), so an
         # honest miner reserved for it would be forced into a slash. Reject at the format gate.
-        assert not provider.is_valid_address('0x' + '00' * 20)
-        assert not provider.is_valid_address('0x' + '0' * 40)
+        assert not provider.chain.is_valid_address('0x' + '00' * 20)
+        assert not provider.chain.is_valid_address('0x' + '0' * 40)
 
     def test_normalize_lowercases(self, provider):
-        assert provider.normalize_address(TEST_ADDR) == TEST_ADDR.lower()
+        assert provider.chain.normalize_address(TEST_ADDR) == TEST_ADDR.lower()
 
 
 class TestProofSigning:
     def test_sign_verify_roundtrip(self, provider):
-        sig = provider.sign_from_proof(TEST_ADDR, 'proof: abc', key=TEST_KEY)
+        sig = provider.chain.sign_from_proof(TEST_ADDR, 'proof: abc', key=TEST_KEY)
         assert sig
-        assert provider.verify_from_proof(TEST_ADDR, 'proof: abc', sig)
+        assert provider.chain.verify_from_proof(TEST_ADDR, 'proof: abc', sig)
 
     def test_verify_is_case_insensitive_on_address(self, provider):
-        sig = provider.sign_from_proof(TEST_ADDR, 'msg', key=TEST_KEY)
-        assert provider.verify_from_proof(TEST_ADDR.lower(), 'msg', sig)
+        sig = provider.chain.sign_from_proof(TEST_ADDR, 'msg', key=TEST_KEY)
+        assert provider.chain.verify_from_proof(TEST_ADDR.lower(), 'msg', sig)
 
     def test_verify_accepts_unprefixed_signature(self, provider):
-        sig = provider.sign_from_proof(TEST_ADDR, 'msg', key=TEST_KEY)
-        assert provider.verify_from_proof(TEST_ADDR, 'msg', sig.removeprefix('0x'))
+        sig = provider.chain.sign_from_proof(TEST_ADDR, 'msg', key=TEST_KEY)
+        assert provider.chain.verify_from_proof(TEST_ADDR, 'msg', sig.removeprefix('0x'))
 
     def test_wrong_message_fails(self, provider):
-        sig = provider.sign_from_proof(TEST_ADDR, 'msg', key=TEST_KEY)
-        assert not provider.verify_from_proof(TEST_ADDR, 'other', sig)
+        sig = provider.chain.sign_from_proof(TEST_ADDR, 'msg', key=TEST_KEY)
+        assert not provider.chain.verify_from_proof(TEST_ADDR, 'other', sig)
 
     def test_wrong_address_fails(self, provider):
-        sig = provider.sign_from_proof(TEST_ADDR, 'msg', key=TEST_KEY)
-        assert not provider.verify_from_proof(RECIPIENT, 'msg', sig)
+        sig = provider.chain.sign_from_proof(TEST_ADDR, 'msg', key=TEST_KEY)
+        assert not provider.chain.verify_from_proof(RECIPIENT, 'msg', sig)
 
     def test_garbage_signature_fails(self, provider):
-        assert not provider.verify_from_proof(TEST_ADDR, 'msg', 'not-hex')
+        assert not provider.chain.verify_from_proof(TEST_ADDR, 'msg', 'not-hex')
 
     def test_sign_key_address_mismatch_refused(self, provider):
         # Signing for an address the key doesn't derive is a wasted (and misleading) proof.
-        assert provider.sign_from_proof(RECIPIENT, 'msg', key=TEST_KEY) == ''
+        assert provider.chain.sign_from_proof(RECIPIENT, 'msg', key=TEST_KEY) == ''
 
     def test_sign_falls_back_to_env_key(self, provider, monkeypatch):
         monkeypatch.setenv('ETH_PRIVATE_KEY', TEST_KEY)
-        sig = provider.sign_from_proof(TEST_ADDR, 'msg')
-        assert provider.verify_from_proof(TEST_ADDR, 'msg', sig)
+        sig = provider.chain.sign_from_proof(TEST_ADDR, 'msg')
+        assert provider.chain.verify_from_proof(TEST_ADDR, 'msg', sig)
 
 
 class TestCanSendFrom:
@@ -220,7 +220,7 @@ class TestFetchMatchingTx:
         def boom(method, params, timeout=15):
             raise RuntimeError('all ETH RPCs failed')
 
-        provider.eth_rpc = boom
+        provider.chain.eth_rpc = boom
         with pytest.raises(ProviderUnreachableError):
             provider.fetch_matching_tx(TX, RECIPIENT, 1)
 
@@ -318,18 +318,18 @@ class TestRpcFailover:
                 raise ConnectionError('refused')
             return self._Resp(body={'result': '0x10'})
 
-        provider.http.post = post
-        provider.rpc_bases = ['https://a.example', 'https://b.example']
-        assert provider.eth_rpc('eth_blockNumber', []) == '0x10'
+        provider.chain.http.post = post
+        provider.chain.rpc_bases = ['https://a.example', 'https://b.example']
+        assert provider.chain.eth_rpc('eth_blockNumber', []) == '0x10'
         assert calls == ['https://a.example', 'https://b.example']
 
     def test_rpc_error_object_fails_over(self, provider):
         responses = iter(
             [self._Resp(body={'error': {'code': -32005, 'message': 'limit'}}), self._Resp(body={'result': '0x1'})]
         )
-        provider.http.post = lambda url, json=None, timeout=15: next(responses)
-        provider.rpc_bases = ['https://a.example', 'https://b.example']
-        assert provider.eth_rpc('eth_chainId', []) == '0x1'
+        provider.chain.http.post = lambda url, json=None, timeout=15: next(responses)
+        provider.chain.rpc_bases = ['https://a.example', 'https://b.example']
+        assert provider.chain.eth_rpc('eth_chainId', []) == '0x1'
 
     def test_null_result_is_authoritative_no_failover(self, provider):
         calls = []
@@ -338,23 +338,23 @@ class TestRpcFailover:
             calls.append(url)
             return self._Resp(body={'result': None})
 
-        provider.http.post = post
-        provider.rpc_bases = ['https://a.example', 'https://b.example']
-        assert provider.eth_rpc('eth_getTransactionByHash', [TX]) is None
+        provider.chain.http.post = post
+        provider.chain.rpc_bases = ['https://a.example', 'https://b.example']
+        assert provider.chain.eth_rpc('eth_getTransactionByHash', [TX]) is None
         assert calls == ['https://a.example']
 
     def test_all_fail_raises(self, provider):
-        provider.http.post = lambda url, json=None, timeout=15: self._Resp(status_code=500)
-        provider.rpc_bases = ['https://a.example']
+        provider.chain.http.post = lambda url, json=None, timeout=15: self._Resp(status_code=500)
+        provider.chain.rpc_bases = ['https://a.example']
         with pytest.raises(Exception):
-            provider.eth_rpc('eth_blockNumber', [])
+            provider.chain.eth_rpc('eth_blockNumber', [])
 
     def test_execution_revert_raises_typed_verdict(self, provider):
         body = {'error': {'code': 3, 'message': 'execution reverted', 'data': '0x'}}
-        provider.http.post = lambda url, json=None, timeout=15: self._Resp(body=body)
-        provider.rpc_bases = ['https://a.example']
+        provider.chain.http.post = lambda url, json=None, timeout=15: self._Resp(body=body)
+        provider.chain.rpc_bases = ['https://a.example']
         with pytest.raises(EvmRpcError) as exc:
-            provider.eth_rpc('eth_estimateGas', [{}])
+            provider.chain.eth_rpc('eth_estimateGas', [{}])
         assert exc.value.is_execution_revert
 
     def test_revert_outranks_later_transport_failure(self, provider):
@@ -365,10 +365,10 @@ class TestRpcFailover:
                 return self._Resp(body={'error': {'code': 3, 'message': 'execution reverted'}})
             raise ConnectionError('down')
 
-        provider.http.post = post
-        provider.rpc_bases = ['https://a.example', 'https://b.example']
+        provider.chain.http.post = post
+        provider.chain.rpc_bases = ['https://a.example', 'https://b.example']
         with pytest.raises(EvmRpcError) as exc:
-            provider.eth_rpc('eth_estimateGas', [{}])
+            provider.chain.eth_rpc('eth_estimateGas', [{}])
         assert exc.value.is_execution_revert
 
 
@@ -433,7 +433,7 @@ class TestFindRecentOutgoing:
                 return {'status': '0x1' if params[0] == matching['hash'] else '0x0'}
             raise AssertionError(method)
 
-        provider.eth_rpc = rpc
+        provider.chain.eth_rpc = rpc
         # Casing crossed on purpose: cursor keys and matching go through normalize_address.
         assert provider.find_recent_outgoing(TEST_ADDR, RECIPIENT, 10**18) == matching['hash']
 
@@ -445,7 +445,7 @@ class TestFindRecentOutgoing:
                 return {'transactions': []}
             raise AssertionError(method)
 
-        provider.eth_rpc = rpc
+        provider.chain.eth_rpc = rpc
         assert provider.find_recent_outgoing(TEST_ADDR, RECIPIENT, 1) is None
         key = (TEST_ADDR.lower(), RECIPIENT.lower(), 1)
         assert provider.scan_cursors[key] == 100
@@ -461,7 +461,7 @@ class TestNetworkGuard:
     def test_unset_defaults_to_mainnet(self, monkeypatch):
         monkeypatch.delenv('ETH_NETWORK', raising=False)
         monkeypatch.delenv('ETH_RPC_URLS', raising=False)
-        assert Ether().network == 'mainnet'
+        assert Ether().chain.network == 'mainnet'
 
 
 class TestAbsenceQuorum:
@@ -483,25 +483,25 @@ class TestAbsenceQuorum:
                 raise value
             return self._Resp({'result': value})
 
-        provider.http.post = post
-        provider.rpc_bases = list(per_url)
+        provider.chain.http.post = post
+        provider.chain.rpc_bases = list(per_url)
 
     def test_second_endpoint_overrules_a_stale_null(self, provider):
         self._posts(provider, {'https://a.example': None, 'https://b.example': {'hash': TX}})
-        assert provider.eth_rpc('eth_getTransactionByHash', [TX], null_needs_quorum=True) == {'hash': TX}
+        assert provider.chain.eth_rpc('eth_getTransactionByHash', [TX], null_needs_quorum=True) == {'hash': TX}
 
     def test_unanimous_null_is_absent(self, provider):
         self._posts(provider, {'https://a.example': None, 'https://b.example': None})
-        assert provider.eth_rpc('eth_getTransactionByHash', [TX], null_needs_quorum=True) is None
+        assert provider.chain.eth_rpc('eth_getTransactionByHash', [TX], null_needs_quorum=True) is None
 
     def test_null_plus_unreachable_raises(self, provider):
         self._posts(provider, {'https://a.example': None, 'https://b.example': ConnectionError('down')})
         with pytest.raises(ProviderUnreachableError):
-            provider.eth_rpc('eth_getTransactionByHash', [TX], null_needs_quorum=True)
+            provider.chain.eth_rpc('eth_getTransactionByHash', [TX], null_needs_quorum=True)
 
     def test_without_flag_null_returns_immediately(self, provider):
         self._posts(provider, {'https://a.example': None, 'https://b.example': {'hash': TX}})
-        assert provider.eth_rpc('eth_getTransactionByHash', [TX]) is None
+        assert provider.chain.eth_rpc('eth_getTransactionByHash', [TX]) is None
 
 
 class TestBlockTimeUnknownNotStale:
@@ -682,7 +682,7 @@ class TestScannerCursorParking:
                 return {'status': '0x1'}
             raise AssertionError(method)
 
-        provider.eth_rpc = rpc
+        provider.chain.eth_rpc = rpc
         key = (TEST_ADDR.lower(), RECIPIENT.lower(), 10**18)
         assert provider.find_recent_outgoing(TEST_ADDR, RECIPIENT, 10**18) is None
         assert provider.scan_cursors[key] == 79

--- a/tests/test_hype_provider.py
+++ b/tests/test_hype_provider.py
@@ -9,7 +9,7 @@ import pytest
 from eth_account import Account
 
 from allways.assets.asset import ProviderUnreachableError
-from allways.assets.evm import HYPERLIQUID
+from allways.assets.evm import HYPERLIQUID, EvmChain
 from allways.assets.evm_coin import MAX_WALK_BLOCKS
 from allways.assets.hype import Hype
 from allways.chains import CHAIN_HYPE, get_chain_def
@@ -45,7 +45,7 @@ def rpc_stub(provider, responses: dict):
         value = responses[method]
         return value(params) if callable(value) else value
 
-    provider.eth_rpc = fake_rpc
+    provider.chain.eth_rpc = fake_rpc
     return provider
 
 
@@ -70,8 +70,11 @@ class TestRegistryRow:
         assert provider.chain_def is CHAIN_HYPE is get_chain_def('hype')
         assert 'hype' in LAUNCH_SPOKES
 
-    def test_native_coin_is_fused_with_its_chain(self, provider):
-        assert provider.chain is provider
+    def test_native_coin_composes_its_chain(self, provider):
+        # A native coin is an asset ON its network, not the network — same seam as a token,
+        # so a second asset can land beside it without either claiming to be the chain.
+        assert isinstance(provider.chain, EvmChain) and provider.chain is not provider
+        assert provider.chain.env_prefix == CHAIN_HYPE.env_prefix
 
     def test_decimals_and_prefix(self):
         assert (CHAIN_HYPE.decimals, CHAIN_HYPE.env_prefix, CHAIN_HYPE.native_unit) == (18, 'HYPE', 'wei')
@@ -83,11 +86,11 @@ class TestRegistryRow:
 
 class TestNetworkSelection:
     def test_mainnet_chain_id(self, provider):
-        assert provider.chain_id == 999
+        assert provider.chain.chain_id == 999
 
     def test_testnet_chain_id(self, monkeypatch):
         monkeypatch.setenv('HYPE_NETWORK', 'testnet')
-        assert Hype().chain_id == 998
+        assert Hype().chain.chain_id == 998
 
     def test_unknown_network_raises(self, monkeypatch):
         # A typo must never fall back to mainnet — that spends real HYPE against test swaps.
@@ -97,16 +100,16 @@ class TestNetworkSelection:
 
     def test_unset_network_defaults_to_mainnet(self, monkeypatch):
         monkeypatch.delenv('HYPE_NETWORK', raising=False)
-        assert Hype().network == 'mainnet'
+        assert Hype().chain.network == 'mainnet'
 
     @pytest.mark.parametrize('network', tuple(HYPERLIQUID.chain_ids))
     def test_every_network_has_a_keyless_default_ladder(self, monkeypatch, network):
         monkeypatch.setenv('HYPE_NETWORK', network)
-        assert Hype().rpc_bases == list(HYPERLIQUID.rpc_urls[network])
+        assert Hype().chain.rpc_bases == list(HYPERLIQUID.rpc_urls[network])
 
     def test_rpc_urls_env_overrides_the_public_ladder(self, monkeypatch):
         monkeypatch.setenv('HYPE_RPC_URLS', 'https://paid.example/key/,https://backup.example')
-        assert Hype().rpc_bases == ['https://paid.example/key', 'https://backup.example']
+        assert Hype().chain.rpc_bases == ['https://paid.example/key', 'https://backup.example']
 
     def test_wrong_network_endpoint_fails_startup(self, monkeypatch):
         # Testnet configured, a mainnet endpoint answering: the ladder must be rejected outright,

--- a/tests/test_network_config.py
+++ b/tests/test_network_config.py
@@ -83,7 +83,7 @@ def test_api_key_composes_onto_network_name(monkeypatch):
 
 def test_name_selected_chains_are_the_registry_rows_that_declare_networks():
     assert set(NAME_SELECTED_CHAINS) == {c for c in SUPPORTED_CHAINS.values() if c.networks}
-    assert CHAIN_NETWORK_KEYS == tuple(f'{c.id}-network' for c in NAME_SELECTED_CHAINS)
+    assert CHAIN_NETWORK_KEYS == tuple(f'{c.env_prefix.lower()}-network' for c in NAME_SELECTED_CHAINS)
     # Every declared network list starts at mainnet — the bundles and `alw config` default to it.
     assert all(c.networks[0] == 'mainnet' for c in NAME_SELECTED_CHAINS)
 


### PR DESCRIPTION
Stacked on #639. Prepares the registry for a second asset on an already-used network (`ethusdc` lands on Ethereum beside `eth`) without either asset having to configure Ethereum twice.

## Two changes

### 1. The native coin composes its chain instead of being it

`EvmCoin(EvmAsset, EvmChain)` → `EvmCoin(EvmAsset)`, holding `self._chain`. That is the shape `Erc20` already had, so both EVM asset kinds now reach the network the same way.

```
before                          after
Ether  is-a  EvmChain           Ether   has-a  EvmChain
ArbUsdc has-a EvmChain          ArbUsdc has-a  EvmChain
```

Fusion says "a native coin is its network." True while a network hosts one asset, false the moment a token lands beside it — and Ethereum is about to host two.

**No production call site changed.** Every one already routed through `.chain` (`swap.py:633,645`, `helpers.py:472,497`, `reserve_engine.py:132,143`, `solana_swap_loop.py:187`); the seam rule was already being honoured. Only tests reached through the fused object, which is the whole test diff.

### 2. `env_prefix` names the network, not the asset

`CHAIN_ARBUSDC.env_prefix` `ARBUSDC` → `ARB`, and the CLI key derives from it rather than the asset id.

| Var | Scope | Example |
|---|---|---|
| `{PREFIX}_NETWORK`, `_RPC_URLS`, `_PRIVATE_KEY` | network | `ARB_NETWORK` |
| `{ASSET_ID}_TOKEN_CONTRACT` | asset | `ARBUSDC_TOKEN_CONTRACT` |

Assets on one network then read one `{PREFIX}_NETWORK` and cannot disagree about which network they are on. `ethusdc` will carry `networks=()` and inherit `ETH_*` — no `ETHUSDC_NETWORK` to drift from `ETH_NETWORK`.

Guarded by a new test: exactly one registry row per `env_prefix` may declare `networks`, so a second asset on a network cannot silently render a duplicate CLI row writing the same env var.

**Breaking for arbusdc operators** — `ARBUSDC_NETWORK` / `_RPC_URLS` / `_PRIVATE_KEY` → `ARB_*`, and `alw config set arbusdc-network` → `arb-network`. Prod has **zero** miners quoting the pair (`api.all-ways.io/miners`, 2026-08-11: 135 quotes, all `sol→btc` and `sol→tao`), so nobody is migrating. Doing it now rather than after the pair has operators.

### Bug this surfaced

`Erc20.send_amount` used `env_prefix` as the asset's label, so a USDC shortfall now printed `Insufficient ARB` — naming the gas token instead of the token that was short. Asset-facing messages now use the asset id; network-facing ones (key env, RPC, broadcast) keep the prefix.

## Not done, deliberately

Assets on one network still build an `EvmChain` **each**. Pooling them behind a process-wide cache costs one global mutable dict and poisons any test that constructs a provider under changed env — for a saving of one `eth_blockNumber` per validator pass. The env-prefix change alone delivers the correctness win; sharing instances is an optimisation, filed rather than built.

## Verification

- `uv run ruff format --check . && uv run ruff check .` — clean
- `uv run pytest tests/ -q` — **1119 passed** (1118 + the new prefix-ownership guard)
- `uv run alw config` → `btc-network`, `eth-network`, `arb-network`, `hype-network` — one row per network
- `uv run alw miner quotes --help` → `--arbusdc-price/--arbusdc-address` — still per asset, correctly

```
network rows:  btc-network  eth-network  arb-network  hype-network
quote flags:   --btc-*  --tao-*  --eth-*  --arbusdc-*  --hype-*  --sol-address
```

## Merge order

Rebased onto `test` after #639 merged. Single commit, no conflicts, CI green.
