### PR TITLE
Add BNB (BNB Smart Chain) as a launch spoke

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,14 @@ HYPE_NETWORK=mainnet                # mainnet | testnet
 # 32-byte hex key — required for miners; optional local signing for `alw swap`
 HYPE_PRIVATE_KEY=
 
+# ─── Chain: BNB Smart Chain (BNB pairs) ────────────────────
+BNB_NETWORK=mainnet                 # mainnet | testnet (Chapel)
+# OPTIONAL ordered JSON-RPC endpoints (keyed providers embed the key in the URL);
+# unset = public (publicnode, the official bnbchain data seed)
+# BNB_RPC_URLS=https://bsc-mainnet.infura.io/v3/your_key,https://bsc-rpc.publicnode.com
+# 32-byte hex key — required for miners; optional local signing for `alw swap`
+BNB_PRIVATE_KEY=
+
 # ─── Miner-only ────────────────────────────────────────────
 # headless miners: unlocks the coldkey at startup for TAO sends; unset = prompt at launch
 MINER_BITTENSOR_COLDKEY_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Native transactions across independent assets — no wrapped tokens, no bridges,
 
 Allways creates a verification layer above independent systems. Assets move natively. Miners complete transactions, validators independently verify the results, and a smart contract enforces outcomes through collateral and slashing.
 
-Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, and SOL ↔ HYPE (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
+Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, and SOL ↔ BNB (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
 
 ## Miner Risk Disclaimer
 
@@ -123,7 +123,7 @@ needs to persist across restarts.
 
 ## Miner Environment Variables
 
-- `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `{ETH,ARB,HYPE}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config. See `.env.example`.
+- `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `BNB_PRIVATE_KEY`, `{ETH,ARB,HYPE,BNB}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config. See `.env.example`.
 
 ## Running a Local Subtensor Lite Node (Validators)
 

--- a/allways/assets/__init__.py
+++ b/allways/assets/__init__.py
@@ -4,6 +4,7 @@ import bittensor as bt
 
 from allways.assets.arbusdc import ArbUsdc
 from allways.assets.asset import Asset, SendResult, TransactionInfo
+from allways.assets.bnb import Bnb
 from allways.assets.btc import Bitcoin
 from allways.assets.chain import Chain
 from allways.assets.erc20 import Erc20
@@ -25,6 +26,7 @@ __all__ = [
     'EvmCoin',
     'Ether',
     'Hype',
+    'Bnb',
     'Erc20',
     'ArbUsdc',
     'create_assets',
@@ -47,6 +49,7 @@ ASSET_REGISTRY: Tuple[AssetSpec, ...] = (
     AssetSpec('eth', Ether, ()),
     AssetSpec('arbusdc', ArbUsdc, ()),
     AssetSpec('hype', Hype, ()),
+    AssetSpec('bnb', Bnb, ()),
 )
 
 

--- a/allways/assets/bnb.py
+++ b/allways/assets/bnb.py
@@ -1,0 +1,11 @@
+from allways.assets.evm_coin import EvmCoin
+from allways.chains import CHAIN_BNB
+
+
+class Bnb(EvmCoin):
+    """BNB on BNB Smart Chain — a config-row binding of the generic EvmCoin (see chains.CHAIN_BNB).
+
+    BSC speaks plain JSON-RPC, so nothing here is chain-specific beyond the pairing."""
+
+    def __init__(self):
+        super().__init__(CHAIN_BNB)

--- a/allways/assets/evm.py
+++ b/allways/assets/evm.py
@@ -98,11 +98,13 @@ BSC = EvmNetwork(
     label='BNB Smart Chain',
     chain_ids={'mainnet': 56, 'testnet': 97},  # testnet = Chapel
     rpc_urls={
-        # Two independent keyless operators. drpc is deliberately absent: its free BSC tier
-        # 429s under a burst, and a ladder whose second endpoint always errors can never reach
-        # null quorum, so every genuinely-absent tx would raise instead of returning None.
-        'mainnet': ('https://bsc-rpc.publicnode.com', 'https://bsc-dataseed.bnbchain.org'),
-        'testnet': ('https://bsc-testnet-rpc.publicnode.com', 'https://bsc-testnet-dataseed.bnbchain.org'),
+        # Picked on a real eth_getTransactionReceipt under load, not on eth_chainId: publicnode's
+        # BSC mainnet node answers chainId and then 403s every receipt ('Archive requests require a
+        # personal token') even one block back, and the receipt IS the settlement check. drpc's free
+        # BSC tier 429s under any burst, which would strand null quorum. Both excluded on purpose.
+        'mainnet': ('https://bsc-dataseed.bnbchain.org', 'https://bsc.blockrazor.xyz'),
+        # publicnode's TESTNET node does serve receipts — the asymmetry with mainnet is deliberate.
+        'testnet': ('https://bsc-testnet-dataseed.bnbchain.org', 'https://bsc-testnet-rpc.publicnode.com'),
     },
 )
 

--- a/allways/assets/evm.py
+++ b/allways/assets/evm.py
@@ -94,9 +94,25 @@ HYPERLIQUID = EvmNetwork(
         'testnet': ('https://rpc.hyperliquid-testnet.xyz/evm', 'https://hyperliquid-testnet.drpc.org'),
     },
 )
+BSC = EvmNetwork(
+    label='BNB Smart Chain',
+    chain_ids={'mainnet': 56, 'testnet': 97},  # testnet = Chapel
+    rpc_urls={
+        # Two independent keyless operators. drpc is deliberately absent: its free BSC tier
+        # 429s under a burst, and a ladder whose second endpoint always errors can never reach
+        # null quorum, so every genuinely-absent tx would raise instead of returning None.
+        'mainnet': ('https://bsc-rpc.publicnode.com', 'https://bsc-dataseed.bnbchain.org'),
+        'testnet': ('https://bsc-testnet-rpc.publicnode.com', 'https://bsc-testnet-dataseed.bnbchain.org'),
+    },
+)
 
 # ChainDefinition.host_chain → the EvmNetwork that hosts the asset.
-EVM_NETWORKS: Mapping[str, EvmNetwork] = {'ethereum': ETHEREUM, 'arbitrum': ARBITRUM, 'hyperliquid': HYPERLIQUID}
+EVM_NETWORKS: Mapping[str, EvmNetwork] = {
+    'ethereum': ETHEREUM,
+    'arbitrum': ARBITRUM,
+    'hyperliquid': HYPERLIQUID,
+    'bsc': BSC,
+}
 
 
 class EvmChain(Chain):

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -155,6 +155,32 @@ CHAIN_HYPE = ChainDefinition(
     replay_grace_secs=60,
 )
 
+CHAIN_BNB = ChainDefinition(
+    id='bnb',
+    name='BNB Smart Chain',
+    native_unit='wei',
+    decimals=18,
+    env_prefix='BNB',
+    host_chain='bsc',
+    networks=('mainnet', 'testnet'),  # testnet = Chapel
+    testnet_network='testnet',
+    # Fermi (Jan 2026) cut blocks to 0.45s — measured 0.4502s over the last 100k mainnet blocks.
+    # 1 is the integer floor, so every derived bound is conservative in wall time, never short.
+    seconds_per_block=1,
+    # BEP-126 finalizes a block once it and its child carry >2/3 attestations — ~2 blocks. That
+    # quorum is not guaranteed: across an epoch's validator-set rotation the attesting set changes
+    # and, below quorum, BSC falls back to its longest-chain rule, whose classic safety bound is
+    # 2/3·21+1 = 15 blocks. At 0.45s that bound costs ~6.8s, so take it instead of trusting fast
+    # finality to hold.
+    min_confirmations=15,
+    # Rate sanity floor, not an economic guarantee: 0.0002 BNB covers a 21k-gas transfer below
+    # ~9.5 gwei — well above the 3-5 gwei BSC sustained through 2022-2024, and ~200x today's
+    # 0.05 gwei minimum. Miners price real gas into their quotes.
+    min_onchain_amount=200_000_000_000_000,
+    # Consensus-stamped timestamps vs the hub clock — modest skew allowance, as on Arbitrum.
+    replay_grace_secs=60,
+)
+
 SUPPORTED_CHAINS = {
     'btc': CHAIN_BTC,
     'tao': CHAIN_TAO,
@@ -162,6 +188,7 @@ SUPPORTED_CHAINS = {
     'eth': CHAIN_ETH,
     'arbusdc': CHAIN_ARBUSDC,
     'hype': CHAIN_HYPE,
+    'bnb': CHAIN_BNB,
 }
 
 

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -167,11 +167,12 @@ CHAIN_BNB = ChainDefinition(
     # Fermi (Jan 2026) cut blocks to 0.45s — measured 0.4502s over the last 100k mainnet blocks.
     # 1 is the integer floor, so every derived bound is conservative in wall time, never short.
     seconds_per_block=1,
-    # BEP-126 finalizes a block once it and its child carry >2/3 attestations — ~2 blocks. That
-    # quorum is not guaranteed: across an epoch's validator-set rotation the attesting set changes
-    # and, below quorum, BSC falls back to its longest-chain rule, whose classic safety bound is
-    # 2/3·21+1 = 15 blocks. At 0.45s that bound costs ~6.8s, so take it instead of trusting fast
-    # finality to hold.
+    # BEP-126 finalizes a block once it and its direct child carry >2/3 attestations (~2 blocks).
+    # Below that quorum — e.g. across an epoch's validator-set rotation — BSC falls back to its
+    # longest-chain rule, where what bounds one dishonest proposer is turn_length: the run of
+    # consecutive blocks a single validator signs (BEP-341; measured 8 on mainnet, 2026-08-11).
+    # 15 outlasts one full turn, so no lone validator can build the whole span. turn_length is a
+    # governance parameter and has already been raised twice — if it rises again, raise this above it.
     min_confirmations=15,
     # Rate sanity floor, not an economic guarantee: 0.0002 BNB covers a 21k-gas transfer below
     # ~9.5 gwei — well above the 3-5 gwei BSC sustained through 2022-2024, and ~200x today's

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -87,7 +87,7 @@ def hub_leg(from_chain: str, to_chain: str) -> str | None:
 
 
 # Chains paired against each hub; add a chain here to launch its pairs.
-LAUNCH_SPOKES = ('btc', 'tao', 'eth', 'arbusdc', 'hype')
+LAUNCH_SPOKES = ('btc', 'tao', 'eth', 'arbusdc', 'hype', 'bnb')
 # Every launch pair as (hub, spoke): each hub pairs against every spoke except itself. sol↔tao
 # lands exactly once (under SOL, its anchor) because sol never appears in LAUNCH_SPOKES.
 LAUNCH_PAIRS: tuple[tuple[str, str], ...] = tuple(

--- a/tests/test_bnb_provider.py
+++ b/tests/test_bnb_provider.py
@@ -7,11 +7,10 @@ time that drives the scanner. BSC's own hazard is a destination that stops accep
 transfer between reserve and payout (EIP-7702 delegation), so the delivery gates are pinned too.
 """
 
-import time
-
 import pytest
 from eth_account import Account
 
+from allways.assets import evm_coin
 from allways.assets.asset import ProviderUnreachableError
 from allways.assets.bnb import Bnb
 from allways.assets.evm import BSC, EvmChain
@@ -23,6 +22,7 @@ TEST_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80' 
 RECIPIENT = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
 TX = '0x' + 'ab' * 32
 BLOCK_HASH = '0x' + 'cd' * 32
+DELEGATION = '0xef0100' + '11' * 20  # EIP-7702 delegation indicator
 MINED_BLOCK = 0xF4240  # 1_000_000
 CONFIRMED_TIP = MINED_BLOCK + CHAIN_BNB.min_confirmations - 1
 
@@ -42,6 +42,14 @@ def provider(monkeypatch):
     monkeypatch.delenv('BNB_RPC_URLS', raising=False)
     monkeypatch.delenv('BNB_PRIVATE_KEY', raising=False)
     return Bnb()
+
+
+@pytest.fixture
+def frozen_now(monkeypatch):
+    """Pin the clock so delivery_refused's span arithmetic lands on exact block offsets."""
+    now = 1_800_000_000
+    monkeypatch.setattr(evm_coin.time, 'time', lambda: now)
+    return now
 
 
 def rpc_stub(provider, responses: dict):
@@ -239,13 +247,28 @@ class TestDeliveryGates:
         rpc_stub(provider, {'eth_getCode': '0x60806040', 'eth_estimateGas': refuse})
         assert provider.can_deliver_to(RECIPIENT, 10**16) is False
 
-    def test_slash_gate_exempts_a_dest_that_gained_code_after_reserve(self, provider):
-        since = int(time.time()) - 60
-        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getCode': '0xef0100' + '11' * 20})
-        assert provider.delivery_refused(RECIPIENT, since) is True
+    def test_slash_gate_exempts_a_dest_that_gained_then_revoked_code(self, provider, frozen_now):
+        # The case only temporal sampling can catch, and the one a miner gets slashed over: the
+        # dest delegates via EIP-7702 after the reservation pinned it, the payout reverts, and the
+        # delegation is revoked before the slash check. 'latest' is clean by then — only the
+        # historical probes still see it. Code lives at the midpoint offset alone, so a passing
+        # run proves all three probe offsets were actually read.
+        probed = []
 
+        def code_at(params):
+            probed.append(params[1])
+            return DELEGATION if params[1] == hex(9_970) else '0x'
+
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getCode': code_at})
+        assert provider.delivery_refused(RECIPIENT, frozen_now - 60) is True
+        # now, then the window's far edge and its midpoint. The 60s window is 60 blocks at the
+        # stored 1s; note the gate's 120-block span cap is only ~54s of real BSC history (0.45s
+        # blocks), so "the window since since_unix" stops being true beyond that.
+        assert probed == ['latest', hex(9_940), hex(9_970)]
+
+    def test_slash_gate_does_not_exempt_a_dest_that_never_had_code(self, provider, frozen_now):
         rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getCode': '0x'})
-        assert provider.delivery_refused(RECIPIENT, since) is False
+        assert provider.delivery_refused(RECIPIENT, frozen_now - 60) is False
 
 
 class TestDepositScanner:

--- a/tests/test_bnb_provider.py
+++ b/tests/test_bnb_provider.py
@@ -1,0 +1,275 @@
+"""Bnb unit tests — all offline (RPC layer mocked, signing is pure crypto).
+
+The EVM behaviour itself is `EvmCoin`, proven by the Ether suite. What is BNB-specific — and
+what a wrong value here would cost — lives in the binding: which network the env selects, the
+chain id every signed tx commits to, the 15-block confirmation depth, and the sub-second block
+time that drives the scanner. BSC's own hazard is a destination that stops accepting a native
+transfer between reserve and payout (EIP-7702 delegation), so the delivery gates are pinned too.
+"""
+
+import time
+
+import pytest
+from eth_account import Account
+
+from allways.assets.asset import ProviderUnreachableError
+from allways.assets.bnb import Bnb
+from allways.assets.evm import BSC, EvmChain
+from allways.assets.evm_coin import MAX_WALK_BLOCKS
+from allways.chains import CHAIN_BNB, get_chain_def
+from allways.constants import LAUNCH_SPOKES
+
+TEST_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'  # hardhat account #0
+RECIPIENT = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+TX = '0x' + 'ab' * 32
+BLOCK_HASH = '0x' + 'cd' * 32
+MINED_BLOCK = 0xF4240  # 1_000_000
+CONFIRMED_TIP = MINED_BLOCK + CHAIN_BNB.min_confirmations - 1
+
+SEND_RESPONSES = {
+    'eth_blockNumber': hex(100),
+    'eth_getBlockByNumber': {'baseFeePerGas': hex(10**9)},
+    'eth_maxPriorityFeePerGas': hex(10**9),
+    'eth_getTransactionCount': '0x0',
+    'eth_getBalance': hex(10**19),
+    'eth_estimateGas': hex(21_000),
+}
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    monkeypatch.setenv('BNB_NETWORK', 'mainnet')
+    monkeypatch.delenv('BNB_RPC_URLS', raising=False)
+    monkeypatch.delenv('BNB_PRIVATE_KEY', raising=False)
+    return Bnb()
+
+
+def rpc_stub(provider, responses: dict):
+    """Replace eth_rpc with a method→response map. A callable value is invoked with params."""
+
+    def fake_rpc(method, params, timeout=15, **kw):
+        value = responses[method]
+        return value(params) if callable(value) else value
+
+    provider.chain.eth_rpc = fake_rpc
+    return provider
+
+
+def mined_responses(status='0x1', tip=CONFIRMED_TIP, value_hex=hex(10**18)):
+    return {
+        'eth_getTransactionByHash': {
+            'hash': TX,
+            'from': '0x' + '11' * 20,
+            # Lowercase on the wire against a checksummed expectation: EIP-55 is display-only,
+            # and a case-sensitive compare would reject an honest miner's payout.
+            'to': RECIPIENT.lower(),
+            'value': value_hex,
+            'blockNumber': hex(MINED_BLOCK),
+            'blockHash': BLOCK_HASH,
+        },
+        'eth_getTransactionReceipt': {'status': status, 'blockNumber': hex(MINED_BLOCK), 'blockHash': BLOCK_HASH},
+        'eth_blockNumber': hex(tip),
+        'eth_getBlockByNumber': {'hash': BLOCK_HASH, 'timestamp': '0x64'},
+    }
+
+
+class TestRegistryRow:
+    def test_is_a_launch_spoke_bound_to_its_registry_row(self, provider):
+        assert provider.chain_def is CHAIN_BNB is get_chain_def('bnb')
+        assert 'bnb' in LAUNCH_SPOKES
+
+    def test_native_coin_composes_its_chain(self, provider):
+        # A native coin is an asset ON its network, not the network — same seam as a token,
+        # so a second BSC asset can land beside it without either claiming to be the chain.
+        assert isinstance(provider.chain, EvmChain) and provider.chain is not provider
+        assert provider.chain.env_prefix == CHAIN_BNB.env_prefix
+
+    def test_decimals_and_prefix(self):
+        assert (CHAIN_BNB.decimals, CHAIN_BNB.env_prefix, CHAIN_BNB.native_unit) == (18, 'BNB', 'wei')
+
+    def test_confirmations_stay_inside_the_program_fulfillment_grace(self):
+        # An unlisted chain gets the program's 600s default grace. 15 × the stored 1s is 15s;
+        # real BSC blocks are 0.45s, so the true leg wait is ~6.8s — both far inside it.
+        assert CHAIN_BNB.min_confirmations * CHAIN_BNB.seconds_per_block < 600
+
+
+class TestNetworkSelection:
+    def test_mainnet_chain_id(self, provider):
+        assert provider.chain.chain_id == 56
+
+    def test_testnet_chain_id(self, monkeypatch):
+        monkeypatch.setenv('BNB_NETWORK', 'testnet')
+        assert Bnb().chain.chain_id == 97
+
+    def test_unknown_network_raises(self, monkeypatch):
+        # A typo must never fall back to mainnet — that spends real BNB against test swaps.
+        monkeypatch.setenv('BNB_NETWORK', 'chapel')
+        with pytest.raises(ValueError, match='BNB_NETWORK'):
+            Bnb()
+
+    def test_unset_network_defaults_to_mainnet(self, monkeypatch):
+        monkeypatch.delenv('BNB_NETWORK', raising=False)
+        assert Bnb().chain.network == 'mainnet'
+
+    @pytest.mark.parametrize('network', tuple(BSC.chain_ids))
+    def test_every_network_has_a_keyless_default_ladder(self, monkeypatch, network):
+        monkeypatch.setenv('BNB_NETWORK', network)
+        assert Bnb().chain.rpc_bases == list(BSC.rpc_urls[network])
+
+    def test_rpc_urls_env_overrides_the_public_ladder(self, monkeypatch):
+        monkeypatch.setenv('BNB_RPC_URLS', 'https://paid.example/key/,https://backup.example')
+        assert Bnb().chain.rpc_bases == ['https://paid.example/key', 'https://backup.example']
+
+    def test_wrong_network_endpoint_fails_startup(self, monkeypatch):
+        # Testnet configured, a mainnet endpoint answering: the ladder must be rejected outright,
+        # never quietly used to verify legs against the wrong chain.
+        monkeypatch.setenv('BNB_NETWORK', 'testnet')
+        p = rpc_stub(Bnb(), {'eth_chainId': hex(56)})
+        with pytest.raises(ConnectionError, match='expected 97'):
+            p.check_connection(require_send=False)
+
+
+class TestVerification:
+    def test_settled_transfer_matches(self, provider):
+        rpc_stub(provider, mined_responses())
+        info = provider.fetch_matching_tx(TX, RECIPIENT, 10**18)
+        assert info is not None and info.confirmed and info.amount == 10**18
+        assert info.block_time == 0x64
+
+    def test_fifteen_confirmations_are_enough(self, provider):
+        rpc_stub(provider, mined_responses(tip=CONFIRMED_TIP))
+        assert provider.fetch_matching_tx(TX, RECIPIENT, 10**18).confirmed
+
+    def test_fourteen_confirmations_are_not(self, provider):
+        rpc_stub(provider, mined_responses(tip=CONFIRMED_TIP - 1))
+        assert provider.fetch_matching_tx(TX, RECIPIENT, 10**18).confirmed is False
+
+    def test_reverted_tx_rejected(self, provider):
+        # Inclusion is not settlement: a reverted tx still carries intact to/value fields.
+        rpc_stub(provider, mined_responses(status='0x0'))
+        assert provider.fetch_matching_tx(TX, RECIPIENT, 10**18) is None
+
+    def test_underpayment_rejected(self, provider):
+        rpc_stub(provider, mined_responses(value_hex=hex(10**17)))
+        assert provider.fetch_matching_tx(TX, RECIPIENT, 10**18) is None
+
+    def test_wrong_recipient_rejected(self, provider):
+        rpc_stub(provider, mined_responses())
+        assert provider.fetch_matching_tx(TX, '0x' + '22' * 20, 10**18) is None
+
+    def test_absent_tx_is_absent(self, provider):
+        rpc_stub(provider, {'eth_getTransactionByHash': None})
+        assert provider.fetch_matching_tx(TX, RECIPIENT, 10**18) is None
+
+    def test_unreadable_receipt_is_unknown_not_absent(self, provider):
+        # 'unknown' must never read as 'no such payment' — that verdict slashes a paying miner.
+        responses = mined_responses()
+        responses['eth_getTransactionReceipt'] = None
+        with pytest.raises(ProviderUnreachableError):
+            rpc_stub(provider, responses).fetch_matching_tx(TX, RECIPIENT, 10**18)
+
+    def test_unreadable_block_timestamp_is_unknown_not_absent(self, provider):
+        # is_tx_fresh fails closed on a missing block_time, so a stale-looking dest leg
+        # would ride to a TIMEOUT slash. Raise instead and let the caller retry.
+        responses = mined_responses()
+        responses['eth_getBlockByNumber'] = {'hash': BLOCK_HASH}
+        with pytest.raises(ProviderUnreachableError):
+            rpc_stub(provider, responses).fetch_matching_tx(TX, RECIPIENT, 10**18)
+
+
+class TestSending:
+    @pytest.fixture(autouse=True)
+    def _key(self, provider, monkeypatch):
+        monkeypatch.setenv('BNB_PRIVATE_KEY', TEST_KEY)
+
+    def test_broadcasts_a_bsc_signed_transfer(self, provider):
+        # Pins the whole signed payload: chain id 56 (a tx signed for any other chain is simply
+        # invalid here), EIP-1559 fees off the stubbed base fee, and the estimated gas + 20%.
+        broadcast = {}
+
+        def capture(params):
+            broadcast['raw'] = params[0]
+            return TX
+
+        rpc_stub(provider, dict(SEND_RESPONSES, eth_sendRawTransaction=capture))
+        assert provider.send_amount(RECIPIENT, 10**16) == (TX, 0)
+
+        expected = Account.sign_transaction(
+            {
+                'chainId': 56,
+                'nonce': 0,
+                'to': RECIPIENT,
+                'value': 10**16,
+                'gas': 25_200,
+                'maxFeePerGas': 3 * 10**9,
+                'maxPriorityFeePerGas': 10**9,
+            },
+            TEST_KEY,
+        )
+        raw = getattr(expected, 'raw_transaction', None) or getattr(expected, 'rawTransaction')
+        assert broadcast['raw'].removeprefix('0x') == raw.hex().removeprefix('0x')
+
+    def test_no_key_refused(self, provider, monkeypatch):
+        monkeypatch.delenv('BNB_PRIVATE_KEY', raising=False)
+        assert provider.send_amount(RECIPIENT, 10**16) is None
+        assert 'BNB_PRIVATE_KEY' in provider.last_send_error
+
+    def test_key_mismatch_refused(self, provider):
+        assert provider.send_amount(RECIPIENT, 10**16, from_address=RECIPIENT) is None
+        assert 'key mismatch' in provider.last_send_error
+
+    def test_insufficient_balance_refused(self, provider):
+        rpc_stub(provider, dict(SEND_RESPONSES, eth_getBalance=hex(10**12)))
+        assert provider.send_amount(RECIPIENT, 10**18) is None
+        assert 'Insufficient BNB' in provider.last_send_error
+
+
+class TestDeliveryGates:
+    """A BSC dest can refuse a native transfer — a contract wallet, or an EOA that delegates to
+    one via EIP-7702 *after* the reservation pinned it. The reserve gate keeps such a swap from
+    starting; the slash gate keeps a miner who cannot pay from being punished for it."""
+
+    def test_reserve_gate_admits_an_eoa_and_blocks_a_reverting_dest(self, provider):
+        rpc_stub(provider, {'eth_getCode': '0x'})
+        assert provider.can_deliver_to(RECIPIENT, 10**16) is True
+
+        def refuse(params):
+            raise RuntimeError('rpc error execution reverted')
+
+        rpc_stub(provider, {'eth_getCode': '0x60806040', 'eth_estimateGas': refuse})
+        assert provider.can_deliver_to(RECIPIENT, 10**16) is False
+
+    def test_slash_gate_exempts_a_dest_that_gained_code_after_reserve(self, provider):
+        since = int(time.time()) - 60
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getCode': '0xef0100' + '11' * 20})
+        assert provider.delivery_refused(RECIPIENT, since) is True
+
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getCode': '0x'})
+        assert provider.delivery_refused(RECIPIENT, since) is False
+
+
+class TestDepositScanner:
+    def test_walk_is_bounded_for_a_sub_second_chain(self, provider):
+        # 5 min of BSC blocks is ~660 real blocks; the stored 1s block time already floors the
+        # lookback at 300, and each one costs a sequential eth_getBlockByNumber. The walk bound
+        # is what keeps a first scan inside a public endpoint's budget.
+        assert provider.SCAN_LOOKBACK_BLOCKS > MAX_WALK_BLOCKS
+
+        scanned = []
+
+        def block(params):
+            scanned.append(int(params[0], 16))
+            return {'transactions': []}
+
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getBlockByNumber': block})
+        assert provider.find_recent_outgoing(RECIPIENT, RECIPIENT, 1) is None
+        assert len(scanned) == MAX_WALK_BLOCKS
+
+    def test_cursor_parks_below_an_unreadable_block(self, provider):
+        def boom(params):
+            raise ConnectionError('down')
+
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getBlockByNumber': boom})
+        assert provider.find_recent_outgoing(RECIPIENT, RECIPIENT, 1) is None
+        # Never leap a block the scan could not read — the deposit in it must stay reachable.
+        assert provider.scan_cursors[(RECIPIENT.lower(), RECIPIENT.lower(), 1)] == 10_000 - MAX_WALK_BLOCKS

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -7,6 +7,7 @@ import pytest
 from allways.assets.evm import EVM_NETWORKS
 from allways.chains import (
     CHAIN_ARBUSDC,
+    CHAIN_BNB,
     CHAIN_BTC,
     CHAIN_ETH,
     CHAIN_HYPE,
@@ -34,6 +35,9 @@ class TestGetChain:
 
     def test_hype(self):
         assert get_chain_def('hype') is CHAIN_HYPE
+
+    def test_bnb(self):
+        assert get_chain_def('bnb') is CHAIN_BNB
 
     def test_unsupported_raises(self):
         with pytest.raises(KeyError):
@@ -67,11 +71,11 @@ class TestGetChain:
     def test_only_self_hosted_assets_lack_a_host_chain(self):
         for chain_id in ('btc', 'tao', 'sol'):
             assert get_chain_def(chain_id).host_chain is None
-        for chain_id in ('eth', 'hype', 'arbusdc'):
+        for chain_id in ('eth', 'hype', 'bnb', 'arbusdc'):
             assert get_chain_def(chain_id).host_chain in EVM_NETWORKS
         # asset_locator is the token-only field: a native coin has no contract to pin.
         assert CHAIN_ARBUSDC.asset_locator.startswith('0x')
-        assert all(get_chain_def(c).asset_locator is None for c in ('btc', 'tao', 'sol', 'eth', 'hype'))
+        assert all(get_chain_def(c).asset_locator is None for c in ('btc', 'tao', 'sol', 'eth', 'hype', 'bnb'))
 
 
 class TestCanonicalPair:
@@ -146,6 +150,10 @@ class TestComputeExtensionTargetSecs:
     def test_hype_remaining_confs(self):
         # hype needs 2 confs, 1s each: remaining=2, raw = 10000 + 2 + 120 = 10122, bucket up to 10200.
         assert compute_extension_target_secs('hype', 0, self.NOW, self.CEILING) == 10_200
+
+    def test_bnb_remaining_confs(self):
+        # bnb needs 15 confs, 1s each: remaining=15, raw = 10000 + 15 + 120 = 10135, bucket up to 10200.
+        assert compute_extension_target_secs('bnb', 0, self.NOW, self.CEILING) == 10_200
 
     def test_unsupported_chain_raises(self):
         with pytest.raises(KeyError):

--- a/tests/test_cli_chain_networks.py
+++ b/tests/test_cli_chain_networks.py
@@ -54,12 +54,13 @@ class TestPinnedContract:
             'eth-network',
             'arb-network',
             'hype-network',
+            'bnb-network',
             'router',
             'env',
         )
 
     def test_chain_network_keys(self):
-        assert CHAIN_NETWORK_KEYS == ('btc-network', 'eth-network', 'arb-network', 'hype-network')
+        assert CHAIN_NETWORK_KEYS == ('btc-network', 'eth-network', 'arb-network', 'hype-network', 'bnb-network')
 
     def test_testnet_bundle(self):
         assert ENV_BUNDLES['testnet'] == {
@@ -69,6 +70,7 @@ class TestPinnedContract:
             'eth-network': 'sepolia',
             'arb-network': 'sepolia',
             'hype-network': 'testnet',
+            'bnb-network': 'testnet',
             'netuid': '19',
             'router': '5HicmHG7fjbxrtx8FZNdv4xxS5jSN84KGpMnTHsKtKv9peao',
         }
@@ -81,6 +83,7 @@ class TestPinnedContract:
             'eth-network': 'mainnet',
             'arb-network': 'mainnet',
             'hype-network': 'mainnet',
+            'bnb-network': 'mainnet',
             'netuid': '7',
             'router': '',
         }
@@ -103,6 +106,7 @@ class TestPinnedContract:
             'eth': ('mainnet', 'sepolia'),
             'arbusdc': ('mainnet', 'sepolia'),
             'hype': ('mainnet', 'testnet'),
+            'bnb': ('mainnet', 'testnet'),
         }
 
 


### PR DESCRIPTION
BSC is a plain EVM JSON-RPC chain, so the pair is a registry row plus a binding of the shared
`EvmCoin` — no contract, DB or consumer changes. Twin: entrius/das-allways#91 — https://github.com/entrius/das-allways/pull/91

## What changed

| File | Change |
|---|---|
| `allways/assets/evm.py` | one `BSC` `EvmNetwork` row + its `EVM_NETWORKS` key |
| `allways/chains.py` | `CHAIN_BNB` + its `SUPPORTED_CHAINS` entry |
| `allways/assets/bnb.py` | the `Bnb` binding, 11 lines |
| `allways/assets/__init__.py` | import, `__all__`, `ASSET_REGISTRY` row |
| `allways/constants.py` | `'bnb'` appended to `LAUNCH_SPOKES` |
| `.env.example`, `README.md` | the `BNB_*` block, mirroring the HYPE spoke |
| `tests/test_bnb_provider.py` | new, 29 tests, fully offline |
| `tests/test_chains.py`, `tests/test_cli_chain_networks.py` | the pinned contracts, updated deliberately |

Everything else derives: CLI keys, env bundles, `alw config` rows, direction pools, E2E scenarios.

## Network facts (probed live, 2026-08-11)

| | mainnet | testnet (Chapel) |
|---|---|---|
| chain id | 56 | 97 |
| explorer | `https://bscscan.com/` | `https://testnet.bscscan.com/` |
| endpoint 1 | `https://bsc-dataseed.bnbchain.org` | `https://bsc-testnet-dataseed.bnbchain.org` |
| endpoint 2 | `https://bsc.blockrazor.xyz` | `https://bsc-testnet-rpc.publicnode.com` |

Chain ids and explorers are both confirmed by Etherscan's own chainlist, which is Cloudflare-free and
is the cheap standard check for these fields:

```
$ curl -s https://api.etherscan.io/v2/chainlist
{'chainname': 'BNB Smart Chain Mainnet', 'chainid': '56', 'blockexplorer': 'https://bscscan.com/', ...}
{'chainname': 'BNB Smart Chain Testnet', 'chainid': '97', 'blockexplorer': 'https://testnet.bscscan.com/', ...}
```

### `eth_chainId` is NOT sufficient verification — read this before adding a BSC endpoint

An endpoint can answer `eth_chainId` perfectly and still be unable to settle a leg.
`https://bsc-rpc.publicnode.com` does exactly that:

```
$ curl -s -X POST -d '{"jsonrpc":"2.0","id":1,"method":"eth_getTransactionReceipt",
                       "params":["0x4ebec27218444ed6f138d50b2eb92e3b49429f0a400b063ff93193bd71fdba0d"]}' \
       https://bsc-rpc.publicnode.com
{"jsonrpc":"2.0","error":{"code":-32602,"message":"Archive requests require a personal token.
 Get one at: https://www.allnodes.com/publicnode"},"id":1}
```

That hash is from **three blocks behind the tip**, so this is not archive depth — publicnode gates
receipts on BSC outright. The receipt is the settlement check (non-negotiable #2: inclusion is not
settlement, `status` must be 1), so an endpoint that cannot serve it cannot verify a leg, no matter
how healthy `eth_chainId` looks. My first pass shipped it as the mainnet primary on a chain-id probe
alone; the fix is to probe the calls the provider actually makes.

Every candidate was re-probed on all of them — 10 rounds each, against a real settled EOA→EOA
transfer, with the `estimateGas`/`call` targets pinned to an EOA so a revert can only mean endpoint
trouble and never an on-chain verdict:

```
=== chain id 56 · 10 rounds · settled tx 0x36bd3d2c... (block 115401336, EOA dest 0x484848...) ===
  FAIL  https://bsc-rpc.publicnode.com
        eth_getTransactionReceipt     0/10  <--   403 Archive requests require a personal token
        (chainId, blockNumber, getTransactionByHash, getBlockByNumber, getBalance,
         getCode, estimateGas, call, absent-tx null: all 10/10)
  PASS  https://bsc-dataseed.bnbchain.org        all 10 probes 10/10
  PASS  https://bsc-dataseed1.bnbchain.org       all 10 probes 10/10
  PASS  https://bsc.blockrazor.xyz               all 10 probes 10/10
  PASS  https://bsc-mainnet.public.blastapi.io   all 10 probes 10/10

=== chain id 97 · 10 rounds · settled tx 0xf52b3560... (block 124544192, EOA dest 0x22359f...) ===
  PASS  https://bsc-testnet-dataseed.bnbchain.org        all 10 probes 10/10
  PASS  https://bsc-testnet-rpc.publicnode.com           all 10 probes 10/10
  PASS  https://data-seed-prebsc-1-s1.bnbchain.org:8545  all 10 probes 10/10
```

Also failed the receipt probe and were dropped: `1rpc.io/bnb` (429, receipt 5/6),
`bsc.meowrpc.com` (429, receipt 0/6), `bsc-pokt.nodies.app` (403 on everything),
`binance.llamarpc.com` (NXDOMAIN), `bsc-testnet.public.blastapi.io` (403),
`bsc-testnet.blockpi.network` (521).

**drpc is excluded too**, for a different reason: `https://bsc.drpc.org` answers a single ping and
returns `429 Too Many Requests` under any burst (0/24 in an earlier load test). A second endpoint
that always errors can never reach null quorum, so with `null_needs_quorum=True` every genuinely
absent tx would raise instead of returning None — structurally broken, not merely flaky.

The shipped ladders are two independent operators per network, each 10/10 on every probe.
publicnode survives on **testnet only** — its Chapel node does serve receipts while its mainnet twin
does not; the `BSC` row carries that asymmetry as a comment so nobody mirrors it upward.

## The judgement calls

**`seconds_per_block` = 1 (stored) / 0.4502s (real).** Measured live off mainnet timestamps:

```
mainnet tip=115398272
  last    100 blocks: 0.4500 s/block
  last   1000 blocks: 0.4520 s/block
  last  10000 blocks: 0.4506 s/block
  last 100000 blocks: 0.4502 s/block
```

Matches the Fermi hard fork (BEP-619, Jan 2026), which took BSC from Maxwell's 0.75s to 0.45s. The
field is an int, so 1 is the floor — the same treatment `sol` and `arbusdc` already get. Consequences:
`SCAN_LOOKBACK_BLOCKS` becomes `300 // 1 = 300` blocks, which is ~135 real seconds rather than the
nominal 300, and `MAX_WALK_BLOCKS = 32` then caps a first scan at ~14 real seconds of chain. Harmless
— the scanner is a hash-finder whose output the confirm path re-verifies by hash — and pinned by
`test_walk_is_bounded_for_a_sub_second_chain`. `compute_extension_target_secs` over-estimates the
remaining wall time by ~2.2x, which errs toward extending longer.

**`min_confirmations` = 15.** BEP-126 finalizes a block once it and its direct child each carry
attestations from >2/3 of the 21-validator set — ~2 blocks, ~1.1s. That quorum is not guaranteed:
BSC rotates its consensus set each epoch (21 drawn from 45 active), and when attestation falls below
the threshold BEP-126 explicitly degrades to "the chain can grow with the previous longest chain
rule … remain original probabilistic finality".

What bounds a single dishonest proposer in that fallback regime is **`turn_length`** — the run of
consecutive blocks one validator signs under BEP-341 — not a count of distinct validators. Measured
live on mainnet: every run was exactly 8 (37/37 runs over 300 blocks, 21 distinct signers). So 15
confirmations spans ~1.9 signers, not 15; the number is right because it outlasts one full turn, so
no lone validator can build the whole span. `turn_length` is a governance parameter that has already
been raised twice, so the registry comment says to raise the depth above it if it rises again.

(My first draft justified 15 as `2/3·21+1`, the pre-BEP-126 bound. That arithmetic does not describe
what 15 blocks buys on today's BSC; the comment now ties the depth to `turn_length` instead.)

Implied leg latency: **15 × 1s = 15s** in registry math, **15 × 0.45s ≈ 6.8s** real. The program's
default fulfillment grace is 600s and BNB is not in the grace table, so both sit far inside it —
asserted by `test_confirmations_stay_inside_the_program_fulfillment_grace`.

**`min_onchain_amount` = 200_000_000_000_000 wei (0.0002 BNB).** A rate-sanity input to
`is_executable_rate`, not an enforced minimum — BSC has no protocol dust floor, and miners price real
gas into their quotes. Sized at a realistic-high gas level, not today's: 0.0002 BNB covers a 21k-gas
transfer below ~9.5 gwei. BSC's validator-set minimum gas price was 5 gwei through 2022–2023 and
3 gwei until April 2024, 1 gwei until May 2025, 0.1 until Oct 2025, and 0.05 gwei today — so the
floor is ~200x the current quiet-day fee and still ~2x the multi-year norm. A legitimate leg stops
being worth its own fee above ~9.5 gwei; at 0.0002 BNB ≈ $0.12 (BNB $613) that break-even is honest
rather than protective.

**`replay_grace_secs` = 60.** Justified on hub-vs-spoke clock skew, not monotonicity: BSC block
timestamps are consensus-stamped and non-decreasing, but that says nothing about the offset between a
BSC block clock and the Solana hub clock that stamps `reservation.created_at`. 60s is the same modest
allowance Arbitrum and Hyperliquid carry, and stays far under `reservation_ttl_secs`.

**`host_chain` = `'bsc'`.** The key names the NETWORK, and BSC is that network's universal
identifier; keeping it distinct from the `bnb` asset id is the same seam `arbitrum`/`arbusdc` draws.

## Evidence

### Lint

```
$ uv run ruff format --check . && uv run ruff check .
154 files already formatted
All checks passed!
```

### Tests

```
$ uv run pytest tests/ -q
1152 passed, 6 deselected, 3 warnings in 9.79s

$ uv run pytest tests/test_bnb_provider.py -q
29 passed in 0.58s
```

`tests/test_bnb_provider.py` is fully offline (the RPC layer is a method→response map). It covers
network selection incl. wrong-network startup rejection, settled / pending-depth / reverted /
not-found / underpaid / wrong-recipient verification, receipt and timestamp unavailability raising
`ProviderUnreachableError`, the send guards (no key / key mismatch / insufficient balance / exact
signed payload at chain id 56), the deposit scanner's walk bound and cursor parking, and BSC's own
hazard — a destination that refuses a native transfer.

### The BSC-specific hazard: a dest that stops accepting BNB

`TestDeliveryGates` pins the pair. `can_deliver_to` admits an EOA and blocks a code-bearing dest whose
simulated transfer reverts, so such a swap never reserves.

`delivery_refused` is pinned with a **block-aware** stub, against a frozen clock. Code exists at the
window's *midpoint offset only* — `latest` is clean and so is the far edge — which reproduces the case
the gate actually exists for: a dest that delegates via EIP-7702 after the reservation pinned it and
revokes before the slash check. A gate that only read `latest` would miss it and slash an honest
miner. The test asserts the exact probe sequence `['latest', 0x26d4, 0x26f2]`, so all three offsets
and the span arithmetic are covered, and it fails if the historical probes are removed (verified by
mutation: dropping them turns the assertion red).

Shared implementation untouched. One true thing the block-aware stub surfaced, recorded in a test
comment and **not fixed here**: `delivery_refused`'s `span = min(120, …)` is 120 blocks, which on
BSC's 0.45s blocks is only ~54s of real history (vs ~24 min on Ethereum), so the docstring's "sampled
across the window since `since_unix`" stops being true beyond 54s. That is `evm_coin.py`, shared with
live `eth` and `hype`, and belongs to the separate porting PR tracked in
`tmp/todos/C3-evmcoin-missing-erc20-hardening.md` — out of bounds for an add-an-asset change.

### Live read-only verification, both networks

```
===== BNB mainnet =====
ladder      : BNB Smart Chain JSON-RPC (mainnet): bsc-dataseed.bnbchain.org, bsc.blockrazor.xyz
chain_id    : 56 | tip: 115401735
recipient   : 0x6AddB9d2DaFD3805f2B89bb436B622D6C1D25F8D (mixed-case, on-chain is lowercase)
settled     : 0x2cceea19422482871a... -> confirmed=True confs=3062 amount=313905500000000000 sender=0xaad48722d43117b32d180d3744a3ee7d1c924653 block=115398675 block_time=1786490003
underpaid   : None (expected None)
wrong sender: None (expected None)
unknown tx  : None (expected None)
balance     : 81485454000000 wei

===== BNB testnet =====
ladder      : BNB Smart Chain JSON-RPC (testnet): bsc-testnet-dataseed.bnbchain.org, bsc-testnet-rpc.publicnode.com
chain_id    : 97 | tip: 124544469
recipient   : 0x42Be57bCE00DE34565984b2715290CBDB249Aa2D (mixed-case, on-chain is lowercase)
settled     : 0x999b84842a32f2e59a... -> confirmed=True confs=3057 amount=1371800000000000 sender=0x53e410535eb2989aec872ceb87670b9a70934c94 block=124541414 block_time=1786490008
underpaid   : None (expected None)
wrong sender: None (expected None)
unknown tx  : None (expected None)
balance     : 1371800000000000 wei
```

Each settled read went through `verify_transaction(..., expected_sender=<real sender>,
require_confirmed=True)` with the recipient passed EIP-55 checksummed while the chain serves it
lowercase. No failover warnings on either network — every call was served by the primary. The
earlier run on the publicnode-primary ladder logged
`publicnode eth_getTransactionReceipt → HTTP 403; falling back to: bnbchain` on every settled read,
which is what the receipt probe above turned into a hard exclusion.

### Derived CLI surfaces

```
$ uv run alw miner quotes --help
│ --bnb-price      NUMBER   BNB per 1 SOL (0/omit to skip BNB).
│ --bnb-address    TEXT     Your BNB address.

$ uv run alw config
│ hype-network   │ mainnet │ default │
│ bnb-network    │ mainnet │ default │
```

### E2E scenarios

```
$ cd alw-utils/dev-environment/solana
$ PYTHONPATH=<this branch's worktree> ./run-suites.sh --list
scenarios:
  sol-btc / btc-sol / sol-tao / tao-sol / sol-eth / eth-sol / sol-arbusdc / arbusdc-sol
  sol-hype / hype-sol
  sol-bnb
  bnb-sol
  blacklist-gate / slash / weights / tao-happy / tao-timeout / w4-*
```

`PYTHONPATH` is required because `run-suites.sh` pins its interpreter to the main checkout's venv;
without it the listing derives from whatever branch that tree is on, not this one. No harness code was
written — the rows derive from `LAUNCH_SPOKES`. **I did not execute a suite** (it needs the full local
stack up).

## Emissions note

`LAUNCH_SPOKES` goes 5 → 6, so `compute_direction_pools` divides by one more pair. A pair with zero
volume in a round now floors at `(1 − POOL_VOLUME_ALPHA) / pairs = 0.34 / 6 = 5.67%` of the miner
pool, down from `0.34 / 5 = 6.8%` — every existing pair's zero-volume floor drops ~17%.

## Merge order

Merge this first. The das twin's CI drift gate reads `chains.py` from `test`, so it stays red until
this lands.
