### PR TITLE
3.1.1: score busy per hub so one purse's swap keeps the other's crown

### DIFF
--- a/allways/__init__.py
+++ b/allways/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '3.1.0'
+__version__ = '3.1.1'
 version_split = __version__.split('.')
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))

--- a/allways/validator/event_index.py
+++ b/allways/validator/event_index.py
@@ -88,7 +88,7 @@ class SolanaEventIndex:
             self.state_store.insert_active_event(block_time, hotkey, name == 'MinerActivated')
             return True
         if name == 'PoolResolved':
-            return self._apply_reservation(hotkey, block_time)
+            return self._apply_reservation(hotkey, block_time, self._event_hub(rec))
         if name == 'SwapFulfilled':
             # Persist the delivery hash for post-close receipts — the Swap PDA (and its
             # to_tx_hash) is gone once the swap completes, and the offering's receipt links
@@ -98,7 +98,9 @@ class SolanaEventIndex:
             )
             return True
         if name in _FULFILL_TRANSITIONS:
-            self.state_store.insert_activity_event(block_time, hotkey, _FULFILL_TRANSITIONS[name])
+            self.state_store.insert_activity_event(
+                block_time, hotkey, _FULFILL_TRANSITIONS[name], hub=self._event_hub(rec)
+            )
             outcome = _OUTCOME_BY_EVENT.get(name)
             if outcome is not None:
                 self.state_store.record_swap_outcome(bytes(rec.fields['swap_key']).hex(), outcome, block_time)
@@ -151,18 +153,27 @@ class SolanaEventIndex:
             return True
         return False  # not a crown-relevant event
 
-    def _apply_reservation(self, hotkey: str, block_time: int) -> bool:
+    def _apply_reservation(self, hotkey: str, block_time: int, hub: Optional[str]) -> bool:
         """PoolResolved → RESERVE_START now + a synthetic RESERVE_EXPIRE at
         ``block_time + reservation_ttl_secs`` (``reserved_until`` isn't on the
         event). Dropped if no TTL source is wired, so the reservation never opens
-        without its matching expiry."""
+        without its matching expiry. The expiry inherits the start's hub so the
+        pair opens and closes the same per-hub machine."""
         ttl = self._reservation_ttl()
         if ttl is None:
             bt.logging.warning('SolanaEventIndex: no reservation_ttl; dropping PoolResolved')
             return False
-        self.state_store.insert_activity_event(block_time, hotkey, ActivityTransition.RESERVE_START)
-        self.state_store.insert_activity_event(block_time + ttl, hotkey, ActivityTransition.RESERVE_EXPIRE)
+        self.state_store.insert_activity_event(block_time, hotkey, ActivityTransition.RESERVE_START, hub=hub)
+        self.state_store.insert_activity_event(block_time + ttl, hotkey, ActivityTransition.RESERVE_EXPIRE, hub=hub)
         return True
+
+    @staticmethod
+    def _event_hub(rec: EventRecord) -> Optional[str]:
+        """The purse a lifecycle event draws against (v3.1 events carry it as
+        ``collateral_chain``). None — global-busy on every hub — for a pre-v3.1
+        payload shape, matching how those swaps actually locked the miner."""
+        chain = rec.fields.get('collateral_chain') if isinstance(rec.fields, dict) else None
+        return str(chain).lower() if chain else None
 
     def _reservation_ttl(self) -> Optional[int]:
         if self._reservation_ttl_fn is None:

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -615,12 +615,14 @@ class EventKind(IntEnum):
 class ReplayEvent:
     """One transition in the chronological replay stream. ``value`` is
     polymorphic on ``kind``: rate as float, active as 0/1, or an
-    ``ActivityTransition`` value for ACTIVITY."""
+    ``ActivityTransition`` value for ACTIVITY. ``hub`` scopes an ACTIVITY
+    transition to one purse's machine (v3.1 per-hub busy); None = every hub."""
 
     block: int
     hotkey: str
     kind: EventKind
     value: float
+    hub: Optional[str] = None
 
     @property
     def sort_key(self) -> Tuple[int, int, int]:
@@ -649,14 +651,16 @@ def reconstruct_window_start_state(
     to_chain: str,
     window_start: int,
     rewardable_hotkeys: Set[str],
-) -> Tuple[Dict[str, float], Dict[str, MinerActivity], Set[str], Dict[str, int]]:
+) -> Tuple[Dict[str, float], Dict[str, Dict[str, MinerActivity]], Set[str], Dict[str, int]]:
     """Snapshot rates, per-miner activity, active set, and posted collateral as
-    they stood at window_start. ``activity`` holds only non-AVAILABLE miners (a
-    reservation/swap open before the window shows RESERVED/FULFILLING at the
-    edge); absent hotkeys default to AVAILABLE. Rate read is one batched query
-    per direction (N rewardable hotkeys would otherwise be N point lookups, runs
-    every forward step from snapshot_current_crown_holders)."""
-    activity: Dict[str, MinerActivity] = dict(event_index.get_activity_state_at(window_start))
+    they stood at window_start. ``activity`` is per (hotkey, hub) — v3.1 busy is
+    per purse — holding only busy hubs (a reservation/swap open before the window
+    shows RESERVED/FULFILLING at the edge); absences default to AVAILABLE. Rate
+    read is one batched query per direction (N rewardable hotkeys would otherwise
+    be N point lookups, runs every forward step from snapshot_current_crown_holders)."""
+    activity: Dict[str, Dict[str, MinerActivity]] = {
+        hk: dict(hubs) for hk, hubs in event_index.get_activity_state_at(window_start).items()
+    }
     active_set: Set[str] = set(event_index.get_active_miners_at(window_start))
 
     all_latest = store.get_latest_rates_before(from_chain, to_chain, window_start)
@@ -686,7 +690,9 @@ def merge_replay_events(
 
     for e in event_index.get_activity_events_in_range(window_start, window_end):
         events.append(
-            ReplayEvent(block=e['block'], hotkey=e['hotkey'], kind=EventKind.ACTIVITY, value=float(e['kind']))
+            ReplayEvent(
+                block=e['block'], hotkey=e['hotkey'], kind=EventKind.ACTIVITY, value=float(e['kind']), hub=e.get('hub')
+            )
         )
 
     for e in store.get_rate_events_in_range(from_chain, to_chain, window_start, window_end):
@@ -701,6 +707,31 @@ def merge_replay_events(
 
     events.sort(key=lambda ev: ev.sort_key)
     return events
+
+
+def direction_serving_hubs(from_chain: str, to_chain: str) -> List[str]:
+    """The hubs a direction can serve through — its hub legs. A spoke↔spoke pair
+    (never scored) falls back to every hub, reproducing the global-busy reading."""
+    hubs = [c for c in (from_chain, to_chain) if c in BACKING_BITS]
+    return hubs or list(BACKING_BITS)
+
+
+def rewardable_by_activity(
+    activity: Dict[str, Dict[str, MinerActivity]],
+    hotkeys: Set[str],
+    serving_hubs: List[str],
+) -> Set[str]:
+    """Hotkeys whose per-hub activity still permits crown on a direction served by
+    ``serving_hubs``: busy forfeits only when EVERY serving hub is mid-reservation/
+    swap — the activity twin of ``direction_eligible``'s any-clean-hub rule (v3.1:
+    a sol-busy miner keeps earning on its tao quotes and vice versa; a hub↔hub
+    direction forfeits only when both purses are busy). Absent = AVAILABLE."""
+    out: Set[str] = set()
+    for hk in hotkeys:
+        per_hub = activity.get(hk) or {}
+        if any(per_hub.get(h, MinerActivity.AVAILABLE) in REWARD_MINER_STATES for h in serving_hubs):
+            out.add(hk)
+    return out
 
 
 def direction_purse_known(from_chain: str, to_chain: str) -> bool:
@@ -828,13 +859,13 @@ def replay_crown_time_window(
 
     bounds_set = min_swap_hub > 0 or max_swap_hub > 0
 
+    serving_hubs = direction_serving_hubs(from_chain, to_chain)
+
     def credit_interval(interval_start: int, interval_end: int) -> None:
         duration = interval_end - interval_start
         if duration <= 0:
             return
-        rewardable_by_state = {
-            hk for hk in rewardable_hotkeys if activity.get(hk, MinerActivity.AVAILABLE) in REWARD_MINER_STATES
-        }
+        rewardable_by_state = rewardable_by_activity(activity, rewardable_hotkeys, serving_hubs)
         rates_for_instant = rates
         holders = crown_holders_at_instant(
             rates_for_instant,
@@ -874,15 +905,22 @@ def replay_crown_time_window(
         if event.kind is EventKind.RATE:
             rates[event.hotkey] = event.value
         elif event.kind is EventKind.ACTIVITY:
-            cur = activity.get(event.hotkey, MinerActivity.AVAILABLE)
-            nxt = next_activity(cur, ActivityTransition(int(event.value)))
-            if nxt is None:
-                warn_unexpected_activity(cur, ActivityTransition(int(event.value)))
-                nxt = cur
-            if nxt is MinerActivity.AVAILABLE:
+            transition = ActivityTransition(int(event.value))
+            per_hub = activity.setdefault(event.hotkey, {})
+            # A hub-scoped edge steps one purse's machine; a NULL-hub edge (legacy
+            # rows, pre-v3.1 payloads) steps every hub — the global-busy reading.
+            for h in [event.hub] if event.hub else list(BACKING_BITS):
+                cur = per_hub.get(h, MinerActivity.AVAILABLE)
+                nxt = next_activity(cur, transition)
+                if nxt is None:
+                    warn_unexpected_activity(cur, transition)
+                    nxt = cur
+                if nxt is MinerActivity.AVAILABLE:
+                    per_hub.pop(h, None)
+                else:
+                    per_hub[h] = nxt
+            if not per_hub:
                 activity.pop(event.hotkey, None)
-            else:
-                activity[event.hotkey] = nxt
         elif event.kind is EventKind.COLLATERAL:
             collaterals[event.hotkey] = max(0, int(event.value))
         else:  # ACTIVE
@@ -952,9 +990,9 @@ def snapshot_current_crown_holders(
         )
         canon_from, _ = canonical_pair(from_chain, to_chain)
         lower_rate_wins = from_chain != canon_from
-        rewardable_by_state = {
-            hk for hk in rewardable_hotkeys if activity.get(hk, MinerActivity.AVAILABLE) in REWARD_MINER_STATES
-        }
+        rewardable_by_state = rewardable_by_activity(
+            activity, rewardable_hotkeys, direction_serving_hubs(from_chain, to_chain)
+        )
 
         # Same predicates the scoring replay uses, so the live table never
         # credits a holder the ledger drops. Built per direction so each

--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -152,12 +152,16 @@ class ValidatorStateStore:
             (block_num, hotkey, 1 if active else 0),
         )
 
-    def insert_activity_event(self, block_num: int, hotkey: str, transition: ActivityTransition) -> None:
+    def insert_activity_event(
+        self, block_num: int, hotkey: str, transition: ActivityTransition, hub: Optional[str] = None
+    ) -> None:
         """Record one edge of a miner's ``MinerActivity`` machine (RESERVE_START,
-        FULFILL_START, FULFILL_END, or the synthetic RESERVE_EXPIRE)."""
+        FULFILL_START, FULFILL_END, or the synthetic RESERVE_EXPIRE). ``hub`` is the
+        purse the swap draws against (v3.1 per-hub busy); NULL applies to every hub —
+        the pre-v3.1.1 global-busy reading, kept for legacy rows and reconcile writes."""
         self._execute(
-            'INSERT INTO activity_events (block_num, hotkey, kind) VALUES (?, ?, ?)',
-            (block_num, hotkey, int(transition)),
+            'INSERT INTO activity_events (block_num, hotkey, kind, hub) VALUES (?, ?, ?, ?)',
+            (block_num, hotkey, int(transition), hub),
         )
 
     def load_all_active_events(self) -> List[dict]:
@@ -165,8 +169,8 @@ class ValidatorStateStore:
         return [{'block_num': r['block_num'], 'hotkey': r['hotkey'], 'active': bool(r['active'])} for r in rows]
 
     def load_all_activity_events(self) -> List[dict]:
-        rows = self._fetchall('SELECT block_num, hotkey, kind FROM activity_events ORDER BY block_num ASC, id ASC')
-        return [{'block_num': r['block_num'], 'hotkey': r['hotkey'], 'kind': r['kind']} for r in rows]
+        rows = self._fetchall('SELECT block_num, hotkey, kind, hub FROM activity_events ORDER BY block_num ASC, id ASC')
+        return [{'block_num': r['block_num'], 'hotkey': r['hotkey'], 'kind': r['kind'], 'hub': r['hub']} for r in rows]
 
     def insert_collateral_event(self, block_num: int, hotkey: str, collateral_rao: int) -> None:
         self._execute(
@@ -221,24 +225,25 @@ class ValidatorStateStore:
     def get_activity_events_in_range(self, start_time: int, end_time: int) -> List[dict]:
         """Activity transitions in ``(start_time, end_time]``. Ordered ``block_num,
         kind`` so coincident-instant edges replay in machine-precedence order
-        (closers/openers before a reservation lapse)."""
+        (closers/openers before a reservation lapse). ``hub`` NULL = every hub."""
         rows = self._fetchall(
             """
-            SELECT id, block_num, hotkey, kind FROM activity_events
+            SELECT id, block_num, hotkey, kind, hub FROM activity_events
             WHERE block_num > ? AND block_num <= ?
             ORDER BY block_num ASC, kind ASC, id ASC
             """,
             (start_time, end_time),
         )
-        return [{'hotkey': r['hotkey'], 'kind': r['kind'], 'block': r['block_num']} for r in rows]
+        return [{'hotkey': r['hotkey'], 'kind': r['kind'], 'block': r['block_num'], 'hub': r['hub']} for r in rows]
 
-    def get_activity_state_at(self, at_time: int) -> Dict[str, MinerActivity]:
-        """Per-hotkey ``MinerActivity`` at ``at_time``, reduced over each miner's
-        transition timeline. Only non-AVAILABLE miners are returned (callers
-        default the rest to AVAILABLE)."""
+    def get_activity_state_at(self, at_time: int) -> Dict[str, Dict[str, MinerActivity]]:
+        """Per-(hotkey, hub) ``MinerActivity`` at ``at_time``, reduced over each
+        miner's per-hub transition timelines (v3.1: busy is per purse). Only busy
+        entries are returned — ``{hotkey: {hub: state}}`` with AVAILABLE hubs
+        omitted; callers default absences to AVAILABLE."""
         rows = self._fetchall(
             """
-            SELECT block_num, hotkey, kind FROM activity_events
+            SELECT block_num, hotkey, kind, hub FROM activity_events
             WHERE block_num <= ?
             ORDER BY block_num ASC, kind ASC, id ASC
             """,
@@ -247,16 +252,26 @@ class ValidatorStateStore:
         return self._reduce_activity(rows)
 
     @staticmethod
-    def _reduce_activity(rows: Sequence[sqlite3.Row]) -> Dict[str, MinerActivity]:
-        """Fold ordered transition rows into ``{hotkey: state}`` for non-AVAILABLE
-        miners. An undefined transition holds the current state (defensive)."""
-        states: Dict[str, MinerActivity] = {}
+    def _reduce_activity(rows: Sequence[sqlite3.Row]) -> Dict[str, Dict[str, MinerActivity]]:
+        """Fold ordered transition rows into ``{hotkey: {hub: state}}`` keeping only
+        non-AVAILABLE hubs. A NULL-hub row (legacy global-busy, reconcile) steps every
+        hub's machine. An undefined transition holds the current state (defensive)."""
+        from allways.solana.pdas import BACKING_BITS
+
+        states: Dict[str, Dict[str, MinerActivity]] = {}
         for r in rows:
             hk = r['hotkey']
-            cur = states.get(hk, MinerActivity.AVAILABLE)
-            nxt = next_activity(cur, ActivityTransition(r['kind']))
-            states[hk] = cur if nxt is None else nxt
-        return {hk: st for hk, st in states.items() if st is not MinerActivity.AVAILABLE}
+            hub = r['hub'] if 'hub' in r.keys() else None
+            per_hub = states.setdefault(hk, {})
+            for h in [hub] if hub else list(BACKING_BITS):
+                cur = per_hub.get(h, MinerActivity.AVAILABLE)
+                nxt = next_activity(cur, ActivityTransition(r['kind']))
+                per_hub[h] = cur if nxt is None else nxt
+        return {
+            hk: busy
+            for hk, per_hub in states.items()
+            if (busy := {h: st for h, st in per_hub.items() if st is not MinerActivity.AVAILABLE})
+        }
 
     def get_collateral_events_in_range(self, start_time: int, end_time: int) -> List[dict]:
         """Collateral transitions in ``(start_time, end_time]``, oldest first.
@@ -645,8 +660,9 @@ class ValidatorStateStore:
         with self.lock:
             conn = self.require_connection()
             all_rows = conn.execute(
-                'SELECT block_num, hotkey, kind FROM activity_events ORDER BY block_num ASC, kind ASC, id ASC'
+                'SELECT block_num, hotkey, kind, hub FROM activity_events ORDER BY block_num ASC, kind ASC, id ASC'
             ).fetchall()
+            # Busy on ANY hub keeps the hotkey's full timeline (the reducer's keys).
             open_hotkeys = set(self._reduce_activity(all_rows))
             if open_hotkeys:
                 placeholders = ','.join('?' * len(open_hotkeys))
@@ -772,6 +788,11 @@ class ValidatorStateStore:
             if cols and 'backing' not in cols:
                 conn.execute("ALTER TABLE routed_requests ADD COLUMN backing TEXT NOT NULL DEFAULT 'sol'")
                 conn.execute('DROP INDEX IF EXISTS idx_routed_requests_key')
+            # v3.1.1: activity gains the per-hub dimension. Pre-upgrade rows stay NULL =
+            # global-busy on every hub — exactly the behavior they were written under.
+            cols = [row[1] for row in conn.execute('PRAGMA table_info(activity_events)')]
+            if cols and 'hub' not in cols:
+                conn.execute('ALTER TABLE activity_events ADD COLUMN hub TEXT')
             conn.executescript(
                 """
                 CREATE TABLE IF NOT EXISTS rate_events (
@@ -801,13 +822,16 @@ class ValidatorStateStore:
                     ON active_events(hotkey);
 
                 -- MinerActivity transitions (D4): kind is an ActivityTransition
-                -- value; the crown replay reduces these into per-instant state so
-                -- a reserved/fulfilling miner forfeits crown (REWARD_MINER_STATES).
+                -- value; the crown replay reduces these into per-instant PER-HUB
+                -- state (v3.1 busy is per purse), so a reserved/fulfilling miner
+                -- forfeits crown only on directions its busy hub serves. hub NULL
+                -- = every hub (legacy rows, reconcile writes).
                 CREATE TABLE IF NOT EXISTS activity_events (
                     id          INTEGER PRIMARY KEY AUTOINCREMENT,
                     block_num   INTEGER NOT NULL,
                     hotkey      TEXT NOT NULL,
-                    kind        INTEGER NOT NULL
+                    kind        INTEGER NOT NULL,
+                    hub         TEXT
                 );
                 CREATE INDEX IF NOT EXISTS idx_activity_events_block
                     ON activity_events(block_num);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "allways"
-version = "3.1.0"
+version = "3.1.1"
 description = "Allways - Universal Transaction Layer: Collateral-backed cross-chain swaps on Bittensor Subnet 7"
 license = "MIT"
 requires-python = ">=3.10,<3.15"

--- a/tests/test_event_index.py
+++ b/tests/test_event_index.py
@@ -4,7 +4,7 @@ bound hotkey at write time."""
 
 from pathlib import Path
 
-from allways.classes import MinerActivity
+from allways.classes import ActivityTransition, MinerActivity
 from allways.constants import RATE_PRECISION
 from allways.solana.events import EventRecord
 from allways.validator.event_index import SolanaEventIndex
@@ -14,6 +14,11 @@ from allways.validator.state_store import ValidatorStateStore
 # pubkey str -> hotkey ss58 (what binding.build_attribution returns).
 ATTR = {'pk_a': 'hk_a', 'pk_b': 'hk_b'}
 RESERVATION_TTL = 300
+
+
+def _both(state):
+    # A hub-less (legacy-shape) event steps every hub's machine — the global-busy reading.
+    return {'sol': state, 'tao': state}
 
 
 DEFAULT_SWAP_KEY = b'\x2a' * 32
@@ -78,8 +83,8 @@ class TestIngestActivity:
             ATTR,
         )
         assert idx.get_activity_state_at(100) == {}  # AVAILABLE before the reservation
-        assert idx.get_activity_state_at(200) == {'hk_a': MinerActivity.RESERVED}
-        assert idx.get_activity_state_at(250) == {'hk_a': MinerActivity.FULFILLING}
+        assert idx.get_activity_state_at(200) == {'hk_a': _both(MinerActivity.RESERVED)}
+        assert idx.get_activity_state_at(250) == {'hk_a': _both(MinerActivity.FULFILLING)}
         assert idx.get_activity_state_at(400) == {}  # completed → AVAILABLE
         store.close()
 
@@ -92,8 +97,8 @@ class TestIngestActivity:
             [rec('PoolResolved', miner='pk_a', block_time=200, winner='pk_router', user='pk_user', requests=1)],
             ATTR,
         )
-        assert idx.get_activity_state_at(200) == {'hk_a': MinerActivity.RESERVED}
-        assert idx.get_activity_state_at(499) == {'hk_a': MinerActivity.RESERVED}
+        assert idx.get_activity_state_at(200) == {'hk_a': _both(MinerActivity.RESERVED)}
+        assert idx.get_activity_state_at(499) == {'hk_a': _both(MinerActivity.RESERVED)}
         assert idx.get_activity_state_at(500) == {}  # 200 + 300 ttl → AVAILABLE
         kinds = [e['kind'] for e in idx.get_activity_events_in_range(0, 1000)]
         assert kinds == [1, 3]  # RESERVE_START then synthetic RESERVE_EXPIRE
@@ -107,7 +112,7 @@ class TestIngestActivity:
             [rec('PoolResolved', miner='pk_a', block_time=200, winner='pk_b', user='pk_user', requests=1)],
             ATTR,
         )
-        assert idx.get_activity_state_at(250) == {'hk_a': MinerActivity.RESERVED}  # not hk_b
+        assert idx.get_activity_state_at(250) == {'hk_a': _both(MinerActivity.RESERVED)}  # not hk_b
         store.close()
 
     def test_pool_resolved_dropped_without_ttl_source(self, tmp_path: Path):
@@ -620,3 +625,93 @@ class TestSwapFulfillmentHash:
         store.prune_swap_outcomes(200)
         assert store.get_swap_fulfillment(DEFAULT_SWAP_KEY.hex()) is None
         store.close()
+
+
+class TestIngestActivityPerHub:
+    """v3.1.1: lifecycle events carry collateral_chain, and the activity machine
+    runs per (hotkey, hub) so a sol-busy miner stays crownable on its tao quotes."""
+
+    def test_pool_resolved_scopes_the_reservation_to_its_hub(self, tmp_path: Path):
+        store = make_store(tmp_path)
+        idx = make_index(store, ttl=300)
+        idx.ingest(
+            [
+                rec(
+                    'PoolResolved',
+                    miner='pk_a',
+                    block_time=200,
+                    winner='pk_router',
+                    user='pk_user',
+                    requests=1,
+                    collateral_chain='tao',
+                )
+            ],
+            ATTR,
+        )
+        assert idx.get_activity_state_at(250) == {'hk_a': {'tao': MinerActivity.RESERVED}}
+        assert idx.get_activity_state_at(500) == {}  # the synthetic expire inherits the hub
+
+    def test_swap_lifecycle_stays_on_its_hub(self, tmp_path: Path):
+        store = make_store(tmp_path)
+        idx = make_index(store, ttl=10**9)
+        idx.ingest(
+            [
+                rec(
+                    'PoolResolved',
+                    miner='pk_a',
+                    block_time=200,
+                    winner='w',
+                    user='u',
+                    requests=1,
+                    collateral_chain='sol',
+                ),
+                rec('SwapInitiated', miner='pk_a', block_time=250, collateral_chain='sol'),
+            ],
+            ATTR,
+        )
+        assert idx.get_activity_state_at(300) == {'hk_a': {'sol': MinerActivity.FULFILLING}}
+        idx.ingest(
+            [
+                rec(
+                    'SwapCompleted',
+                    miner='pk_a',
+                    block_time=400,
+                    from_chain='sol',
+                    to_chain='btc',
+                    from_amount=1,
+                    to_amount=1,
+                    collateral_chain='sol',
+                )
+            ],
+            ATTR,
+        )
+        assert idx.get_activity_state_at(450) == {}
+
+
+def test_activity_events_hub_column_migrates_in_place(tmp_path: Path):
+    """A pre-v3.1.1 state.db (no hub column) gains it on open; its legacy rows read
+    NULL = busy on every hub, exactly the meaning they were written under."""
+    import sqlite3
+
+    db = tmp_path / 'state.db'
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        """
+        CREATE TABLE activity_events (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            block_num   INTEGER NOT NULL,
+            hotkey      TEXT NOT NULL,
+            kind        INTEGER NOT NULL
+        );
+        INSERT INTO activity_events (block_num, hotkey, kind) VALUES (100, 'hk_a', 1);
+        """
+    )
+    conn.commit()
+    conn.close()
+    store = ValidatorStateStore(db_path=db)
+    assert store.get_activity_state_at(150) == {'hk_a': {'sol': MinerActivity.RESERVED, 'tao': MinerActivity.RESERVED}}
+    store.insert_activity_event(200, 'hk_a', ActivityTransition(2), hub='sol')  # FULFILL_START, sol purse
+    state = store.get_activity_state_at(250)
+    assert state['hk_a']['sol'] == MinerActivity.FULFILLING
+    assert state['hk_a']['tao'] == MinerActivity.RESERVED
+    store.close()

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -133,27 +133,41 @@ class CrownSeeder:
         elif name == 'PoolResolved':
             # RESERVE_START now + RESERVE_EXPIRE at block+ttl (default beyond any
             # test window, so a swap's FULFILL_END is what returns to AVAILABLE).
+            # hub mirrors the real ingest: collateral_chain when present, else global.
             ttl = fields.get('ttl', 10**9)
-            self.state_store.insert_activity_event(block, miner, ActivityTransition.RESERVE_START)
-            self.state_store.insert_activity_event(block + ttl, miner, ActivityTransition.RESERVE_EXPIRE)
+            hub = fields.get('collateral_chain')
+            self.state_store.insert_activity_event(block, miner, ActivityTransition.RESERVE_START, hub=hub)
+            self.state_store.insert_activity_event(block + ttl, miner, ActivityTransition.RESERVE_EXPIRE, hub=hub)
         elif name == 'SwapInitiated':
-            self.state_store.insert_activity_event(block, miner, ActivityTransition.FULFILL_START)
+            self.state_store.insert_activity_event(
+                block, miner, ActivityTransition.FULFILL_START, hub=fields.get('collateral_chain')
+            )
         elif name in ('SwapCompleted', 'SwapTimedOut'):
-            self.state_store.insert_activity_event(block, miner, ActivityTransition.FULFILL_END)
+            self.state_store.insert_activity_event(
+                block, miner, ActivityTransition.FULFILL_END, hub=fields.get('collateral_chain')
+            )
         elif name in ('CollateralPosted', 'CollateralWithdrawn'):
             self.state_store.insert_collateral_event(block, miner, int(fields['total']))
         else:
             raise ValueError(f'CrownSeeder: unsupported event {name}')
 
     def reserve_then_swap(
-        self, miner: str, reserve_block: int, init_block: int, end_block: int, end='SwapCompleted', ttl: int = 10**9
+        self,
+        miner: str,
+        reserve_block: int,
+        init_block: int,
+        end_block: int,
+        end='SwapCompleted',
+        ttl: int = 10**9,
+        backing: str | None = None,
     ):
         """Realistic busy span: PoolResolved → SwapInitiated → completion. The
         reservation's RESERVE_EXPIRE is parked at reserve_block + ttl (default
-        beyond the window)."""
-        self.apply_event(reserve_block, 'PoolResolved', {'miner': miner, 'ttl': ttl})
-        self.apply_event(init_block, 'SwapInitiated', {'miner': miner})
-        self.apply_event(end_block, end, {'miner': miner})
+        beyond the window). ``backing`` scopes the span to one hub's machine
+        (v3.1); None = the legacy hub-less shape, busy on every hub."""
+        self.apply_event(reserve_block, 'PoolResolved', {'miner': miner, 'ttl': ttl, 'collateral_chain': backing})
+        self.apply_event(init_block, 'SwapInitiated', {'miner': miner, 'collateral_chain': backing})
+        self.apply_event(end_block, end, {'miner': miner, 'collateral_chain': backing})
 
     def get_active_miners_at(self, at_time: int) -> set[str]:
         return self.state_store.get_active_state_at(at_time)
@@ -1035,7 +1049,9 @@ class TestReplayCrownTime:
         watcher.reserve_then_swap('hk_a', reserve_block=50, init_block=50, end_block=500)
 
         # Window-start state shows A FULFILLING (open swap spans the edge).
-        assert store.get_activity_state_at(100) == {'hk_a': MinerActivity.FULFILLING}
+        assert store.get_activity_state_at(100) == {
+            'hk_a': {'sol': MinerActivity.FULFILLING, 'tao': MinerActivity.FULFILLING}
+        }
         crown = replay_crown_time_window(
             store=store,
             event_index=SolanaEventIndex(store),
@@ -1122,7 +1138,9 @@ class TestCrownRewardStates:
         """A reservation open before window_start shows RESERVED at the edge."""
         store, watcher = self._seed_solo(tmp_path)
         watcher.apply_event(50, 'PoolResolved', {'miner': 'hk_a', 'ttl': 400})  # expire @ 450
-        assert store.get_activity_state_at(100) == {'hk_a': MinerActivity.RESERVED}
+        assert store.get_activity_state_at(100) == {
+            'hk_a': {'sol': MinerActivity.RESERVED, 'tao': MinerActivity.RESERVED}
+        }
         crown = self._replay(store, rewardable_hotkeys={'hk_a'})
         # RESERVED (100,450] forfeited (solo); earns (450,1100] = 650.
         assert crown == {'hk_a': 650.0}
@@ -1134,7 +1152,9 @@ class TestCrownRewardStates:
         store, watcher = self._seed_solo(tmp_path)
         # ttl 100 → RESERVE_EXPIRE @ 400, but the swap runs 350..800.
         watcher.reserve_then_swap('hk_a', reserve_block=300, init_block=350, end_block=800, ttl=100)
-        assert store.get_activity_state_at(500) == {'hk_a': MinerActivity.FULFILLING}  # past the expire, still busy
+        assert store.get_activity_state_at(500) == {
+            'hk_a': {'sol': MinerActivity.FULFILLING, 'tao': MinerActivity.FULFILLING}
+        }  # past the expire, still busy
         crown = self._replay(store, rewardable_hotkeys={'hk_a'})
         # Forfeits (300,800]; earns (100,300]=200 + (800,1100]=300 = 500.
         assert crown == {'hk_a': 500.0}
@@ -2694,3 +2714,75 @@ class TestCrownCanFund:
             max_swap_hub=500_000_000,
             collaterals={},
         )
+
+
+class TestPerHubBusy:
+    """v3.1.1: busy is per purse in the crown too. A miner mid-swap on one hub keeps
+    earning on directions its other hub serves; a hub↔hub direction forfeits only
+    when both purses are busy — the activity twin of ``direction_eligible``."""
+
+    def _seed(self, tmp_path: Path, directions):
+        store = ValidatorStateStore(db_path=tmp_path / 'state.db')
+        watcher = make_watcher(store, active={'hk_a'})
+        conn = store.require_connection()
+        for from_c, to_c, rate in directions:
+            conn.execute(
+                'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+                ('hk_a', from_c, to_c, rate, 0),
+            )
+        conn.commit()
+        return store, watcher
+
+    def _replay(self, store, from_chain, to_chain):
+        return replay_crown_time_window(
+            store=store,
+            event_index=SolanaEventIndex(store),
+            from_chain=from_chain,
+            to_chain=to_chain,
+            window_start=100,
+            window_end=1100,
+            rewardable_hotkeys={'hk_a'},
+        )
+
+    def test_sol_busy_keeps_tao_hub_crown(self, tmp_path: Path):
+        # A sol-backed swap spans (300,800]: the sol-hub direction forfeits that span,
+        # the tao-hub direction earns the whole window — serving both purses at once
+        # is exactly what v3.1 enables, and it must not cost the other hub's crown.
+        store, watcher = self._seed(tmp_path, [('sol', 'btc', 300.0), ('tao', 'btc', 0.003)])
+        watcher.reserve_then_swap('hk_a', reserve_block=300, init_block=300, end_block=800, backing='sol')
+        assert self._replay(store, 'sol', 'btc') == {'hk_a': 500.0}
+        assert self._replay(store, 'tao', 'btc') == {'hk_a': 1000.0}
+        store.close()
+
+    def test_tao_busy_keeps_sol_hub_crown(self, tmp_path: Path):
+        store, watcher = self._seed(tmp_path, [('sol', 'btc', 300.0), ('tao', 'btc', 0.003)])
+        watcher.reserve_then_swap('hk_a', reserve_block=300, init_block=300, end_block=800, backing='tao')
+        assert self._replay(store, 'tao', 'btc') == {'hk_a': 500.0}
+        assert self._replay(store, 'sol', 'btc') == {'hk_a': 1000.0}
+        store.close()
+
+    def test_hub_hub_direction_forfeits_only_when_both_purses_busy(self, tmp_path: Path):
+        # sol busy (300,800], tao busy (600,900] → sol↔tao forfeits only the overlap
+        # (600,800]: while either purse is clean, its quote can still be reserved.
+        store, watcher = self._seed(tmp_path, [('sol', 'tao', 2.0)])
+        watcher.reserve_then_swap('hk_a', reserve_block=300, init_block=300, end_block=800, backing='sol')
+        watcher.reserve_then_swap('hk_a', reserve_block=600, init_block=600, end_block=900, backing='tao')
+        assert self._replay(store, 'sol', 'tao') == {'hk_a': 800.0}
+        store.close()
+
+    def test_legacy_hubless_span_forfeits_every_direction(self, tmp_path: Path):
+        # A pre-v3.1.1 row (NULL hub) keeps its original meaning: busy everywhere.
+        store, watcher = self._seed(tmp_path, [('sol', 'btc', 300.0), ('tao', 'btc', 0.003)])
+        watcher.reserve_then_swap('hk_a', reserve_block=300, init_block=300, end_block=800)
+        assert self._replay(store, 'sol', 'btc') == {'hk_a': 500.0}
+        assert self._replay(store, 'tao', 'btc') == {'hk_a': 500.0}
+        store.close()
+
+    def test_window_edge_reconstruction_is_per_hub(self, tmp_path: Path):
+        # A sol swap open across window_start forfeits only sol-hub time at the edge.
+        store, watcher = self._seed(tmp_path, [('sol', 'btc', 300.0), ('tao', 'btc', 0.003)])
+        watcher.reserve_then_swap('hk_a', reserve_block=50, init_block=50, end_block=500, backing='sol')
+        assert store.get_activity_state_at(100) == {'hk_a': {'sol': MinerActivity.FULFILLING}}
+        assert self._replay(store, 'sol', 'btc') == {'hk_a': 600.0}
+        assert self._replay(store, 'tao', 'btc') == {'hk_a': 1000.0}
+        store.close()

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "allways"
-version = "3.1.0"
+version = "3.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "base58" },


### PR DESCRIPTION
Closes the incentive gap between v3.1's per-hub concurrency and the crown: the on-chain model lets a miner serve both purses at once, but the scoring replay still treated RESERVED/FULFILLING as one global state — a sol-backed swap zeroed the miner's tao-hub crown for the whole span (and vice versa), punishing exactly the behavior v3.1 enables.

- `activity_events` gains a `hub` column; the ingest writes each lifecycle event's `collateral_chain` (already on the wire since v3.1). NULL = the legacy global-busy reading — pre-upgrade rows migrate in place and keep their original meaning; the synthetic RESERVE_EXPIRE inherits its RESERVE_START's hub.
- The activity reducer and crown replay run one MinerActivity machine per (hotkey, hub). A direction forfeits only when EVERY hub it can serve through is busy — the activity twin of `direction_eligible`'s any-clean-hub rule: sol↔spoke forfeits on sol-busy, tao↔spoke on tao-busy, sol↔tao only when both purses are.
- `snapshot_current_crown_holders` applies the same predicate, so the live table never disagrees with the ledger.
- SQLite migration follows the existing PRAGMA/ALTER pattern; prune keeps a hotkey's timeline while ANY hub is mid-flight.

Validator-only: no program, provider, das, or CLI surface changes. Suite: 1363 passing (8 new: per-hub replay spans incl. the hub↔hub overlap case, legacy NULL-row semantics, hub-scoped ingest, in-place migration). Bumps to 3.1.1.