### PR TITLE
Add USDC on Base as a launch spoke

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,17 @@ AVAX_NETWORK=mainnet                # mainnet | fuji
 # AVAX_RPC_URLS=https://avalanche-mainnet.infura.io/v3/your_key,https://api.avax.network/ext/bc/C/rpc
 # 32-byte hex key — required for miners; optional local signing for `alw swap`
 AVAX_PRIVATE_KEY=
+# ─── Network: Base (baseusdc pairs) ────────────────────────
+# Vars are per NETWORK, shared by every asset on it (BASE_ here, not BASEUSDC_).
+BASE_NETWORK=mainnet                # mainnet | sepolia (Base Sepolia)
+# OPTIONAL ordered JSON-RPC endpoints (keyed providers embed the key in the URL);
+# unset = public (publicnode, drpc)
+# BASE_RPC_URLS=https://base-mainnet.g.alchemy.com/v2/your_key,https://base-rpc.publicnode.com
+# 32-byte hex key — required for miners (fund USDC for legs + ETH-on-Base for gas);
+# optional local signing for `alw swap`
+BASE_PRIVATE_KEY=
+# OPTIONAL token contract override (dev/e2e fakes) — per ASSET, unset = Circle's canonical deployment
+# BASEUSDC_TOKEN_CONTRACT=
 
 # ─── Miner-only ────────────────────────────────────────────
 # headless miners: unlocks the coldkey at startup for TAO sends; unset = prompt at launch

--- a/.env.example
+++ b/.env.example
@@ -80,8 +80,9 @@ AVAX_PRIVATE_KEY=
 # Vars are per NETWORK, shared by every asset on it (BASE_ here, not BASEUSDC_).
 BASE_NETWORK=mainnet                # mainnet | sepolia (Base Sepolia)
 # OPTIONAL ordered JSON-RPC endpoints (keyed providers embed the key in the URL);
-# unset = public (publicnode, drpc)
-# BASE_RPC_URLS=https://base-mainnet.g.alchemy.com/v2/your_key,https://base-rpc.publicnode.com
+# unset = public (mainnet.base.org, drpc) — the public gateways rate-limit under load, so
+# prefer a keyed primary. NOT publicnode: its free Base endpoint 403s every receipt read.
+# BASE_RPC_URLS=https://base-mainnet.g.alchemy.com/v2/your_key,https://base.drpc.org
 # 32-byte hex key — required for miners (fund USDC for legs + ETH-on-Base for gas);
 # optional local signing for `alw swap`
 BASE_PRIVATE_KEY=

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Native transactions across independent assets — no wrapped tokens, no bridges,
 
 Allways creates a verification layer above independent systems. Assets move natively. Miners complete transactions, validators independently verify the results, and a smart contract enforces outcomes through collateral and slashing.
 
-Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, and SOL ↔ AVAX (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
+Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, and SOL ↔ USDC-on-Base (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
 
 ## Miner Risk Disclaimer
 
@@ -123,7 +123,7 @@ needs to persist across restarts.
 
 ## Miner Environment Variables
 
-- `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `BNB_PRIVATE_KEY`, `AVAX_PRIVATE_KEY`, `{ETH,ARB,HYPE,BNB,AVAX}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config. See `.env.example`.
+- `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `BNB_PRIVATE_KEY`, `AVAX_PRIVATE_KEY`, `BASE_PRIVATE_KEY`, `{ETH,ARB,HYPE,BNB,AVAX,BASE}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config. See `.env.example`.
 
 ## Running a Local Subtensor Lite Node (Validators)
 

--- a/allways/assets/__init__.py
+++ b/allways/assets/__init__.py
@@ -5,6 +5,7 @@ import bittensor as bt
 from allways.assets.arbusdc import ArbUsdc
 from allways.assets.asset import Asset, SendResult, TransactionInfo
 from allways.assets.avax import Avax
+from allways.assets.baseusdc import BaseUsdc
 from allways.assets.bnb import Bnb
 from allways.assets.btc import Bitcoin
 from allways.assets.chain import Chain
@@ -31,6 +32,7 @@ __all__ = [
     'Avax',
     'Erc20',
     'ArbUsdc',
+    'BaseUsdc',
     'create_assets',
 ]
 
@@ -53,6 +55,7 @@ ASSET_REGISTRY: Tuple[AssetSpec, ...] = (
     AssetSpec('hype', Hype, ()),
     AssetSpec('bnb', Bnb, ()),
     AssetSpec('avax', Avax, ()),
+    AssetSpec('baseusdc', BaseUsdc, ()),
 )
 
 

--- a/allways/assets/baseusdc.py
+++ b/allways/assets/baseusdc.py
@@ -1,0 +1,9 @@
+from allways.assets.erc20 import Erc20
+from allways.chains import CHAIN_BASEUSDC
+
+
+class BaseUsdc(Erc20):
+    """Native Circle USDC on Base — a config-row binding of the generic Erc20 (see chains.CHAIN_BASEUSDC)."""
+
+    def __init__(self):
+        super().__init__(CHAIN_BASEUSDC)

--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -35,6 +35,8 @@ DEFAULT_TOKEN_TRANSFER_GAS = 120_000
 TESTNET_TOKEN_CONTRACTS = {
     # Circle-verified native USDC on Arbitrum Sepolia (developers.circle.com, 2026-08-07).
     'arbusdc': {'sepolia': '0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d'},
+    # Circle-verified native USDC on Base Sepolia (developers.circle.com, 2026-08-11).
+    'baseusdc': {'sepolia': '0x036CbD53842c5426634e7929541eC2318f3dCF7e'},
 }
 
 

--- a/allways/assets/evm.py
+++ b/allways/assets/evm.py
@@ -127,6 +127,17 @@ AVALANCHE = EvmNetwork(
     },
 )
 
+BASE = EvmNetwork(
+    label='Base',
+    chain_ids={'mainnet': 8_453, 'sepolia': 84_532},
+    rpc_urls={
+        # publicnode is deliberately absent: its free Base mainnet endpoint 403s every
+        # eth_getTransactionReceipt as an "archive request", so it can never settle a leg.
+        'mainnet': ('https://mainnet.base.org', 'https://base.drpc.org'),
+        'sepolia': ('https://sepolia.base.org', 'https://base-sepolia.drpc.org'),
+    },
+)
+
 # ChainDefinition.host_chain → the EvmNetwork that hosts the asset.
 EVM_NETWORKS: Mapping[str, EvmNetwork] = {
     'ethereum': ETHEREUM,
@@ -134,6 +145,7 @@ EVM_NETWORKS: Mapping[str, EvmNetwork] = {
     'hyperliquid': HYPERLIQUID,
     'bsc': BSC,
     'avalanche': AVALANCHE,
+    'base': BASE,
 }
 
 

--- a/allways/assets/evm.py
+++ b/allways/assets/evm.py
@@ -133,6 +133,9 @@ BASE = EvmNetwork(
     rpc_urls={
         # publicnode is deliberately absent: its free Base mainnet endpoint 403s every
         # eth_getTransactionReceipt as an "archive request", so it can never settle a leg.
+        # The official gateways rate-limit under load (429s observed on mainnet.base.org),
+        # which makes an absent tx raise instead of resolving; operators running volume
+        # should point {PREFIX}_RPC_URLS at a keyed endpoint, as on Hyperliquid.
         'mainnet': ('https://mainnet.base.org', 'https://base.drpc.org'),
         'sepolia': ('https://sepolia.base.org', 'https://base-sepolia.drpc.org'),
     },

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -203,6 +203,32 @@ CHAIN_AVAX = ChainDefinition(
     replay_grace_secs=60,
 )
 
+CHAIN_BASEUSDC = ChainDefinition(
+    id='baseusdc',
+    name='USDC (Base)',
+    native_unit='µUSDC',
+    decimals=6,
+    env_prefix='BASE',
+    networks=('mainnet', 'sepolia'),  # sepolia = Base Sepolia
+    testnet_network='sepolia',
+    # Measured live on both networks (2026-08-11): exactly 2s between consecutive blocks.
+    seconds_per_block=2,
+    # Base is an OP-stack rollup: the sequencer can reorg its own unsafe head before the L1
+    # batch posts, so it needs far more depth than a fast-finality chain. 120 × 2s ≈ 240s,
+    # well inside the program's 600s default fulfillment grace.
+    min_confirmations=120,
+    # ERC-20 transfers have no protocol minimum and Base's L2 gas is negligible, so 1 is the
+    # honest floor — a rate sanity input, not an economic guarantee (as on Arbitrum).
+    min_onchain_amount=1,
+    # Sequencer-stamped timestamps vs the hub clock — modest skew allowance (monotonic
+    # timestamps say nothing about how far the sequencer's clock sits from the hub's).
+    replay_grace_secs=60,
+    host_chain='base',
+    # Circle-verified native USDC on Base (developers.circle.com, 2026-08-11) — NOT the
+    # bridged USDbC at 0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA.
+    asset_locator='0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+)
+
 SUPPORTED_CHAINS = {
     'btc': CHAIN_BTC,
     'tao': CHAIN_TAO,
@@ -212,6 +238,7 @@ SUPPORTED_CHAINS = {
     'hype': CHAIN_HYPE,
     'bnb': CHAIN_BNB,
     'avax': CHAIN_AVAX,
+    'baseusdc': CHAIN_BASEUSDC,
 }
 
 

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -87,7 +87,7 @@ def hub_leg(from_chain: str, to_chain: str) -> str | None:
 
 
 # Chains paired against each hub; add a chain here to launch its pairs.
-LAUNCH_SPOKES = ('btc', 'tao', 'eth', 'arbusdc', 'hype', 'bnb', 'avax')
+LAUNCH_SPOKES = ('btc', 'tao', 'eth', 'arbusdc', 'hype', 'bnb', 'avax', 'baseusdc')
 # Every launch pair as (hub, spoke): each hub pairs against every spoke except itself. sol↔tao
 # lands exactly once (under SOL, its anchor) because sol never appears in LAUNCH_SPOKES.
 LAUNCH_PAIRS: tuple[tuple[str, str], ...] = tuple(

--- a/tests/test_baseusdc_provider.py
+++ b/tests/test_baseusdc_provider.py
@@ -343,7 +343,7 @@ class TestSendGuards:
         assert provider.send_amount(RECIPIENT, AMOUNT, from_address=TEST_ADDR) == ('0x' + 'ee' * 32, 0)
         assert SEL_TRANSFER.removeprefix('0x') in sent['raw']
         assert CONTRACT.lower().removeprefix('0x') in sent['raw']  # addressed to the pinned token
-        assert list(provider.broadcasted_txids.values()) == [(RECIPIENT.lower(), AMOUNT, 1000)]
+        assert list(provider.broadcasted_txids.values()) == [(RECIPIENT.lower(), AMOUNT, '', 1000)]
 
 
 class TestScanner:

--- a/tests/test_baseusdc_provider.py
+++ b/tests/test_baseusdc_provider.py
@@ -1,0 +1,366 @@
+"""BaseUsdc unit tests — all offline (RPC layer mocked, signing is pure crypto).
+
+The generic ERC-20 behaviour is `Erc20`, proven by the arbusdc suite. What is Base-specific
+lives in the binding: which network the env selects, the chain id every signed tx commits to,
+and — the hazard that makes this asset different from every other spoke — that the pinned
+contract is Circle's native USDC and never the bridged USDbC deployed beside it.
+"""
+
+import pytest
+
+from allways.assets.asset import ProviderUnreachableError
+from allways.assets.baseusdc import BaseUsdc
+from allways.assets.erc20 import (
+    SEL_BALANCE_OF,
+    SEL_IS_BLACKLISTED,
+    SEL_PAUSED,
+    SEL_TRANSFER,
+    TRANSFER_TOPIC0,
+)
+from allways.assets.evm import BASE, EvmChain
+from allways.chains import CHAIN_BASEUSDC, get_chain_def
+from allways.constants import LAUNCH_SPOKES
+from allways.utils.rate import is_executable_rate
+
+TEST_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'  # hardhat account #0
+TEST_ADDR = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+
+CONTRACT = '0x036CbD53842c5426634e7929541eC2318f3dCF7e'  # Circle USDC, Base Sepolia
+# Bridged USD Base Coin — a different contract paying a well-formed Transfer nobody asked for.
+USDBC = '0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA'
+SENDER = '0x' + '11' * 20
+RECIPIENT = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+TX = '0x' + 'ab' * 32
+BLOCK_HASH = '0x' + 'cd' * 32
+AMOUNT = 150_000_000  # 150 USDC in µUSDC
+MINED = 1_000_000
+SETTLED_TIP = MINED + CHAIN_BASEUSDC.min_confirmations - 1
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    monkeypatch.setenv('BASE_NETWORK', 'sepolia')
+    for var in ('BASE_RPC_URLS', 'BASE_PRIVATE_KEY', 'BASEUSDC_TOKEN_CONTRACT'):
+        monkeypatch.delenv(var, raising=False)
+    return BaseUsdc()
+
+
+def rpc_stub(provider, responses: dict):
+    """Replace eth_rpc with a method→response map. A callable value is invoked with params."""
+
+    def fake_rpc(method, params, timeout=15, **kw):
+        value = responses[method]
+        return value(params) if callable(value) else value
+
+    provider.chain.eth_rpc = fake_rpc  # the asset talks through its chain (composed seam)
+    return provider
+
+
+def topic(address: str) -> str:
+    return '0x' + '00' * 12 + address.lower().removeprefix('0x')
+
+
+def transfer_log(contract=CONTRACT, sender=SENDER, recipient=RECIPIENT, amount=AMOUNT) -> dict:
+    return {'address': contract, 'topics': [TRANSFER_TOPIC0, topic(sender), topic(recipient)], 'data': hex(amount)}
+
+
+def mined_tx_responses(logs=None, status='0x1', tip=SETTLED_TIP, receipt=..., timestamp='0x64'):
+    if logs is None:
+        logs = [transfer_log()]
+    if receipt is ...:
+        receipt = {'status': status, 'blockNumber': hex(MINED), 'blockHash': BLOCK_HASH, 'logs': logs}
+    return {
+        'eth_getTransactionByHash': {
+            'hash': TX,
+            'from': SENDER,
+            'to': CONTRACT,
+            'blockNumber': hex(MINED),
+            'blockHash': BLOCK_HASH,
+        },
+        'eth_getTransactionReceipt': receipt,
+        'eth_blockNumber': hex(tip),
+        'eth_getBlockByNumber': {'hash': BLOCK_HASH, 'timestamp': timestamp},
+    }
+
+
+def eth_call_views(blacklisted=(), paused=False, balances=None):
+    """eth_call dispatcher over the token's views, keyed by selector."""
+
+    def call(params):
+        data = params[0]['data']
+        if data.startswith(SEL_PAUSED):
+            return hex(int(paused))
+        addr = '0x' + data[-40:]
+        if data.startswith(SEL_IS_BLACKLISTED):
+            return hex(int(addr in {a.lower() for a in blacklisted}))
+        if data.startswith(SEL_BALANCE_OF):
+            return hex((balances or {}).get(addr, 0))
+        raise AssertionError(f'unexpected eth_call {data[:10]}')
+
+    return call
+
+
+class TestRegistryRow:
+    def test_is_a_launch_spoke_bound_to_its_registry_row(self, provider):
+        assert provider.chain_def is CHAIN_BASEUSDC is get_chain_def('baseusdc')
+        assert 'baseusdc' in LAUNCH_SPOKES
+
+    def test_token_composes_its_network(self, provider):
+        assert isinstance(provider.chain, EvmChain) and provider.chain is not provider
+        assert provider.chain.env_prefix == 'BASE'  # the NETWORK's identity, not the asset's
+
+    def test_decimals_and_units(self):
+        assert (CHAIN_BASEUSDC.decimals, CHAIN_BASEUSDC.native_unit) == (6, 'µUSDC')
+
+    def test_confirmations_stay_inside_the_program_fulfillment_grace(self):
+        # An unlisted chain gets the program's 600s default grace; 120 × 2s = 240s is inside it.
+        assert CHAIN_BASEUSDC.min_confirmations * CHAIN_BASEUSDC.seconds_per_block == 240
+
+    @pytest.mark.parametrize('pair', (('baseusdc', 'sol'), ('sol', 'baseusdc')))
+    def test_sane_rates_execute_in_both_directions(self, pair):
+        # 6 decimals against the hub's 9 plus a floor of 1 µUSDC: the gate must route a real
+        # ~200 USDC/SOL market both ways, and still reject a nonsense rate.
+        assert is_executable_rate(200.0, *pair, 10_000_000, 100_000_000_000) is True
+        assert is_executable_rate(1e-20, *pair, 10_000_000, 100_000_000_000) is False
+
+
+class TestNetworkAndContract:
+    def test_mainnet_chain_id_and_circle_contract(self, monkeypatch):
+        for var in ('BASE_NETWORK', 'BASE_RPC_URLS', 'BASEUSDC_TOKEN_CONTRACT'):
+            monkeypatch.delenv(var, raising=False)
+        p = BaseUsdc()
+        assert (p.chain.network, p.chain.chain_id) == ('mainnet', 8_453)
+        assert p.token_contract == CHAIN_BASEUSDC.asset_locator
+        # Native Circle USDC, not the bridged USD Base Coin deployed on the same network.
+        assert p.token_contract.lower() != USDBC.lower()
+
+    def test_sepolia_uses_the_testnet_deployment(self, provider):
+        assert (provider.chain.chain_id, provider.token_contract) == (84_532, CONTRACT)
+
+    def test_unknown_network_raises(self, monkeypatch):
+        # A typo must never fall back to mainnet — that spends real USDC against test swaps.
+        monkeypatch.setenv('BASE_NETWORK', 'seplia')
+        with pytest.raises(ValueError, match='BASE_NETWORK'):
+            BaseUsdc()
+
+    @pytest.mark.parametrize('network', tuple(BASE.chain_ids))
+    def test_every_network_has_a_two_deep_keyless_ladder(self, monkeypatch, network):
+        monkeypatch.setenv('BASE_NETWORK', network)
+        # Two endpoints or null quorum can never be reached, and every absent tx would raise.
+        assert BaseUsdc().chain.rpc_bases == list(BASE.rpc_urls[network]) and len(BASE.rpc_urls[network]) == 2
+
+    def test_env_override_wins(self, monkeypatch):
+        monkeypatch.setenv('BASEUSDC_TOKEN_CONTRACT', '0x' + '42' * 20)
+        assert BaseUsdc().token_contract == '0x' + '42' * 20
+
+    def test_lookback_window_is_time_based(self, provider):
+        assert provider.SCAN_LOOKBACK_BLOCKS == 150  # ≈5 min of 2s blocks
+
+
+class TestCheckConnection:
+    def test_wrong_network_endpoint_deeper_in_ladder_fails_boot(self, provider):
+        # Every configured endpoint is probed — a mainnet URL at position 2 would otherwise
+        # surface only mid-outage, quietly verifying legs against the wrong chain.
+        def fake_rpc(method, params, timeout=15, bases=None, **kw):
+            if method == 'eth_chainId':
+                return hex(8_453) if bases and 'drpc' in bases[0] else hex(84_532)
+            return '0x10'
+
+        provider.chain.eth_rpc = fake_rpc
+        with pytest.raises(ConnectionError, match='drpc serves chain id 8453'):
+            provider.check_connection(require_send=False)
+
+    def test_codeless_contract_fails(self, provider):
+        rpc_stub(provider, {'eth_chainId': hex(84_532), 'eth_blockNumber': '0x10', 'eth_getCode': '0x'})
+        with pytest.raises(ConnectionError, match='no code'):
+            provider.check_connection(require_send=False)
+
+    def test_missing_key_fails_when_send_required(self, provider):
+        with pytest.raises(ConnectionError, match='BASE_PRIVATE_KEY'):
+            provider.check_connection(require_send=True)
+
+
+class TestVerification:
+    def test_settled_transfer_matches_with_the_sender_pinned(self, provider):
+        rpc_stub(provider, mined_tx_responses())
+        info = provider.verify_transaction(TX, RECIPIENT.lower(), AMOUNT, expected_sender=SENDER.upper())
+        assert info is not None and info.confirmed
+        assert (info.sender, info.amount, info.block_time) == (SENDER, AMOUNT, 0x64)
+
+    def test_one_short_of_the_confirmation_depth_is_unconfirmed(self, provider):
+        rpc_stub(provider, mined_tx_responses(tip=SETTLED_TIP - 1))
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT).confirmed is False
+
+    def test_pending_transfer_calldata_matches_unconfirmed(self, provider):
+        pending = {
+            'hash': TX,
+            'from': SENDER,
+            'to': CONTRACT,
+            'input': SEL_TRANSFER + topic(RECIPIENT).removeprefix('0x') + f'{AMOUNT:064x}',
+            'blockNumber': None,
+        }
+        rpc_stub(provider, {'eth_getTransactionByHash': pending})
+        info = provider.verify_transaction(TX, RECIPIENT, AMOUNT)
+        assert info is not None and not info.confirmed and info.sender == SENDER
+
+    @pytest.mark.parametrize(
+        'responses',
+        (
+            mined_tx_responses(status='0x0'),  # inclusion is not settlement
+            mined_tx_responses(logs=[transfer_log(amount=AMOUNT - 1)]),  # underpaid
+            mined_tx_responses(logs=[transfer_log(recipient='0x' + '22' * 20)]),  # wrong recipient
+            mined_tx_responses(logs=[transfer_log(sender=RECIPIENT)]),  # self-transfer
+            {'eth_getTransactionByHash': None},  # not found
+        ),
+    )
+    def test_rejected(self, provider, responses):
+        assert rpc_stub(provider, responses).verify_transaction(TX, RECIPIENT, AMOUNT) is None
+
+    def test_sender_mismatch_rejected(self, provider):
+        rpc_stub(provider, mined_tx_responses())
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT, expected_sender=TEST_ADDR) is None
+
+    def test_receipt_unavailable_raises(self, provider):
+        # 'unknown' must never read as 'no such payment' — that verdict slashes a paying miner.
+        rpc_stub(provider, mined_tx_responses(receipt=None))
+        with pytest.raises(ProviderUnreachableError):
+            provider.verify_transaction(TX, RECIPIENT, AMOUNT)
+
+    def test_timestamp_unavailable_raises(self, provider):
+        # is_tx_fresh fails closed on a missing block_time, so a stale-looking dest leg would
+        # ride to a TIMEOUT slash. Raise instead and let the caller retry.
+        rpc_stub(provider, mined_tx_responses(timestamp='0x0'))
+        with pytest.raises(ProviderUnreachableError):
+            provider.verify_transaction(TX, RECIPIENT, AMOUNT)
+
+
+class TestContractPin:
+    """Base ships two USDCs. A leg is only paid if the log came from the pinned one."""
+
+    def test_usdbc_transfer_never_satisfies_a_usdc_leg(self, provider):
+        rpc_stub(provider, mined_tx_responses(logs=[transfer_log(contract=USDBC)]))
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT) is None
+
+    def test_the_pinned_log_is_found_among_impostors(self, provider):
+        noise = [transfer_log(contract=USDBC), transfer_log(contract='0x' + '99' * 20), transfer_log()]
+        rpc_stub(provider, mined_tx_responses(logs=noise))
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT) is not None
+
+    def test_a_rejected_tx_never_enters_the_settled_cache(self, provider):
+        # The cache skips the log scan, so a rejected counterfeit must leave no entry to
+        # later vouch for it — the pin has to hold on the cached path too.
+        rpc_stub(provider, mined_tx_responses(logs=[transfer_log(contract=USDBC)]))
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT) is None
+        assert TX not in provider._settled_cache
+        provider.chain.clear_pass_tip()
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT) is None
+
+    def test_the_cache_never_vouches_for_a_different_leg(self, provider):
+        rpc_stub(provider, mined_tx_responses())
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT) is not None
+        provider.chain.clear_pass_tip()
+        assert provider.verify_transaction(TX, '0x' + '22' * 20, AMOUNT) is None
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT + 1) is None
+
+
+class TestIssuerGates:
+    """USDC on Base is Circle's FiatToken: isBlacklisted/paused answer (verified live)."""
+
+    @pytest.mark.parametrize('views', (eth_call_views(blacklisted=[RECIPIENT]), eth_call_views(paused=True)))
+    def test_issuer_refusal_bounces_reserve_and_defers_slash(self, provider, views):
+        rpc_stub(provider, {'eth_blockNumber': hex(1000), 'eth_call': views})
+        assert provider.can_deliver_to(RECIPIENT, AMOUNT) is False
+        assert provider.delivery_refused(RECIPIENT, since_unix=0) is True
+
+    def test_clean_dest_passes_both_gates(self, provider):
+        rpc_stub(provider, {'eth_blockNumber': hex(1000), 'eth_call': eth_call_views()})
+        assert provider.can_deliver_to(RECIPIENT, AMOUNT) is True
+        assert provider.delivery_refused(RECIPIENT, since_unix=0) is False
+
+    def test_slash_gate_raises_on_rpc_trouble(self, provider):
+        # A missing/renamed view (Tether spells it isBlackListed) would revert here; the caller
+        # must defer the slash rather than resolve it — a flaky RPC postpones, never falsifies.
+        def boom(params):
+            raise ConnectionError('down')
+
+        rpc_stub(provider, {'eth_blockNumber': hex(1000), 'eth_call': boom})
+        with pytest.raises(Exception):
+            provider.delivery_refused(RECIPIENT, since_unix=0)
+
+
+class TestSendGuards:
+    def _responses(self, token_balance=10 * AMOUNT, gas_balance=10**18, est='0xfde8'):  # est 65k
+        return {
+            'eth_blockNumber': hex(1000),
+            'eth_getBlockByNumber': {'baseFeePerGas': hex(10**8)},
+            'eth_maxPriorityFeePerGas': hex(10**7),
+            'eth_estimateGas': est,
+            'eth_call': eth_call_views(balances={TEST_ADDR.lower(): token_balance}),
+            'eth_getBalance': hex(gas_balance),
+            'eth_getTransactionCount': '0x0',
+            'eth_sendRawTransaction': '0x' + 'ee' * 32,
+        }
+
+    def test_no_key_refused(self, provider):
+        assert provider.send_amount(RECIPIENT, AMOUNT) is None
+        assert 'BASE_PRIVATE_KEY' in provider.last_send_error
+
+    def test_key_mismatch_refused(self, provider, monkeypatch):
+        monkeypatch.setenv('BASE_PRIVATE_KEY', TEST_KEY)
+        assert provider.send_amount(RECIPIENT, AMOUNT, from_address=RECIPIENT) is None
+        assert 'key mismatch' in provider.last_send_error
+
+    def test_insufficient_token_balance_refused(self, provider, monkeypatch):
+        monkeypatch.setenv('BASE_PRIVATE_KEY', TEST_KEY)
+        rpc_stub(provider, self._responses(token_balance=AMOUNT - 1))
+        assert provider.send_amount(RECIPIENT, AMOUNT) is None
+        assert 'insufficient balance' in provider.last_send_error
+
+    def test_token_rich_gas_poor_refuses_before_broadcasting(self, provider, monkeypatch):
+        # Base gas is cheap but never free; a doomed transfer must be refused, not burned.
+        monkeypatch.setenv('BASE_PRIVATE_KEY', TEST_KEY)
+        responses = self._responses(gas_balance=10)
+        responses['eth_sendRawTransaction'] = lambda params: pytest.fail('must not broadcast')
+        rpc_stub(provider, responses)
+        assert provider.send_amount(RECIPIENT, AMOUNT) is None
+        assert 'Insufficient gas balance' in provider.last_send_error
+
+    def test_happy_path_broadcasts_pinned_transfer_calldata(self, provider, monkeypatch):
+        monkeypatch.setenv('BASE_PRIVATE_KEY', TEST_KEY)
+        sent = {}
+        responses = self._responses()
+
+        def capture(params):
+            sent['raw'] = params[0]
+            return '0x' + 'ee' * 32
+
+        responses['eth_sendRawTransaction'] = capture
+        rpc_stub(provider, responses)
+        assert provider.send_amount(RECIPIENT, AMOUNT, from_address=TEST_ADDR) == ('0x' + 'ee' * 32, 0)
+        assert SEL_TRANSFER.removeprefix('0x') in sent['raw']
+        assert CONTRACT.lower().removeprefix('0x') in sent['raw']  # addressed to the pinned token
+        assert list(provider.broadcasted_txids.values()) == [(RECIPIENT.lower(), AMOUNT, 1000)]
+
+
+class TestScanner:
+    def test_getlogs_hit_is_bounded_and_pinned(self, provider):
+        found = '0x' + 'bb' * 32
+
+        def logs(params):
+            f = params[0]
+            assert f['address'] == CONTRACT  # a USDbC transfer is not even queried for
+            assert int(f['toBlock'], 16) - int(f['fromBlock'], 16) < provider.SCAN_LOOKBACK_BLOCKS
+            return [{'data': hex(AMOUNT), 'transactionHash': found}]
+
+        rpc_stub(provider, {'eth_blockNumber': hex(1000), 'eth_getLogs': logs})
+        assert provider.find_recent_outgoing(TEST_ADDR, RECIPIENT, AMOUNT) == found
+
+    def test_failed_range_parks_cursor(self, provider):
+        def boom(params):
+            raise ConnectionError('range too large')
+
+        rpc_stub(provider, {'eth_blockNumber': hex(1000), 'eth_getLogs': boom})
+        assert provider.find_recent_outgoing(TEST_ADDR, RECIPIENT, AMOUNT) is None
+        # Parked just below the failed range start — the same span is retried, never leapt.
+        key = (TEST_ADDR.lower(), RECIPIENT.lower(), AMOUNT)
+        assert provider.scan_cursors[key] == 1000 - provider.SCAN_LOOKBACK_BLOCKS

--- a/tests/test_baseusdc_provider.py
+++ b/tests/test_baseusdc_provider.py
@@ -26,6 +26,10 @@ TEST_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80' 
 TEST_ADDR = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
 
 CONTRACT = '0x036CbD53842c5426634e7929541eC2318f3dCF7e'  # Circle USDC, Base Sepolia
+# Circle-verified native USDC on Base mainnet (developers.circle.com) — symbol 'USDC', name
+# 'USD Coin'. Pinned as a literal: a transposed character yields a DIFFERENT REAL TOKEN, which
+# has code and so passes every other gate, and miners would pay in an asset nobody asked for.
+MAINNET_CONTRACT = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
 # Bridged USD Base Coin — a different contract paying a well-formed Transfer nobody asked for.
 USDBC = '0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA'
 SENDER = '0x' + '11' * 20
@@ -130,7 +134,7 @@ class TestNetworkAndContract:
             monkeypatch.delenv(var, raising=False)
         p = BaseUsdc()
         assert (p.chain.network, p.chain.chain_id) == ('mainnet', 8_453)
-        assert p.token_contract == CHAIN_BASEUSDC.asset_locator
+        assert p.token_contract == CHAIN_BASEUSDC.asset_locator == MAINNET_CONTRACT
         # Native Circle USDC, not the bridged USD Base Coin deployed on the same network.
         assert p.token_contract.lower() != USDBC.lower()
 

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -8,6 +8,7 @@ from allways.assets.evm import EVM_NETWORKS
 from allways.chains import (
     CHAIN_ARBUSDC,
     CHAIN_AVAX,
+    CHAIN_BASEUSDC,
     CHAIN_BNB,
     CHAIN_BTC,
     CHAIN_ETH,
@@ -42,6 +43,9 @@ class TestGetChain:
 
     def test_avax(self):
         assert get_chain_def('avax') is CHAIN_AVAX
+
+    def test_baseusdc(self):
+        assert get_chain_def('baseusdc') is CHAIN_BASEUSDC
 
     def test_unsupported_raises(self):
         with pytest.raises(KeyError):
@@ -80,6 +84,12 @@ class TestGetChain:
         # asset_locator is the token-only field: a native coin has no contract to pin.
         assert CHAIN_ARBUSDC.asset_locator.startswith('0x')
         assert all(get_chain_def(c).asset_locator is None for c in ('btc', 'tao', 'sol', 'eth', 'hype', 'bnb', 'avax'))
+        for chain_id in ('eth', 'hype', 'arbusdc', 'baseusdc'):
+            assert get_chain_def(chain_id).host_chain in EVM_NETWORKS
+        # asset_locator is the token-only field: a native coin has no contract to pin.
+        assert CHAIN_ARBUSDC.asset_locator.startswith('0x')
+        assert CHAIN_BASEUSDC.asset_locator.startswith('0x')
+        assert all(get_chain_def(c).asset_locator is None for c in ('btc', 'tao', 'sol', 'eth', 'hype'))
 
 
 class TestCanonicalPair:
@@ -158,6 +168,10 @@ class TestComputeExtensionTargetSecs:
     def test_bnb_remaining_confs(self):
         # bnb needs 15 confs, 1s each: remaining=15, raw = 10000 + 15 + 120 = 10135, bucket up to 10200.
         assert compute_extension_target_secs('bnb', 0, self.NOW, self.CEILING) == 10_200
+
+    def test_baseusdc_remaining_confs(self):
+        # baseusdc needs 120 confs, 2s each: remaining=120, raw = 10000 + 240 + 120 = 10360, bucket up to 10800.
+        assert compute_extension_target_secs('baseusdc', 0, self.NOW, self.CEILING) == 10_800
 
     def test_unsupported_chain_raises(self):
         with pytest.raises(KeyError):

--- a/tests/test_cli_chain_networks.py
+++ b/tests/test_cli_chain_networks.py
@@ -56,6 +56,7 @@ class TestPinnedContract:
             'hype-network',
             'bnb-network',
             'avax-network',
+            'base-network',
             'router',
             'env',
         )
@@ -69,6 +70,7 @@ class TestPinnedContract:
             'bnb-network',
             'avax-network',
         )
+        assert CHAIN_NETWORK_KEYS == ('btc-network', 'eth-network', 'arb-network', 'hype-network', 'base-network')
 
     def test_testnet_bundle(self):
         assert ENV_BUNDLES['testnet'] == {
@@ -80,6 +82,7 @@ class TestPinnedContract:
             'hype-network': 'testnet',
             'bnb-network': 'testnet',
             'avax-network': 'fuji',
+            'base-network': 'sepolia',
             'netuid': '19',
             'router': '5HicmHG7fjbxrtx8FZNdv4xxS5jSN84KGpMnTHsKtKv9peao',
         }
@@ -94,6 +97,7 @@ class TestPinnedContract:
             'hype-network': 'mainnet',
             'bnb-network': 'mainnet',
             'avax-network': 'mainnet',
+            'base-network': 'mainnet',
             'netuid': '7',
             'router': '',
         }
@@ -118,6 +122,7 @@ class TestPinnedContract:
             'hype': ('mainnet', 'testnet'),
             'bnb': ('mainnet', 'testnet'),
             'avax': ('mainnet', 'fuji'),
+            'baseusdc': ('mainnet', 'sepolia'),
         }
 
 

--- a/tests/test_cli_chain_networks.py
+++ b/tests/test_cli_chain_networks.py
@@ -69,8 +69,8 @@ class TestPinnedContract:
             'hype-network',
             'bnb-network',
             'avax-network',
+            'base-network',
         )
-        assert CHAIN_NETWORK_KEYS == ('btc-network', 'eth-network', 'arb-network', 'hype-network', 'base-network')
 
     def test_testnet_bundle(self):
         assert ENV_BUNDLES['testnet'] == {


### PR DESCRIPTION
Native Circle USDC on Base as a launch spoke. Base is a plain EVM JSON-RPC network and USDC is a
Circle FiatToken, so the pair is a registry row plus a binding of the shared `Erc20` — no contract,
DB or consumer changes.

Twin: entrius/das-allways#89 (https://github.com/entrius/das-allways/pull/89) — serving registry
entry. Merge this one first; the das drift gate reads `chains.py` from `test`.

## What changed

| File | Change |
|---|---|
| `allways/assets/evm.py` | one `BASE` `EvmNetwork` row + its `EVM_NETWORKS` key |
| `allways/chains.py` | `CHAIN_BASEUSDC` + its `SUPPORTED_CHAINS` entry |
| `allways/assets/erc20.py` | one `TESTNET_TOKEN_CONTRACTS` entry |
| `allways/assets/baseusdc.py` | the `BaseUsdc` binding, 8 lines |
| `allways/assets/__init__.py`, `constants.py` | registry row + `LAUNCH_SPOKES` append |
| `.env.example`, `README.md` | the `BASE_*` block, mirroring Arbitrum's |
| `tests/` | new `test_baseusdc_provider.py`; pinned CLI/chain contracts updated |

Everything else derives: CLI flags, `alw config` rows, env bundles and the E2E scenarios all come
off the registry.

## Which USDC — the load-bearing decision

Base ships two. Verified against **Circle's own published list**
(`developers.circle.com/stablecoins/usdc-contract-addresses`, fetched 2026-08-11), then confirmed
on-chain:

| | address | `symbol()` | `name()` | `decimals()` |
|---|---|---|---|---|
| **pinned** (mainnet) | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` | `USDC` | `USD Coin` | 6 |
| **NOT** pinned — bridged | `0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA` | `USDbC` | `USD Base Coin` | 6 |
| **pinned** (Base Sepolia) | `0x036CbD53842c5426634e7929541eC2318f3dCF7e` | `USDC` | `USDC` | 6 |

Both pinned addresses carry contract code. The mainnet address lives once, in the registry row's
`asset_locator`; the testnet one lives once, in `TESTNET_TOKEN_CONTRACTS`.

`Erc20` only credits a leg off a `Transfer` log emitted by the pinned contract, so a USDbC transfer
can never satisfy a USDC leg — pinned in `TestContractPin`, including on the settled-tx cache path
(a rejected tx never enters the cache, so the cache can never later vouch for it).

## Judgement calls

**`min_confirmations = 120`, `seconds_per_block = 2`.** Block time measured live on both networks
(2026-08-11): 100 blocks = 200s and 1000 blocks = 2000s — exactly 2s, mainnet and Sepolia alike.
Base is an OP-stack rollup whose sequencer can reorg its own unsafe head before the L1 batch posts —
unlike BNB/AVAX-style fast finality, and unlike HyperBFT, which finalizes on inclusion — so it needs
materially more depth than a fast-finality chain. Implied leg latency is `120 × 2s = 240s`,
comfortably inside the program's **600s default fulfillment grace** (360s of headroom). Extension
math lands on the same bucket as ETH and arbusdc: `10000 + 240 + 120 = 10360 → 10800`.

**`min_onchain_amount = 1`.** Following `CHAIN_ARBUSDC`: ERC-20 has no protocol minimum, and Base L2
gas is negligible, so 1 µUSDC is the honest floor. No invented economic floor. The 6-vs-9 decimal
question belongs to the executable-rate gate, not to this value — checked at both direction extremes
at a real ~200 USDC/SOL market:

```
sol->baseusdc             1 lamports ->               0 uUSDC   (floors to 0, far below min_swap)
sol->baseusdc      10000000 lamports ->         2000000 uUSDC   (0.01 SOL, the min)
sol->baseusdc  100000000000 lamports ->     20000000000 uUSDC   (100 SOL, the max)
baseusdc->sol             1 uUSDC    ->               5 lamports
baseusdc->sol   20000000000 uUSDC    ->    100000000000 lamports
is_executable_rate(200.0, sol->baseusdc / baseusdc->sol) -> True / True
is_executable_rate(1e-20, both directions)               -> False / False
```

Identical to arbusdc (same decimals, same floor), so `tests/test_rate.py` gained no cases.

**`replay_grace_secs = 60`.** Base timestamps are sequencer-stamped, as Arbitrum's are. The grace is
for **hub-vs-spoke clock skew**, not monotonicity — monotonic timestamps say nothing about how far
the sequencer's clock sits from the hub's.

## RPC ladder — publicnode is deliberately absent

The obvious mainnet endpoint does not work for this asset. `https://base-rpc.publicnode.com` answers
`eth_chainId`, `eth_blockNumber`, `eth_getLogs` and latest-block `eth_call` fine, but returns **HTTP
403 on every `eth_getTransactionReceipt`**:

```
{"jsonrpc":"2.0","error":{"code":-32602,
 "message":"Archive requests require a personal token. Get one at: https://www.allnodes.com/publicnode"}}
```

The receipt is the settlement check, so that endpoint can never settle a leg — and historical
`eth_call`, which the slash gate samples, 403s too. Shipped ladder is the official gateway plus drpc;
both serve the full method set on both networks, including historical `eth_call`:

| network | ladder | absent-receipt null probe |
|---|---|---|
| mainnet (8453) | `https://mainnet.base.org`, `https://base.drpc.org` | 12/12, 12/12 |
| sepolia (84532) | `https://sepolia.base.org`, `https://base-sepolia.drpc.org` | 12/12, 12/12 |

The repeat-load probe matters because of `null_needs_quorum`: a second endpoint that only *sometimes*
answers turns every genuinely-absent tx into `ProviderUnreachableError` forever.

**Operator note — the public gateways rate-limit under load.** Review measured `mainnet.base.org` at
13-15/20 under a burst while `base.drpc.org` held 20/20, and through the real code path a 429 sets
`last_err`, so an absent-tx lookup raises instead of returning `None`. That is the designed
fail-closed behaviour and costs no money — it delays a legitimate slash rather than causing an unfair
one. My own 20-call burst on all four endpoints came back 20/20, so the limit is IP- and
time-dependent rather than a fixed budget; both observations are real.

**I kept `mainnet.base.org` first rather than reordering drpc ahead of it.** Reordering does not fix
the failure mode: on the quorum path (`eth_getTransactionByHash` with `null_needs_quorum`) *both*
endpoints are contacted whenever the first returns null, so a 429 on either one raises regardless of
order. It would only shift routine read load onto a third-party aggregator and away from the chain's
own gateway. The real mitigation is a keyed primary, so this follows the `HYPERLIQUID` precedent
exactly — official gateway first, an explicit warning in the `EvmNetwork` row, and `.env.example`
steering volume operators at `BASE_RPC_URLS`.

## Evidence

```
$ uv run ruff format --check . && uv run ruff check .
154 files already formatted
All checks passed!

$ uv run pytest tests/ -q
1165 passed, 6 deselected, 3 warnings in 9.99s
```

`.env.example` names the real defaults and recommends `base.drpc.org` as the fallback — an earlier
revision had copy-pasted the ETH/ARB block and steered operators at the very publicnode endpoint this
PR removes, which would have left them with a receipt-blind sole fallback.

### Live, read-only — mainnet

```
--- mainnet --- Base JSON-RPC (mainnet): mainnet.base.org, base.drpc.org — token 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913
check_connection OK; chain_id=8453 tip=49850465
settled transfer tx=0x92345f289ff170103150cee3360cc5ef91d1e92b9792ab69df4794e33dffd27d
  sender=0x2192bc3b4028acc1113f2cd9ac2cba70c36520db recipient=0xb2cc224c1c9fee385f8ad6a55b4d94e92359dc59 amount=735120657239 µUSDC
verify(mixed-case recipient 0xB2CC224C1C9FEE385F8Ad6a55b4d94e92359dc59, sender pinned) -> confirmed=True amount=735120657239 sender=0x2192bc3b4028acc1113f2cd9ac2cba70c36520db confs=202 block_time=1786489877
underpayment demand (amount+1) -> None
wrong sender pin            -> None
wrong recipient             -> None
unknown tx                  -> None
balance(recipient)          -> 5179147448078 µUSDC
can_deliver_to(recipient)   -> True
```

### Live, read-only — Base Sepolia

```
--- sepolia --- Base JSON-RPC (sepolia): sepolia.base.org, base-sepolia.drpc.org — token 0x036CbD53842c5426634e7929541eC2318f3dCF7e
check_connection OK; chain_id=84532 tip=45360996
settled transfer tx=0x08bb689e7f34b80fe06bdf4653057f8d7ca087a7d72dbf3b38406c41c7791f04
  sender=0x0f1e5f444e54cf6fc4171b5d7cbf37a1d78672e0 recipient=0x0fe6cf065368212f6d6407fd9cc41c2d6f639de5 amount=1000 µUSDC
verify(mixed-case recipient 0x0FE6CF065368212F6D6407fd9cc41c2d6f639de5, sender pinned) -> confirmed=True amount=1000 sender=0x0f1e5f444e54cf6fc4171b5d7cbf37a1d78672e0 confs=202 block_time=1786489880
underpayment demand (amount+1) -> None
wrong sender pin            -> None
wrong recipient             -> None
unknown tx                  -> None
balance(recipient)          -> 236000 µUSDC
can_deliver_to(recipient)   -> True
```

### Issuer gates answer on the real deployment

The `Erc20` gates call `isBlacklisted(address)` / `paused()`. Tether spells it `isBlackListed`, whose
selector would revert here and make the slash gate defer forever — proving USDC-on-Base does not have
that problem, live:

```
mainnet isBlacklisted(0x…01) -> 0x0…0     mainnet paused() -> 0x0…0
sepolia isBlacklisted(0x…01) -> 0x0…0     sepolia paused() -> 0x0…0
mainnet isBlackListed (Tether spelling)   -> {"code":3,"message":"execution reverted"}
```

### Derived CLI surfaces — no hand-enumeration

```
$ uv run alw miner quotes --help
│ --baseusdc-price       NUMBER   BASEUSDC per 1 SOL (0/omit to skip BASEUSDC).
│ --baseusdc-address     TEXT     Your BASEUSDC address.

$ uv run alw config
│ arb-network    │ mainnet │ default │
│ hype-network   │ mainnet │ default │
│ base-network   │ mainnet │ default │
```

`base-network` is a new row, correctly: `baseusdc` is the first asset on Base, so it is the row that
declares `networks`. `env_prefix` is the NETWORK's (`BASE`), not the asset's, so a second Base asset
would share it and add no row.

### E2E scenarios derive from LAUNCH_SPOKES

```
$ cd alw-utils/dev-environment/solana
$ PYTHONPATH=<this branch's checkout> ./run-suites.sh --list
scenarios:
  sol-btc / btc-sol / sol-tao / tao-sol / sol-eth / eth-sol
  sol-arbusdc / arbusdc-sol / sol-hype / hype-sol
  sol-baseusdc / baseusdc-sol
  blacklist-gate / slash / weights / tao-happy / tao-timeout / w4-*
```

`PYTHONPATH` is required — `run-suites.sh` hardcodes the main checkout's venv, which would otherwise
list the wrong registry. No harness code was written; the rows derive. **I did not execute a suite** —
that needs the full local stack up, and nothing here touches the program or the neurons.

`blacklist-gate` is a static row pinned to `SWAP_FROM=sol SWAP_TO=arbusdc`; it is untouched and still
listed. A `baseusdc` analogue would exercise the same `Erc20` gate code path against a second
deployment — worth a follow-up only if we ever want per-deployment coverage, not now.

## Notes for review

- **Both deployments are proxies.** The pin is to the proxy address, which is the right target — that
  is what every wallet and integrator uses, and Circle upgrades behind it. If an implementation
  upgrade ever changed `transfer` semantics (fee-on-transfer, a different `Transfer` event shape),
  verification would start rejecting honest legs rather than crediting wrong ones: the log match
  requires `amount >= expected` from the pinned address, so a short-paying transfer fails closed.
  That is the safe direction, but it is a live-issue class, not a build-time one.
- **Emission dilution.** This is the 6th spoke, so `DIRECTION_POOLS` now splits across 12 directions
  instead of 10: every pair's zero-volume emission floor drops to `(1 − α)/pairs` with the pair count
  up by 2. Existing pairs earn proportionally less at zero volume.
- **The mainnet contract is pinned as a literal in `tests/test_baseusdc_provider.py`**, not just
  compared against `asset_locator` (which was tautological). A transposed character produces a
  different *real* token that has code and passes every other gate; mutating the last two characters
  now fails the suite:
  `AssertionError: assert '0x833589fCD6...71b54bdA02931' == '0x833589fCD6...71b54bdA02913'`.
- **The logo stays byte-identical to `arbusdc.png`** (md5 `7dfa6cbc…`). It is the same asset — Circle
  USDC — and that file is the plain USDC mark, so it is the correct image for both. Adding a
  Base-blue chip would mean inventing branding Circle does not publish. `arbusdc` already ships the
  plain mark under the same `symbol: "USDC"`, so this matches the existing precedent; `name`
  (`USDC (Arbitrum)` / `USDC (Base)`) is what disambiguates them, and das serves it alongside.
  If pickers later need visual separation, that is a UI-side chain-badge decision, not a logo fork.
- No shared code was modified beyond the two additions the brief allows (one `EvmNetwork` row, one
  `TESTNET_TOKEN_CONTRACTS` entry). `evm_coin.py` untouched.
