### PR TITLE
Add CRO (Cronos) as a launch spoke

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,6 +93,15 @@ BASE_PRIVATE_KEY=
 # OPTIONAL token contract override (dev/e2e fakes) — per ASSET, unset = Circle's canonical deployment
 # BASEUSDC_TOKEN_CONTRACT=
 
+# ─── Chain: Cronos (CRO pairs) ─────────────────────────────
+CRO_NETWORK=mainnet                 # mainnet | testnet
+# OPTIONAL ordered JSON-RPC endpoints (keyed providers embed the key in the URL);
+# unset = public (the official Cronos gateway, publicnode); the gateway leads as the only
+# mainnet rung serving the historical state the slash gate reads
+# CRO_RPC_URLS=https://cronos-mainnet.g.alchemy.com/v2/your_key,https://evm.cronos.org
+# 32-byte hex key — required for miners; optional local signing for `alw swap`
+CRO_PRIVATE_KEY=
+
 # ─── Miner-only ────────────────────────────────────────────
 # headless miners: unlocks the coldkey at startup for TAO sends; unset = prompt at launch
 MINER_BITTENSOR_COLDKEY_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Native transactions across independent assets — no wrapped tokens, no bridges,
 
 Allways creates a verification layer above independent systems. Assets move natively. Miners complete transactions, validators independently verify the results, and a smart contract enforces outcomes through collateral and slashing.
 
-Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, SOL ↔ USDC-on-Base, and SOL ↔ USDC-on-Ethereum (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
+Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, SOL ↔ USDC-on-Base, SOL ↔ USDC-on-Ethereum, and SOL ↔ CRO (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
 
 ## Miner Risk Disclaimer
 
@@ -123,7 +123,7 @@ needs to persist across restarts.
 
 ## Miner Environment Variables
 
-- `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `BNB_PRIVATE_KEY`, `AVAX_PRIVATE_KEY`, `BASE_PRIVATE_KEY`, `{ETH,ARB,HYPE,BNB,AVAX,BASE}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config (ETH and ethusdc both ride the `ETH_*` vars). See `.env.example`.
+- `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `BNB_PRIVATE_KEY`, `AVAX_PRIVATE_KEY`, `BASE_PRIVATE_KEY`, `CRO_PRIVATE_KEY`, `{ETH,ARB,HYPE,BNB,AVAX,BASE,CRO}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config (ETH and ethusdc both ride the `ETH_*` vars). See `.env.example`.
 
 ## Running a Local Subtensor Lite Node (Validators)
 

--- a/allways/assets/__init__.py
+++ b/allways/assets/__init__.py
@@ -9,6 +9,7 @@ from allways.assets.baseusdc import BaseUsdc
 from allways.assets.bnb import Bnb
 from allways.assets.btc import Bitcoin
 from allways.assets.chain import Chain
+from allways.assets.cro import Cro
 from allways.assets.erc20 import Erc20
 from allways.assets.eth import Ether
 from allways.assets.ethusdc import EthUsdc
@@ -31,6 +32,7 @@ __all__ = [
     'Hype',
     'Bnb',
     'Avax',
+    'Cro',
     'Erc20',
     'ArbUsdc',
     'BaseUsdc',
@@ -59,6 +61,7 @@ ASSET_REGISTRY: Tuple[AssetSpec, ...] = (
     AssetSpec('avax', Avax, ()),
     AssetSpec('baseusdc', BaseUsdc, ()),
     AssetSpec('ethusdc', EthUsdc, ()),
+    AssetSpec('cro', Cro, ()),
 )
 
 

--- a/allways/assets/cro.py
+++ b/allways/assets/cro.py
@@ -1,0 +1,12 @@
+from allways.assets.evm_coin import EvmCoin
+from allways.chains import CHAIN_CRO
+
+
+class Cro(EvmCoin):
+    """CRO on Cronos — a config-row binding of the generic EvmCoin (see chains.CHAIN_CRO).
+
+    Cronos is an Ethermint EVM behind plain JSON-RPC, so nothing here is chain-specific
+    beyond the pairing."""
+
+    def __init__(self):
+        super().__init__(CHAIN_CRO)

--- a/allways/assets/evm.py
+++ b/allways/assets/evm.py
@@ -146,9 +146,10 @@ CRONOS = EvmNetwork(
     chain_ids={'mainnet': 25, 'testnet': 338},
     rpc_urls={
         # The official gateway leads as the only mainnet rung serving historical eth_getCode, which
-        # delivery_refused probes up to 120 blocks back on every overdue swap: publicnode prunes
-        # Ethermint state at tip-107 and errors below it (measured 2026-08-12). publicnode stays
-        # second — it serves receipts, blocks and tx lookups cleanly, which is what null quorum needs.
+        # delivery_refused probes up to 120 blocks back on every overdue swap: publicnode keeps only
+        # ~100 blocks of Ethermint state (the Cosmos SDK pruning-keep-recent default) and errors
+        # below it. publicnode stays second — it serves receipts, blocks and tx lookups cleanly,
+        # which is what null quorum needs.
         'mainnet': ('https://evm.cronos.org', 'https://cronos-evm-rpc.publicnode.com'),
         # Both testnet rungs serve historical eth_getCode past 100k blocks; official leads for symmetry.
         'testnet': ('https://evm-t3.cronos.org', 'https://cronos-testnet.drpc.org'),

--- a/allways/assets/evm.py
+++ b/allways/assets/evm.py
@@ -141,6 +141,20 @@ BASE = EvmNetwork(
     },
 )
 
+CRONOS = EvmNetwork(
+    label='Cronos',
+    chain_ids={'mainnet': 25, 'testnet': 338},
+    rpc_urls={
+        # The official gateway leads as the only mainnet rung serving historical eth_getCode, which
+        # delivery_refused probes up to 120 blocks back on every overdue swap: publicnode prunes
+        # Ethermint state at tip-107 and errors below it (measured 2026-08-12). publicnode stays
+        # second — it serves receipts, blocks and tx lookups cleanly, which is what null quorum needs.
+        'mainnet': ('https://evm.cronos.org', 'https://cronos-evm-rpc.publicnode.com'),
+        # Both testnet rungs serve historical eth_getCode past 100k blocks; official leads for symmetry.
+        'testnet': ('https://evm-t3.cronos.org', 'https://cronos-testnet.drpc.org'),
+    },
+)
+
 # ChainDefinition.host_chain → the EvmNetwork that hosts the asset.
 EVM_NETWORKS: Mapping[str, EvmNetwork] = {
     'ethereum': ETHEREUM,
@@ -149,6 +163,7 @@ EVM_NETWORKS: Mapping[str, EvmNetwork] = {
     'bsc': BSC,
     'avalanche': AVALANCHE,
     'base': BASE,
+    'cronos': CRONOS,
 }
 
 

--- a/allways/assets/evm.py
+++ b/allways/assets/evm.py
@@ -145,12 +145,12 @@ CRONOS = EvmNetwork(
     label='Cronos',
     chain_ids={'mainnet': 25, 'testnet': 338},
     rpc_urls={
-        # The official gateway leads as the only mainnet rung serving historical eth_getCode, which
-        # delivery_refused probes up to 120 blocks back on every overdue swap: publicnode keeps only
-        # ~100 blocks of Ethermint state (the Cosmos SDK pruning-keep-recent default) and errors
-        # below it. publicnode stays second — it serves receipts, blocks and tx lookups cleanly,
-        # which is what null quorum needs.
-        'mainnet': ('https://evm.cronos.org', 'https://cronos-evm-rpc.publicnode.com'),
+        # publicnode leads: it tracks the tip closely (the official gateway measured a median 25
+        # blocks behind it, 32% of samples past 32) and so serves every hot-path call. It keeps
+        # only ~100 blocks of Ethermint state (the Cosmos SDK pruning-keep-recent default), so the
+        # official gateway trails as the archive rung that answers delivery_refused's 120-block
+        # probe by fall-through — a rung need not lead to serve a call the leader errors on.
+        'mainnet': ('https://cronos-evm-rpc.publicnode.com', 'https://evm.cronos.org'),
         # Both testnet rungs serve historical eth_getCode past 100k blocks; official leads for symmetry.
         'testnet': ('https://evm-t3.cronos.org', 'https://cronos-testnet.drpc.org'),
     },

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -265,8 +265,10 @@ CHAIN_CRO = ChainDefinition(
     host_chain='cronos',
     networks=('mainnet', 'testnet'),
     testnet_network='testnet',
-    # 0.4749s measured over the last 100k mainnet blocks; 1 is the integer floor, so every derived
-    # bound is conservative in wall time, never short.
+    # 0.4749s measured over the last 100k mainnet blocks; 1 is the integer floor. Flooring up is
+    # safe where the value is MULTIPLIED (the extension target overestimates the wait) but not
+    # where a window is DIVIDED out of it: the 300s scan lookback lands at ~142s of wall time and
+    # delivery_refused's 120-block cap at ~57s. See the SCAN_LOOKBACK_SECS note in assets/evm.py.
     seconds_per_block=1,
     # Cronos is Ethermint on CometBFT: a block commits only with >2/3 pre-commits and no fork-choice
     # rule can revert it, so finality IS inclusion — there is no reorg depth to outrun, as on

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -256,6 +256,30 @@ CHAIN_ETHUSDC = ChainDefinition(
     asset_locator='0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
 )
 
+CHAIN_CRO = ChainDefinition(
+    id='cro',
+    name='Cronos',
+    native_unit='wei',
+    decimals=18,
+    env_prefix='CRO',
+    host_chain='cronos',
+    networks=('mainnet', 'testnet'),
+    testnet_network='testnet',
+    # 0.4749s measured over the last 100k mainnet blocks; 1 is the integer floor, so every derived
+    # bound is conservative in wall time, never short.
+    seconds_per_block=1,
+    # Cronos is Ethermint on CometBFT: a block commits only with >2/3 pre-commits and no fork-choice
+    # rule can revert it, so finality IS inclusion — there is no reorg depth to outrun, as on
+    # Avalanche. 2 is a one-block margin against an endpoint serving a head consensus hasn't sealed.
+    min_confirmations=2,
+    # Rate sanity floor, not an economic guarantee: 0.5 CRO covers a 21k-gas transfer below ~23,800
+    # gwei — ~63x the 375 gwei base fee measured on mainnet, whose gas prices sit three orders of
+    # magnitude above L1's. Miners price real gas into their quotes.
+    min_onchain_amount=500_000_000_000_000_000,
+    # Consensus-stamped timestamps vs the hub clock — modest skew allowance, as on Arbitrum.
+    replay_grace_secs=60,
+)
+
 SUPPORTED_CHAINS = {
     'btc': CHAIN_BTC,
     'tao': CHAIN_TAO,
@@ -267,6 +291,7 @@ SUPPORTED_CHAINS = {
     'avax': CHAIN_AVAX,
     'baseusdc': CHAIN_BASEUSDC,
     'ethusdc': CHAIN_ETHUSDC,
+    'cro': CHAIN_CRO,
 }
 
 

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -87,7 +87,7 @@ def hub_leg(from_chain: str, to_chain: str) -> str | None:
 
 
 # Chains paired against each hub; add a chain here to launch its pairs.
-LAUNCH_SPOKES = ('btc', 'tao', 'eth', 'arbusdc', 'hype', 'bnb', 'avax', 'baseusdc', 'ethusdc')
+LAUNCH_SPOKES = ('btc', 'tao', 'eth', 'arbusdc', 'hype', 'bnb', 'avax', 'baseusdc', 'ethusdc', 'cro')
 # Every launch pair as (hub, spoke): each hub pairs against every spoke except itself. sol↔tao
 # lands exactly once (under SOL, its anchor) because sol never appears in LAUNCH_SPOKES.
 LAUNCH_PAIRS: tuple[tuple[str, str], ...] = tuple(

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -11,6 +11,7 @@ from allways.chains import (
     CHAIN_BASEUSDC,
     CHAIN_BNB,
     CHAIN_BTC,
+    CHAIN_CRO,
     CHAIN_ETH,
     CHAIN_ETHUSDC,
     CHAIN_HYPE,
@@ -50,6 +51,9 @@ class TestGetChain:
 
     def test_ethusdc(self):
         assert get_chain_def('ethusdc') is CHAIN_ETHUSDC
+
+    def test_cro(self):
+        assert get_chain_def('cro') is CHAIN_CRO
 
     def test_unsupported_raises(self):
         with pytest.raises(KeyError):
@@ -91,11 +95,13 @@ class TestGetChain:
     def test_only_self_hosted_assets_lack_a_host_chain(self):
         for chain_id in ('btc', 'tao', 'sol'):
             assert get_chain_def(chain_id).host_chain is None
-        for chain_id in ('eth', 'hype', 'bnb', 'avax', 'arbusdc'):
+        for chain_id in ('eth', 'hype', 'bnb', 'avax', 'cro', 'arbusdc'):
             assert get_chain_def(chain_id).host_chain in EVM_NETWORKS
         # asset_locator is the token-only field: a native coin has no contract to pin.
         assert CHAIN_ARBUSDC.asset_locator.startswith('0x')
-        assert all(get_chain_def(c).asset_locator is None for c in ('btc', 'tao', 'sol', 'eth', 'hype', 'bnb', 'avax'))
+        assert all(
+            get_chain_def(c).asset_locator is None for c in ('btc', 'tao', 'sol', 'eth', 'hype', 'bnb', 'avax', 'cro')
+        )
         for chain_id in ('eth', 'hype', 'arbusdc', 'baseusdc'):
             assert get_chain_def(chain_id).host_chain in EVM_NETWORKS
         # asset_locator is the token-only field: a native coin has no contract to pin.
@@ -190,6 +196,10 @@ class TestComputeExtensionTargetSecs:
     def test_baseusdc_remaining_confs(self):
         # baseusdc needs 120 confs, 2s each: remaining=120, raw = 10000 + 240 + 120 = 10360, bucket up to 10800.
         assert compute_extension_target_secs('baseusdc', 0, self.NOW, self.CEILING) == 10_800
+
+    def test_cro_remaining_confs(self):
+        # cro needs 2 confs, 1s each: remaining=2, raw = 10000 + 2 + 120 = 10122, bucket up to 10200.
+        assert compute_extension_target_secs('cro', 0, self.NOW, self.CEILING) == 10_200
 
     def test_unsupported_chain_raises(self):
         with pytest.raises(KeyError):

--- a/tests/test_cli_chain_networks.py
+++ b/tests/test_cli_chain_networks.py
@@ -57,6 +57,7 @@ class TestPinnedContract:
             'bnb-network',
             'avax-network',
             'base-network',
+            'cro-network',
             'router',
             'env',
         )
@@ -70,6 +71,7 @@ class TestPinnedContract:
             'bnb-network',
             'avax-network',
             'base-network',
+            'cro-network',
         )
 
     def test_testnet_bundle(self):
@@ -83,6 +85,7 @@ class TestPinnedContract:
             'bnb-network': 'testnet',
             'avax-network': 'fuji',
             'base-network': 'sepolia',
+            'cro-network': 'testnet',
             'netuid': '19',
             'router': '5HicmHG7fjbxrtx8FZNdv4xxS5jSN84KGpMnTHsKtKv9peao',
         }
@@ -98,6 +101,7 @@ class TestPinnedContract:
             'bnb-network': 'mainnet',
             'avax-network': 'mainnet',
             'base-network': 'mainnet',
+            'cro-network': 'mainnet',
             'netuid': '7',
             'router': '',
         }
@@ -123,6 +127,7 @@ class TestPinnedContract:
             'bnb': ('mainnet', 'testnet'),
             'avax': ('mainnet', 'fuji'),
             'baseusdc': ('mainnet', 'sepolia'),
+            'cro': ('mainnet', 'testnet'),
         }
 
 

--- a/tests/test_cro_provider.py
+++ b/tests/test_cro_provider.py
@@ -1,0 +1,304 @@
+"""Cro unit tests — all offline (RPC layer mocked, signing is pure crypto).
+
+The EVM behaviour itself is `EvmCoin`, proven by the Ether suite. What is Cronos-specific — and
+what a wrong value here would cost — lives in the binding: which network the env selects, the
+chain id every signed tx commits to, the 2-block confirmation depth CometBFT's instant finality
+earns, and the sub-second block time that drives the scanner. Cronos's own hazard is that only
+one public mainnet rung serves the historical state the slash gate reads, so the ladder order
+is pinned too, alongside the delivery gates a code-bearing destination trips.
+"""
+
+import pytest
+from eth_account import Account
+
+from allways.assets import evm_coin
+from allways.assets.asset import ProviderUnreachableError
+from allways.assets.cro import Cro
+from allways.assets.evm import CRONOS, EvmChain
+from allways.assets.evm_coin import MAX_WALK_BLOCKS
+from allways.chains import CHAIN_CRO, get_chain_def
+from allways.constants import LAUNCH_SPOKES
+
+TEST_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'  # hardhat account #0
+RECIPIENT = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+TX = '0x' + 'ab' * 32
+BLOCK_HASH = '0x' + 'cd' * 32
+DELEGATION = '0xef0100' + '11' * 20  # EIP-7702 delegation indicator
+MINED_BLOCK = 0xF4240  # 1_000_000
+CONFIRMED_TIP = MINED_BLOCK + CHAIN_CRO.min_confirmations - 1
+
+SEND_RESPONSES = {
+    'eth_blockNumber': hex(100),
+    'eth_getBlockByNumber': {'baseFeePerGas': hex(10**9)},
+    'eth_maxPriorityFeePerGas': hex(10**9),
+    'eth_getTransactionCount': '0x0',
+    'eth_getBalance': hex(10**19),
+    'eth_estimateGas': hex(21_000),
+}
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    monkeypatch.setenv('CRO_NETWORK', 'mainnet')
+    monkeypatch.delenv('CRO_RPC_URLS', raising=False)
+    monkeypatch.delenv('CRO_PRIVATE_KEY', raising=False)
+    return Cro()
+
+
+@pytest.fixture
+def frozen_now(monkeypatch):
+    """Pin the clock so delivery_refused's span arithmetic lands on exact block offsets."""
+    now = 1_800_000_000
+    monkeypatch.setattr(evm_coin.time, 'time', lambda: now)
+    return now
+
+
+def rpc_stub(provider, responses: dict):
+    """Replace eth_rpc with a method→response map. A callable value is invoked with params."""
+
+    def fake_rpc(method, params, timeout=15, **kw):
+        value = responses[method]
+        return value(params) if callable(value) else value
+
+    provider.chain.eth_rpc = fake_rpc
+    return provider
+
+
+def mined_responses(status='0x1', tip=CONFIRMED_TIP, value_hex=hex(10**18)):
+    return {
+        'eth_getTransactionByHash': {
+            'hash': TX,
+            'from': '0x' + '11' * 20,
+            # Lowercase on the wire against a checksummed expectation: EIP-55 is display-only,
+            # and a case-sensitive compare would reject an honest miner's payout.
+            'to': RECIPIENT.lower(),
+            'value': value_hex,
+            'blockNumber': hex(MINED_BLOCK),
+            'blockHash': BLOCK_HASH,
+        },
+        'eth_getTransactionReceipt': {'status': status, 'blockNumber': hex(MINED_BLOCK), 'blockHash': BLOCK_HASH},
+        'eth_blockNumber': hex(tip),
+        'eth_getBlockByNumber': {'hash': BLOCK_HASH, 'timestamp': '0x64'},
+    }
+
+
+class TestRegistryRow:
+    def test_is_a_launch_spoke_bound_to_its_registry_row(self, provider):
+        assert provider.chain_def is CHAIN_CRO is get_chain_def('cro')
+        assert 'cro' in LAUNCH_SPOKES
+
+    def test_native_coin_composes_its_chain(self, provider):
+        # A native coin is an asset ON its network, not the network — same seam as a token,
+        # so a second Cronos asset can land beside it without either claiming to be the chain.
+        assert isinstance(provider.chain, EvmChain) and provider.chain is not provider
+        assert provider.chain.env_prefix == CHAIN_CRO.env_prefix
+
+    def test_decimals_and_prefix(self):
+        assert (CHAIN_CRO.decimals, CHAIN_CRO.env_prefix, CHAIN_CRO.native_unit) == (18, 'CRO', 'wei')
+
+    def test_confirmations_stay_inside_the_program_fulfillment_grace(self):
+        # An unlisted chain gets the program's 600s default grace. 2 × the stored 1s is 2s;
+        # real Cronos blocks are 0.47s, so the true leg wait is ~1s — both far inside it.
+        assert CHAIN_CRO.min_confirmations * CHAIN_CRO.seconds_per_block < 600
+
+
+class TestNetworkSelection:
+    def test_mainnet_chain_id(self, provider):
+        assert provider.chain.chain_id == 25
+
+    def test_testnet_chain_id(self, monkeypatch):
+        monkeypatch.setenv('CRO_NETWORK', 'testnet')
+        assert Cro().chain.chain_id == 338
+
+    def test_unknown_network_raises(self, monkeypatch):
+        # A typo must never fall back to mainnet — that spends real CRO against test swaps.
+        monkeypatch.setenv('CRO_NETWORK', 'testnet3')
+        with pytest.raises(ValueError, match='CRO_NETWORK'):
+            Cro()
+
+    def test_unset_network_defaults_to_mainnet(self, monkeypatch):
+        monkeypatch.delenv('CRO_NETWORK', raising=False)
+        assert Cro().chain.network == 'mainnet'
+
+    @pytest.mark.parametrize('network', tuple(CRONOS.chain_ids))
+    def test_every_network_has_a_keyless_default_ladder(self, monkeypatch, network):
+        monkeypatch.setenv('CRO_NETWORK', network)
+        assert Cro().chain.rpc_bases == list(CRONOS.rpc_urls[network])
+
+    def test_mainnet_ladder_leads_with_the_archive_rung(self, provider):
+        # delivery_refused reads state up to 120 blocks back and publicnode prunes Cronos state
+        # at tip-107, so the official gateway must stay first or every slash check pays a failover.
+        assert provider.chain.rpc_bases[0] == 'https://evm.cronos.org'
+
+    def test_rpc_urls_env_overrides_the_public_ladder(self, monkeypatch):
+        monkeypatch.setenv('CRO_RPC_URLS', 'https://paid.example/key/,https://backup.example')
+        assert Cro().chain.rpc_bases == ['https://paid.example/key', 'https://backup.example']
+
+    def test_wrong_network_endpoint_fails_startup(self, monkeypatch):
+        # Testnet configured, a mainnet endpoint answering: the ladder must be rejected outright,
+        # never quietly used to verify legs against the wrong chain.
+        monkeypatch.setenv('CRO_NETWORK', 'testnet')
+        p = rpc_stub(Cro(), {'eth_chainId': hex(25)})
+        with pytest.raises(ConnectionError, match='expected 338'):
+            p.check_connection(require_send=False)
+
+
+class TestVerification:
+    def test_settled_transfer_matches(self, provider):
+        rpc_stub(provider, mined_responses())
+        info = provider.fetch_matching_tx(TX, RECIPIENT, 10**18)
+        assert info is not None and info.confirmed and info.amount == 10**18
+        assert info.block_time == 0x64
+
+    def test_two_confirmations_are_enough(self, provider):
+        rpc_stub(provider, mined_responses(tip=CONFIRMED_TIP))
+        assert provider.fetch_matching_tx(TX, RECIPIENT, 10**18).confirmed
+
+    def test_one_confirmation_is_not(self, provider):
+        rpc_stub(provider, mined_responses(tip=CONFIRMED_TIP - 1))
+        assert provider.fetch_matching_tx(TX, RECIPIENT, 10**18).confirmed is False
+
+    def test_reverted_tx_rejected(self, provider):
+        # Inclusion is not settlement: a reverted tx still carries intact to/value fields.
+        rpc_stub(provider, mined_responses(status='0x0'))
+        assert provider.fetch_matching_tx(TX, RECIPIENT, 10**18) is None
+
+    def test_underpayment_rejected(self, provider):
+        rpc_stub(provider, mined_responses(value_hex=hex(10**17)))
+        assert provider.fetch_matching_tx(TX, RECIPIENT, 10**18) is None
+
+    def test_wrong_recipient_rejected(self, provider):
+        rpc_stub(provider, mined_responses())
+        assert provider.fetch_matching_tx(TX, '0x' + '22' * 20, 10**18) is None
+
+    def test_absent_tx_is_absent(self, provider):
+        rpc_stub(provider, {'eth_getTransactionByHash': None})
+        assert provider.fetch_matching_tx(TX, RECIPIENT, 10**18) is None
+
+    def test_unreadable_receipt_is_unknown_not_absent(self, provider):
+        # 'unknown' must never read as 'no such payment' — that verdict slashes a paying miner.
+        responses = mined_responses()
+        responses['eth_getTransactionReceipt'] = None
+        with pytest.raises(ProviderUnreachableError):
+            rpc_stub(provider, responses).fetch_matching_tx(TX, RECIPIENT, 10**18)
+
+    def test_unreadable_block_timestamp_is_unknown_not_absent(self, provider):
+        # is_tx_fresh fails closed on a missing block_time, so a stale-looking dest leg
+        # would ride to a TIMEOUT slash. Raise instead and let the caller retry.
+        responses = mined_responses()
+        responses['eth_getBlockByNumber'] = {'hash': BLOCK_HASH}
+        with pytest.raises(ProviderUnreachableError):
+            rpc_stub(provider, responses).fetch_matching_tx(TX, RECIPIENT, 10**18)
+
+
+class TestSending:
+    @pytest.fixture(autouse=True)
+    def _key(self, provider, monkeypatch):
+        monkeypatch.setenv('CRO_PRIVATE_KEY', TEST_KEY)
+
+    def test_broadcasts_a_cronos_signed_transfer(self, provider):
+        # Pins the whole signed payload: chain id 25 (a tx signed for any other chain is simply
+        # invalid here), EIP-1559 fees off the stubbed base fee, and the estimated gas + 20%.
+        broadcast = {}
+
+        def capture(params):
+            broadcast['raw'] = params[0]
+            return TX
+
+        rpc_stub(provider, dict(SEND_RESPONSES, eth_sendRawTransaction=capture))
+        assert provider.send_amount(RECIPIENT, 10**16) == (TX, 0)
+
+        expected = Account.sign_transaction(
+            {
+                'chainId': 25,
+                'nonce': 0,
+                'to': RECIPIENT,
+                'value': 10**16,
+                'gas': 25_200,
+                'maxFeePerGas': 3 * 10**9,
+                'maxPriorityFeePerGas': 10**9,
+            },
+            TEST_KEY,
+        )
+        raw = getattr(expected, 'raw_transaction', None) or getattr(expected, 'rawTransaction')
+        assert broadcast['raw'].removeprefix('0x') == raw.hex().removeprefix('0x')
+
+    def test_no_key_refused(self, provider, monkeypatch):
+        monkeypatch.delenv('CRO_PRIVATE_KEY', raising=False)
+        assert provider.send_amount(RECIPIENT, 10**16) is None
+        assert 'CRO_PRIVATE_KEY' in provider.last_send_error
+
+    def test_key_mismatch_refused(self, provider):
+        assert provider.send_amount(RECIPIENT, 10**16, from_address=RECIPIENT) is None
+        assert 'key mismatch' in provider.last_send_error
+
+    def test_insufficient_balance_refused(self, provider):
+        rpc_stub(provider, dict(SEND_RESPONSES, eth_getBalance=hex(10**12)))
+        assert provider.send_amount(RECIPIENT, 10**18) is None
+        assert 'Insufficient CRO' in provider.last_send_error
+
+
+class TestDeliveryGates:
+    """A Cronos dest can refuse a native transfer — a contract wallet, or an EOA that delegates to
+    one via EIP-7702 *after* the reservation pinned it. The reserve gate keeps such a swap from
+    starting; the slash gate keeps a miner who cannot pay from being punished for it."""
+
+    def test_reserve_gate_admits_an_eoa_and_blocks_a_reverting_dest(self, provider):
+        rpc_stub(provider, {'eth_getCode': '0x'})
+        assert provider.can_deliver_to(RECIPIENT, 10**16) is True
+
+        def refuse(params):
+            raise RuntimeError('rpc error execution reverted')
+
+        rpc_stub(provider, {'eth_getCode': '0x60806040', 'eth_estimateGas': refuse})
+        assert provider.can_deliver_to(RECIPIENT, 10**16) is False
+
+    def test_slash_gate_exempts_a_dest_that_gained_then_revoked_code(self, provider, frozen_now):
+        # The case only temporal sampling can catch, and the one a miner gets slashed over: the
+        # dest delegates via EIP-7702 after the reservation pinned it, the payout reverts, and the
+        # delegation is revoked before the slash check. 'latest' is clean by then — only the
+        # historical probes still see it. Code lives at the midpoint offset alone, so a passing
+        # run proves all three probe offsets were actually read.
+        probed = []
+
+        def code_at(params):
+            probed.append(params[1])
+            return DELEGATION if params[1] == hex(9_970) else '0x'
+
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getCode': code_at})
+        assert provider.delivery_refused(RECIPIENT, frozen_now - 60) is True
+        # now, then the window's far edge and its midpoint. The 60s window is 60 blocks at the
+        # stored 1s — inside the 107-block state depth publicnode serves, but the gate's 120-block
+        # cap is not, which is why the archive gateway leads the mainnet ladder.
+        assert probed == ['latest', hex(9_940), hex(9_970)]
+
+    def test_slash_gate_does_not_exempt_a_dest_that_never_had_code(self, provider, frozen_now):
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getCode': '0x'})
+        assert provider.delivery_refused(RECIPIENT, frozen_now - 60) is False
+
+
+class TestDepositScanner:
+    def test_walk_is_bounded_for_a_sub_second_chain(self, provider):
+        # 5 min of Cronos blocks is ~630 real blocks; the stored 1s block time already floors the
+        # lookback at 300, and each one costs a sequential eth_getBlockByNumber. The walk bound
+        # is what keeps a first scan inside a public endpoint's budget.
+        assert provider.SCAN_LOOKBACK_BLOCKS > MAX_WALK_BLOCKS
+
+        scanned = []
+
+        def block(params):
+            scanned.append(int(params[0], 16))
+            return {'transactions': []}
+
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getBlockByNumber': block})
+        assert provider.find_recent_outgoing(RECIPIENT, RECIPIENT, 1) is None
+        assert len(scanned) == MAX_WALK_BLOCKS
+
+    def test_cursor_parks_below_an_unreadable_block(self, provider):
+        def boom(params):
+            raise ConnectionError('down')
+
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getBlockByNumber': boom})
+        assert provider.find_recent_outgoing(RECIPIENT, RECIPIENT, 1) is None
+        # Never leap a block the scan could not read — the deposit in it must stay reachable.
+        assert provider.scan_cursors[(RECIPIENT.lower(), RECIPIENT.lower(), 1)] == 10_000 - MAX_WALK_BLOCKS

--- a/tests/test_cro_provider.py
+++ b/tests/test_cro_provider.py
@@ -125,10 +125,14 @@ class TestNetworkSelection:
         monkeypatch.setenv('CRO_NETWORK', network)
         assert Cro().chain.rpc_bases == list(CRONOS.rpc_urls[network])
 
-    def test_mainnet_ladder_leads_with_the_archive_rung(self, provider):
-        # delivery_refused reads state up to 120 blocks back and publicnode keeps only ~100 blocks
-        # of it, so the official gateway must stay first or every slash check pays a failover.
-        assert provider.chain.rpc_bases[0] == 'https://evm.cronos.org'
+    def test_mainnet_ladder_keeps_an_archive_rung_behind_the_fresh_one(self, provider):
+        # The leader serves every hot-path call, so it is the rung that tracks the tip. The
+        # official gateway trails purely as the archive rung: it is reached by fall-through for
+        # the one call publicnode cannot serve — a probe past its ~100 blocks of retained state.
+        assert provider.chain.rpc_bases == [
+            'https://cronos-evm-rpc.publicnode.com',
+            'https://evm.cronos.org',
+        ]
 
     def test_rpc_urls_env_overrides_the_public_ladder(self, monkeypatch):
         monkeypatch.setenv('CRO_RPC_URLS', 'https://paid.example/key/,https://backup.example')
@@ -269,7 +273,7 @@ class TestDeliveryGates:
         assert provider.delivery_refused(RECIPIENT, frozen_now - 60) is True
         # now, then the window's far edge and its midpoint. The 60s window is 60 blocks at the
         # stored 1s — inside the ~100 blocks of state publicnode keeps, but the gate's 120-block
-        # cap is not, which is why the archive gateway leads the mainnet ladder.
+        # cap is not, which is why the mainnet ladder carries an archive rung behind publicnode.
         assert probed == ['latest', hex(9_940), hex(9_970)]
 
     def test_slash_gate_does_not_exempt_a_dest_that_never_had_code(self, provider, frozen_now):

--- a/tests/test_cro_provider.py
+++ b/tests/test_cro_provider.py
@@ -126,8 +126,8 @@ class TestNetworkSelection:
         assert Cro().chain.rpc_bases == list(CRONOS.rpc_urls[network])
 
     def test_mainnet_ladder_leads_with_the_archive_rung(self, provider):
-        # delivery_refused reads state up to 120 blocks back and publicnode prunes Cronos state
-        # at tip-107, so the official gateway must stay first or every slash check pays a failover.
+        # delivery_refused reads state up to 120 blocks back and publicnode keeps only ~100 blocks
+        # of it, so the official gateway must stay first or every slash check pays a failover.
         assert provider.chain.rpc_bases[0] == 'https://evm.cronos.org'
 
     def test_rpc_urls_env_overrides_the_public_ladder(self, monkeypatch):
@@ -268,7 +268,7 @@ class TestDeliveryGates:
         rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getCode': code_at})
         assert provider.delivery_refused(RECIPIENT, frozen_now - 60) is True
         # now, then the window's far edge and its midpoint. The 60s window is 60 blocks at the
-        # stored 1s — inside the 107-block state depth publicnode serves, but the gate's 120-block
+        # stored 1s — inside the ~100 blocks of state publicnode keeps, but the gate's 120-block
         # cap is not, which is why the archive gateway leads the mainnet ladder.
         assert probed == ['latest', hex(9_940), hex(9_970)]
 


### PR DESCRIPTION
Adds CRO (Cronos native coin) as a launch spoke: a `CRONOS` `EvmNetwork` row, a `CHAIN_CRO`
registry row, an `EvmCoin` binding, and the `LAUNCH_SPOKES` entry. No shared-code changes —
Cronos is a plain Ethermint EVM, so `EvmCoin` covers it unmodified.

das twin: entrius/das-allways#97 (serves `cro` from the chain registry).

## Multi-hub: this is TWO pairs, not one

TAO is a second hub, so one `LAUNCH_SPOKES` entry produces both `sol-cro` and `tao-cro`.
**Miners are expected to quote the TAO leg too**, not just the SOL leg.

| | pairs | directions | zero-volume floor per direction |
|---|---|---|---|
| before | 17 | 34 | 0.294118% |
| after | **19** | **38** | **0.263158%** |

`floor = MINER_POOL_SHARE / (2 * len(LAUNCH_PAIRS))`, computed per PAIR. Volume weighting
(`POOL_VOLUME_ALPHA = 0.66`) lets a busy pair recover most of the difference; a pair with no
volume does not.

## Judgement calls

### `min_confirmations = 2`

Cronos is Ethermint on CometBFT, **not** an OP-stack rollup — Base's sequencer-reorg reasoning
does not transfer. A CometBFT block commits only once >2/3 of the validator set pre-commits it,
and there is no fork-choice rule that can revert a committed block: finality *is* inclusion.
The only way to unwind one is a >1/3 Byzantine coalition signing conflicting commits, which is
an accountable safety fault requiring social intervention, not a reorg the protocol can produce.

So 2 is a one-block margin against an endpoint serving a head its consensus has not sealed yet —
the same reasoning already shipped for Avalanche (Snowman) and Hyperliquid (HyperBFT), and
deliberately not BSC's 15 (BSC keeps a longest-chain fallback below quorum).

Empirically: 60s of head-tracking across both mainnet rungs, no block hash ever changed.

Implied leg latency: `seconds_per_block × min_confirmations` = 1 × 2 = **2s** in the stored
integer math; at the real 0.4749s block time it is **~0.95s**. Both far inside the program's
600s default fulfillment grace, so no `fulfillment_grace_secs` table arm is needed.

### `seconds_per_block = 1`

Measured live on mainnet, not taken from docs:

| window | elapsed | s/block |
|---|---|---|
| 99 blocks | 47s | 0.4747 |
| 1,000 blocks | 486s | 0.4860 |
| 100,000 blocks | 47,492s | **0.4749** |
| 1,000,000 blocks | 483,607s | 0.4836 |

Sub-second, so 1 is the integer floor. Same treatment as arbusdc/hype/bnb/avax.

**Which way that rounding cuts.** An earlier revision of this PR claimed the floor made "every
derived bound conservative in wall time, never short". That is only half true, and the shared
code says so at the `SCAN_LOOKBACK_SECS` note in `assets/evm.py`. It depends on whether the
value is multiplied or divided:

| derived bound | direction | stored | real at 0.4749s |
|---|---|---|---|
| `compute_extension_target_secs` | **×** — overestimates the wait, extends longer | 2 confs → 2s | 0.95s → **safe** |
| `SCAN_LOOKBACK_BLOCKS` (300s intent) | **÷** — window shortens | 300 blocks | **~142s, 47% of intent** |
| `delivery_refused` 120-block cap | **÷** — window shortens | 120 blocks | **~57s of real history** |

**Neither shortening is introduced by this PR, and neither is specific to `cro`.** Both fall out
of the shared `EvmAsset` / `EvmCoin` code the moment a chain's real block time is under a second,
so they already apply to `arbusdc`, `hype`, `bnb` and `avax`. `cro`'s 120-block refusal cap is
~57s of real history; `bnb`'s is ~54s, so `bnb` is the worst case, not this row. Nothing here
changes that behaviour — only the comment that described it.

The two are not equally benign, and an earlier revision of this section wrongly implied they were:

- **Scan window (~142s of the intended 300s) — benign.** `find_recent_outgoing` is a hash-finder;
  a miss falls through to paths that re-verify by exact tx hash, and the walk is separately capped
  at `MAX_WALK_BLOCKS = 32` anyway, so the lookback was never the binding constraint.
- **Refusal window (~57s) — a known open issue, tracked in the security backlog (C7).** A window
  too short to still see a destination's refusal makes `delivery_refused` answer `False`, and
  failing to *exempt* a miner is exactly how an honest one gets slashed: the miner genuinely could
  not deliver, the reason was the destination, and the gate exists to detect that reason. Calling
  this "not a fund-safety issue" was wrong — it is a pre-existing shared-code finding that this PR
  neither introduces nor fixes, and it is not `cro`'s to fix.

Fixed in `Say which way the block-time floor rounds`.

### `min_onchain_amount = 500_000_000_000_000_000` (0.5 CRO, 18 decimals)

Priced at a realistic-high gas level, not today's quiet day. Measured live on mainnet:
base fee **375 gwei**, priority 3.75 gwei, `eth_gasPrice` 378.75 gwei. Cronos gas prices sit
roughly three orders of magnitude above L1's because CRO's unit value is small — 375 gwei is
the *normal* level here, not congestion.

0.5 CRO covers a 21k-gas transfer below ~23,800 gwei, i.e. ~63× the measured base fee. At the
gas the provider actually buys (`eth_estimateGas` returns **21,000** for an EOA recipient —
re-measured against three of them — and `_transfer_gas` adds 20% → **25,200**, which is what
`tests/test_cro_provider.py` asserts) it covers **~19,840 gwei, ~53×**. Against a plausible
congested level of 5,000 gwei the floor is ~4× the transfer cost — "a few × the fee at a
realistic-high level".

**This is a rate-sanity input, not an enforced minimum.** It feeds
`is_executable_rate` / `min_executable_sol_leg` in `utils/rate.py`; the enforced trade bounds
are the program's `min_swap_amount` / `max_swap_amount`, denominated in SOL lamports. A spoke
payout below this floor is still reachable.

### `replay_grace_secs = 60`

Justified on **hub-vs-spoke clock skew**, not on timestamp monotonicity. Cronos block
timestamps are CometBFT BFT-time (the stake-weighted median of validators' locally reported
clocks); the floor they are compared against is Solana's `Clock.unix_timestamp`, itself an
estimate. Two independent clock estimates warrant a modest allowance, so 60 — matching every
other consensus-stamped EVM row (arbusdc, hype, bnb, avax). Monotonic timestamps would say
nothing about how far Cronos's clock sits from the hub's, which is why that argument is not
used here.

## RPC ladder — probed per endpoint per method, not on `eth_chainId` alone

Both networks reach two independent providers. Every rung was probed on the methods the
provider actually calls, because the repo has twice been burned by endpoints that answer
`eth_chainId` and then fail the call that settles a leg (publicnode on BSC mainnet, publicnode
on Base — both 403 receipts).

### Mainnet — chain id 25 (`0x19`), both rungs verified

| method | `cronos-evm-rpc.publicnode.com` (leads) | `evm.cronos.org` (archive fallback) |
|---|---|---|
| `eth_chainId` | 25 ✓ | 25 ✓ |
| `eth_blockNumber` | ok | ok |
| `eth_getBlockByNumber` (latest / by number / by hash) | ok | ok |
| `eth_getTransactionByHash` (real tx) | ok | ok |
| **`eth_getTransactionReceipt`** (real settled tx) | **ok, status 1** | **ok, status 1** |
| `eth_getTransactionReceipt` (unknown tx) | authoritative null | authoritative null |
| `eth_getBalance` / `eth_gasPrice` / `eth_maxPriorityFeePerGas` / `eth_estimateGas` / `eth_getTransactionCount` | ok | ok |
| `eth_getCode` @ latest | ok | ok |
| **`eth_getCode` @ historical** | **~100 blocks only** | **ok to 100k+ blocks** |

publicnode prunes Ethermint state: a deep `eth_getCode` returns
`-32000 … codespace sdk code 18: invalid request: failed to load state at height`. It keeps
**~100 blocks** — the Cosmos SDK `pruning-keep-recent` default.

The cutoff is deliberately written as "~100" rather than an exact integer, because it is not
one. Re-probed 8× per depth with the tip refreshed immediately before each probe:

| nominal depth | result |
|---|---|
| ≤ 102 | always served (8/8) |
| 103–108 | **mixed** — same depth answers both ways across rounds |
| ≥ 109 | always refused (8/8) |

The mixed band is publicnode load-balancing over several pruned nodes whose retained windows
differ, so no single integer is the boundary. (An earlier revision of this PR claimed tip-107;
that was a binary search reusing a stale tip while the chain minted ~2 blocks/s underneath it,
and it landed inside the unstable band. Corrected in `Correct the publicnode state retention
depth`.)

`delivery_refused` probes up to **120 blocks back** on every overdue swap — beyond even the
always-refused floor of 109 — so publicnode can never serve the deepest probe. That is why the
ladder carries a second, archive-capable rung at all.

### Which rung leads

An earlier revision put the archive gateway **first**, reasoning that it is the only rung that
can serve the deep probe. Red team showed the conclusion does not follow, and re-measurement
agreed on both counts:

1. **`eth_rpc` is a fallback ladder.** A rung does not need to lead to serve a call the leader
   errors on. Tested live under both orderings, the deep probe resolves identically:

   ```
   publicnode FIRST   getCode @ tip-120 -> '0x'   [cronos-evm-rpc=RPCERR -> evm=OK]
   evm.cronos FIRST   getCode @ tip-120 -> '0x'   [evm=OK]
   ```

2. **The archive gateway is measurably stale at the tip.** Independently re-measured, n=25,
   2s apart: it ran a **median 25 blocks behind** publicnode (mean 25.2, max 91), with
   **32% of samples more than 32 blocks stale**, and slightly slower (121ms vs 104ms mean).
   Leading with it would have served every `eth_getTransactionByHash`, receipt, block fetch,
   balance, nonce, gas estimate and broadcast from the staler node — to buy a fall-through that
   already worked.

So **publicnode leads** and the official gateway trails as the archive rung. The only cost is
one extra round trip on the deepest `delivery_refused` probe, on overdue swaps only — measured
at 517ms for the full three-probe gate against an EOA, versus 228ms when the first probe hits.
Fixed in `Lead the Cronos ladder with the rung that tracks the tip`.

One margin worth stating: with the fresh rung leading, `tip` comes from it, so the archive rung
must be within ~120 blocks or `tip - span` lands in *its* future. Sampled 8×, the deep probe
never failed (worst margin +38 blocks; the archive rung was never more than 91 behind, and
never past 120 in 25 samples). Even if it were, the failure is fail-safe: both rungs erroring
raises, and the caller defers the slash rather than issuing one.

**No endpoint was excluded.** publicnode stays as the second rung because it serves receipts,
blocks and tx lookups cleanly, and `null_needs_quorum` needs two reachable endpoints to ever
return an authoritative "absent". Its state error is a plain RPC error, so `eth_rpc` falls
through to the archive rung rather than treating it as a verdict — and the error text contains
no "revert", so it cannot be mistaken for an execution verdict either.

### Testnet — chain id 338 (`0x152`), both rungs verified

| method | `evm-t3.cronos.org` | `cronos-testnet.drpc.org` |
|---|---|---|
| `eth_chainId` | 338 ✓ | 338 ✓ |
| all tx / block / receipt / balance / gas methods | ok | ok |
| `eth_getCode` @ historical | ok to 100k+ blocks | ok to 100k+ blocks |

Both testnet rungs are archive-capable, so the ordering is symmetry with mainnet (official
gateway first) rather than a capability constraint.

Head lag between rungs was sampled 5× on each network: 0–1 blocks steady state, one transient
17-block excursion on mainnet. A lagging rung reads *fewer* confirmations, so it errs toward
waiting, never toward accepting an under-confirmed leg.

## Live read-only verification

No key, no funds, no broadcasts. Run against the real provider on both networks.

```
===== CRONOS MAINNET =====
ladder      : ['https://cronos-evm-rpc.publicnode.com', 'https://evm.cronos.org']
describe    : Cronos JSON-RPC (mainnet): cronos-evm-rpc.publicnode.com, evm.cronos.org
check_connection(require_send=False): OK (chain_id=25)
tip         : 87891768
settled tx  : VERIFIED  recipient passed as MIXED CASE 0x2032AC1f28A5BcDe131905CD5BF32aC4BAE86D70
              amount=2338000000000000000000 block=87862235 confs=29535
              block_time=1786557839 sender=0xcf60ea36994ea96c0d3df1005b3635fccc99637e (pinned, matched)
underpaid   : REJECTED (asked for 2338000000000000000001, tx pays 2338000000000000000000)
wrong sender: REJECTED (pinned 0x1111111111111111111111111111111111111111)
wrong recip : REJECTED (pinned 0x1111111111111111111111111111111111111111)
unknown tx  : REJECTED (authoritative null across the ladder)
balance     : 104252091147885858377 wei = 104.252091 CRO at 0xcf60ea36994ea96c0d3df1005b3635fccc99637e
can_deliver_to(EOA)                   : True
delivery_refused(EOA, 1h overdue)     : False
delivery_refused(contract, 1h overdue): True  <- slash exemption holds

===== CRONOS TESTNET =====
ladder      : ['https://evm-t3.cronos.org', 'https://cronos-testnet.drpc.org']
describe    : Cronos JSON-RPC (testnet): evm-t3.cronos.org, cronos-testnet.drpc.org
check_connection(require_send=False): OK (chain_id=338)
tip         : 110426175
settled tx  : VERIFIED  recipient passed as MIXED CASE 0x4f07991e18af0BCF90d142c798bCB48fD038A424
              amount=400000000000000000 block=110388936 confs=37242
              block_time=1786556697 sender=0x3ebf837ce74d0a65d270cbdf7d27311cbb1cff2b (pinned, matched)
underpaid   : REJECTED (asked for 400000000000000001, tx pays 400000000000000000)
wrong sender: REJECTED (pinned 0x1111111111111111111111111111111111111111)
wrong recip : REJECTED (pinned 0x1111111111111111111111111111111111111111)
unknown tx  : REJECTED (authoritative null across the ladder)
balance     : 98365499749803938273482 wei = 98365.499750 CRO at 0x3ebf837ce74d0a65d270cbdf7d27311cbb1cff2b
can_deliver_to(EOA)                   : True
delivery_refused(EOA, 1h overdue)     : False

ALL LIVE CHECKS PASSED ON BOTH NETWORKS
```

Reference transactions: mainnet
[`0xbb7f4d24…`](https://explorer.cronos.com/tx/0xbb7f4d2428797107cf338eae2c26c1b853166608512b24ee19d087685ba30797),
testnet `0x34ee3c88…` (block 110388936).

The mainnet recipient's own balance reads 0 — it swept the funds after receiving them. Both
rungs agree on that 0, so it is real data, not a swallowed error; the balance read above uses
the sender, which is funded on both networks.

## Tests

```
ruff format --check .   → 169 files already formatted
ruff check .            → All checks passed!
pytest tests/ -q        → 1545 passed, 6 deselected in 36.28s   (base was 1510)
```

- New `tests/test_cro_provider.py` — fully offline, RPC layer stubbed with a method→response
  map. Covers network selection, wrong-network startup rejection, settled / pending-depth /
  reverted / not-found / underpaid / wrong-recipient verification, receipt-unavailable and
  timestamp-unavailable both **raising** rather than returning a verdict, send guards
  (no key / key mismatch / insufficient balance), the signed-payload pin at chain id 25,
  the delivery gates, and the deposit scanner's walk bound and cursor parking.
- One CRO-specific addition over the BNB template:
  `test_mainnet_ladder_keeps_an_archive_rung_behind_the_fresh_one` pins the full mainnet
  tuple, so neither a reorder nor a dropped archive rung can land silently.
- `tests/test_chains.py` — registry lookup, host-chain/asset-locator membership, and the
  extension-target case.
- `tests/test_cli_chain_networks.py` — the pinned CLI contract. Adding a chain fails this
  suite by design; updated deliberately (settable keys, chain network keys, both env bundles,
  accepted network names).
- `tests/test_rate.py` — **no new cases**, 18 decimals is already covered.

## Derived surfaces (not hand-written)

```
$ alw miner quotes --help
  --cro-price     NUMBER   CRO per 1 hub unit (0/omit to skip CRO).
  --cro-address   TEXT     Your CRO address.

$ alw config
  │ cro-network    │ mainnet │ default │
```

## e2e

`alw-utils#123` (one fake RPC per network) is merged, so the harness needs no edits. Against
`alw-utils` `origin/main` with this branch on `PYTHONPATH`, `run-suites.sh --list` shows:

```
  sol-cro
  cro-sol
```

**I did not run the suite** — it needs the full local Solana stack up, which is outside this
PR's scope. The rows are derived from `LAUNCH_SPOKES`, so no harness change was needed.

## Merge order

Merge this before its das twin — das CI's chain-drift gate reads `allways/chains.py` from
`test`, so the twin stays red until this lands. That is by design; do not "fix" it there.




