### PR TITLE
Add USDC on Ethereum as a launch spoke

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,13 +34,17 @@ BTC_NETWORK=mainnet                 # mainnet | testnet | testnet4
 # WIF — required for miners; optional local signing for `alw swap`
 BTC_PRIVATE_KEY=
 
-# ─── Chain: Ethereum (ETH pairs) ───────────────────────────
+# ─── Network: Ethereum (ETH + ethusdc pairs) ───────────────
+# Vars are per NETWORK, shared by every asset on it — ethusdc adds no network vars of its own.
 ETH_NETWORK=mainnet                 # mainnet | sepolia
 # OPTIONAL ordered JSON-RPC endpoints (keyed providers embed the key in the URL);
 # unset = public (publicnode, drpc)
 # ETH_RPC_URLS=https://mainnet.infura.io/v3/your_key,https://ethereum-rpc.publicnode.com
-# 32-byte hex key — required for miners; optional local signing for `alw swap`
+# 32-byte hex key — required for miners (fund ETH for the ETH legs, USDC + ETH-for-gas for
+# the ethusdc legs); optional local signing for `alw swap`
 ETH_PRIVATE_KEY=
+# OPTIONAL token contract override (dev/e2e fakes) — per ASSET, unset = Circle's canonical deployment
+# ETHUSDC_TOKEN_CONTRACT=
 
 # ─── Network: Arbitrum (arbusdc pairs) ─────────────────────
 # Vars are per NETWORK, shared by every asset on it (ARB_ here, not ARBUSDC_).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Native transactions across independent assets — no wrapped tokens, no bridges,
 
 Allways creates a verification layer above independent systems. Assets move natively. Miners complete transactions, validators independently verify the results, and a smart contract enforces outcomes through collateral and slashing.
 
-Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, and SOL ↔ USDC-on-Base (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
+Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, SOL ↔ USDC-on-Base, and SOL ↔ USDC-on-Ethereum (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
 
 ## Miner Risk Disclaimer
 
@@ -123,7 +123,7 @@ needs to persist across restarts.
 
 ## Miner Environment Variables
 
-- `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `BNB_PRIVATE_KEY`, `AVAX_PRIVATE_KEY`, `BASE_PRIVATE_KEY`, `{ETH,ARB,HYPE,BNB,AVAX,BASE}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config. See `.env.example`.
+- `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `BNB_PRIVATE_KEY`, `AVAX_PRIVATE_KEY`, `BASE_PRIVATE_KEY`, `{ETH,ARB,HYPE,BNB,AVAX,BASE}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config (ETH and ethusdc both ride the `ETH_*` vars). See `.env.example`.
 
 ## Running a Local Subtensor Lite Node (Validators)
 

--- a/allways/assets/__init__.py
+++ b/allways/assets/__init__.py
@@ -11,6 +11,7 @@ from allways.assets.btc import Bitcoin
 from allways.assets.chain import Chain
 from allways.assets.erc20 import Erc20
 from allways.assets.eth import Ether
+from allways.assets.ethusdc import EthUsdc
 from allways.assets.evm_coin import EvmCoin
 from allways.assets.hype import Hype
 from allways.assets.sol import Sol
@@ -33,6 +34,7 @@ __all__ = [
     'Erc20',
     'ArbUsdc',
     'BaseUsdc',
+    'EthUsdc',
     'create_assets',
 ]
 
@@ -56,6 +58,7 @@ ASSET_REGISTRY: Tuple[AssetSpec, ...] = (
     AssetSpec('bnb', Bnb, ()),
     AssetSpec('avax', Avax, ()),
     AssetSpec('baseusdc', BaseUsdc, ()),
+    AssetSpec('ethusdc', EthUsdc, ()),
 )
 
 

--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -37,6 +37,8 @@ TESTNET_TOKEN_CONTRACTS = {
     'arbusdc': {'sepolia': '0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d'},
     # Circle-verified native USDC on Base Sepolia (developers.circle.com, 2026-08-11).
     'baseusdc': {'sepolia': '0x036CbD53842c5426634e7929541eC2318f3dCF7e'},
+    # Circle-verified native USDC on Ethereum Sepolia (developers.circle.com, 2026-08-11).
+    'ethusdc': {'sepolia': '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238'},
 }
 
 

--- a/allways/assets/ethusdc.py
+++ b/allways/assets/ethusdc.py
@@ -1,0 +1,13 @@
+from allways.assets.erc20 import Erc20
+from allways.chains import CHAIN_ETHUSDC
+
+
+class EthUsdc(Erc20):
+    """USDC on Ethereum — a config-row binding of the generic Erc20 (see chains.CHAIN_ETHUSDC).
+
+    First asset to land on an already-configured network: it shares Ethereum's env identity
+    with native ETH (ETH_NETWORK, ETH_RPC_URLS, ETH_PRIVATE_KEY), adding only its own
+    ETHUSDC_TOKEN_CONTRACT override."""
+
+    def __init__(self):
+        super().__init__(CHAIN_ETHUSDC)

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -229,6 +229,33 @@ CHAIN_BASEUSDC = ChainDefinition(
     asset_locator='0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
 )
 
+CHAIN_ETHUSDC = ChainDefinition(
+    id='ethusdc',
+    name='USDC (Ethereum)',
+    native_unit='µUSDC',
+    decimals=6,
+    # Ethereum's prefix, shared with CHAIN_ETH: one ETH_NETWORK / ETH_RPC_URLS / ETH_PRIVATE_KEY
+    # serves both assets, so they can never disagree about which Ethereum they are on.
+    env_prefix='ETH',
+    host_chain='ethereum',
+    # CHAIN_ETH already declares the ETH_NETWORK names; a second declaration would render a
+    # duplicate CLI row writing the same var.
+    networks=(),
+    seconds_per_block=12,
+    # CHAIN_ETH's finality, deliberately identical — two assets on one chain must not disagree
+    # about its reorg depth. 32 × 12s = 384s, inside the program's 600s default fulfillment grace.
+    min_confirmations=32,
+    # Economic floor, not a protocol one (ERC-20 has no minimum): FiatToken's transfer burns
+    # ~65k gas, ≈$5 at 40 gwei and $1.9k ETH, so a smaller L1 leg cannot cover its own fee.
+    # Diverges from arbusdc's unit floor on purpose — L2 gas is cents, L1 gas is not.
+    min_onchain_amount=5_000_000,
+    # Ethereum's clock, as CHAIN_ETH: what this absorbs is hub-vs-spoke skew, and two assets on
+    # one chain disagreeing about that chain's clock would be indefensible.
+    replay_grace_secs=0,
+    # Circle-verified native USDC on Ethereum (developers.circle.com, 2026-08-11).
+    asset_locator='0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+)
+
 SUPPORTED_CHAINS = {
     'btc': CHAIN_BTC,
     'tao': CHAIN_TAO,
@@ -239,6 +266,7 @@ SUPPORTED_CHAINS = {
     'bnb': CHAIN_BNB,
     'avax': CHAIN_AVAX,
     'baseusdc': CHAIN_BASEUSDC,
+    'ethusdc': CHAIN_ETHUSDC,
 }
 
 

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -245,9 +245,9 @@ CHAIN_ETHUSDC = ChainDefinition(
     # CHAIN_ETH's finality, deliberately identical — two assets on one chain must not disagree
     # about its reorg depth. 32 × 12s = 384s, inside the program's 600s default fulfillment grace.
     min_confirmations=32,
-    # Economic floor, not a protocol one (ERC-20 has no minimum): FiatToken's transfer burns
-    # ~65k gas, ≈$5 at 40 gwei and $1.9k ETH, so a smaller L1 leg cannot cover its own fee.
-    # Diverges from arbusdc's unit floor on purpose — L2 gas is cents, L1 gas is not.
+    # Rate sanity floor, not an economic guarantee: 5 USDC covers FiatToken's ~65k-gas transfer
+    # only below ~41 gwei — miners price real gas into their quotes, and the per-swap lever is the
+    # contract's min_swap_amount. Above arbusdc's unit floor because L1 gas is not L2 gas.
     min_onchain_amount=5_000_000,
     # Ethereum's clock, as CHAIN_ETH: what this absorbs is hub-vs-spoke skew, and two assets on
     # one chain disagreeing about that chain's clock would be indefensible.

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -87,7 +87,7 @@ def hub_leg(from_chain: str, to_chain: str) -> str | None:
 
 
 # Chains paired against each hub; add a chain here to launch its pairs.
-LAUNCH_SPOKES = ('btc', 'tao', 'eth', 'arbusdc', 'hype', 'bnb', 'avax', 'baseusdc')
+LAUNCH_SPOKES = ('btc', 'tao', 'eth', 'arbusdc', 'hype', 'bnb', 'avax', 'baseusdc', 'ethusdc')
 # Every launch pair as (hub, spoke): each hub pairs against every spoke except itself. sol↔tao
 # lands exactly once (under SOL, its anchor) because sol never appears in LAUNCH_SPOKES.
 LAUNCH_PAIRS: tuple[tuple[str, str], ...] = tuple(

--- a/tests/test_assets_optional.py
+++ b/tests/test_assets_optional.py
@@ -46,11 +46,12 @@ def test_none_means_all_required(registry):
 
 def test_evm_network_names_match_the_rpc_registry():
     """chains.py names the networks the CLI accepts; assets/evm.py names the chain ids the
-    provider dials. One fact in two files, so CI compares them."""
+    provider dials. One fact in two files, so CI compares them — for the row that declares the
+    names. A row that declares none (ethusdc) rides the one that does and has nothing of its own."""
     for chain_id, cls, kwarg_names in cp.ASSET_REGISTRY:
         if kwarg_names:
             continue
         asset = cls()
         served = getattr(asset.chain, 'network_def', None)
-        if served:
+        if served and asset.chain_def.networks:
             assert set(asset.chain_def.networks) == set(served.chain_ids), chain_id

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -64,19 +64,27 @@ class TestGetChain:
             assert chain.id == chain_id
 
     def test_assets_on_one_network_share_its_env_identity(self):
-        """A network is configured once. Rows sharing a host_chain MUST share env_prefix —
-        otherwise the second asset reads an unset {PREFIX}_NETWORK, silently defaults to
-        mainnet, and a testnet miner pays real funds against test swaps. Exactly one of them
-        declares ``networks``: two would render duplicate CLI rows writing the same var."""
+        """A network is configured once, by EXACTLY ONE of its rows. Rows sharing a host_chain
+        MUST share env_prefix, and exactly one of them declares ``networks`` — no more, because
+        two would render duplicate CLI rows writing the same var, and no fewer, because a network
+        nobody declares gets no CLI row at all: `alw config set env testnet` never writes its
+        {PREFIX}_NETWORK, EvmChain defaults it to mainnet, and a testnet miner pays real funds
+        against test swaps."""
         prefixes: dict[str, set[str]] = {}
+        declared: dict[str, list[str]] = {}
         owners: dict[str, list[str]] = {}
         for chain in SUPPORTED_CHAINS.values():
             if chain.host_chain:
                 prefixes.setdefault(chain.host_chain, set()).add(chain.env_prefix)
+                declared.setdefault(chain.host_chain, [])
             if chain.networks:
                 owners.setdefault(chain.env_prefix, []).append(chain.id)
+                if chain.host_chain:
+                    declared[chain.host_chain].append(chain.id)
         for host, found in prefixes.items():
             assert len(found) == 1, f'{host} assets disagree on env_prefix: {sorted(found)}'
+        for host, ids in declared.items():
+            assert len(ids) == 1, f'{host} needs exactly one networks-declaring row, found {ids}'
         for prefix, ids in owners.items():
             assert len(ids) == 1, f'{prefix}_NETWORK is declared by more than one row: {ids}'
 

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -12,6 +12,7 @@ from allways.chains import (
     CHAIN_BNB,
     CHAIN_BTC,
     CHAIN_ETH,
+    CHAIN_ETHUSDC,
     CHAIN_HYPE,
     CHAIN_TAO,
     EXTENSION_BUCKET_SECONDS,
@@ -46,6 +47,9 @@ class TestGetChain:
 
     def test_baseusdc(self):
         assert get_chain_def('baseusdc') is CHAIN_BASEUSDC
+
+    def test_ethusdc(self):
+        assert get_chain_def('ethusdc') is CHAIN_ETHUSDC
 
     def test_unsupported_raises(self):
         with pytest.raises(KeyError):
@@ -89,7 +93,13 @@ class TestGetChain:
         # asset_locator is the token-only field: a native coin has no contract to pin.
         assert CHAIN_ARBUSDC.asset_locator.startswith('0x')
         assert CHAIN_BASEUSDC.asset_locator.startswith('0x')
+        for chain_id in ('eth', 'hype', 'arbusdc', 'ethusdc'):
+            assert get_chain_def(chain_id).host_chain in EVM_NETWORKS
+        # asset_locator is the token-only field: a native coin has no contract to pin.
+        assert CHAIN_ARBUSDC.asset_locator.startswith('0x') and CHAIN_ETHUSDC.asset_locator.startswith('0x')
         assert all(get_chain_def(c).asset_locator is None for c in ('btc', 'tao', 'sol', 'eth', 'hype'))
+        # ethusdc rides CHAIN_ETH's network row — same host, same prefix, no networks of its own.
+        assert (CHAIN_ETHUSDC.host_chain, CHAIN_ETHUSDC.env_prefix) == (CHAIN_ETH.host_chain, CHAIN_ETH.env_prefix)
 
 
 class TestCanonicalPair:

--- a/tests/test_ethusdc_provider.py
+++ b/tests/test_ethusdc_provider.py
@@ -1,0 +1,282 @@
+"""EthUsdc unit tests — all offline (RPC layer mocked, signing is pure crypto).
+
+Generic ERC-20 behaviour is proven by the arbusdc suite; this covers what is ethusdc-specific.
+Chiefly the shared env identity: ethusdc is the first asset to land on an already-configured
+network, so ONE ETH_NETWORK moves both it and native ETH. A second prefix here would leave
+ethusdc reading an unset var, silently defaulting to mainnet, and a testnet miner would pay
+real USDC against test swaps.
+"""
+
+import pytest
+
+from allways.assets.asset import ProviderUnreachableError
+from allways.assets.erc20 import SEL_IS_BLACKLISTED, SEL_TRANSFER, TESTNET_TOKEN_CONTRACTS, TRANSFER_TOPIC0
+from allways.assets.eth import Ether
+from allways.assets.ethusdc import EthUsdc
+from allways.chains import CHAIN_ETH, CHAIN_ETHUSDC, get_chain_def
+from allways.constants import LAUNCH_SPOKES
+
+TEST_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'  # hardhat account #0
+SENDER = '0x' + '11' * 20
+RECIPIENT = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+CONTRACT = TESTNET_TOKEN_CONTRACTS['ethusdc']['sepolia']
+COUNTERFEIT = '0x' + '99' * 20
+TX = '0x' + 'ab' * 32
+BLOCK_HASH = '0x' + 'cd' * 32
+AMOUNT = 150_000_000  # 150 USDC in µUSDC
+SEPOLIA_ID = 11_155_111
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    monkeypatch.setenv('ETH_NETWORK', 'sepolia')
+    for var in ('ETH_RPC_URLS', 'ETH_PRIVATE_KEY', 'ETHUSDC_TOKEN_CONTRACT'):
+        monkeypatch.delenv(var, raising=False)
+    return EthUsdc()
+
+
+def rpc_stub(provider, responses: dict):
+    """Replace eth_rpc with a method→response map. A callable value is invoked with params."""
+
+    def fake_rpc(method, params, timeout=15, **kw):
+        value = responses[method]
+        return value(params) if callable(value) else value
+
+    provider.chain.eth_rpc = fake_rpc  # the asset talks through its chain (composed seam)
+    return provider
+
+
+def topic(address: str) -> str:
+    return '0x' + '00' * 12 + address.lower().removeprefix('0x')
+
+
+def transfer_log(contract=CONTRACT, recipient=RECIPIENT, amount=AMOUNT) -> dict:
+    return {
+        'address': contract,
+        'topics': [TRANSFER_TOPIC0, topic(SENDER), topic(recipient)],
+        'data': hex(amount),
+        'transactionHash': TX,
+    }
+
+
+def mined(logs=None, status='0x1', tip=1_000_100, block=None) -> dict:
+    return {
+        'eth_getTransactionByHash': {'hash': TX, 'blockNumber': '0xf4240', 'blockHash': BLOCK_HASH},
+        'eth_getTransactionReceipt': {
+            'status': status,
+            'blockNumber': '0xf4240',
+            'blockHash': BLOCK_HASH,
+            'logs': [transfer_log()] if logs is None else logs,
+        },
+        'eth_blockNumber': hex(tip),
+        'eth_getBlockByNumber': {'hash': BLOCK_HASH, 'timestamp': '0x64'} if block is None else block,
+    }
+
+
+class TestSharedEnvIdentity:
+    """The whole point of this row: ethusdc names the NETWORK, not the asset."""
+
+    def test_row_is_a_launch_spoke_on_ethereums_identity(self, provider):
+        assert provider.chain_def is CHAIN_ETHUSDC is get_chain_def('ethusdc')
+        assert 'ethusdc' in LAUNCH_SPOKES
+        assert (CHAIN_ETHUSDC.env_prefix, CHAIN_ETHUSDC.host_chain) == (CHAIN_ETH.env_prefix, CHAIN_ETH.host_chain)
+        # CHAIN_ETH owns ETH_NETWORK; a second declaration renders a duplicate CLI row.
+        assert CHAIN_ETHUSDC.networks == ()
+
+    @pytest.mark.parametrize('network,chain_id', (('mainnet', 1), ('sepolia', SEPOLIA_ID)))
+    def test_one_eth_network_moves_both_assets(self, monkeypatch, network, chain_id):
+        monkeypatch.setenv('ETH_NETWORK', network)
+        assert EthUsdc().chain.chain_id == Ether().chain.chain_id == chain_id
+
+    def test_token_contract_follows_the_shared_network(self, provider, monkeypatch):
+        assert provider.token_contract == CONTRACT  # sepolia deployment, off ETH_NETWORK
+        monkeypatch.setenv('ETH_NETWORK', 'mainnet')
+        assert EthUsdc().token_contract == CHAIN_ETHUSDC.asset_locator
+
+    def test_env_override_wins(self, monkeypatch):
+        monkeypatch.setenv('ETHUSDC_TOKEN_CONTRACT', '0x' + '42' * 20)
+        assert EthUsdc().token_contract == '0x' + '42' * 20
+
+    def test_unknown_network_raises(self, monkeypatch):
+        monkeypatch.setenv('ETH_NETWORK', 'seplia')
+        with pytest.raises(ValueError, match='ETH_NETWORK'):
+            EthUsdc()
+
+    def test_finality_matches_the_chain_it_shares(self):
+        # Two assets on one chain must not disagree about its reorg depth, and the implied
+        # 384s leg stays inside the program's 600s default fulfillment grace.
+        assert (CHAIN_ETHUSDC.min_confirmations, CHAIN_ETHUSDC.seconds_per_block) == (
+            CHAIN_ETH.min_confirmations,
+            CHAIN_ETH.seconds_per_block,
+        )
+        assert CHAIN_ETHUSDC.replay_grace_secs == CHAIN_ETH.replay_grace_secs
+        assert CHAIN_ETHUSDC.min_confirmations * CHAIN_ETHUSDC.seconds_per_block < 600
+
+    def test_lookback_window_is_time_based(self, provider):
+        assert provider.SCAN_LOOKBACK_BLOCKS == 25  # ≈5 min of 12s blocks
+
+    def test_wrong_network_endpoint_fails_startup(self, provider):
+        # Sepolia configured, a mainnet endpoint answering: reject outright rather than
+        # quietly verify legs against the wrong chain.
+        rpc_stub(provider, {'eth_chainId': '0x1'})
+        with pytest.raises(ConnectionError, match=f'expected {SEPOLIA_ID}'):
+            provider.check_connection(require_send=False)
+
+    def test_codeless_contract_fails_startup(self, provider):
+        rpc_stub(provider, {'eth_chainId': hex(SEPOLIA_ID), 'eth_blockNumber': '0x10', 'eth_getCode': '0x'})
+        with pytest.raises(ConnectionError, match='no code'):
+            provider.check_connection(require_send=False)
+
+
+class TestVerification:
+    def test_settled_transfer_matches_with_sender_pinned(self, provider):
+        rpc_stub(provider, mined())
+        info = provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT)
+        assert info.confirmed and info.amount == AMOUNT and info.block_time == 0x64
+        assert info.sender == SENDER.lower()
+
+    def test_below_min_confs_unconfirmed(self, provider):
+        rpc_stub(provider, mined(tip=1_000_030))  # 31 confs of the 32 required
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT).confirmed is False
+
+    def test_reverted_rejected(self, provider):
+        # Inclusion is not settlement: a reverted tx moved no funds.
+        rpc_stub(provider, mined(status='0x0'))
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+    def test_underpay_rejected(self, provider):
+        rpc_stub(provider, mined(logs=[transfer_log(amount=AMOUNT - 1)]))
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+    def test_wrong_recipient_rejected(self, provider):
+        rpc_stub(provider, mined(logs=[transfer_log(recipient=SENDER)]))
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+    def test_pending_transfer_matches_off_calldata(self, provider):
+        calldata = SEL_TRANSFER + topic(RECIPIENT).removeprefix('0x') + f'{AMOUNT:064x}'
+        pending = {'hash': TX, 'from': SENDER, 'to': CONTRACT, 'input': calldata, 'blockNumber': None}
+        rpc_stub(provider, {'eth_getTransactionByHash': pending})
+        info = provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT)
+        assert info.confirmed is False and info.sender == SENDER.lower() and info.amount == AMOUNT
+
+    def test_pending_transfer_to_a_counterfeit_contract_rejected(self, provider):
+        calldata = SEL_TRANSFER + topic(RECIPIENT).removeprefix('0x') + f'{AMOUNT:064x}'
+        pending = {'hash': TX, 'from': SENDER, 'to': COUNTERFEIT, 'input': calldata, 'blockNumber': None}
+        rpc_stub(provider, {'eth_getTransactionByHash': pending})
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+    def test_absent_tx_is_absent(self, provider):
+        rpc_stub(provider, {'eth_getTransactionByHash': None})
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+    def test_receipt_unavailable_is_unknown_not_absent(self, provider):
+        # 'unknown' must never read as 'no such payment' — that verdict slashes a paying miner.
+        with pytest.raises(ProviderUnreachableError):
+            rpc_stub(provider, dict(mined(), eth_getTransactionReceipt=None)).fetch_matching_tx(
+                TX, RECIPIENT.lower(), AMOUNT
+            )
+
+    def test_missing_block_timestamp_is_unknown_not_absent(self, provider):
+        with pytest.raises(ProviderUnreachableError):
+            rpc_stub(provider, mined(block={'hash': BLOCK_HASH})).fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT)
+
+    def test_counterfeit_token_log_never_matches_even_on_the_cache_path(self, provider):
+        """A fake token emitting a well-formed Transfer must not settle the leg, and must not
+        settle it on the re-verify either: the cache is only written from a pinned-contract match."""
+        rpc_stub(provider, mined(logs=[transfer_log(contract=COUNTERFEIT)]))
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+        assert provider._settled_cache == {}
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+
+class TestIssuerGates:
+    """USDC is Circle's FiatToken, so isBlacklisted/paused answer — verified live on mainnet."""
+
+    def views(self, provider, blacklisted=False, paused=False):
+        def call(params):
+            hit = blacklisted if params[0]['data'].startswith(SEL_IS_BLACKLISTED) else paused
+            return f'0x{int(hit):064x}'
+
+        return rpc_stub(provider, {'eth_call': call, 'eth_blockNumber': hex(1_000_000)})
+
+    def test_clean_dest_passes_reserve(self, provider):
+        assert self.views(provider).can_deliver_to(RECIPIENT, AMOUNT) is True
+
+    @pytest.mark.parametrize('gate', ('blacklisted', 'paused'))
+    def test_issuer_freeze_bounces_reserve_and_defers_the_slash(self, provider, gate):
+        # Freezing the payout address after reserve makes delivery impossible through no
+        # fault of the miner — positive evidence, never a slash.
+        p = self.views(provider, **{gate: True})
+        assert p.can_deliver_to(RECIPIENT, AMOUNT) is False
+        assert p.delivery_refused(RECIPIENT, 0) is True
+
+    def test_slash_gate_raises_on_rpc_trouble(self, provider):
+        def boom(params):
+            raise ConnectionError('down')
+
+        rpc_stub(provider, {'eth_call': boom})
+        with pytest.raises(ConnectionError):  # a flaky RPC postpones a slash, never falsifies one
+            provider.delivery_refused(RECIPIENT, 0)
+
+
+class TestSendGuards:
+    SEND = {
+        'eth_blockNumber': hex(100),
+        'eth_getBlockByNumber': {'baseFeePerGas': hex(10**9)},
+        'eth_maxPriorityFeePerGas': hex(10**9),
+        'eth_getTransactionCount': '0x0',
+        'eth_getBalance': hex(10**18),
+        'eth_estimateGas': hex(65_000),
+        'eth_call': f'0x{AMOUNT:064x}',  # balanceOf
+    }
+
+    def test_no_key_refused(self, provider):
+        assert provider.send_amount(RECIPIENT, AMOUNT) is None
+        assert 'ETH_PRIVATE_KEY' in provider.last_send_error
+
+    def test_key_mismatch_refused(self, provider, monkeypatch):
+        monkeypatch.setenv('ETH_PRIVATE_KEY', TEST_KEY)
+        assert provider.send_amount(RECIPIENT, AMOUNT, from_address=RECIPIENT) is None
+        assert 'key mismatch' in provider.last_send_error
+
+    def test_insufficient_token_balance_refused(self, provider, monkeypatch):
+        monkeypatch.setenv('ETH_PRIVATE_KEY', TEST_KEY)
+        rpc_stub(provider, dict(self.SEND, eth_call=f'0x{AMOUNT - 1:064x}'))
+        assert provider.send_amount(RECIPIENT, AMOUNT) is None
+        assert 'insufficient balance' in provider.last_send_error
+
+    def test_gas_poor_miner_refuses_before_broadcasting(self, provider, monkeypatch):
+        # Token-rich but ETH-poor: refuse here rather than burn a revert on L1.
+        monkeypatch.setenv('ETH_PRIVATE_KEY', TEST_KEY)
+        rpc_stub(provider, dict(self.SEND, eth_getBalance=hex(10**9)))
+        assert provider.send_amount(RECIPIENT, AMOUNT) is None
+        assert 'Insufficient gas balance' in provider.last_send_error
+
+    def test_broadcast_returns_a_hash(self, provider, monkeypatch):
+        monkeypatch.setenv('ETH_PRIVATE_KEY', TEST_KEY)
+        rpc_stub(provider, dict(self.SEND, eth_sendRawTransaction=TX))
+        assert provider.send_amount(RECIPIENT, AMOUNT) == (TX, 0)
+
+
+class TestDepositScanner:
+    def test_getlogs_hit_is_bounded_to_the_lookback_window(self, provider):
+        seen = {}
+
+        def logs(params):
+            seen.update(params[0])
+            return [transfer_log()]
+
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getLogs': logs})
+        assert provider.find_recent_outgoing(SENDER, RECIPIENT, AMOUNT) == TX
+        assert int(seen['fromBlock'], 16) == 10_000 - provider.SCAN_LOOKBACK_BLOCKS + 1
+        assert seen['address'] == CONTRACT
+
+    def test_failed_range_parks_the_cursor(self, provider):
+        def boom(params):
+            raise ConnectionError('down')
+
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getLogs': boom})
+        assert provider.find_recent_outgoing(SENDER, RECIPIENT, AMOUNT) is None
+        # Never leap a range the scan could not read — the deposit in it must stay reachable.
+        key = (SENDER.lower(), RECIPIENT.lower(), AMOUNT)
+        assert provider.scan_cursors[key] == 10_000 - provider.SCAN_LOOKBACK_BLOCKS

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -463,8 +463,8 @@ class TestIsExecutableRate:
         assert is_executable_rate(150.0, 'sol', 'arbusdc', self.MIN, self.MAX) is True
 
     def test_ethusdc_routes_at_its_five_dollar_floor(self):
-        """ethusdc ships the economic floor arbusdc declined (5 USDC — an L1 transfer's own
-        gas): non-binding at real bounds, since 0.1 SOL already needs ~15 USDC at 150/SOL."""
+        """ethusdc's floor is a rate-sanity input, not a per-swap minimum (that is the
+        contract's min_swap_amount): non-binding here, since 0.1 SOL needs ~15 USDC at 150/SOL."""
         assert get_chain_def('ethusdc').min_onchain_amount == 5_000_000
         assert is_executable_rate(150.0, 'ethusdc', 'sol', self.MIN, self.MAX) is True
         assert is_executable_rate(150.0, 'sol', 'ethusdc', self.MIN, self.MAX) is True

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -462,6 +462,17 @@ class TestIsExecutableRate:
         assert is_executable_rate(150.0, 'arbusdc', 'sol', self.MIN, self.MAX) is True
         assert is_executable_rate(150.0, 'sol', 'arbusdc', self.MIN, self.MAX) is True
 
+    def test_ethusdc_routes_at_its_five_dollar_floor(self):
+        """ethusdc ships the economic floor arbusdc declined (5 USDC — an L1 transfer's own
+        gas): non-binding at real bounds, since 0.1 SOL already needs ~15 USDC at 150/SOL."""
+        assert get_chain_def('ethusdc').min_onchain_amount == 5_000_000
+        assert is_executable_rate(150.0, 'ethusdc', 'sol', self.MIN, self.MAX) is True
+        assert is_executable_rate(150.0, 'sol', 'ethusdc', self.MIN, self.MAX) is True
+
+    def test_crown_squat_low_ethusdc_rate_rejected(self):
+        """1e-9 µUSDC/SOL: even the 5 USDC floor overshoots max_swap — unroutable."""
+        assert is_executable_rate(1e-9, 'ethusdc', 'sol', self.MIN, self.MAX) is False
+
     def test_arbusdc_survives_a_real_dust_floor(self):
         """What PR-E unlocks: with the orientation fixed, a real economic floor
         (0.01 USDC = 10_000 µUSDC) no longer kills the arbusdc→sol direction —


### PR DESCRIPTION
Adds `ethusdc` — Circle's native USDC on Ethereum — as the sixth launch spoke. A registry row, a
9-line `Erc20` binding, one testnet contract entry, one `LAUNCH_SPOKES` append. No shared code changed.

Twin: entrius/das-allways#90 (serving registry). Merge order: the alw-utils harness fix (in flight,
see below) → **this PR** → das#90, whose drift gate reads `chains.py` from `test` and stays red until
this one lands.

## What is different about this spoke

Ethereum was already in the registry. `ethusdc` is the first asset to land on an **already-configured
network**, so it adds no `EvmNetwork` row and no network env vars — it shares Ethereum's env identity
with native ETH.

| Field | Value | Why |
|---|---|---|
| `env_prefix` | `ETH` | Names the NETWORK. One `ETH_NETWORK` / `ETH_RPC_URLS` / `ETH_PRIVATE_KEY` for both assets, so eth and ethusdc can never disagree about which Ethereum they are on. |
| `networks` | `()` | `CHAIN_ETH` already declares them. Exactly one row per prefix may — two would render duplicate CLI rows writing the same var. |
| `host_chain` | `ethereum` | Reuses the existing `ETHEREUM` row; `assets/evm.py` is untouched. |
| `asset_locator` | `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48` | Circle-published mainnet USDC. |
| Sepolia | `0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238` | `erc20.py::TESTNET_TOKEN_CONTRACTS` — each address lives exactly once. |

Both addresses taken from Circle's own list (developers.circle.com/stablecoins/usdc-contract-addresses),
not an explorer search, then confirmed on-chain: mainnet `symbol()`=`USDC`, `name()`=`USD Coin`,
`decimals()`=6, 4374 bytes of code; Sepolia `symbol()`=`USDC`, `decimals()`=6, 3598 bytes of code.

**Consequence, and the correct outcome:** `tests/test_cli_chain_networks.py` needed **no change** — no
new `<id>-network` key, no `ENV_BUNDLES` entry, and `alw config` grows **no new row**. `ethusdc`'s
network comes from `ETH_NETWORK`, shared with native ETH.

## Judgement calls

**`min_confirmations = 32`, `seconds_per_block = 12`** — identical to `CHAIN_ETH`, and the identity is
the point: two assets on one chain must not disagree about that chain's finality. 32 blocks ≈ 1 beacon
epoch. Implied leg latency **32 × 12 = 384s**, inside the program's **600s** default fulfillment grace
(216s of headroom), so no grace-table arm is needed.

**`min_onchain_amount = 5_000_000` (5 USDC)** — a **rate-sanity floor, not an economic guarantee**,
deliberately diverging from `CHAIN_ARBUSDC`'s `1`. FiatToken's `transfer` burns ~65k gas; at ETH $1,878
(live, 2026-08-11) that is **$0.1221 per gwei**, which is what sizes the number:

| gas price | L1 transfer cost | share of a 5 USDC leg |
|---|---|---|
| 0.06 gwei (live base fee today) | $0.008 | 0.2% |
| 9 gwei (top of the typical 2026 band) | $1.10 | 22% |
| 41 gwei | $5.00 | 100% — break-even |
| 100–500 gwei (congestion spikes) | $12–$61 | miners widen quotes |

So 5 USDC is the leg size that stops covering its own fee only once L1 gas reaches a congestion
regime. The same transfer on Arbitrum costs ~$0.0001, which is why `arbusdc`'s unit floor is honest
there and would be dishonest here — the divergence is intentional.

**What this value does NOT do.** It is not a per-swap minimum and does not stop a small leg. It is
read in exactly two places, `utils/rate.py:209` and `:250`, and both are rate-*existence* questions
("does any fundable source amount map into the SOL band?"); `min_executable_sol_leg` does not read the
spoke's floor at all in the `sol → spoke` direction. Every enforced per-swap bound is on the SOL leg —
the contract's `min_swap_amount` / `max_swap_amount` in lamports — so a 0.001 SOL swap delivering
150 µUSDC is gated by `min_swap_amount`, not by this field. `min_swap_amount` is the lever to reach for
if a real per-swap floor is ever wanted. The value is also non-binding at realistic bounds (0.1 SOL
already needs ~15 USDC at 150 USDC/SOL), so in practice it only bites the crown-squat regime it exists
for. Both properties are pinned in `tests/test_rate.py`.

**`replay_grace_secs = 0`** — matched to `CHAIN_ETH` for same-chain uniformity; two assets on one chain
disagreeing about its clock would be indefensible. Noting honestly that `CHAIN_ETH`'s stated reasoning
("timestamps must strictly exceed the parent's") is a non-sequitur: monotonicity of the spoke's own
clock says nothing about hub-vs-spoke skew, which is what this field actually absorbs. Revisiting
eth's value is a separate PR; it is **not** changed here.

## Token-specific hazards

- **Issuer gates answer.** USDC is Circle's FiatToken, so `isBlacklisted(address)` / `paused()` work
  unchanged. Verified with a live `eth_call` on mainnet: `isBlacklisted` → `0x00…00`, `paused()` →
  `0x00…00`. Tether's `isBlackListed` spelling (selector `0xe47d6060`) **reverts** on USDC
  (`{"code":3,"message":"execution reverted"}`) — i.e. the failure mode where the slash gate raises on
  every evaluation and defers forever does **not** apply to USDC-on-Ethereum.
- **Freeze mid-swap.** Blacklisting the miner's payout address after reserve makes delivery impossible
  through no fault of the miner. Confirmed `can_deliver_to` → False and `delivery_refused` → True (the
  slash defers, never lands), for both the blacklist and the pause arm; and that an RPC failure on the
  latest probe raises so the caller defers rather than falsifies. Shared implementation unchanged.
- **Proxies.** Both deployments are proxies (mainnet's FiatTokenProxy points at
  `0x43506849d7c04f9138d1a2050bbf3a0c054402dd`). An implementation upgrade that changed `transfer`
  semantics — a different `Transfer` log shape, a fee-on-transfer deduction, or a non-reverting
  failure — would break settlement, not safety: verification requires a status-1 receipt carrying a
  `Transfer` from the pinned contract paying >= the expected amount, so a changed shape reads as "no
  such payment" (leg unresolved, miner not credited) rather than a false confirm.
- **6 decimals vs the hub's 9.** `decimal_diff = -3`; both `calculate_to_amount` branches stay
  integer-exact and floor (never round up). Same shape as `arbusdc`, already pinned in
  `tests/test_rate.py::TestSolArbusdc`; the executable-rate gate is exercised at both direction
  extremes for ethusdc's 5 USDC floor.
- **Counterfeit tokens.** The contract is pinned on every path: the log scan filters on
  `log.address`, the pending path filters on `tx.to`, `eth_getLogs` filters server-side on `address`,
  and the settled-tx cache is only *written* from a pinned-contract match — so a fake token cannot
  poison it and then be served on the 12s re-verify. Test covers both the first read and the re-read.

## Evidence

**Lint + suite**

```
$ uv run ruff format --check . && uv run ruff check .
154 files already formatted
All checks passed!

$ uv run pytest tests/ -q
1154 passed, 6 deselected, 3 warnings in 9.74s
```

`tests/test_ethusdc_provider.py` is new and fully offline (RPC stubbed with a method→response map).
Deliberately terse — generic ERC-20 behaviour is already proven by the 561-line arbusdc suite, so this
covers what the binding decides: the shared env identity (one `ETH_NETWORK` moves both assets;
`ETH_NETWORK=sepolia` moves both; the Sepolia token resolves off that shared network), wrong-network
startup rejection, codeless-contract rejection, settled / pending / reverted / not-found / underpaid /
wrong-recipient verification, receipt-unavailable and timestamp-unavailable both raising rather than
reading as absent, the issuer gates, send guards (no key / key mismatch / insufficient token balance /
gas-poor), and the deposit scanner's bounds + cursor parking.

**Registry guard, moved rather than dropped.** `test_assets_optional.py::test_evm_network_names_match_the_rpc_registry`
compared every EVM row's `networks` against its `EvmNetwork.chain_ids`, which assumed every asset owns
its network. A row that declares none rides the row that does, so it is now skipped — but that assert
was *also* the only thing enforcing "every EVM network has a row declaring its names", and
`test_chains.py` covered only the *at most one* half, never *at least one*. The missing half is now
asserted at the right level, in `test_assets_on_one_network_share_its_env_identity`:

```python
for host, ids in declared.items():
    assert len(ids) == 1, f'{host} needs exactly one networks-declaring row, found {ids}'
```

Verified against the exact mistake it exists to catch — a new network whose only asset forgets
`networks`, which would otherwise get no CLI row, never have its `{PREFIX}_NETWORK` written by
`alw config set env testnet`, and default to **mainnet** with a testnet miner spending real funds:

```
a new host whose only row omits networks : FAIL — 'zeta needs exactly one networks-declaring row, found []'
same network, names declared             : PASS
two declaring rows on one host           : FAIL — 'ethereum needs exactly one networks-declaring row, found [...]'
```

**Live read-only verification — mainnet**

```
--- mainnet: Ethereum JSON-RPC (mainnet): ethereum-rpc.publicnode.com, eth.drpc.org — token 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
tip = 25734995
settled tx 0x28d11179c242b42d1d5425444b70f89e1dc83e57a6e64b890a885daa10f2f706
  sender=0xbaa67174531f0c031f91a373f6788c7e821af2c5 recipient=0x0767b19e6a8420bc10536a249ab019fa773e81d6 amount=28080000 (28.08 USDC)
VERIFY mixed-case recipient 0x0767B19E6A8420bC10536a249AB019Fa773E81D6 + sender pinned -> confirmed=True confs=46 amount=28080000 sender=0xbaa67174531f0c031f91a373f6788c7e821af2c5 block_time=1786489787
REJECT underpay (ask for amount+1): None
REJECT wrong sender: None            # verify_transaction: sender mismatch on tx 0x28d11179c242b4...
REJECT wrong recipient: None         # no Transfer log from 0xA0b8... paying 0x2222...
REJECT unknown tx (single-endpoint ladder): None
BALANCE 0x28C6c06298d514Db089934071355E5743bf21d60: 50810846175 µUSDC
can_deliver_to: True
delivery_refused (issuer gate, latest + history): False
```

**Live read-only verification — Sepolia**

```
--- sepolia: Ethereum JSON-RPC (sepolia): ethereum-sepolia-rpc.publicnode.com, sepolia.gateway.tenderly.co — token 0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238
tip = 11469335
settled tx 0x08a0a9e4e7363a29c2e3d616919fe16a554d1742b803283f7a0835c9612f8604
  sender=0x70e3fb28e1794bb91d5bceb7d66b731d0c61af8e recipient=0x7a69ae26dcf04af3239ce71c064786be0891d406 amount=20000000 (20.0 USDC)
VERIFY mixed-case recipient 0x7A69Ae26DcF04af3239CE71C064786bE0891d406 + sender pinned -> confirmed=True confs=199 amount=20000000 sender=0x70e3fb28e1794bb91d5bceb7d66b731d0c61af8e block_time=1786487868
REJECT underpay (ask for amount+1): None
REJECT wrong sender: None
REJECT wrong recipient: None
REJECT unknown tx: None
BALANCE of 0x7a69ae26dcf04af3239ce71c064786be0891d406: 105000000 µUSDC
can_deliver_to: True
delivery_refused (issuer gate, latest + history): False
```

Note on the mainnet unknown-tx line: on the **default two-endpoint ladder**, `eth.drpc.org` answers
`eth_getTransactionByHash` for a nonexistent hash with HTTP 408 (reproduced with raw curl), so the
null never reaches quorum and the read raises `ProviderUnreachableError` instead of returning None.
That is the designed fail-safe (unknown ≠ absent) firing correctly — it defers rather than falsely
concluding "no such payment". It is a property of the shared `ETHEREUM` ladder that affects native ETH
identically, is not introduced here, and disappears with any single healthy endpoint in `ETH_RPC_URLS`
(shown above).

**Derived CLI surfaces**

```
$ uv run alw miner quotes --help
│ --ethusdc-price      NUMBER   ETHUSDC per 1 SOL (0/omit to skip ETHUSDC).
│ --ethusdc-address    TEXT     Your ETHUSDC address.

$ uv run alw config
│ btc-network    │ mainnet │ default │
│ eth-network    │ mainnet │ default │
│ arb-network    │ mainnet │ default │
│ hype-network   │ mainnet │ default │
```

No `ethusdc-network` row appeared — that is the correct outcome for an asset that shares a network.

**E2E scenario derivation**

Run with `PYTHONPATH` pointed at this branch's checkout, because `run-suites.sh` hardcodes the main
checkout's venv python (which sits on an unrelated branch):

```
$ cd alw-utils/dev-environment/solana
$ PYTHONPATH=<this branch's allways checkout> ./run-suites.sh --list
scenarios:
  sol-btc / btc-sol / sol-tao / tao-sol / sol-eth / eth-sol
  sol-arbusdc / arbusdc-sol / sol-hype / hype-sol
  sol-ethusdc / ethusdc-sol
  blacklist-gate / slash / weights / tao-happy / tao-timeout / w4-*
```

Both rows derive from `LAUNCH_SPOKES`; no harness code was written. **No suite was executed** — see below.

### Harness blocker for whoever runs the suites (alw-utils, not this PR)

`full-e2e.sh` assumes one fake JSON-RPC per **EVM spoke** (alw-utils#120) and assigns ports and wallets
per **asset id**, but emits env vars keyed by **`env_prefix`**. `ethusdc` is the first case where two
assets share a prefix, so the loop writes `ETH_NETWORK`, `ETH_RPC_URLS` and `ETH_PRIVATE_KEY` twice and
last-wins (ethusdc, being last in `LAUNCH_SPOKES`). Reproduced on this branch:

```
btc:BTC:utxo::
tao:TAO:ss58::
eth:ETH:evm:sepolia:11155111
arbusdc:ARB:token:sepolia:421614
hype:HYPE:evm:testnet:998
ethusdc:ETH:token:sepolia:11155111      <- same prefix, same network, same chain id
```

Effects: both providers dial ethusdc's fake while eth's fake sits idle; the eth leg is configured with
ethusdc's key but eth's committed address, so `send_amount` refuses on key mismatch; and
`ETHRPC_URL="${SPOKE_URL[eth]}"` (slash / blacklist scenarios) points at the unused instance. The fix
is to key ports, wallets and env by `env_prefix` rather than asset id and hang the token contract off
the shared instance — the script's own comment ("each spoke's provider checks the served eth_chainId
against its own network, so they cannot share one instance") does not hold for two assets on the *same*
network, which can and must share one. Not touched here, per scope.

**Merge dependency:** a fix is in flight as a separate alw-utils PR. **This PR should merge after it**,
so the suites are runnable the moment `ethusdc` reaches `test`.

## Emissions

A sixth spoke dilutes every pair's zero-volume emission floor from `(1−α)/5` to `(1−α)/6` of
`MINER_POOL_SHARE` (α = `POOL_VOLUME_ALPHA` = 0.66 → 6.8% → 5.7% per pair); `DIRECTION_POOLS` derives
this from `LAUNCH_SPOKES` and needs no edit.