### PR TITLE
Enforce one env identity per EVM network

### DIFF
--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -305,8 +305,7 @@ class Erc20(EvmAsset):
         Returns (tx_hash, 0) or None; dedup/rescue ladder mirrors the native EVM send.
         """
         self.last_send_error = None
-        # prefix names the NETWORK (its key/RPC env); token names the ASSET being moved.
-        prefix, token = self.chain_def.env_prefix, self.chain_def.id.upper()
+        prefix = self.chain_def.env_prefix  # the NETWORK's key/RPC env
         norm = self.chain.normalize_address
         acct = self.chain._account()
         if acct is None:
@@ -348,13 +347,13 @@ class Erc20(EvmAsset):
             # estimator too, which would misread as the destination refusing.
             token_balance = self.get_balance(acct.address)
             if token_balance < amount:
-                self._send_error(f'Insufficient {token}: have {token_balance} units, need {amount}')
+                self._send_error(f'{self._log} insufficient balance: have {token_balance} units, need {amount}')
                 return None
 
             calldata = SEL_TRANSFER[2:] + _pad_addr(to_address) + f'{int(amount):064x}'
             gas = self._transfer_gas(acct.address, calldata)
             if gas is None:
-                self._send_error(f'destination {to_address} refuses {token} transfers — not sending')
+                self._send_error(f'{self._log} destination {to_address} refuses transfers — not sending')
                 return None
 
             gas_balance = int(self.chain.eth_rpc('eth_getBalance', [acct.address, 'latest']), 16)
@@ -399,11 +398,11 @@ class Erc20(EvmAsset):
                 self._send_error(f'{prefix} broadcast failed: {broadcast_err}')
                 return None
 
-            bt.logging.info(f'Sent {amount} {token} units to {to_address} (tx: {tx_hash}, maxFee: {max_fee})')
+            bt.logging.info(f'{self._log} sent {amount} units to {to_address} (tx: {tx_hash}, maxFee: {max_fee})')
             # A quirky null broadcast reply must never persist as a blank tx hash.
             return (tx_hash or expected_txid, 0)
         except Exception as e:
-            self._send_error(f'{prefix} send failed: {type(e).__name__}: {e}')
+            self._send_error(f'{self._log} send failed: {type(e).__name__}: {e}')
             return None
 
     def _transfer_gas(self, from_addr: str, calldata: str) -> Optional[int]:

--- a/allways/assets/eth.py
+++ b/allways/assets/eth.py
@@ -1,4 +1,3 @@
-from allways.assets.evm import ETHEREUM
 from allways.assets.evm_coin import EvmCoin
 from allways.chains import CHAIN_ETH
 
@@ -10,4 +9,4 @@ class Ether(EvmCoin):
     same shape every native EVM coin takes."""
 
     def __init__(self):
-        super().__init__(CHAIN_ETH, ETHEREUM)
+        super().__init__(CHAIN_ETH)

--- a/allways/assets/evm.py
+++ b/allways/assets/evm.py
@@ -316,9 +316,9 @@ class EvmAsset(Asset):
     """Base for assets on EVM chains: key handling, send dedup ladder, deposit-scan
     cursors, the settled-tx cache, and the connection check scaffold.
 
-    Chain questions route through ``self.chain`` (seam rule): a fused native coin is its
-    own chain; a token binds ``self._chain`` to its host network's `EvmChain` at
-    construction. Env vars key off the asset's ``chain_def.env_prefix``.
+    Chain questions route through ``self.chain`` (seam rule): every EVM asset, coin or
+    token, binds ``self._chain`` to its host network's `EvmChain` at construction. Env
+    vars key off that NETWORK's ``env_prefix``, shared by every asset on it.
     """
 
     # Settled-tx cache bound — comfortably above any realistic concurrent-leg count.

--- a/allways/assets/evm_coin.py
+++ b/allways/assets/evm_coin.py
@@ -6,7 +6,7 @@ from eth_account import Account
 from eth_utils import to_checksum_address
 
 from allways.assets.asset import ProviderUnreachableError, SendResult, TransactionInfo
-from allways.assets.evm import FALLBACK_PRIORITY_FEE_WEI, EvmAsset, EvmChain, EvmNetwork
+from allways.assets.evm import EVM_NETWORKS, FALLBACK_PRIORITY_FEE_WEI, EvmAsset, EvmChain
 from allways.chains import ChainDefinition
 
 TRANSFER_GAS = 21_000
@@ -32,9 +32,9 @@ class EvmCoin(EvmAsset):
     moment a token lands beside it. Both are bound by a registry row, never subclassed.
     """
 
-    def __init__(self, chain_def: ChainDefinition, network_def: EvmNetwork):
+    def __init__(self, chain_def: ChainDefinition):
         self._chain_def = chain_def
-        self._chain = EvmChain(network_def, chain_def.env_prefix)
+        self._chain = EvmChain(EVM_NETWORKS[chain_def.host_chain], chain_def.env_prefix)
         EvmAsset.__init__(self)
 
     @property

--- a/allways/assets/hype.py
+++ b/allways/assets/hype.py
@@ -1,4 +1,3 @@
-from allways.assets.evm import HYPERLIQUID
 from allways.assets.evm_coin import EvmCoin
 from allways.chains import CHAIN_HYPE
 
@@ -9,4 +8,4 @@ class Hype(EvmCoin):
     HyperEVM speaks plain JSON-RPC, so nothing here is chain-specific beyond the pairing."""
 
     def __init__(self):
-        super().__init__(CHAIN_HYPE, HYPERLIQUID)
+        super().__init__(CHAIN_HYPE)

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -36,9 +36,10 @@ class ChainDefinition:
     # Default 0 (at-or-after the floor; only a tx that predates it is a replay). Absorbs honest miner
     # clock skew; MUST stay well under reservation_ttl_secs — the replay window is exactly this wide (B2).
     replay_grace_secs: int = 0
-    # Layered-asset fields: the wire id stays flat, the layering lives here. None for
-    # assets that are their own network (btc/tao/sol/eth).
-    host_chain: str | None = None  # network whose txs carry this asset (assets/evm.py EVM_NETWORKS key)
+    # The network whose txs carry this asset (assets/evm.py EVM_NETWORKS key). Every EVM row
+    # sets it — native coin and token alike — so both resolve their chain the same way.
+    # None only for assets that ARE their own network (btc/tao/sol).
+    host_chain: str | None = None
     # Canonical MAINNET contract of a hosted asset. Testnet deployments + env overrides
     # resolve in the provider (assets/erc20.py) — each address lives exactly once.
     asset_locator: str | None = None
@@ -94,6 +95,7 @@ CHAIN_ETH = ChainDefinition(
     native_unit='wei',
     decimals=18,
     env_prefix='ETH',
+    host_chain='ethereum',
     networks=('mainnet', 'sepolia'),
     testnet_network='sepolia',
     seconds_per_block=12,
@@ -138,6 +140,7 @@ CHAIN_HYPE = ChainDefinition(
     native_unit='wei',
     decimals=18,
     env_prefix='HYPE',
+    host_chain='hyperliquid',
     networks=('mainnet', 'testnet'),
     testnet_network='testnet',
     # ~1s small blocks (transfers never need the 60s big blocks — those carry >2M gas).

--- a/tests/test_arbusdc_provider.py
+++ b/tests/test_arbusdc_provider.py
@@ -353,7 +353,7 @@ class TestSendGuards:
         monkeypatch.setenv('ARB_PRIVATE_KEY', TEST_KEY)
         rpc_stub(provider, self._send_responses(token_balance=AMOUNT - 1))
         assert provider.send_amount(RECIPIENT, AMOUNT) is None
-        assert 'Insufficient ARBUSDC' in provider.last_send_error
+        assert 'insufficient balance' in provider.last_send_error
 
     def test_insufficient_gas_balance_refused(self, provider, monkeypatch):
         # F6: token-rich but gas-poor must refuse BEFORE broadcasting a doomed transfer.
@@ -374,7 +374,7 @@ class TestSendGuards:
         responses['eth_estimateGas'] = revert
         rpc_stub(provider, responses)
         assert provider.send_amount(RECIPIENT, AMOUNT) is None
-        assert 'Insufficient ARBUSDC' in provider.last_send_error
+        assert 'insufficient balance' in provider.last_send_error
 
     def test_reverting_transfer_refused(self, provider, monkeypatch):
         monkeypatch.setenv('ARB_PRIVATE_KEY', TEST_KEY)

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -4,6 +4,7 @@ import re
 
 import pytest
 
+from allways.assets.evm import EVM_NETWORKS
 from allways.chains import (
     CHAIN_ARBUSDC,
     CHAIN_BTC,
@@ -46,23 +47,31 @@ class TestGetChain:
             assert re.fullmatch(r'[a-z0-9]{1,10}', chain_id), chain_id
             assert chain.id == chain_id
 
-    def test_one_row_per_env_prefix_owns_the_network_setting(self):
-        """env_prefix names the NETWORK, so assets sharing one share its {PREFIX}_NETWORK.
-        Exactly one of them may declare ``networks`` — two would render duplicate CLI rows
-        writing the same env var, and a second asset on a network must carry networks=()."""
+    def test_assets_on_one_network_share_its_env_identity(self):
+        """A network is configured once. Rows sharing a host_chain MUST share env_prefix —
+        otherwise the second asset reads an unset {PREFIX}_NETWORK, silently defaults to
+        mainnet, and a testnet miner pays real funds against test swaps. Exactly one of them
+        declares ``networks``: two would render duplicate CLI rows writing the same var."""
+        prefixes: dict[str, set[str]] = {}
         owners: dict[str, list[str]] = {}
         for chain in SUPPORTED_CHAINS.values():
+            if chain.host_chain:
+                prefixes.setdefault(chain.host_chain, set()).add(chain.env_prefix)
             if chain.networks:
                 owners.setdefault(chain.env_prefix, []).append(chain.id)
+        for host, found in prefixes.items():
+            assert len(found) == 1, f'{host} assets disagree on env_prefix: {sorted(found)}'
         for prefix, ids in owners.items():
             assert len(ids) == 1, f'{prefix}_NETWORK is declared by more than one row: {ids}'
 
-    def test_layered_fields_default_none_for_native_assets(self):
-        for chain_id in ('btc', 'tao', 'sol', 'eth', 'hype'):
+    def test_only_self_hosted_assets_lack_a_host_chain(self):
+        for chain_id in ('btc', 'tao', 'sol'):
             assert get_chain_def(chain_id).host_chain is None
-            assert get_chain_def(chain_id).asset_locator is None
-        assert CHAIN_ARBUSDC.host_chain == 'arbitrum'
+        for chain_id in ('eth', 'hype', 'arbusdc'):
+            assert get_chain_def(chain_id).host_chain in EVM_NETWORKS
+        # asset_locator is the token-only field: a native coin has no contract to pin.
         assert CHAIN_ARBUSDC.asset_locator.startswith('0x')
+        assert all(get_chain_def(c).asset_locator is None for c in ('btc', 'tao', 'sol', 'eth', 'hype'))
 
 
 class TestCanonicalPair:

--- a/tests/test_network_config.py
+++ b/tests/test_network_config.py
@@ -83,7 +83,6 @@ def test_api_key_composes_onto_network_name(monkeypatch):
 
 def test_name_selected_chains_are_the_registry_rows_that_declare_networks():
     assert set(NAME_SELECTED_CHAINS) == {c for c in SUPPORTED_CHAINS.values() if c.networks}
-    assert CHAIN_NETWORK_KEYS == tuple(f'{c.env_prefix.lower()}-network' for c in NAME_SELECTED_CHAINS)
     # Every declared network list starts at mainnet — the bundles and `alw config` default to it.
     assert all(c.networks[0] == 'mainnet' for c in NAME_SELECTED_CHAINS)
 


### PR DESCRIPTION
Review follow-up on #640. Its stated invariant — assets on one network cannot disagree about which network they are on — was **not enforced**; the guard checked a symptom.

## The hole

A row with `env_prefix='ETHUSDC', networks=()` passed every test. Reproduced against `test`:

```
ETH_NETWORK=sepolia   →  eth      sepolia
                         ethusdc  mainnet    (ETHUSDC_NETWORK unset → silent default)
```

A testnet miner pays real mainnet USDC. Exactly the failure #640 existed to prevent.

The old guard asserted "one row per env_prefix declares `networks`" — true of the broken config, so it passed.

## Fix

Real invariant: **same `host_chain` ⇒ same `env_prefix`.** Native EVM rows had `host_chain=None`, so there was nothing to group on; they now carry it (`eth`→`ethereum`, `hype`→`hyperliquid`).

```
ethereum assets disagree on env_prefix: ['ETH', 'ETHUSDC']   ← new guard, verified firing
```

That also collapses the two constructors into one shape — `EvmCoin` resolves its chain exactly as `Erc20` does, so a binding is now the registry row alone:

```python
class Ether(EvmCoin):
    def __init__(self):
        super().__init__(CHAIN_ETH)      # was: (CHAIN_ETH, ETHEREUM)
```

Drops the `network_def` param and the per-file network import — from every current binding and from all four in the incoming batch.

## Also

| | |
|---|---|
| `erc20.py` | `f'{prefix} send failed'` named the network on an asset failure — the sibling of the bug #640 fixed. All four asset-facing messages now use `self._log`, matching the other 12 in the file. Deletes the `token` local. |
| `evm.py` | `EvmAsset` docstring still described the fused shape and asset-keyed env. Both false since #640 — I rewrote the docstrings either side of it and missed this one. |
| `test_network_config.py` | An assertion had become a verbatim restatement of `network_key`'s body. Deleted. |

Not done: the `alw config` help label reads "USDC (Arbitrum) network name" beside `arb-network`. Correcting it costs an import in `main.py` for a cosmetic string — left alone.

## Verification

- `uv run ruff format --check . && uv run ruff check .` — clean
- `uv run pytest tests/ -q` — 1119 passed
- New guard proven to fire on the exact config the old one admitted (above)
- 9 files, +38/−30

Companion: alw-utils fixes the `_TOKEN_CONTRACT` var rename and three stale `allways.assets.subtensor` imports.
