### PR TITLE
Add ASTER on BNB Smart Chain as a launch spoke

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,13 +66,18 @@ HYPE_NETWORK=mainnet                # mainnet | testnet
 # 32-byte hex key — required for miners; optional local signing for `alw swap`
 HYPE_PRIVATE_KEY=
 
-# ─── Chain: BNB Smart Chain (BNB pairs) ────────────────────
+# ─── Network: BNB Smart Chain (BNB + aster pairs) ──────────
+# Vars are per NETWORK, shared by every asset on it — aster adds no network vars of its own.
 BNB_NETWORK=mainnet                 # mainnet | testnet (Chapel)
 # OPTIONAL ordered JSON-RPC endpoints (keyed providers embed the key in the URL);
 # unset = public (publicnode, the official bnbchain data seed)
 # BNB_RPC_URLS=https://bsc-mainnet.infura.io/v3/your_key,https://bsc-rpc.publicnode.com
-# 32-byte hex key — required for miners; optional local signing for `alw swap`
+# 32-byte hex key — required for miners (fund BNB for the BNB legs, ASTER + BNB-for-gas for
+# the aster legs); optional local signing for `alw swap`
 BNB_PRIVATE_KEY=
+# OPTIONAL token contract override (dev/e2e fakes) — per ASSET, unset = the issuer's canonical deployment
+# ASTER_TOKEN_CONTRACT=
+
 # ─── Chain: Avalanche C-Chain (AVAX pairs) ─────────────────
 AVAX_NETWORK=mainnet                # mainnet | fuji
 # OPTIONAL ordered JSON-RPC endpoints (keyed providers embed the key in the URL);

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Native transactions across independent assets — no wrapped tokens, no bridges,
 Allways creates a verification layer above independent systems. Assets move natively. Miners complete transactions, validators independently verify the results, and a smart contract enforces outcomes through collateral and slashing.
 
 Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, SOL ↔ USDC-on-Base, SOL ↔ USDC-on-Ethereum, and SOL ↔ CRO (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
+Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, SOL ↔ USDC-on-Base, SOL ↔ USDC-on-Ethereum, and SOL ↔ ASTER (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
 
 ## Miner Risk Disclaimer
 
@@ -124,6 +125,7 @@ needs to persist across restarts.
 ## Miner Environment Variables
 
 - `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `BNB_PRIVATE_KEY`, `AVAX_PRIVATE_KEY`, `BASE_PRIVATE_KEY`, `CRO_PRIVATE_KEY`, `{ETH,ARB,HYPE,BNB,AVAX,BASE,CRO}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config (ETH and ethusdc both ride the `ETH_*` vars). See `.env.example`.
+- `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `BNB_PRIVATE_KEY`, `AVAX_PRIVATE_KEY`, `BASE_PRIVATE_KEY`, `{ETH,ARB,HYPE,BNB,AVAX,BASE}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config (ETH and ethusdc both ride the `ETH_*` vars; BNB and aster both ride the `BNB_*` vars). See `.env.example`.
 
 ## Running a Local Subtensor Lite Node (Validators)
 

--- a/allways/assets/__init__.py
+++ b/allways/assets/__init__.py
@@ -4,6 +4,7 @@ import bittensor as bt
 
 from allways.assets.arbusdc import ArbUsdc
 from allways.assets.asset import Asset, SendResult, TransactionInfo
+from allways.assets.aster import Aster
 from allways.assets.avax import Avax
 from allways.assets.baseusdc import BaseUsdc
 from allways.assets.bnb import Bnb
@@ -37,6 +38,7 @@ __all__ = [
     'ArbUsdc',
     'BaseUsdc',
     'EthUsdc',
+    'Aster',
     'create_assets',
 ]
 
@@ -62,6 +64,7 @@ ASSET_REGISTRY: Tuple[AssetSpec, ...] = (
     AssetSpec('baseusdc', BaseUsdc, ()),
     AssetSpec('ethusdc', EthUsdc, ()),
     AssetSpec('cro', Cro, ()),
+    AssetSpec('aster', Aster, ()),
 )
 
 

--- a/allways/assets/aster.py
+++ b/allways/assets/aster.py
@@ -1,0 +1,12 @@
+from allways.assets.erc20 import Erc20
+from allways.chains import CHAIN_ASTER
+
+
+class Aster(Erc20):
+    """ASTER on BNB Smart Chain — a config-row binding of the generic Erc20 (see chains.CHAIN_ASTER).
+
+    Rides BSC's env identity alongside native BNB (BNB_NETWORK, BNB_RPC_URLS, BNB_PRIVATE_KEY),
+    adding only its own ASTER_TOKEN_CONTRACT override."""
+
+    def __init__(self):
+        super().__init__(CHAIN_ASTER)

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -288,6 +288,38 @@ CHAIN_CRO = ChainDefinition(
     replay_grace_secs=60,
 )
 
+CHAIN_ASTER = ChainDefinition(
+    id='aster',
+    name='Aster',
+    native_unit='wei',
+    decimals=18,
+    # BNB Smart Chain's prefix, shared with CHAIN_BNB: one BNB_NETWORK / BNB_RPC_URLS /
+    # BNB_PRIVATE_KEY serves both assets, so they can never disagree about which BSC they are on.
+    env_prefix='BNB',
+    host_chain='bsc',
+    # CHAIN_BNB already declares the BNB_NETWORK names; a second declaration would render a
+    # duplicate CLI row writing the same var.
+    networks=(),
+    seconds_per_block=1,
+    # CHAIN_BNB's finality, deliberately identical — two assets on one chain must not disagree
+    # about its reorg depth. See CHAIN_BNB for the derivation (BEP-126 quorum, BEP-341
+    # turn_length 8). 15 × 1s, inside the program's 600s default fulfillment grace.
+    min_confirmations=15,
+    # Rate sanity floor, not an economic guarantee. Break-even at CHAIN_BNB's 9.5 gwei reference
+    # is 0.48 ASTER for a ~50k-gas BEP-20 transfer (measured 29,698 warm); rounded up to 1, which
+    # prices ~19 gwei. Deliberately the strictest floor in the registry — a floor can only
+    # over-restrict, never slash. Miners price real gas in; the per-swap lever is min_swap_amount.
+    min_onchain_amount=1_000_000_000_000_000_000,
+    # BSC's clock, as CHAIN_BNB: what this absorbs is hub-vs-spoke skew, and two assets on one
+    # chain disagreeing about that chain's clock would be indefensible.
+    replay_grace_secs=60,
+    # ASTER as published by the issuer (docs.asterdex.com, 2026-08-12).
+    asset_locator='0x000Ae314E2A2172a039B26378814C252734f556A',
+    # Verified source is stock OpenZeppelin ERC20 + ERC20Permit with no blacklist and no pause,
+    # on a contract that can never gain one: EIP-1967 slots empty, owner() reverts (2026-08-12).
+    refusal_checks=(),
+)
+
 SUPPORTED_CHAINS = {
     'btc': CHAIN_BTC,
     'tao': CHAIN_TAO,
@@ -300,6 +332,7 @@ SUPPORTED_CHAINS = {
     'baseusdc': CHAIN_BASEUSDC,
     'ethusdc': CHAIN_ETHUSDC,
     'cro': CHAIN_CRO,
+    'aster': CHAIN_ASTER,
 }
 
 

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -101,7 +101,7 @@ def declarable_backings(from_chain: str, to_chain: str) -> list[str]:
 
 
 # Chains paired against each hub; add a chain here to launch its pairs.
-LAUNCH_SPOKES = ('btc', 'tao', 'eth', 'arbusdc', 'hype', 'bnb', 'avax', 'baseusdc', 'ethusdc', 'cro')
+LAUNCH_SPOKES = ('btc', 'tao', 'eth', 'arbusdc', 'hype', 'bnb', 'avax', 'baseusdc', 'ethusdc', 'cro', 'aster')
 # Every launch pair as (hub, spoke): each hub pairs against every spoke except itself. sol↔tao
 # lands exactly once (under SOL, its anchor) because sol never appears in LAUNCH_SPOKES.
 LAUNCH_PAIRS: tuple[tuple[str, str], ...] = tuple(

--- a/tests/test_aster_provider.py
+++ b/tests/test_aster_provider.py
@@ -1,0 +1,306 @@
+"""Aster unit tests — all offline (RPC layer mocked, signing is pure crypto).
+
+Generic ERC-20 behaviour is proven by the arbusdc suite; this covers what is aster-specific.
+Two things: the shared env identity (ONE BNB_NETWORK moves aster and native BNB, so a testnet
+miner can never pay real ASTER against test swaps), and the 'unfreezable' declaration — ASTER
+implements neither isBlacklisted nor paused, both of which REVERT, and a revert read as a
+verdict is what leaves a pair's miners permanently unslashable.
+
+ASTER has no deployment on Chapel, so this suite never constructs a testnet provider without
+the ASTER_TOKEN_CONTRACT override — see TestTestnetGap.
+"""
+
+import pytest
+
+from allways.assets.asset import ProviderUnreachableError
+from allways.assets.aster import Aster
+from allways.assets.bnb import Bnb
+from allways.assets.erc20 import SEL_TRANSFER, TESTNET_TOKEN_CONTRACTS, TRANSFER_TOPIC0
+from allways.assets.evm import EvmRpcError
+from allways.chains import CHAIN_ASTER, CHAIN_BNB, get_chain_def
+from allways.constants import LAUNCH_SPOKES
+
+TEST_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'  # hardhat account #0
+SENDER = '0x' + '11' * 20
+RECIPIENT = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+CONTRACT = CHAIN_ASTER.asset_locator
+COUNTERFEIT = '0x' + '99' * 20
+TX = '0x' + 'ab' * 32
+BLOCK_HASH = '0x' + 'cd' * 32
+AMOUNT = 25 * 10**18  # 25 ASTER in wei
+BSC_ID = 56
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    monkeypatch.setenv('BNB_NETWORK', 'mainnet')
+    for var in ('BNB_RPC_URLS', 'BNB_PRIVATE_KEY', 'ASTER_TOKEN_CONTRACT'):
+        monkeypatch.delenv(var, raising=False)
+    return Aster()
+
+
+def rpc_stub(provider, responses: dict):
+    """Replace eth_rpc with a method→response map. A callable value is invoked with params."""
+
+    def fake_rpc(method, params, timeout=15, **kw):
+        value = responses[method]
+        return value(params) if callable(value) else value
+
+    provider.chain.eth_rpc = fake_rpc  # the asset talks through its chain (composed seam)
+    return provider
+
+
+def topic(address: str) -> str:
+    return '0x' + '00' * 12 + address.lower().removeprefix('0x')
+
+
+def transfer_log(contract=CONTRACT, recipient=RECIPIENT, amount=AMOUNT) -> dict:
+    return {
+        'address': contract,
+        'topics': [TRANSFER_TOPIC0, topic(SENDER), topic(recipient)],
+        'data': hex(amount),
+        'transactionHash': TX,
+    }
+
+
+def mined(logs=None, status='0x1', tip=1_000_100, block=None) -> dict:
+    return {
+        'eth_getTransactionByHash': {'hash': TX, 'blockNumber': '0xf4240', 'blockHash': BLOCK_HASH},
+        'eth_getTransactionReceipt': {
+            'status': status,
+            'blockNumber': '0xf4240',
+            'blockHash': BLOCK_HASH,
+            'logs': [transfer_log()] if logs is None else logs,
+        },
+        'eth_blockNumber': hex(tip),
+        'eth_getBlockByNumber': {'hash': BLOCK_HASH, 'timestamp': '0x64'} if block is None else block,
+    }
+
+
+class TestSharedEnvIdentity:
+    """The whole point of this row: aster names the NETWORK, not the asset."""
+
+    def test_row_is_a_launch_spoke_on_bscs_identity(self, provider):
+        assert provider.chain_def is CHAIN_ASTER is get_chain_def('aster')
+        assert 'aster' in LAUNCH_SPOKES
+        # decimals is pinned here because nothing else in this repo guards it: the drift gate that
+        # would catch a typo lives in das, and allways merges first.
+        assert (CHAIN_ASTER.decimals, CHAIN_ASTER.native_unit) == (18, 'wei')
+        assert (CHAIN_ASTER.env_prefix, CHAIN_ASTER.host_chain) == (CHAIN_BNB.env_prefix, CHAIN_BNB.host_chain)
+        # CHAIN_BNB owns BNB_NETWORK; a second declaration renders a duplicate CLI row.
+        assert CHAIN_ASTER.networks == ()
+
+    @pytest.mark.parametrize('network,chain_id', (('mainnet', BSC_ID), ('testnet', 97)))
+    def test_one_bnb_network_moves_both_assets(self, monkeypatch, network, chain_id):
+        monkeypatch.setenv('BNB_NETWORK', network)
+        monkeypatch.setenv('ASTER_TOKEN_CONTRACT', CONTRACT)  # no Chapel deployment — see TestTestnetGap
+        assert Aster().chain.chain_id == Bnb().chain.chain_id == chain_id
+
+    def test_env_override_wins(self, provider, monkeypatch):
+        assert provider.token_contract == CHAIN_ASTER.asset_locator
+        monkeypatch.setenv('ASTER_TOKEN_CONTRACT', '0x' + '42' * 20)
+        assert Aster().token_contract == '0x' + '42' * 20
+
+    def test_unknown_network_raises(self, monkeypatch):
+        monkeypatch.setenv('BNB_NETWORK', 'chapel')
+        with pytest.raises(ValueError, match='BNB_NETWORK'):
+            Aster()
+
+    def test_finality_matches_the_chain_it_shares(self):
+        # Two assets on one chain must not disagree about its reorg depth, and the implied
+        # 15s leg stays inside the program's 600s default fulfillment grace.
+        assert (CHAIN_ASTER.min_confirmations, CHAIN_ASTER.seconds_per_block) == (
+            CHAIN_BNB.min_confirmations,
+            CHAIN_BNB.seconds_per_block,
+        )
+        assert CHAIN_ASTER.replay_grace_secs == CHAIN_BNB.replay_grace_secs
+        assert CHAIN_ASTER.min_confirmations * CHAIN_ASTER.seconds_per_block < 600
+
+    def test_lookback_window_is_time_based(self, provider):
+        assert provider.SCAN_LOOKBACK_BLOCKS == 300  # ≈5 min of BSC's sub-second blocks
+
+    def test_wrong_network_endpoint_fails_startup(self, provider):
+        # Mainnet configured, a Chapel endpoint answering: reject outright rather than
+        # quietly verify legs against the wrong chain.
+        rpc_stub(provider, {'eth_chainId': '0x61'})
+        with pytest.raises(ConnectionError, match=f'expected {BSC_ID}'):
+            provider.check_connection(require_send=False)
+
+    def test_codeless_contract_fails_startup(self, provider):
+        rpc_stub(provider, {'eth_chainId': hex(BSC_ID), 'eth_blockNumber': '0x10', 'eth_getCode': '0x'})
+        with pytest.raises(ConnectionError, match='no code'):
+            provider.check_connection(require_send=False)
+
+
+class TestTestnetGap:
+    """ASTER is deployed on BSC mainnet only. Until a project-deployed test token is pinned in
+    TESTNET_TOKEN_CONTRACTS, a Chapel provider must fail LOUDLY at construction and name the
+    override — silently defaulting to mainnet is how a testnet miner spends real ASTER."""
+
+    def test_chapel_has_no_pinned_contract(self, monkeypatch):
+        assert 'aster' not in TESTNET_TOKEN_CONTRACTS
+        monkeypatch.setenv('BNB_NETWORK', 'testnet')
+        monkeypatch.delenv('ASTER_TOKEN_CONTRACT', raising=False)
+        with pytest.raises(ValueError, match='ASTER_TOKEN_CONTRACT'):
+            Aster()
+
+
+class TestVerification:
+    def test_settled_transfer_matches_with_sender_pinned(self, provider):
+        rpc_stub(provider, mined())
+        info = provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT)
+        assert info.confirmed and info.amount == AMOUNT and info.block_time == 0x64
+        assert info.sender == SENDER.lower()
+
+    def test_below_min_confs_unconfirmed(self, provider):
+        rpc_stub(provider, mined(tip=1_000_013))  # 14 confs of the 15 required
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT).confirmed is False
+
+    def test_reverted_rejected(self, provider):
+        # Inclusion is not settlement: a reverted tx moved no funds.
+        rpc_stub(provider, mined(status='0x0'))
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+    def test_underpay_rejected(self, provider):
+        rpc_stub(provider, mined(logs=[transfer_log(amount=AMOUNT - 1)]))
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+    def test_wrong_recipient_rejected(self, provider):
+        rpc_stub(provider, mined(logs=[transfer_log(recipient=SENDER)]))
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+    def test_pending_transfer_matches_off_calldata(self, provider):
+        calldata = SEL_TRANSFER + topic(RECIPIENT).removeprefix('0x') + f'{AMOUNT:064x}'
+        pending = {'hash': TX, 'from': SENDER, 'to': CONTRACT, 'input': calldata, 'blockNumber': None}
+        rpc_stub(provider, {'eth_getTransactionByHash': pending})
+        info = provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT)
+        assert info.confirmed is False and info.sender == SENDER.lower() and info.amount == AMOUNT
+
+    def test_pending_transfer_to_a_counterfeit_contract_rejected(self, provider):
+        calldata = SEL_TRANSFER + topic(RECIPIENT).removeprefix('0x') + f'{AMOUNT:064x}'
+        pending = {'hash': TX, 'from': SENDER, 'to': COUNTERFEIT, 'input': calldata, 'blockNumber': None}
+        rpc_stub(provider, {'eth_getTransactionByHash': pending})
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+    def test_absent_tx_is_absent(self, provider):
+        rpc_stub(provider, {'eth_getTransactionByHash': None})
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+    def test_receipt_unavailable_is_unknown_not_absent(self, provider):
+        # 'unknown' must never read as 'no such payment' — that verdict slashes a paying miner.
+        with pytest.raises(ProviderUnreachableError):
+            rpc_stub(provider, dict(mined(), eth_getTransactionReceipt=None)).fetch_matching_tx(
+                TX, RECIPIENT.lower(), AMOUNT
+            )
+
+    def test_missing_block_timestamp_is_unknown_not_absent(self, provider):
+        with pytest.raises(ProviderUnreachableError):
+            rpc_stub(provider, mined(block={'hash': BLOCK_HASH})).fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT)
+
+    def test_counterfeit_token_log_never_matches_even_on_the_cache_path(self, provider):
+        """A fake token emitting a well-formed Transfer must not settle the leg, and must not
+        settle it on the re-verify either: the cache is only written from a pinned-contract match."""
+        rpc_stub(provider, mined(logs=[transfer_log(contract=COUNTERFEIT)]))
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+        assert provider._settled_cache == {}
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+
+class TestUnfreezableDeclaration:
+    """ASTER's verified source is stock OpenZeppelin ERC20 + ERC20Permit — no blacklist, no pause
+    — on a contract that can never gain one (EIP-1967 slots empty, owner() reverts). Both halves
+    are what 'unfreezable' asserts. On-chain, isBlacklisted and paused REVERT (probed live on BSC
+    mainnet, 2026-08-12), so both gates answer from the registry with ZERO RPC calls; probing
+    would raise, and a raise in delivery_refused defers every slash on the pair forever."""
+
+    def dead_rpc(self, provider):
+        def boom(method, params, timeout=15, **kw):
+            raise AssertionError(f'no RPC may be made for an unfreezable token (got {method})')
+
+        provider.chain.eth_rpc = boom
+        return provider
+
+    def test_row_declares_no_freeze_surface(self):
+        assert CHAIN_ASTER.refusal_checks == ()
+
+    def test_reserve_gate_passes_without_rpc(self, provider):
+        assert self.dead_rpc(provider).can_deliver_to(RECIPIENT, AMOUNT) is True
+
+    def test_slash_gate_answers_false_without_rpc(self, provider):
+        # The regression guard: an RPC here would revert on ASTER, raise, and make every miner
+        # on the pair permanently unslashable.
+        assert self.dead_rpc(provider).delivery_refused(RECIPIENT, 0) is False
+
+    def test_boot_falsifier_clears_against_asters_real_answers(self, provider):
+        # Both freeze probes revert on the real contract, which is what the declaration predicts.
+        def call(params):
+            raise EvmRpcError('execution reverted', {'code': 3, 'message': 'execution reverted'})
+
+        rpc_stub(
+            provider,
+            {'eth_chainId': hex(BSC_ID), 'eth_blockNumber': '0x10', 'eth_getCode': '0xfe', 'eth_call': call},
+        )
+        provider.check_connection(require_send=False)
+
+
+class TestSendGuards:
+    SEND = {
+        'eth_blockNumber': hex(100),
+        'eth_getBlockByNumber': {'baseFeePerGas': hex(10**9)},
+        'eth_maxPriorityFeePerGas': hex(10**9),
+        'eth_getTransactionCount': '0x0',
+        'eth_getBalance': hex(10**18),
+        'eth_estimateGas': hex(65_000),
+        'eth_call': f'0x{AMOUNT:064x}',  # balanceOf
+    }
+
+    def test_no_key_refused(self, provider):
+        assert provider.send_amount(RECIPIENT, AMOUNT) is None
+        assert 'BNB_PRIVATE_KEY' in provider.last_send_error
+
+    def test_key_mismatch_refused(self, provider, monkeypatch):
+        monkeypatch.setenv('BNB_PRIVATE_KEY', TEST_KEY)
+        assert provider.send_amount(RECIPIENT, AMOUNT, from_address=RECIPIENT) is None
+        assert 'key mismatch' in provider.last_send_error
+
+    def test_insufficient_token_balance_refused(self, provider, monkeypatch):
+        monkeypatch.setenv('BNB_PRIVATE_KEY', TEST_KEY)
+        rpc_stub(provider, dict(self.SEND, eth_call=f'0x{AMOUNT - 1:064x}'))
+        assert provider.send_amount(RECIPIENT, AMOUNT) is None
+        assert 'insufficient balance' in provider.last_send_error
+
+    def test_gas_poor_miner_refuses_before_broadcasting(self, provider, monkeypatch):
+        # Token-rich but BNB-poor: refuse here rather than burn a revert on-chain.
+        monkeypatch.setenv('BNB_PRIVATE_KEY', TEST_KEY)
+        rpc_stub(provider, dict(self.SEND, eth_getBalance=hex(10**9)))
+        assert provider.send_amount(RECIPIENT, AMOUNT) is None
+        assert 'Insufficient gas balance' in provider.last_send_error
+
+    def test_broadcast_returns_a_hash(self, provider, monkeypatch):
+        monkeypatch.setenv('BNB_PRIVATE_KEY', TEST_KEY)
+        rpc_stub(provider, dict(self.SEND, eth_sendRawTransaction=TX))
+        assert provider.send_amount(RECIPIENT, AMOUNT) == (TX, 0)
+
+
+class TestDepositScanner:
+    def test_getlogs_hit_is_bounded_to_the_lookback_window(self, provider):
+        seen = {}
+
+        def logs(params):
+            seen.update(params[0])
+            return [transfer_log()]
+
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getLogs': logs})
+        assert provider.find_recent_outgoing(SENDER, RECIPIENT, AMOUNT) == TX
+        assert int(seen['fromBlock'], 16) == 10_000 - provider.SCAN_LOOKBACK_BLOCKS + 1
+        assert seen['address'] == CONTRACT
+
+    def test_failed_range_parks_the_cursor(self, provider):
+        def boom(params):
+            raise ConnectionError('down')
+
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getLogs': boom})
+        assert provider.find_recent_outgoing(SENDER, RECIPIENT, AMOUNT) is None
+        # Never leap a range the scan could not read — the deposit in it must stay reachable.
+        key = (SENDER.lower(), RECIPIENT.lower(), AMOUNT)
+        assert provider.scan_cursors[key] == 10_000 - provider.SCAN_LOOKBACK_BLOCKS

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -9,6 +9,7 @@ from allways.assets.erc20 import Erc20
 from allways.assets.evm import EVM_NETWORKS
 from allways.chains import (
     CHAIN_ARBUSDC,
+    CHAIN_ASTER,
     CHAIN_AVAX,
     CHAIN_BASEUSDC,
     CHAIN_BNB,
@@ -56,6 +57,9 @@ class TestGetChain:
 
     def test_cro(self):
         assert get_chain_def('cro') is CHAIN_CRO
+
+    def test_aster(self):
+        assert get_chain_def('aster') is CHAIN_ASTER
 
     def test_unsupported_raises(self):
         with pytest.raises(KeyError):


### PR DESCRIPTION
> ## ⛔ BLOCKED: awaiting testnet deployment — do not merge
>
> ASTER has **no deployment at its address on Chapel (BSC testnet)**, and testnet mock
> deployments are deferred out of this batch. `Erc20._token_contract` raises when a non-mainnet
> network has no `TESTNET_TOKEN_CONTRACTS` entry, and validators construct **every** provider at
> boot (`neurons/validator.py`, `required_chains=None`) — so merging this, which adds `aster` to
> `LAUNCH_SPOKES`, would stop a testnet validator from starting **at all**. Boot-blocking, not a
> testing inconvenience.
>
> **What unparks it:** a project-deployed minimal BEP-20 (symbol `ASTER`, 18 decimals) on Chapel,
> pinned in `erc20.py::TESTNET_TOKEN_CONTRACTS` with a comment stating plainly that it is a
> **project-deployed test token, not an issuer deployment**. No shared-code change, no fail-soft
> boot path, and no third party's contract — a wrong pin means miners pay in the wrong asset.
>
> ⚠️ **The mock must have no pause and no blacklist — immutability alone is not enough.**
> `issuer_controls='unfreezable'` is a claim about the contract that actually resolves, and on
> testnet that is the mock. An OpenZeppelin `ERC20Pausable` mock is immutable and would still
> satisfy the old criterion, yet the moment it were paused every honest miner on the pair would be
> slashed for a delivery failure that is not theirs. Deploy plain `ERC20`, nothing else.
>
> **Base branch:** this PR targets `refactor/erc20-refusal-interface` (PR #647), not `test`. ASTER
> implements neither `isBlacklisted` nor `paused`; both **revert**, and before #647 a revert
> propagated out of `delivery_refused` and deferred every slash on the pair forever. Retarget to
> `test` after #647 merges.

Adds ASTER (BEP-20 on BNB Smart Chain) as a launch spoke. It rides `CHAIN_BNB`'s network identity
— one `BNB_NETWORK` / `BNB_RPC_URLS` / `BNB_PRIVATE_KEY` moves both assets, so they can never
disagree about which BSC they are on — and adds only `ASTER_TOKEN_CONTRACT` of its own.

das twin: entrius/das-allways#96 — merge this first, the das drift gate reads `chains.py` from `test`.

## Registry row

| Field | Value | Why |
|---|---|---|
| `host_chain` / `env_prefix` | `bsc` / `BNB` | The NETWORK's identity, shared with `CHAIN_BNB` |
| `networks` | `()` | `CHAIN_BNB` already declares the `BNB_NETWORK` names; a second declaration renders a duplicate CLI row writing the same var |
| `decimals` | 18 | `decimals()` read live on mainnet |
| `asset_locator` | `0x000Ae314E2A2172a039B26378814C252734f556A` | Published by the issuer at `docs.asterdex.com/usdaster-token/overview` — exact 42-char match, EIP-55 casing included |
| `issuer_controls` | `unfreezable` | Both halves proven: no freeze/pause surface in the verified source **and** it can never gain one (see diligence) |

### The two judgement calls

**`min_confirmations = 15`, `seconds_per_block = 1`, `replay_grace_secs = 60` — inherited from
`CHAIN_BNB`, deliberately identical.** These are facts about BNB Smart Chain, not about ASTER: two
assets settling on one chain disagreeing about its reorg depth or its clock skew would be
indefensible — whichever number is wrong, one of the two assets is being verified against a
finality assumption its own chain does not hold. `CHAIN_BNB` derives the 15 from BEP-126 finality
(quorum at ~2 blocks) with a longest-chain fallback bounded by BEP-341 `turn_length` (measured 8 on
mainnet); 15 outlasts one full turn, so no lone validator can build the whole span. Implied leg
latency 15 × 1s = 15s, far inside the program's 600s default fulfillment grace. A test pins the
equality so the two rows cannot drift apart.

**`min_onchain_amount = 1 ASTER (1e18)`.** An economic floor priced at realistic-high BSC gas, not
quiet-day gas. A BEP-20 transfer on this contract measured **29,698 gas** live (warm recipient
slot); a fresh recipient slot costs ~50k. That gas figure is higher than `CHAIN_BNB`'s 21k and
must be — a token transfer runs contract code where a native send does not.

The gwei level is a **separate, stated assumption, and it does not match `CHAIN_BNB`'s.** At
`CHAIN_BNB`'s 9.5 gwei reference the strict break-even is **0.48 ASTER**; 1 ASTER is that rounded
up to a whole unit, which implicitly prices **~19 gwei**. In USD that makes this the strictest
floor in the registry (~$0.60, vs bnb ~$0.12 and eth ~$0.15). That is a deliberate acceptance, not
a claimed virtue: the floor is a rate-sanity input to `is_executable_rate`, so it can only
**over**-restrict which rates count as executable — it can never under-restrict, and it cannot
cause a slash. If the roundness is judged the wrong trade, 0.48e18 is the strict-parity value.

Stated plainly either way: **this is not an enforced per-swap minimum.** The enforced bounds are
the contract's `min_swap_amount` / `max_swap_amount` on the hub leg, and a spoke payout below this
floor is still reachable.

## Token diligence

`Erc20` verifies a leg by matching a `Transfer` log from the pinned contract against an expected
amount, so anything that decouples log value from received balance is a slash vector. Evidence, not
docs links:

| Property | Evidence |
|---|---|
| **Not fee-on-transfer** | Real mainnet transfer `0xd0412b40…e69bf` (block 115552945). `Transfer` log value `2520000000000000000`. Recipient `balanceOf` at block-1 `177284054624753860911` → at block `179804054624753860911`, **delta `2520000000000000000` — equal to the log value exactly**. Sender debited the same `2520000000000000000`. No skim on either side. |
| **Not rebasing** | Source is stock OpenZeppelin v5.1.0 `ERC20` + `ERC20Permit`; `_update` is not overridden, so balances are plain storage and move only on transfer. Fixed supply: `_mint` is called once in the constructor and there is no external mint or burn. `totalSupply()` reads `8000000000.000000000000000000` — exactly the constructor mint. |
| **No freeze/pause surface** (half 1 of `unfreezable`) | The verified source has none: the whole project file is a constructor, and every other file is stock OpenZeppelin v5.1.0 — no `Pausable`, no blacklist mapping, no gated `_update`. Corroborated against the deployed 3839-byte runtime by scanning it for PUSH4 of each candidate selector: `paused` `pause` `unpause` `owner` `getOwner` `admin` `renounceOwnership` `transferOwnership` `mint` `burn` `burnFrom` `isBlacklisted` `isBlackListed` `blacklisted` `blacklist` `isFrozen` `freeze` `getBlackListStatus` `isBlocked` `isBanned` `upgradeTo` `upgradeToAndCall` `implementation` `setFee` `setTaxRate` `excludeFromFee` — **all 26 absent**. The selectors that *are* dispatched are exactly ERC-20 + `permit`/`nonces`/`DOMAIN_SEPARATOR`/`eip712Domain`. (A dispatchable function must appear as a PUSH4 of its selector, so absence is conclusive; the scan's few unresolved hits are misaligned false positives from constants such as the `Transfer` topic.) Live, a 13-selector sweep of the same shapes has **every one revert** on mainnet. |
| **Cannot gain one** (half 2 of `unfreezable`) | Re-confirmed live: EIP-1967 **implementation**, **admin** and **beacon** slots all read `0x00…00`; `implementation()` reverts; `owner()` reverts (the contract is not `Ownable` — the constructor's `owner` arg is only the mint recipient, no stored role); code size **3839 bytes**. There is no admin and no upgrade path, so nothing can add a blacklist tomorrow. |
| **Standard `Transfer` event** | Decoded from that same real log: `topic0 = 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef` = `keccak("Transfer(address,address,uint256)")`, indexed `from` / `to`, value in data. One token log in the receipt — no wrapper events. |
| **`transfer` return convention** | Same tx: calldata selector `0xa9059cbb` (`transfer(address,uint256)`) sent directly to the pinned contract, `tx.value = 0`, receipt **`status = 0x1`**, `gasUsed = 29698`. No revert-on-false weirdness; we read receipt status + logs, never a bool. |
| **Source published, matches bytecode** | BscScan reports `Contract Source Code Verified` — **Exact Match** — for `AsterToken`, solc `v0.8.25+commit.b61c2a91`, optimizer on (200 runs), EVM `paris`, MIT. The bundle is 19 stock OpenZeppelin v5.1.0 files plus one 458-char project file whose entire body is a constructor minting 8e9 to one address. Corroborated against the deployed 3839-byte runtime: no `owner()` / `mint` / `pause` / blacklist / `upgradeTo` selectors present, `permit` / `DOMAIN_SEPARATOR` / `nonces` present — exactly what the source predicts. The source↔bytecode equivalence rests on BscScan's Exact Match plus that selector corroboration; it was **not** independently recompiled. |

Both halves are required and neither suffices alone: an immutable contract can ship a hardcoded
blacklist from day one, and a pause-free contract that is upgradeable can grow one tomorrow.

Fee-on-transfer was hunted in every disguise, not just as a declared tax: there is no transfer hook
(OZ v5 removed `_before/_afterTokenTransfer` and its successor `_update` is not overridden), no
rebase-on-claim, and no pause path that could deliver partially. The one caveat worth carrying
forward: the docs describe bi-weekly "burns", but the contract has **no burn function** and
`totalSupply()` is still exactly 8e9 — those are transfers to a dead address, so nothing here may
assume `totalSupply()` declines.

## Verified live on BNB Chain mainnet (read-only)

Against the configured ladder (`bsc-dataseed.bnbchain.org`, `bsc.blockrazor.xyz`) — publicnode and
drpc stay excluded per the `evm.py` BSC comment, and were not used.

```
check_connection(require_send=False)   PASSED  — _falsify_declaration cleared the row against
                                       the bytecode that actually resolved on mainnet
describe            BNB Smart Chain JSON-RPC (mainnet): bsc-dataseed.bnbchain.org,
                    bsc.blockrazor.xyz — token 0x000Ae314E2A2172a039B26378814C252734f556A
chain_id            56          tip 115552996         gasPrice 0.05 gwei
name/symbol/decimals/totalSupply    Aster / ASTER / 18 / 8000000000

13-selector freeze sweep, all REVERT: paused() pause() owner() getOwner() admin()
  isBlacklisted isBlackListed blacklisted isFrozen getBlackListStatus isBlocked isBanned
  implementation()
issuer_controls 'unfreezable'  →  delivery_refused = False and can_deliver_to = True,
                                  both answered with ZERO RPC calls

# all four calls are Asset.verify_transaction, NOT the raw fetch_matching_tx — the mixed-case
# recipient is canonicalized by verify_transaction (asset.py), so fetch_matching_tx alone would
# correctly return None for it (erc20.py: expecteds arrive already canonicalized).
verify_transaction(tx 0xd0412b40…e69bf,
       MIXED-CASE recipient 0xa6f460a2d65C176D9Da5208B9FaB3B90a8cA2CdD,
       2520000000000000000, expected_sender=0x4a74…d6a8)
      → confirmed=True  amount=2520000000000000000  sender=0x4a74…d6a8  block_time=1786559444
verify_transaction(expect value+1)          → None   (underpayment rejected)
verify_transaction(expected_sender=0x22…22) → None   (wrong sender rejected)
verify_transaction(recipient=0x33…33)       → None   (wrong recipient rejected)
verify_transaction(0xdede…de)               → None   (unknown tx rejected)

get_balance(0xa6f4…2cdd)                198.9106946247539 ASTER
get_balance(same, mixed case)           198.9106946247539 ASTER   (casing is a display checksum)
```

**The testnet half is not available and was not faked.** There is no code at
`0x000Ae314…556A` on Chapel, so there is no real transfer to verify and no provider to construct.
That is the whole reason this PR is parked; see the banner.

## CLI — derived, not written

```
alw miner quotes --help
  --aster-price     NUMBER   ASTER per 1 hub unit (0/omit to skip ASTER).
  --aster-address   TEXT     Your ASTER address.

alw config
  … bnb-network │ mainnet │ default …      ← no aster-network row: aster rides BNB's.
```

An `aster-network` row would be a bug — it would render a duplicate CLI key writing the same
`BNB_NETWORK`, and `test_chains.py::test_assets_on_one_network_share_its_env_identity` fails if a
second row on a host declares `networks`.

## e2e

`alw-utils#123` is merged, and it keys the harness's fake RPC, wallet and env block by
`env_prefix`, with `{ASSET_ID}_TOKEN_CONTRACT` staying per asset — so `bnb` and `aster` correctly
share one `BNB_RPC_URLS` / `BNB_PRIVATE_KEY` and one fake BSC node, and the miner cannot end up
holding one asset's key while committing the other's address. Both rows derive with zero harness
edits:

```
./dev-environment/solana/run-suites.sh --list
  …  sol-ethusdc  ethusdc-sol  sol-aster  aster-sol  blacklist-gate  slash  …
```

The suites themselves were **not** run for this PR — they boot a full local stack per scenario, and
the asset is parked short of a testnet rehearsal anyway.

## Emission dilution — per PAIR

Multi-hub is live (`HUB_CHAINS = ('sol', 'tao')`), so `aster` creates **two** pairs, `sol-aster`
**and** `tao-aster`. **Miners are expected to quote the TAO leg too**, not just the SOL leg.

```
floor per direction = MINER_POOL_SHARE / (2 × len(LAUNCH_PAIRS))

before   9 spokes → 17 pairs → 34 directions → 0.2941%
after   10 spokes → 19 pairs → 38 directions → 0.2632%
```

A ~10.5% cut to the equal-split zero-volume floor. Volume weighting
(`POOL_VOLUME_ALPHA = 0.66`) means a busy pair recovers most of it; an idle pair does not. Three
sibling assets in this batch move the same number, so re-derive it at merge time.

## Checks

```
ruff format --check .   183 files already formatted
ruff check .            All checks passed!
pytest tests/ -q        1558 passed, 6 deselected
```

New `tests/test_aster_provider.py` is fully offline (RPC layer stubbed, signing is pure crypto) and
never constructs a testnet provider without the documented `ASTER_TOKEN_CONTRACT` override —
`TestTestnetGap` pins the park itself, asserting that a Chapel provider fails loudly at
construction and names the override rather than silently defaulting to mainnet. `TestUnfreezableDeclaration`
is the regression guard for the reverting-probe bug: it swaps in an RPC that raises on **any** call
and asserts `delivery_refused` still answers `False`, and it drives `check_connection` through
#647's `_falsify_declaration` with the answers ASTER actually gives on mainnet (both freeze probes
reverting) to prove the row boots clean.

`test_row_is_a_launch_spoke_on_bscs_identity` also pins `decimals` and `native_unit`. Nothing else
in this repo guards `decimals`: mutating it 18→6 previously left the whole suite green, and the gate
that would catch it (`check-chain-drift.mjs`) lives in **das**, which by merge order runs after
allways has already landed. Mutation-checked both directions now — `decimals` 18→8 and
`native_unit` `wei`→`gwei` each fail exactly one test.

`tests/test_cli_chain_networks.py` needed **no** edit — its pinned contract covers
`NAME_SELECTED_CHAINS`, and a row declaring `networks=()` correctly never appears there.
`tests/test_rate.py` needed none either: 18 decimals is already covered.


