### PR TITLE
Add AVAX (Avalanche C-Chain) as a launch spoke

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,13 @@ BNB_NETWORK=mainnet                 # mainnet | testnet (Chapel)
 # BNB_RPC_URLS=https://bsc-mainnet.infura.io/v3/your_key,https://bsc-rpc.publicnode.com
 # 32-byte hex key — required for miners; optional local signing for `alw swap`
 BNB_PRIVATE_KEY=
+# ─── Chain: Avalanche C-Chain (AVAX pairs) ─────────────────
+AVAX_NETWORK=mainnet                # mainnet | fuji
+# OPTIONAL ordered JSON-RPC endpoints (keyed providers embed the key in the URL);
+# unset = public (publicnode, drpc). Ava Labs' own gateways carry a path and work as-is.
+# AVAX_RPC_URLS=https://api.avax.network/ext/bc/C/rpc,https://avalanche-c-chain-rpc.publicnode.com
+# 32-byte hex key — required for miners; optional local signing for `alw swap`
+AVAX_PRIVATE_KEY=
 
 # ─── Miner-only ────────────────────────────────────────────
 # headless miners: unlocks the coldkey at startup for TAO sends; unset = prompt at launch

--- a/.env.example
+++ b/.env.example
@@ -72,8 +72,8 @@ BNB_PRIVATE_KEY=
 # ─── Chain: Avalanche C-Chain (AVAX pairs) ─────────────────
 AVAX_NETWORK=mainnet                # mainnet | fuji
 # OPTIONAL ordered JSON-RPC endpoints (keyed providers embed the key in the URL);
-# unset = public (publicnode, drpc). Ava Labs' own gateways carry a path and work as-is.
-# AVAX_RPC_URLS=https://api.avax.network/ext/bc/C/rpc,https://avalanche-c-chain-rpc.publicnode.com
+# unset = public (Ava Labs' gateway, publicnode, drpc); the gateway leads as the only archive rung
+# AVAX_RPC_URLS=https://avalanche-mainnet.infura.io/v3/your_key,https://api.avax.network/ext/bc/C/rpc
 # 32-byte hex key — required for miners; optional local signing for `alw swap`
 AVAX_PRIVATE_KEY=
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Native transactions across independent assets — no wrapped tokens, no bridges,
 
 Allways creates a verification layer above independent systems. Assets move natively. Miners complete transactions, validators independently verify the results, and a smart contract enforces outcomes through collateral and slashing.
 
-Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, and SOL ↔ BNB (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
+Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, and SOL ↔ AVAX (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
 
 ## Miner Risk Disclaimer
 
@@ -123,7 +123,7 @@ needs to persist across restarts.
 
 ## Miner Environment Variables
 
-- `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `BNB_PRIVATE_KEY`, `{ETH,ARB,HYPE,BNB}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config. See `.env.example`.
+- `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `BNB_PRIVATE_KEY`, `AVAX_PRIVATE_KEY`, `{ETH,ARB,HYPE,BNB,AVAX}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config. See `.env.example`.
 
 ## Running a Local Subtensor Lite Node (Validators)
 

--- a/allways/assets/__init__.py
+++ b/allways/assets/__init__.py
@@ -4,8 +4,8 @@ import bittensor as bt
 
 from allways.assets.arbusdc import ArbUsdc
 from allways.assets.asset import Asset, SendResult, TransactionInfo
-from allways.assets.bnb import Bnb
 from allways.assets.avax import Avax
+from allways.assets.bnb import Bnb
 from allways.assets.btc import Bitcoin
 from allways.assets.chain import Chain
 from allways.assets.erc20 import Erc20

--- a/allways/assets/__init__.py
+++ b/allways/assets/__init__.py
@@ -5,6 +5,7 @@ import bittensor as bt
 from allways.assets.arbusdc import ArbUsdc
 from allways.assets.asset import Asset, SendResult, TransactionInfo
 from allways.assets.bnb import Bnb
+from allways.assets.avax import Avax
 from allways.assets.btc import Bitcoin
 from allways.assets.chain import Chain
 from allways.assets.erc20 import Erc20
@@ -27,6 +28,7 @@ __all__ = [
     'Ether',
     'Hype',
     'Bnb',
+    'Avax',
     'Erc20',
     'ArbUsdc',
     'create_assets',
@@ -50,6 +52,7 @@ ASSET_REGISTRY: Tuple[AssetSpec, ...] = (
     AssetSpec('arbusdc', ArbUsdc, ()),
     AssetSpec('hype', Hype, ()),
     AssetSpec('bnb', Bnb, ()),
+    AssetSpec('avax', Avax, ()),
 )
 
 

--- a/allways/assets/avax.py
+++ b/allways/assets/avax.py
@@ -1,0 +1,12 @@
+from allways.assets.evm_coin import EvmCoin
+from allways.chains import CHAIN_AVAX
+
+
+class Avax(EvmCoin):
+    """AVAX on the Avalanche C-Chain — a config-row binding of the generic EvmCoin (see chains.CHAIN_AVAX).
+
+    The C-Chain speaks plain JSON-RPC. Its atomic P/X-chain imports credit a balance outside the EVM
+    tx set entirely, so they are invisible here — a swap leg has to be an ordinary EVM transfer."""
+
+    def __init__(self):
+        super().__init__(CHAIN_AVAX)

--- a/allways/assets/evm.py
+++ b/allways/assets/evm.py
@@ -108,18 +108,18 @@ BSC = EvmNetwork(
 AVALANCHE = EvmNetwork(
     label='Avalanche',
     chain_ids={'mainnet': 43_114, 'fuji': 43_113},
-    # Three rungs: publicnode prunes historical state and drpc's free tier times out on it, but
-    # delivery_refused's getCode-at-depth probes need it — Ava Labs' own gateway always serves them.
+    # Ava Labs' gateway leads because it is the only rung serving historical eth_getCode, which
+    # delivery_refused probes on every overdue swap — publicnode prunes state, drpc times out.
     rpc_urls={
         'mainnet': (
+            'https://api.avax.network/ext/bc/C/rpc',
             'https://avalanche-c-chain-rpc.publicnode.com',
             'https://avalanche.drpc.org',
-            'https://api.avax.network/ext/bc/C/rpc',
         ),
         'fuji': (
+            'https://api.avax-test.network/ext/bc/C/rpc',
             'https://avalanche-fuji-c-chain-rpc.publicnode.com',
             'https://avalanche-fuji.drpc.org',
-            'https://api.avax-test.network/ext/bc/C/rpc',
         ),
     },
 )

--- a/allways/assets/evm.py
+++ b/allways/assets/evm.py
@@ -108,9 +108,19 @@ BSC = EvmNetwork(
 AVALANCHE = EvmNetwork(
     label='Avalanche',
     chain_ids={'mainnet': 43_114, 'fuji': 43_113},
+    # Three rungs: publicnode prunes historical state and drpc's free tier times out on it, but
+    # delivery_refused's getCode-at-depth probes need it — Ava Labs' own gateway always serves them.
     rpc_urls={
-        'mainnet': ('https://avalanche-c-chain-rpc.publicnode.com', 'https://avalanche.drpc.org'),
-        'fuji': ('https://avalanche-fuji-c-chain-rpc.publicnode.com', 'https://avalanche-fuji.drpc.org'),
+        'mainnet': (
+            'https://avalanche-c-chain-rpc.publicnode.com',
+            'https://avalanche.drpc.org',
+            'https://api.avax.network/ext/bc/C/rpc',
+        ),
+        'fuji': (
+            'https://avalanche-fuji-c-chain-rpc.publicnode.com',
+            'https://avalanche-fuji.drpc.org',
+            'https://api.avax-test.network/ext/bc/C/rpc',
+        ),
     },
 )
 

--- a/allways/assets/evm.py
+++ b/allways/assets/evm.py
@@ -105,6 +105,12 @@ BSC = EvmNetwork(
         'mainnet': ('https://bsc-dataseed.bnbchain.org', 'https://bsc.blockrazor.xyz'),
         # publicnode's TESTNET node does serve receipts — the asymmetry with mainnet is deliberate.
         'testnet': ('https://bsc-testnet-dataseed.bnbchain.org', 'https://bsc-testnet-rpc.publicnode.com'),
+AVALANCHE = EvmNetwork(
+    label='Avalanche',
+    chain_ids={'mainnet': 43_114, 'fuji': 43_113},
+    rpc_urls={
+        'mainnet': ('https://avalanche-c-chain-rpc.publicnode.com', 'https://avalanche.drpc.org'),
+        'fuji': ('https://avalanche-fuji-c-chain-rpc.publicnode.com', 'https://avalanche-fuji.drpc.org'),
     },
 )
 
@@ -114,6 +120,7 @@ EVM_NETWORKS: Mapping[str, EvmNetwork] = {
     'arbitrum': ARBITRUM,
     'hyperliquid': HYPERLIQUID,
     'bsc': BSC,
+    'avalanche': AVALANCHE,
 }
 
 

--- a/allways/assets/evm.py
+++ b/allways/assets/evm.py
@@ -105,6 +105,9 @@ BSC = EvmNetwork(
         'mainnet': ('https://bsc-dataseed.bnbchain.org', 'https://bsc.blockrazor.xyz'),
         # publicnode's TESTNET node does serve receipts — the asymmetry with mainnet is deliberate.
         'testnet': ('https://bsc-testnet-dataseed.bnbchain.org', 'https://bsc-testnet-rpc.publicnode.com'),
+    },
+)
+
 AVALANCHE = EvmNetwork(
     label='Avalanche',
     chain_ids={'mainnet': 43_114, 'fuji': 43_113},

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -178,6 +178,10 @@ CHAIN_BNB = ChainDefinition(
     # ~9.5 gwei — well above the 3-5 gwei BSC sustained through 2022-2024, and ~200x today's
     # 0.05 gwei minimum. Miners price real gas into their quotes.
     min_onchain_amount=200_000_000_000_000,
+    # Consensus-stamped timestamps vs the hub clock — modest skew allowance, as on Arbitrum.
+    replay_grace_secs=60,
+)
+
 CHAIN_AVAX = ChainDefinition(
     id='avax',
     name='Avalanche',

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -178,6 +178,23 @@ CHAIN_BNB = ChainDefinition(
     # ~9.5 gwei — well above the 3-5 gwei BSC sustained through 2022-2024, and ~200x today's
     # 0.05 gwei minimum. Miners price real gas into their quotes.
     min_onchain_amount=200_000_000_000_000,
+CHAIN_AVAX = ChainDefinition(
+    id='avax',
+    name='Avalanche',
+    native_unit='wei',
+    decimals=18,
+    env_prefix='AVAX',
+    host_chain='avalanche',
+    networks=('mainnet', 'fuji'),
+    testnet_network='fuji',
+    # ~1.1s measured on C-Chain mainnet; the integer floor is 1, as on Arbitrum.
+    seconds_per_block=1,
+    # Snowman accepts a block irreversibly, so finality IS inclusion — there is no reorg
+    # depth to outrun. 2 is a one-block margin against an endpoint serving an unaccepted head.
+    min_confirmations=2,
+    # Rate sanity floor, not an economic guarantee: 0.001 AVAX covers a 21k-gas transfer below
+    # ~47 gwei — a congested C-Chain level, ~1000x the quiet base fee its dynamic fee floats at.
+    min_onchain_amount=1_000_000_000_000_000,
     # Consensus-stamped timestamps vs the hub clock — modest skew allowance, as on Arbitrum.
     replay_grace_secs=60,
 )
@@ -190,6 +207,7 @@ SUPPORTED_CHAINS = {
     'arbusdc': CHAIN_ARBUSDC,
     'hype': CHAIN_HYPE,
     'bnb': CHAIN_BNB,
+    'avax': CHAIN_AVAX,
 }
 
 

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -87,7 +87,7 @@ def hub_leg(from_chain: str, to_chain: str) -> str | None:
 
 
 # Chains paired against each hub; add a chain here to launch its pairs.
-LAUNCH_SPOKES = ('btc', 'tao', 'eth', 'arbusdc', 'hype', 'bnb')
+LAUNCH_SPOKES = ('btc', 'tao', 'eth', 'arbusdc', 'hype', 'bnb', 'avax')
 # Every launch pair as (hub, spoke): each hub pairs against every spoke except itself. sol↔tao
 # lands exactly once (under SOL, its anchor) because sol never appears in LAUNCH_SPOKES.
 LAUNCH_PAIRS: tuple[tuple[str, str], ...] = tuple(

--- a/tests/test_avax_provider.py
+++ b/tests/test_avax_provider.py
@@ -1,0 +1,268 @@
+"""Avax unit tests — all offline (RPC layer mocked, signing is pure crypto).
+
+The EVM behaviour itself is `EvmCoin`, proven by the Ether suite. What is AVAX-specific — and
+what a wrong value here would cost — lives in the binding: which network the env selects, the
+chain id every signed tx commits to, and the C-Chain's atomic P/X-chain imports, which credit a
+balance with no EVM transaction and so must stay invisible to the deposit scanner.
+"""
+
+import pytest
+from eth_account import Account
+
+from allways.assets.asset import ProviderUnreachableError
+from allways.assets.avax import Avax
+from allways.assets.evm import AVALANCHE, EvmChain
+from allways.assets.evm_coin import MAX_WALK_BLOCKS
+from allways.chains import CHAIN_AVAX, get_chain_def
+from allways.constants import LAUNCH_SPOKES
+
+TEST_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'  # hardhat account #0
+RECIPIENT = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+OTHER = '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC'
+TX = '0x' + 'ab' * 32
+BLOCK_HASH = '0x' + 'cd' * 32
+
+SEND_RESPONSES = {
+    'eth_blockNumber': hex(100),
+    'eth_getBlockByNumber': {'baseFeePerGas': hex(10**9)},
+    'eth_maxPriorityFeePerGas': hex(10**9),
+    'eth_getTransactionCount': '0x0',
+    'eth_getBalance': hex(10**19),
+    'eth_estimateGas': hex(21_000),
+}
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    monkeypatch.setenv('AVAX_NETWORK', 'mainnet')
+    monkeypatch.delenv('AVAX_RPC_URLS', raising=False)
+    monkeypatch.delenv('AVAX_PRIVATE_KEY', raising=False)
+    return Avax()
+
+
+def rpc_stub(provider, responses: dict):
+    """Replace eth_rpc with a method→response map. A callable value is invoked with params."""
+
+    def fake_rpc(method, params, timeout=15, **kw):
+        value = responses[method]
+        return value(params) if callable(value) else value
+
+    provider.chain.eth_rpc = fake_rpc
+    return provider
+
+
+def mined_responses(status='0x1', tip=1_000_002, value_hex=hex(10**18), to=RECIPIENT):
+    return {
+        'eth_getTransactionByHash': {
+            'hash': TX,
+            'from': '0x' + '11' * 20,
+            'to': to,
+            'value': value_hex,
+            'blockNumber': '0xf4240',
+            'blockHash': BLOCK_HASH,
+        },
+        'eth_getTransactionReceipt': {'status': status, 'blockNumber': '0xf4240', 'blockHash': BLOCK_HASH},
+        'eth_blockNumber': hex(tip),
+        'eth_getBlockByNumber': {'hash': BLOCK_HASH, 'timestamp': '0x64'},
+    }
+
+
+class TestRegistryRow:
+    def test_is_a_launch_spoke_bound_to_its_registry_row(self, provider):
+        assert provider.chain_def is CHAIN_AVAX is get_chain_def('avax')
+        assert 'avax' in LAUNCH_SPOKES
+
+    def test_native_coin_composes_its_chain(self, provider):
+        # A native coin is an asset ON its network, not the network — same seam as a token,
+        # so a second asset can land beside it without either claiming to be the chain.
+        assert isinstance(provider.chain, EvmChain) and provider.chain is not provider
+        assert provider.chain.env_prefix == CHAIN_AVAX.env_prefix
+
+    def test_decimals_and_prefix(self):
+        assert (CHAIN_AVAX.decimals, CHAIN_AVAX.env_prefix, CHAIN_AVAX.native_unit) == (18, 'AVAX', 'wei')
+
+    def test_confirmations_stay_inside_the_program_fulfillment_grace(self):
+        # An unlisted chain gets the program's 600s default grace; 2 × 1s blocks is far inside it.
+        assert CHAIN_AVAX.min_confirmations * CHAIN_AVAX.seconds_per_block < 600
+
+
+class TestNetworkSelection:
+    def test_mainnet_chain_id(self, provider):
+        assert provider.chain.chain_id == 43_114
+
+    def test_fuji_chain_id(self, monkeypatch):
+        monkeypatch.setenv('AVAX_NETWORK', 'fuji')
+        assert Avax().chain.chain_id == 43_113
+
+    def test_unknown_network_raises(self, monkeypatch):
+        # A typo must never fall back to mainnet — that spends real AVAX against test swaps.
+        # 'testnet' is the typo to beat here: Avalanche's testnet is named fuji.
+        monkeypatch.setenv('AVAX_NETWORK', 'testnet')
+        with pytest.raises(ValueError, match='AVAX_NETWORK'):
+            Avax()
+
+    def test_unset_network_defaults_to_mainnet(self, monkeypatch):
+        monkeypatch.delenv('AVAX_NETWORK', raising=False)
+        assert Avax().chain.network == 'mainnet'
+
+    @pytest.mark.parametrize('network', tuple(AVALANCHE.chain_ids))
+    def test_every_network_has_a_keyless_default_ladder(self, monkeypatch, network):
+        monkeypatch.setenv('AVAX_NETWORK', network)
+        assert Avax().chain.rpc_bases == list(AVALANCHE.rpc_urls[network])
+
+    def test_rpc_urls_env_keeps_the_c_chain_path(self, monkeypatch):
+        # Ava Labs' own gateways are path-bearing (/ext/bc/C/rpc) unlike every other EVM
+        # endpoint in the registry; only a trailing slash may be trimmed.
+        monkeypatch.setenv('AVAX_RPC_URLS', 'https://api.avax.network/ext/bc/C/rpc/,https://backup.example')
+        assert Avax().chain.rpc_bases == ['https://api.avax.network/ext/bc/C/rpc', 'https://backup.example']
+
+    def test_wrong_network_endpoint_fails_startup(self, monkeypatch):
+        # Fuji configured, a mainnet endpoint answering: the ladder must be rejected outright,
+        # never quietly used to verify legs against the wrong chain.
+        monkeypatch.setenv('AVAX_NETWORK', 'fuji')
+        p = rpc_stub(Avax(), {'eth_chainId': hex(43_114)})
+        with pytest.raises(ConnectionError, match='expected 43113'):
+            p.check_connection(require_send=False)
+
+
+class TestVerification:
+    def test_settled_transfer_matches(self, provider):
+        rpc_stub(provider, mined_responses())
+        info = provider.fetch_matching_tx(TX, RECIPIENT, 10**18)
+        assert info is not None and info.confirmed and info.amount == 10**18
+        assert info.block_time == 0x64
+
+    def test_two_confirmations_are_enough(self, provider):
+        rpc_stub(provider, mined_responses(tip=1_000_001))  # mined block + 1
+        assert provider.fetch_matching_tx(TX, RECIPIENT, 10**18).confirmed
+
+    def test_one_confirmation_is_not(self, provider):
+        rpc_stub(provider, mined_responses(tip=1_000_000))
+        assert provider.fetch_matching_tx(TX, RECIPIENT, 10**18).confirmed is False
+
+    def test_mempool_tx_matches_but_is_unconfirmed(self, provider):
+        responses = mined_responses()
+        responses['eth_getTransactionByHash'] |= {'blockNumber': None, 'blockHash': None}
+        info = rpc_stub(provider, responses).fetch_matching_tx(TX, RECIPIENT, 10**18)
+        assert info is not None and info.confirmed is False and info.block_time is None
+
+    def test_reverted_tx_rejected(self, provider):
+        # Inclusion is not settlement: a reverted tx still carries intact to/value fields.
+        rpc_stub(provider, mined_responses(status='0x0'))
+        assert provider.fetch_matching_tx(TX, RECIPIENT, 10**18) is None
+
+    def test_underpayment_rejected(self, provider):
+        rpc_stub(provider, mined_responses(value_hex=hex(10**17)))
+        assert provider.fetch_matching_tx(TX, RECIPIENT, 10**18) is None
+
+    def test_wrong_recipient_rejected(self, provider):
+        rpc_stub(provider, mined_responses(to=OTHER))
+        assert provider.fetch_matching_tx(TX, RECIPIENT, 10**18) is None
+
+    def test_absent_tx_is_absent(self, provider):
+        rpc_stub(provider, {'eth_getTransactionByHash': None})
+        assert provider.fetch_matching_tx(TX, RECIPIENT, 10**18) is None
+
+    def test_unreadable_receipt_is_unknown_not_absent(self, provider):
+        # 'unknown' must never read as 'no such payment' — that verdict slashes a paying miner.
+        responses = mined_responses()
+        responses['eth_getTransactionReceipt'] = None
+        with pytest.raises(ProviderUnreachableError):
+            rpc_stub(provider, responses).fetch_matching_tx(TX, RECIPIENT, 10**18)
+
+    def test_unreadable_block_timestamp_is_unknown_not_absent(self, provider):
+        # is_tx_fresh fails closed on a missing block_time, so a stale-looking dest leg
+        # would ride to a TIMEOUT slash. Raise instead and let the caller retry.
+        responses = mined_responses()
+        responses['eth_getBlockByNumber'] = {'hash': BLOCK_HASH}
+        with pytest.raises(ProviderUnreachableError):
+            rpc_stub(provider, responses).fetch_matching_tx(TX, RECIPIENT, 10**18)
+
+
+class TestSending:
+    @pytest.fixture(autouse=True)
+    def _key(self, provider, monkeypatch):
+        monkeypatch.setenv('AVAX_PRIVATE_KEY', TEST_KEY)
+
+    def test_broadcasts_a_c_chain_signed_transfer(self, provider):
+        # Pins the whole signed payload: chain id 43114 (a tx signed for any other chain is simply
+        # invalid here), EIP-1559 fees off the stubbed base fee, and the estimated gas + 20%.
+        broadcast = {}
+
+        def capture(params):
+            broadcast['raw'] = params[0]
+            return TX
+
+        rpc_stub(provider, dict(SEND_RESPONSES, eth_sendRawTransaction=capture))
+        assert provider.send_amount(RECIPIENT, 10**16) == (TX, 0)
+
+        expected = Account.sign_transaction(
+            {
+                'chainId': 43_114,
+                'nonce': 0,
+                'to': RECIPIENT,
+                'value': 10**16,
+                'gas': 25_200,
+                'maxFeePerGas': 3 * 10**9,
+                'maxPriorityFeePerGas': 10**9,
+            },
+            TEST_KEY,
+        )
+        raw = getattr(expected, 'raw_transaction', None) or getattr(expected, 'rawTransaction')
+        assert broadcast['raw'].removeprefix('0x') == raw.hex().removeprefix('0x')
+
+    def test_no_key_refused(self, provider, monkeypatch):
+        monkeypatch.delenv('AVAX_PRIVATE_KEY', raising=False)
+        assert provider.send_amount(RECIPIENT, 10**16) is None
+        assert 'AVAX_PRIVATE_KEY' in provider.last_send_error
+
+    def test_key_mismatch_refused(self, provider):
+        assert provider.send_amount(RECIPIENT, 10**16, from_address=RECIPIENT) is None
+        assert 'key mismatch' in provider.last_send_error
+
+    def test_insufficient_balance_refused(self, provider):
+        rpc_stub(provider, dict(SEND_RESPONSES, eth_getBalance=hex(10**12)))
+        assert provider.send_amount(RECIPIENT, 10**18) is None
+        assert 'Insufficient AVAX' in provider.last_send_error
+
+
+class TestDepositScanner:
+    def test_walk_is_bounded_for_a_sub_second_chain(self, provider):
+        # 5 min of ~1.1s blocks would be ~300 sequential eth_getBlockByNumber calls per first
+        # scan. The walk bound is what keeps a public endpoint's rate budget intact.
+        assert provider.SCAN_LOOKBACK_BLOCKS > MAX_WALK_BLOCKS
+
+        scanned = []
+
+        def block(params):
+            scanned.append(int(params[0], 16))
+            return {'transactions': []}
+
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getBlockByNumber': block})
+        assert provider.find_recent_outgoing(RECIPIENT, RECIPIENT, 1) is None
+        assert len(scanned) == MAX_WALK_BLOCKS
+
+    def test_cursor_parks_below_an_unreadable_block(self, provider):
+        def boom(params):
+            raise ConnectionError('down')
+
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getBlockByNumber': boom})
+        assert provider.find_recent_outgoing(RECIPIENT, RECIPIENT, 1) is None
+        # Never leap a block the scan could not read — the deposit in it must stay reachable.
+        assert provider.scan_cursors[(RECIPIENT.lower(), RECIPIENT.lower(), 1)] == 10_000 - MAX_WALK_BLOCKS
+
+    def test_atomic_import_is_not_a_deposit(self, provider):
+        # A P/X→C atomic import credits an EVM address from the block's extra data, producing no
+        # EVM transaction: the payment is real but unverifiable, so the scanner must not claim it
+        # (a claim needs a tx hash the confirm path can re-verify, and there is none).
+        # The C-Chain's extra block fields must also not perturb the walk.
+        atomic_block = {
+            'transactions': [],
+            'extDataGasUsed': '0x2bde',
+            'extDataHash': '0x' + 'ef' * 32,
+            'blockExtraData': '0x0000000000010000000000000001',
+            'blockGasCost': '0x0',
+            'timestampMilliseconds': '0x18f',
+        }
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getBlockByNumber': atomic_block})
+        assert provider.find_recent_outgoing(OTHER, RECIPIENT, 1) is None

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -7,8 +7,8 @@ import pytest
 from allways.assets.evm import EVM_NETWORKS
 from allways.chains import (
     CHAIN_ARBUSDC,
-    CHAIN_BNB,
     CHAIN_AVAX,
+    CHAIN_BNB,
     CHAIN_BTC,
     CHAIN_ETH,
     CHAIN_HYPE,
@@ -39,6 +39,7 @@ class TestGetChain:
 
     def test_bnb(self):
         assert get_chain_def('bnb') is CHAIN_BNB
+
     def test_avax(self):
         assert get_chain_def('avax') is CHAIN_AVAX
 

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -8,6 +8,7 @@ from allways.assets.evm import EVM_NETWORKS
 from allways.chains import (
     CHAIN_ARBUSDC,
     CHAIN_BNB,
+    CHAIN_AVAX,
     CHAIN_BTC,
     CHAIN_ETH,
     CHAIN_HYPE,
@@ -38,6 +39,8 @@ class TestGetChain:
 
     def test_bnb(self):
         assert get_chain_def('bnb') is CHAIN_BNB
+    def test_avax(self):
+        assert get_chain_def('avax') is CHAIN_AVAX
 
     def test_unsupported_raises(self):
         with pytest.raises(KeyError):
@@ -71,11 +74,11 @@ class TestGetChain:
     def test_only_self_hosted_assets_lack_a_host_chain(self):
         for chain_id in ('btc', 'tao', 'sol'):
             assert get_chain_def(chain_id).host_chain is None
-        for chain_id in ('eth', 'hype', 'bnb', 'arbusdc'):
+        for chain_id in ('eth', 'hype', 'bnb', 'avax', 'arbusdc'):
             assert get_chain_def(chain_id).host_chain in EVM_NETWORKS
         # asset_locator is the token-only field: a native coin has no contract to pin.
         assert CHAIN_ARBUSDC.asset_locator.startswith('0x')
-        assert all(get_chain_def(c).asset_locator is None for c in ('btc', 'tao', 'sol', 'eth', 'hype', 'bnb'))
+        assert all(get_chain_def(c).asset_locator is None for c in ('btc', 'tao', 'sol', 'eth', 'hype', 'bnb', 'avax'))
 
 
 class TestCanonicalPair:

--- a/tests/test_cli_chain_networks.py
+++ b/tests/test_cli_chain_networks.py
@@ -61,8 +61,14 @@ class TestPinnedContract:
         )
 
     def test_chain_network_keys(self):
-        assert CHAIN_NETWORK_KEYS == ('btc-network', 'eth-network', 'arb-network', 'hype-network', 'bnb-network')
-        assert CHAIN_NETWORK_KEYS == ('btc-network', 'eth-network', 'arb-network', 'hype-network', 'avax-network')
+        assert CHAIN_NETWORK_KEYS == (
+            'btc-network',
+            'eth-network',
+            'arb-network',
+            'hype-network',
+            'bnb-network',
+            'avax-network',
+        )
 
     def test_testnet_bundle(self):
         assert ENV_BUNDLES['testnet'] == {

--- a/tests/test_cli_chain_networks.py
+++ b/tests/test_cli_chain_networks.py
@@ -55,12 +55,14 @@ class TestPinnedContract:
             'arb-network',
             'hype-network',
             'bnb-network',
+            'avax-network',
             'router',
             'env',
         )
 
     def test_chain_network_keys(self):
         assert CHAIN_NETWORK_KEYS == ('btc-network', 'eth-network', 'arb-network', 'hype-network', 'bnb-network')
+        assert CHAIN_NETWORK_KEYS == ('btc-network', 'eth-network', 'arb-network', 'hype-network', 'avax-network')
 
     def test_testnet_bundle(self):
         assert ENV_BUNDLES['testnet'] == {
@@ -71,6 +73,7 @@ class TestPinnedContract:
             'arb-network': 'sepolia',
             'hype-network': 'testnet',
             'bnb-network': 'testnet',
+            'avax-network': 'fuji',
             'netuid': '19',
             'router': '5HicmHG7fjbxrtx8FZNdv4xxS5jSN84KGpMnTHsKtKv9peao',
         }
@@ -84,6 +87,7 @@ class TestPinnedContract:
             'arb-network': 'mainnet',
             'hype-network': 'mainnet',
             'bnb-network': 'mainnet',
+            'avax-network': 'mainnet',
             'netuid': '7',
             'router': '',
         }
@@ -107,6 +111,7 @@ class TestPinnedContract:
             'arbusdc': ('mainnet', 'sepolia'),
             'hype': ('mainnet', 'testnet'),
             'bnb': ('mainnet', 'testnet'),
+            'avax': ('mainnet', 'fuji'),
         }
 
 


### PR DESCRIPTION
Adds AVAX on the Avalanche C-Chain as the sixth launch spoke. The C-Chain is a plain EVM
JSON-RPC network, so this is a registry row plus a binding of the shared `EvmCoin` — no
contract, DB or consumer changes. Twin: entrius/das-allways#92.

## What changed

| File | Change |
|---|---|
| `allways/assets/evm.py` | one `AVALANCHE` `EvmNetwork` row (3-rung ladder per network, archive rung first) + its `EVM_NETWORKS` key |
| `allways/chains.py` | `CHAIN_AVAX` + its `SUPPORTED_CHAINS` entry |
| `allways/assets/avax.py` | the `Avax` binding (11 lines) |
| `allways/assets/__init__.py` | import, `__all__`, `ASSET_REGISTRY` row |
| `allways/constants.py` | `'avax'` appended to `LAUNCH_SPOKES` |
| `.env.example`, `README.md` | mirror the HYPE spoke |
| `tests/` | new `test_avax_provider.py`; pinned contracts in `test_chains.py` / `test_cli_chain_networks.py` updated |

Nothing else. CLI keys, env bundles, `alw config` rows, quote flags and the e2e scenario
list all derive from the registry.

## The two judgement calls

**`min_confirmations = 2`** — Avalanche runs Snowman, not longest-chain. A block is
*accepted*, and acceptance is irreversible: there is no reorg depth to outrun, so finality
is inclusion. 2 is a one-block margin against an endpoint serving a head its consensus has
not yet sealed, the same reasoning HyperBFT gets in `CHAIN_HYPE`.

**`seconds_per_block = 1`** — measured live on C-Chain mainnet, not assumed:

```
block 92592629 ts 1786489840
block 92592529 ts 1786489729   ->  100 blocks / 111s  = 1.11 s/block
block 92591629 ts 1786488731   -> 1000 blocks / 1109s = 1.109 s/block
```

Integer floor is 1, as on Arbitrum. That measurement is **mainnet's**; Fuji produces blocks
on demand and measured 5.6–7.0 s/block. The value stays 1 — it is the mainnet rate that
governs the live pair, and a larger `seconds_per_block` would only inflate the extension
target and shrink `SCAN_LOOKBACK_BLOCKS`. **Implied leg latency = `seconds_per_block ×
min_confirmations` = 2s (≈2.2s real) against the program's 600s default fulfillment grace —
0.4% of it.** No grace-table arm needed.

**`min_onchain_amount = 1e15 wei` (0.001 AVAX)** — an economic floor priced at a
realistic-*high* C-Chain gas level, deliberately not today's quiet gas. Avalanche's base fee
is fully dynamic (ACP-176) and spikes hard under load; the quiet-day reading right now is
three orders of magnitude below a congested one:

```
eth_gasPrice now: 0.0536 gwei
baseFee over the last 1024 blocks (~19 min): min 0.0469  p50 0.0547  p95 0.0596  max 0.0622 gwei
```

0.001 AVAX covers a 21,000-gas transfer up to **~47.6 gwei** — a congested C-Chain level,
~1000× the p50 above and comfortably over the 25 gwei that used to be the protocol floor.
As on `CHAIN_ETH` and `CHAIN_HYPE` this is a **rate-sanity input to `is_executable_rate`,
not an enforced minimum** — miners price real gas into their quotes; this only keeps
unroutable rates out of the crown.

**`replay_grace_secs = 60`** — justified on hub-vs-spoke clock skew, not on timestamp
monotonicity. C-Chain timestamps are consensus-stamped and non-decreasing, but that says
nothing about how the Avalanche validator set's clock sits relative to the Solana hub's,
and the freshness gate compares a C-Chain block time against a hub-stamped
`reservation.created_at`. 60s matches Arbitrum and Hyperliquid.

## AVAX-specific hazard: atomic P/X→C imports

AVAX crosses between the P/X chains and the C-Chain via *atomic transactions*, which credit
a C-Chain EVM balance **without producing an EVM transaction**. I investigated this
concretely rather than reasoning about it.

Real mainnet example, block **92592469**. Decoding the block's `blockExtraData` yields an
`ImportTx` from the P-Chain (all-zero source chain id) with one `EVMOutput`:

```
atomic ImportTx  source chain (all-zero = P-Chain): 0000...0000
  credits EVM address 0xf3bea6ee245b402d60fdb419eaabd63fc17c02d2 = 108.194867287 AVAX
  EVM txs in block 92592469 : 44
  ...of which pay that address: NONE
  ...sent by that address: NONE
```

The credit is real — confirmed against an archive endpoint:

```
balance 92592468 = 0.49771012233603656 AVAX -> 92592469 = 108.69257740933604 AVAX  delta 108.19486728700001
```

And the atomic tx is not addressable through the EVM namespace at all. Its id is CB58, not
0x-hex, and it is served by a **separate API surface**:

```
atomic tx id: 2EZXX28yR96NWkQSqpmAbLWzaj3RBdP98YNGP6o4umnLyfygpk
  /ext/bc/C/avax  avax.getAtomicTxStatus -> {'status': 'Accepted', 'blockHeight': '92592469'}
  eth_getTransactionByHash (same id as hex) -> None
```

**Findings, in order of the questions asked:**

| Question | Answer |
|---|---|
| What does the provider see? | Nothing. The credit lives in `blockExtraData`; the provider reads only `transactions`, `timestamp` and `hash`. |
| Can an atomic import appear in `eth_getBlockByNumber` transactions? | **No** — proven above: 44 EVM txs in the block, none referencing the credited address. |
| Could the deposit scanner trip over its shape? | No. It iterates `transactions`, which never contains one. The extra C-Chain block fields (`extDataGasUsed`, `extDataHash`, `blockExtraData`, `blockGasCost`, `timestampMilliseconds`, and on Fuji `settledExcess`/`targetExponent`/`minPriceExponent`) are simply never read — every access is a `.get()` on a named key. Covered by `test_atomic_import_is_not_a_deposit`. |
| What does a user who funds a swap that way experience? | The source leg is unverifiable, so `find_recent_outgoing` never surfaces it and there is no 0x hash to submit. The reservation lapses at `reserved_until`; per `reserve_engine.confirm_deposit` that means no claim, no `Swap`, no timeout and no refund. It **hangs to reservation expiry and the deposit is stranded**, not rejected with an error at send time. |
| Is it a code problem? | **No — this is a user-education problem, not a code problem.** It fails safe in the protocol's direction: never a false confirm, never a false slash (no `Swap` is ever created, so no miner is at risk). It is the same class as sending to the wrong address. Per instruction I have **not** added code to handle it. |

One UX detail worth recording: the taker does not even get an accurate error. An atomic tx
id is CB58, so `eth_getTransactionByHash` rejects it as a malformed argument on every rung,
which `eth_rpc` classifies as endpoint trouble and turns into `ProviderUnreachableError` —
surfacing as *"Source-chain provider unreachable; resend shortly"* rather than "this is not
an EVM transaction". Confirmed live against the real atomic id above:

```
AvalancheRpc [1/3] avax       eth_getTransactionByHash -> rpc error {'code': -32602, 'message':
  'invalid argument 0: json: cannot unmarshal hex string without 0x prefix into common.Hash'}
AvalancheRpc [2/3] publicnode eth_getTransactionByHash -> same
AvalancheRpc [3/3] drpc       eth_getTransactionByHash -> HTTP 400
raised ProviderUnreachableError: AVAX RPC unreachable: ... eth_getTransactionByHash: 400
```

Documented, not fixed — per instruction, no code added for this.

The realistic exposure is narrow: a user would have to fund the miner's C-Chain address by
exporting from X/P and importing directly to it, rather than sending from their own C-Chain
wallet. The `source_address` pinned at reserve time is a C-Chain EOA, so the normal path is
the only one the UI ever suggests.

Nothing about C-Chain block or receipt shape breaks the shared parsing. Receipts carry the
standard Etherscan-family key set (`status`, `blockHash`, `blockNumber`,
`effectiveGasPrice`, …) and `baseFeePerGas` is present and well-formed on both networks
(mainnet ~0.055 gwei, Fuji 0xa = 10 wei), so the EIP-1559 send path works unchanged.

## Endpoint verification — why THREE rungs, and why the official gateway LEADS

`eth_chainId` answering does not qualify an endpoint. A sibling implementer found a
publicnode endpoint on another network that answers `eth_chainId` perfectly and 403s on
**every** `eth_getTransactionReceipt`; the receipt *is* the settlement check, so such an
endpoint cannot settle a leg. Every endpoint was therefore probed individually — not through
the failover ladder — over **20 rounds interleaving the hot path and the archive path**,
including `eth_getCode` at the two depths `delivery_refused` actually probes:

```
===== mainnet (chainId 43114) — 20 rounds, hot path + archive interleaved =====
  https://api.avax.network/ext/bc/C/rpc
    OK  eth_chainId / blockNumber / receipt / txByHash / block(full) / call   20/20 each
    OK  getCode 'latest'             20/20
    OK  getCode tip-60               20/20
    OK  getCode tip-120              20/20
  https://avalanche-c-chain-rpc.publicnode.com
    OK  eth_chainId / blockNumber / receipt / txByHash / block(full) / call   20/20 each
    OK  getCode 'latest'             20/20
    BAD getCode tip-60                0/20   20x RPCERR (-32000 missing trie node)
    BAD getCode tip-120               0/20   20x RPCERR (-32000 missing trie node)
  https://avalanche.drpc.org
    OK  eth_chainId / blockNumber / receipt / txByHash / block(full) / call   20/20 each
    FLK getCode 'latest'             19/20   1x HTTP
    FLK getCode tip-60               11/20   7x RPCERR, 2x HTTP
    FLK getCode tip-120               5/20   11x RPCERR, 4x HTTP
===== fuji (chainId 43113) — 20 rounds, hot path + archive interleaved =====
  https://api.avax-test.network/ext/bc/C/rpc
    OK  everything incl. getCode tip-60 / tip-120                20/20 each
  https://avalanche-fuji-c-chain-rpc.publicnode.com
    OK  everything except archive                                20/20 each
    BAD getCode tip-60 / tip-120      0/20   20x RPCERR (-32000 missing trie node)
  https://avalanche-fuji.drpc.org
    OK  everything incl. getCode tip-60 / tip-120                20/20 each
```

**Three rungs, because Avalanche is not like its siblings.** `avalanche-c-chain-rpc.publicnode.com`
does not serve historical state at all, while `ethereum-rpc.publicnode.com` and
`arbitrum-one-rpc.publicnode.com` serve `getCode` at tip-120 fine — this is AVAX-specific,
not a family trait. And drpc's free tier is *intermittent* at those depths on mainnet
(**5/20** at tip-120), flaking even on `getCode 'latest'` (19/20).

**The official gateway leads, because the archive path is the NORMAL path, not a rare one.**
`any()` in `delivery_refused` short-circuits on the `'latest'` probe — but only when that
probe finds code. Every honest EOA destination returns `0x`, so the historical probes run on
**every real swap**. And `span` is effectively pinned at its 120 clamp for any overdue swap,
since `elapsed >= fulfillment_timeout` (600s) with 1s blocks. So under the previous
publicnode-first order, every slash evaluation on mainnet paid a guaranteed failed
round-trip, then a second failed one ~75% of the time, before reaching an endpoint that
answers — plus a routine `WARNING ... missing trie node` pair that operators would learn to
ignore. The Ava Labs gateway serves the hot path as well as publicnode **and** the archive
path neither other rung reliably serves, so leading with it costs nothing and removes those
failures. publicnode and drpc stay as rungs 2 and 3 for independence.

Why this matters beyond tidiness: `delivery_refused` is the gate that exempts a miner from a
slash when the destination bears code. When every rung fails it raises, `_dest_refuses`
catches, and the swap returns `WAIT`. There is no false slash — the fail-safe direction
holds — but a **genuinely timed-out swap goes unslashed while the miner's collateral and the
user's source funds stay locked**, self-healing only when a rung happens to answer.

`.env.example` already offered this gateway as the sample `AVAX_RPC_URLS` override, so the
docs were ahead of the code default; that line now shows a keyed provider instead and names
the real default order.

`connect_network` probes **every** rung against the expected chain id at startup, so all
three are qualified on both networks before any leg is verified (live output below). The
C-Chain's unusual `/ext/bc/C/rpc` path needs **no shared-code change** — `EvmChain` posts to
the base URL verbatim and only trims a trailing slash, which is what makes the official
gateway usable as a rung at all.

## Evidence

### Lint

```
$ uv run ruff format --check . && uv run ruff check .
154 files already formatted
All checks passed!
```

### Tests

```
$ uv run pytest tests/ -q
1151 passed, 6 deselected, 3 warnings in 11.43s
```

`tests/test_avax_provider.py` is fully offline (RPC layer stubbed with a method→response
map). It covers network selection (mainnet/fuji ids, unknown-name rejection — with
`AVAX_NETWORK=testnet` as the typo to beat, since Avalanche's testnet is named *fuji* —
unset→mainnet default, keyless ladders, `AVAX_RPC_URLS` override preserving the
`/ext/bc/C/rpc` path, and **wrong-network startup rejection**), verification
(settled / mempool / reverted / underpaid / wrong-recipient / not-found, plus **receipt
unavailability** and **timestamp unavailability** both raising `ProviderUnreachableError`),
send guards (no key / key mismatch / insufficient balance, plus the full signed payload
pinned to chain id 43114), and the deposit scanner (walk bound, cursor parking below an
unreadable block, and the atomic-import case).

No `compute_extension_target_secs` case was added to `test_chains.py`: AVAX's inputs
(2 confs × 1s) are byte-identical to HYPE's, which is already pinned there — a duplicate
would be rot, not coverage.

### Live, mainnet

```
--- AVAX mainnet --- Avalanche JSON-RPC (mainnet): api.avax.network, avalanche-c-chain-rpc.publicnode.com, avalanche.drpc.org
[AvalancheRpc] connected: network=mainnet, chain_id=43114, tip=92602886   (all 3 rungs chain-id checked)
tip                    : 92602889
settled transfer       : recipient(mixed-case)=0x390BD1CCE479711925cf326403C5d32A78A11bB4
  -> confirmed=True confs=9858 block=92593031 time=1786490283
  -> amount=28653807920000000000 sender=0x6c54723805154aa221ff8e3a342311505560878d
underpaid (2x amount)  : None
wrong sender pinned    : None
    verify_transaction: sender mismatch on tx 0xd98c4d26a48dcf... (expected 0x1111..., got '0x6c547238...')
wrong recipient        : None
unknown tx             : None
balance 0x390bd1cce479711925cf326403c5d32a78a11bb4: 603146549294384801
```

tx `0xd98c4d26a48dcf887210029426a1e6d6a30b15bbd2f6fdb83f63c2bc84c6dc54`

### Live, Fuji

```
--- AVAX fuji --- Avalanche JSON-RPC (fuji): api.avax-test.network, avalanche-fuji-c-chain-rpc.publicnode.com, avalanche-fuji.drpc.org
[AvalancheRpc] connected: network=fuji, chain_id=43113, tip=57713949   (all 3 rungs chain-id checked)
tip                    : 57713949
settled transfer       : recipient(mixed-case)=0x4cF609fc3fd878b34c7Ea3D63f732248fd7a5B4c
  -> confirmed=True confs=1570 block=57712380 time=1786490117
  -> amount=1837339856487125732 sender=0x7f79991446a8bf4e77bd96afad009171c68ad34a
underpaid (2x amount)  : None
wrong sender pinned    : None
    verify_transaction: sender mismatch on tx 0x15f8734622b5cb... (expected 0x1111..., got '0x7f799914...')
wrong recipient        : None
unknown tx             : None
balance 0x4cf609fc3fd878b34c7ea3d63f732248fd7a5b4c: 47970863675983420585398
```

tx `0x15f8734622b5cbf31bde5d11315ec714ab7cc568cfffd4f99a74f3855c0bf8b8`

### Live: the path-bearing rung in isolation, and wrong-network rejection

```
$ AVAX_RPC_URLS=https://api.avax.network/ext/bc/C/rpc
Avalanche JSON-RPC (mainnet): api.avax.network
[AvalancheRpc] connected: network=mainnet, chain_id=43114, tip=92593494

$ AVAX_NETWORK=fuji AVAX_RPC_URLS=https://api.avax-test.network/ext/bc/C/rpc
Avalanche JSON-RPC (fuji): api.avax-test.network
[AvalancheRpc] connected: network=fuji, chain_id=43113, tip=57712465

$ AVAX_NETWORK=fuji AVAX_RPC_URLS=https://avalanche-c-chain-rpc.publicnode.com
ConnectionError: AVAX endpoint publicnode serves chain id 43114, expected 43113 for fuji
                 — AVAX_RPC_URLS and AVAX_NETWORK disagree
```

### Derived CLI surfaces

```
$ uv run alw miner quotes --help
--avax-price   NUMBER   AVAX per 1 SOL (0/omit to skip AVAX).
--avax-address TEXT     Your AVAX address.

$ uv run alw config
│ hype-network   │ mainnet │ default │
│ avax-network   │ mainnet │ default │
```

### e2e scenarios

`run-suites.sh` pins its interpreter to the main checkout's venv, so `PYTHONPATH` is needed
to make the rows derive from this branch rather than the unrelated tree that path resolves to:

```
$ cd alw-utils/dev-environment/solana
$ PYTHONPATH=<this worktree> ./run-suites.sh --list
scenarios:
  sol-btc / btc-sol / sol-tao / tao-sol / sol-eth / eth-sol
  sol-arbusdc / arbusdc-sol / sol-hype / hype-sol
  sol-avax
  avax-sol
  ...
```

No harness code was written — the scenarios derive from `LAUNCH_SPOKES`.
**I did not execute a suite** (that needs the full local stack up).

## Emission note

This is the sixth spoke. The zero-volume emission floor per pair is
`(1 - POOL_VOLUME_ALPHA) / pairs`, where `pairs = len(LAUNCH_SPOKES)` (the hub is not a
spoke), with `POOL_VOLUME_ALPHA = 0.66`:

| | pairs | floor per pair | equal split per direction |
|---|---|---|---|
| `test` today | 5 | 6.80% | 1/10 |
| this PR alone | 6 | 5.67% | 1/12 |
| **all four new spokes merged** | **9** | **3.78%** | **1/18** |

So this PR alone dilutes the floor by 16.7%, but **merged together the four new spokes
dilute it by 44.4%** — the number that actually matters, and much larger than any single
PR implies.

(Note on the figure: 44.4% is computed from `LAUNCH_SPOKES` going 5 -> 9. A 40% figure
corresponds to 6 -> 10, which is `len(SUPPORTED_CHAINS)` — that count includes the hub
`sol`, which earns no pool. The pool math keys off `LAUNCH_SPOKES`, so 5 -> 9 / 44.4% is
the operative one.)

## Merge order

Merge this first. entrius/das-allways#92's CI drift gate reads `chains.py` from `test`
and is red by design until this lands.
