### PR TITLE
Add UNI on Ethereum as a launch spoke

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,17 +34,18 @@ BTC_NETWORK=mainnet                 # mainnet | testnet | testnet4
 # WIF — required for miners; optional local signing for `alw swap`
 BTC_PRIVATE_KEY=
 
-# ─── Network: Ethereum (ETH + ethusdc pairs) ───────────────
-# Vars are per NETWORK, shared by every asset on it — ethusdc adds no network vars of its own.
+# ─── Network: Ethereum (ETH + ethusdc + uni pairs) ─────────
+# Vars are per NETWORK, shared by every asset on it — ethusdc and uni add none of their own.
 ETH_NETWORK=mainnet                 # mainnet | sepolia
 # OPTIONAL ordered JSON-RPC endpoints (keyed providers embed the key in the URL);
 # unset = public (publicnode, drpc)
 # ETH_RPC_URLS=https://mainnet.infura.io/v3/your_key,https://ethereum-rpc.publicnode.com
-# 32-byte hex key — required for miners (fund ETH for the ETH legs, USDC + ETH-for-gas for
-# the ethusdc legs); optional local signing for `alw swap`
+# 32-byte hex key — required for miners (fund ETH for the ETH legs, and the token + ETH-for-gas
+# for each token leg); optional local signing for `alw swap`
 ETH_PRIVATE_KEY=
-# OPTIONAL token contract override (dev/e2e fakes) — per ASSET, unset = Circle's canonical deployment
+# OPTIONAL token contract overrides (dev/e2e fakes) — per ASSET, unset = the canonical deployment
 # ETHUSDC_TOKEN_CONTRACT=
+# UNI_TOKEN_CONTRACT=
 
 # ─── Network: Arbitrum (arbusdc pairs) ─────────────────────
 # Vars are per NETWORK, shared by every asset on it (ARB_ here, not ARBUSDC_).

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Allways creates a verification layer above independent systems. Assets move nati
 
 Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, SOL ↔ USDC-on-Base, SOL ↔ USDC-on-Ethereum, and SOL ↔ CRO (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
 Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, SOL ↔ USDC-on-Base, SOL ↔ USDC-on-Ethereum, and SOL ↔ ASTER (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
+Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, SOL ↔ USDC-on-Base, SOL ↔ USDC-on-Ethereum, and SOL ↔ UNI (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
 
 ## Miner Risk Disclaimer
 
@@ -126,6 +127,7 @@ needs to persist across restarts.
 
 - `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `BNB_PRIVATE_KEY`, `AVAX_PRIVATE_KEY`, `BASE_PRIVATE_KEY`, `CRO_PRIVATE_KEY`, `{ETH,ARB,HYPE,BNB,AVAX,BASE,CRO}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config (ETH and ethusdc both ride the `ETH_*` vars). See `.env.example`.
 - `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `BNB_PRIVATE_KEY`, `AVAX_PRIVATE_KEY`, `BASE_PRIVATE_KEY`, `{ETH,ARB,HYPE,BNB,AVAX,BASE}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config (ETH and ethusdc both ride the `ETH_*` vars; BNB and aster both ride the `BNB_*` vars). See `.env.example`.
+- `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `BNB_PRIVATE_KEY`, `AVAX_PRIVATE_KEY`, `BASE_PRIVATE_KEY`, `{ETH,ARB,HYPE,BNB,AVAX,BASE}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config (ETH, ethusdc and uni all ride the `ETH_*` vars). See `.env.example`.
 
 ## Running a Local Subtensor Lite Node (Validators)
 

--- a/allways/assets/__init__.py
+++ b/allways/assets/__init__.py
@@ -18,6 +18,7 @@ from allways.assets.evm_coin import EvmCoin
 from allways.assets.hype import Hype
 from allways.assets.sol import Sol
 from allways.assets.tao import Tao
+from allways.assets.uni import Uni
 
 __all__ = [
     'Asset',
@@ -39,6 +40,7 @@ __all__ = [
     'BaseUsdc',
     'EthUsdc',
     'Aster',
+    'Uni',
     'create_assets',
 ]
 
@@ -65,6 +67,7 @@ ASSET_REGISTRY: Tuple[AssetSpec, ...] = (
     AssetSpec('ethusdc', EthUsdc, ()),
     AssetSpec('cro', Cro, ()),
     AssetSpec('aster', Aster, ()),
+    AssetSpec('uni', Uni, ()),
 )
 
 

--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -46,6 +46,9 @@ TESTNET_TOKEN_CONTRACTS = {
     'baseusdc': {'sepolia': '0x036CbD53842c5426634e7929541eC2318f3dCF7e'},
     # Circle-verified native USDC on Ethereum Sepolia (developers.circle.com, 2026-08-11).
     'ethusdc': {'sepolia': '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238'},
+    # Same address as mainnet and byte-identical runtime bytecode (keccak
+    # 0xdeba17f1…0868, 12567 bytes) — verified symbol UNI, 18 decimals, 1e27 supply.
+    'uni': {'sepolia': '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984'},
 }
 
 

--- a/allways/assets/uni.py
+++ b/allways/assets/uni.py
@@ -1,0 +1,13 @@
+from allways.assets.erc20 import Erc20
+from allways.chains import CHAIN_UNI
+
+
+class Uni(Erc20):
+    """UNI on Ethereum — a config-row binding of the generic Erc20 (see chains.CHAIN_UNI).
+
+    Third asset on Ethereum's network identity (ETH_NETWORK, ETH_RPC_URLS, ETH_PRIVATE_KEY),
+    adding only its own UNI_TOKEN_CONTRACT override. Uni.sol has no issuer freeze surface,
+    which the registry row declares rather than the provider probing for it."""
+
+    def __init__(self):
+        super().__init__(CHAIN_UNI)

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -338,17 +338,19 @@ CHAIN_UNI = ChainDefinition(
     min_confirmations=32,
     # Rate sanity floor, not an enforced minimum: 3 UNI covers a 90k-gas dest leg (the observed
     # 57k worst case plus the two delegation checkpoints a transfer can write) only below ~62
-    # gwei — a realistic-high L1 level, not the 0.1 gwei of a quiet day. Above CHAIN_ETHUSDC's
-    # floor in value because UNI's transfer moves voting power and FiatToken's does not.
+    # gwei — a realistic-high L1 level, not the 0.1 gwei of a quiet day. Worth 2.1x
+    # CHAIN_ETHUSDC's floor: 1.38x of that is the bigger gas budget, 1.51x is a higher assumed
+    # gwei. Assumed gas price is per-asset economics, unlike min_confirmations which is a chain fact.
     min_onchain_amount=3_000_000_000_000_000_000,
     # Ethereum's clock, as CHAIN_ETH: what this absorbs is hub-vs-spoke skew, and two assets on
     # one chain disagreeing about that chain's clock would be indefensible.
     replay_grace_secs=60,
     # UNI as published by Uniswap (docs.uniswap.org governance/UNI reference, 2026-08-12).
     asset_locator='0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984',
-    # Both halves hold: Uni.sol ships no blacklist or pause in its verified source, and cannot
-    # gain one — EIP-1967 implementation/admin/beacon slots all zero, owner()/admin() revert.
-    # The minter (governance timelock) can only inflate supply, never freeze an address.
+    # No freeze surface: the PUSH4 dispatch table resolves 27 selectors, exactly Uni.sol's ABI, so
+    # there is no blacklist/pause/owner entry point to call. It cannot gain one either — EIP-1967
+    # implementation/admin/beacon slots are all zero. The minter (governance timelock) only
+    # inflates supply; it can never freeze an address.
     refusal_checks=(),
 )
 

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -320,6 +320,38 @@ CHAIN_ASTER = ChainDefinition(
     refusal_checks=(),
 )
 
+CHAIN_UNI = ChainDefinition(
+    id='uni',
+    name='Uniswap',
+    native_unit='wei',
+    decimals=18,
+    # Ethereum's prefix, shared with CHAIN_ETH and CHAIN_ETHUSDC: one ETH_NETWORK / ETH_RPC_URLS /
+    # ETH_PRIVATE_KEY serves every asset on it, so they can never disagree about which Ethereum.
+    env_prefix='ETH',
+    host_chain='ethereum',
+    # CHAIN_ETH already declares the ETH_NETWORK names; a second declaration would render a
+    # duplicate CLI row writing the same var.
+    networks=(),
+    seconds_per_block=12,
+    # CHAIN_ETH's finality, deliberately identical — two assets on one chain must not disagree
+    # about its reorg depth. 32 × 12s = 384s, inside the program's 600s default fulfillment grace.
+    min_confirmations=32,
+    # Rate sanity floor, not an enforced minimum: 3 UNI covers a 90k-gas dest leg (the observed
+    # 57k worst case plus the two delegation checkpoints a transfer can write) only below ~62
+    # gwei — a realistic-high L1 level, not the 0.1 gwei of a quiet day. Above CHAIN_ETHUSDC's
+    # floor in value because UNI's transfer moves voting power and FiatToken's does not.
+    min_onchain_amount=3_000_000_000_000_000_000,
+    # Ethereum's clock, as CHAIN_ETH: what this absorbs is hub-vs-spoke skew, and two assets on
+    # one chain disagreeing about that chain's clock would be indefensible.
+    replay_grace_secs=60,
+    # UNI as published by Uniswap (docs.uniswap.org governance/UNI reference, 2026-08-12).
+    asset_locator='0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984',
+    # Both halves hold: Uni.sol ships no blacklist or pause in its verified source, and cannot
+    # gain one — EIP-1967 implementation/admin/beacon slots all zero, owner()/admin() revert.
+    # The minter (governance timelock) can only inflate supply, never freeze an address.
+    refusal_checks=(),
+)
+
 SUPPORTED_CHAINS = {
     'btc': CHAIN_BTC,
     'tao': CHAIN_TAO,
@@ -333,6 +365,7 @@ SUPPORTED_CHAINS = {
     'ethusdc': CHAIN_ETHUSDC,
     'cro': CHAIN_CRO,
     'aster': CHAIN_ASTER,
+    'uni': CHAIN_UNI,
 }
 
 

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -101,7 +101,7 @@ def declarable_backings(from_chain: str, to_chain: str) -> list[str]:
 
 
 # Chains paired against each hub; add a chain here to launch its pairs.
-LAUNCH_SPOKES = ('btc', 'tao', 'eth', 'arbusdc', 'hype', 'bnb', 'avax', 'baseusdc', 'ethusdc', 'cro', 'aster')
+LAUNCH_SPOKES = ('btc', 'tao', 'eth', 'arbusdc', 'hype', 'bnb', 'avax', 'baseusdc', 'ethusdc', 'cro', 'aster', 'uni')
 # Every launch pair as (hub, spoke): each hub pairs against every spoke except itself. sol↔tao
 # lands exactly once (under SOL, its anchor) because sol never appears in LAUNCH_SPOKES.
 LAUNCH_PAIRS: tuple[tuple[str, str], ...] = tuple(

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -19,6 +19,7 @@ from allways.chains import (
     CHAIN_ETHUSDC,
     CHAIN_HYPE,
     CHAIN_TAO,
+    CHAIN_UNI,
     EXTENSION_BUCKET_SECONDS,
     SUPPORTED_CHAINS,
     canonical_pair,
@@ -60,6 +61,9 @@ class TestGetChain:
 
     def test_aster(self):
         assert get_chain_def('aster') is CHAIN_ASTER
+
+    def test_uni(self):
+        assert get_chain_def('uni') is CHAIN_UNI
 
     def test_unsupported_raises(self):
         with pytest.raises(KeyError):
@@ -127,6 +131,19 @@ class TestGetChain:
         assert all(get_chain_def(c).asset_locator is None for c in ('btc', 'tao', 'sol', 'eth', 'hype'))
         # ethusdc rides CHAIN_ETH's network row — same host, same prefix, no networks of its own.
         assert (CHAIN_ETHUSDC.host_chain, CHAIN_ETHUSDC.env_prefix) == (CHAIN_ETH.host_chain, CHAIN_ETH.env_prefix)
+        """btc/tao/sol ARE their own network; every EVM row names the network it rides. Only the
+        self-hosted list is enumerated — a new EVM asset needs no edit here."""
+        for chain_id, chain in SUPPORTED_CHAINS.items():
+            if chain_id in ('btc', 'tao', 'sol'):
+                assert chain.host_chain is None, chain_id
+            else:
+                assert chain.host_chain in EVM_NETWORKS, chain_id
+        # Ethereum hosts several assets (eth, ethusdc, uni). Every rider takes CHAIN_ETH's network
+        # row — same prefix, no networks of its own — so one ETH_NETWORK moves all of them.
+        riders = [c for c in SUPPORTED_CHAINS.values() if c.host_chain == CHAIN_ETH.host_chain and c is not CHAIN_ETH]
+        assert CHAIN_ETHUSDC in riders and CHAIN_UNI in riders
+        for chain in riders:
+            assert (chain.env_prefix, chain.networks) == (CHAIN_ETH.env_prefix, ()), chain.id
 
 
 class TestCanonicalPair:

--- a/tests/test_uni_provider.py
+++ b/tests/test_uni_provider.py
@@ -5,14 +5,14 @@ tests/test_erc20_refusal_checks.py; this covers what is uni-specific. Two things
 
   * UNI is the first REAL row to declare ``refusal_checks=()``. Uni.sol has no
     isBlacklisted/paused, so probing them reverts — and a revert read as a verdict is what made
-    such a pair permanently unslashable. The gates must answer without touching the RPC, and boot
-    must falsify the claim against whatever contract actually resolved.
+    such a pair permanently unslashable. The gates must answer without touching the RPC.
   * It is the THIRD asset on Ethereum's env identity (eth, ethusdc, uni). One ETH_NETWORK must
     move all three, or uni reads an unset var, silently defaults to mainnet, and a testnet miner
     pays real UNI against test swaps.
 """
 
 import pytest
+from eth_utils import keccak
 
 from allways.assets.asset import ProviderUnreachableError
 from allways.assets.erc20 import (
@@ -37,6 +37,12 @@ AMOUNT = 12_500_000_000_000_000_000  # 12.5 UNI in wei — 18 decimals, not 6
 SEPOLIA_ID = 11_155_111
 # Startup reads: chain id, tip, then the token's code before the declaration is falsified.
 BOOT = {'eth_chainId': hex(SEPOLIA_ID), 'eth_blockNumber': '0x10', 'eth_getCode': '0xdeadbeef'}
+
+# Siblings UNI emits from the same contract. Approval is the dangerous one: 3 topics, holder
+# and spender indexed, value in `data` — structurally identical to Transfer, so ONLY topic0
+# separates them. Computed, never transcribed.
+APPROVAL_TOPIC0 = '0x' + keccak(text='Approval(address,address,uint256)').hex()
+DELEGATE_VOTES_TOPIC0 = '0x' + keccak(text='DelegateVotesChanged(address,uint256,uint256)').hex()
 
 
 @pytest.fixture
@@ -71,6 +77,24 @@ def transfer_log(contract=CONTRACT, recipient=RECIPIENT, amount=AMOUNT) -> dict:
     }
 
 
+def approval_log(amount=AMOUNT) -> dict:
+    """approve(RECIPIENT, amount) — same contract, same arity, same indexed slots as Transfer."""
+    return dict(transfer_log(amount=amount), topics=[APPROVAL_TOPIC0, topic(SENDER), topic(RECIPIENT)])
+
+
+def delegate_votes_log() -> dict:
+    """DelegateVotesChanged — 2 topics, both balances packed into `data`."""
+    return dict(transfer_log(), topics=[DELEGATE_VOTES_TOPIC0, topic(RECIPIENT)], data=f'0x{0:064x}{AMOUNT:064x}')
+
+
+def nft_transfer_log() -> dict:
+    """An ERC-721-style Transfer: indexed-ness is not hashed, so it carries the SAME topic0 as
+    the ERC-20 one and is separated ONLY by its 4th topic. `data` is populated so that arity is
+    the single thing under test — a real ERC-721 leaves it empty and the amount check would
+    also reject it."""
+    return dict(transfer_log(), topics=[*transfer_log()['topics'], f'0x{7:064x}'])
+
+
 def mined(logs=None, status='0x1', tip=1_000_100, block=None) -> dict:
     return {
         'eth_getTransactionByHash': {'hash': TX, 'blockNumber': '0xf4240', 'blockHash': BLOCK_HASH},
@@ -92,6 +116,10 @@ class TestSharedEnvIdentity:
         assert provider.chain_def is CHAIN_UNI is get_chain_def('uni')
         assert 'uni' in LAUNCH_SPOKES
         assert (CHAIN_UNI.env_prefix, CHAIN_UNI.host_chain) == (CHAIN_ETH.env_prefix, CHAIN_ETH.host_chain)
+        # Pinned here because nothing else on the allways side guards them: a typo'd decimals
+        # ships green through this CI and is only caught by the das drift gate, which runs
+        # after allways merges.
+        assert (CHAIN_UNI.decimals, CHAIN_UNI.native_unit) == (18, 'wei')
         # CHAIN_ETH owns ETH_NETWORK; a second declaration renders a duplicate CLI row.
         assert CHAIN_UNI.networks == ()
 
@@ -194,12 +222,24 @@ class TestVerification:
         rpc_stub(provider, mined(logs=[transfer_log(recipient=SENDER)]))
         assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
 
-    def test_delegation_logs_alongside_the_transfer_are_ignored(self, provider):
-        # A UNI transfer also moves voting power, emitting DelegateVotesChanged from the SAME
-        # contract. Only topic0 == Transfer may settle a leg.
-        votes = dict(transfer_log(), topics=['0x' + 'de' * 32, topic(SENDER), topic(RECIPIENT)])
-        rpc_stub(provider, mined(logs=[votes, transfer_log()]))
+    def test_approval_alone_never_settles_a_leg(self, provider):
+        # THE collision: approve() emits 3 topics with the spender in topics[2] and the value
+        # in data, exactly Transfer's shape. Settling on it would confirm a swap in which no
+        # funds moved — miner keeps the source, user is paid nothing. Only topic0 says no.
+        rpc_stub(provider, mined(logs=[approval_log()]))
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+    def test_approval_never_outranks_the_real_transfer(self, provider):
+        # Ordered first and paying double, so a match on it is unmistakable in the amount.
+        rpc_stub(provider, mined(logs=[approval_log(amount=AMOUNT * 2), transfer_log()]))
         assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT).amount == AMOUNT
+
+    @pytest.mark.parametrize('decoy', (delegate_votes_log, nft_transfer_log), ids=('two_topics', 'four_topics'))
+    def test_a_log_with_the_wrong_arity_never_settles_a_leg(self, provider, decoy):
+        # Transfer is exactly 3 topics. Fewer is a different event; more is an ERC-721 Transfer
+        # wearing the identical topic0, whose third topic is a tokenId and not a value.
+        rpc_stub(provider, mined(logs=[decoy()]))
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
 
     def test_pending_transfer_matches_off_calldata(self, provider):
         calldata = SEL_TRANSFER + topic(RECIPIENT).removeprefix('0x') + f'{AMOUNT:064x}'

--- a/tests/test_uni_provider.py
+++ b/tests/test_uni_provider.py
@@ -1,0 +1,295 @@
+"""Uni unit tests — all offline (RPC layer mocked, signing is pure crypto).
+
+Generic ERC-20 behaviour is proven by the arbusdc suite and the declared-refusal contract by
+tests/test_erc20_refusal_checks.py; this covers what is uni-specific. Two things:
+
+  * UNI is the first REAL row to declare ``refusal_checks=()``. Uni.sol has no
+    isBlacklisted/paused, so probing them reverts — and a revert read as a verdict is what made
+    such a pair permanently unslashable. The gates must answer without touching the RPC, and boot
+    must falsify the claim against whatever contract actually resolved.
+  * It is the THIRD asset on Ethereum's env identity (eth, ethusdc, uni). One ETH_NETWORK must
+    move all three, or uni reads an unset var, silently defaults to mainnet, and a testnet miner
+    pays real UNI against test swaps.
+"""
+
+import pytest
+
+from allways.assets.asset import ProviderUnreachableError
+from allways.assets.erc20 import (
+    SEL_TRANSFER,
+    TESTNET_TOKEN_CONTRACTS,
+    TRANSFER_TOPIC0,
+)
+from allways.assets.eth import Ether
+from allways.assets.ethusdc import EthUsdc
+from allways.assets.uni import Uni
+from allways.chains import CHAIN_ETH, CHAIN_UNI, get_chain_def
+from allways.constants import LAUNCH_SPOKES
+
+TEST_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'  # hardhat account #0
+SENDER = '0x' + '11' * 20
+RECIPIENT = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'  # mixed case on purpose
+CONTRACT = TESTNET_TOKEN_CONTRACTS['uni']['sepolia']
+COUNTERFEIT = '0x' + '99' * 20
+TX = '0x' + 'ab' * 32
+BLOCK_HASH = '0x' + 'cd' * 32
+AMOUNT = 12_500_000_000_000_000_000  # 12.5 UNI in wei — 18 decimals, not 6
+SEPOLIA_ID = 11_155_111
+# Startup reads: chain id, tip, then the token's code before the declaration is falsified.
+BOOT = {'eth_chainId': hex(SEPOLIA_ID), 'eth_blockNumber': '0x10', 'eth_getCode': '0xdeadbeef'}
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    monkeypatch.setenv('ETH_NETWORK', 'sepolia')
+    for var in ('ETH_RPC_URLS', 'ETH_PRIVATE_KEY', 'UNI_TOKEN_CONTRACT'):
+        monkeypatch.delenv(var, raising=False)
+    return Uni()
+
+
+def rpc_stub(provider, responses: dict):
+    """Replace eth_rpc with a method→response map. A callable value is invoked with params."""
+
+    def fake_rpc(method, params, timeout=15, **kw):
+        value = responses[method]
+        return value(params) if callable(value) else value
+
+    provider.chain.eth_rpc = fake_rpc  # the asset talks through its chain (composed seam)
+    return provider
+
+
+def topic(address: str) -> str:
+    return '0x' + '00' * 12 + address.lower().removeprefix('0x')
+
+
+def transfer_log(contract=CONTRACT, recipient=RECIPIENT, amount=AMOUNT) -> dict:
+    return {
+        'address': contract,
+        'topics': [TRANSFER_TOPIC0, topic(SENDER), topic(recipient)],
+        'data': hex(amount),
+        'transactionHash': TX,
+    }
+
+
+def mined(logs=None, status='0x1', tip=1_000_100, block=None) -> dict:
+    return {
+        'eth_getTransactionByHash': {'hash': TX, 'blockNumber': '0xf4240', 'blockHash': BLOCK_HASH},
+        'eth_getTransactionReceipt': {
+            'status': status,
+            'blockNumber': '0xf4240',
+            'blockHash': BLOCK_HASH,
+            'logs': [transfer_log()] if logs is None else logs,
+        },
+        'eth_blockNumber': hex(tip),
+        'eth_getBlockByNumber': {'hash': BLOCK_HASH, 'timestamp': '0x64'} if block is None else block,
+    }
+
+
+class TestSharedEnvIdentity:
+    """Ethereum is configured once, by CHAIN_ETH, for every asset that rides it."""
+
+    def test_row_is_a_launch_spoke_on_ethereums_identity(self, provider):
+        assert provider.chain_def is CHAIN_UNI is get_chain_def('uni')
+        assert 'uni' in LAUNCH_SPOKES
+        assert (CHAIN_UNI.env_prefix, CHAIN_UNI.host_chain) == (CHAIN_ETH.env_prefix, CHAIN_ETH.host_chain)
+        # CHAIN_ETH owns ETH_NETWORK; a second declaration renders a duplicate CLI row.
+        assert CHAIN_UNI.networks == ()
+
+    @pytest.mark.parametrize('network,chain_id', (('mainnet', 1), ('sepolia', SEPOLIA_ID)))
+    def test_one_eth_network_moves_all_three_assets(self, monkeypatch, network, chain_id):
+        monkeypatch.setenv('ETH_NETWORK', network)
+        assert Uni().chain.chain_id == EthUsdc().chain.chain_id == Ether().chain.chain_id == chain_id
+
+    def test_token_contract_follows_the_shared_network(self, provider, monkeypatch):
+        # UNI's Sepolia deployment sits at the mainnet address with byte-identical runtime code,
+        # so the two resolve to the same string — assert the SOURCE, not just the value.
+        assert provider.token_contract == CONTRACT == CHAIN_UNI.asset_locator
+        monkeypatch.setenv('ETH_NETWORK', 'mainnet')
+        assert Uni().token_contract == CHAIN_UNI.asset_locator
+
+    def test_env_override_wins(self, monkeypatch):
+        monkeypatch.setenv('UNI_TOKEN_CONTRACT', '0x' + '42' * 20)
+        assert Uni().token_contract == '0x' + '42' * 20
+
+    def test_unknown_network_raises(self, monkeypatch):
+        monkeypatch.setenv('ETH_NETWORK', 'seplia')
+        with pytest.raises(ValueError, match='ETH_NETWORK'):
+            Uni()
+
+    def test_finality_and_clock_match_the_chain_it_shares(self):
+        # Two assets on one chain must not disagree about its reorg depth or its clock, and the
+        # implied 384s leg stays inside the program's 600s default fulfillment grace.
+        assert (CHAIN_UNI.min_confirmations, CHAIN_UNI.seconds_per_block, CHAIN_UNI.replay_grace_secs) == (
+            CHAIN_ETH.min_confirmations,
+            CHAIN_ETH.seconds_per_block,
+            CHAIN_ETH.replay_grace_secs,
+        )
+        assert CHAIN_UNI.min_confirmations * CHAIN_UNI.seconds_per_block < 600
+
+    def test_wrong_network_endpoint_fails_startup(self, provider):
+        # Sepolia configured, a mainnet endpoint answering: reject outright rather than
+        # quietly verify legs against the wrong chain.
+        rpc_stub(provider, {'eth_chainId': '0x1'})
+        with pytest.raises(ConnectionError, match=f'expected {SEPOLIA_ID}'):
+            provider.check_connection(require_send=False)
+
+    def test_codeless_contract_fails_startup(self, provider):
+        rpc_stub(provider, {'eth_chainId': hex(SEPOLIA_ID), 'eth_blockNumber': '0x10', 'eth_getCode': '0x'})
+        with pytest.raises(ConnectionError, match='no code'):
+            provider.check_connection(require_send=False)
+
+
+class TestUnfreezable:
+    """Uni.sol has no freeze surface and cannot gain one. Probing for one reverts, and a revert
+    propagating out of delivery_refused makes the caller defer every slash on the pair forever."""
+
+    def test_row_declares_unfreezable(self):
+        assert CHAIN_UNI.refusal_checks == ()
+
+    def test_gates_answer_without_reaching_the_rpc(self, provider):
+        def forbidden(*_a, **_kw):
+            raise AssertionError('UNI has no issuer surface — the gates must not probe for one')
+
+        provider.chain.eth_rpc = forbidden
+        assert provider.delivery_refused(RECIPIENT, since_unix=0) is False
+        assert provider.can_deliver_to(RECIPIENT, AMOUNT) is True
+
+    def test_boot_probes_nothing(self, provider):
+        # Nothing declared, nothing to read: boot must not reach for a surface UNI never had.
+        def reverts(params):
+            raise AssertionError('UNI declares no checks — boot must not probe for one')
+
+        rpc_stub(provider, dict(BOOT, eth_call=reverts))
+        provider.check_connection(require_send=False)
+
+
+class TestVerification:
+    def test_settled_transfer_matches_a_mixed_case_recipient_with_sender_pinned(self, provider):
+        # Through verify_transaction, which is where casing canonicalizes: a checksummed
+        # expected recipient against a lowercase on-chain topic must still settle the leg.
+        rpc_stub(provider, mined())
+        info = provider.verify_transaction(TX, RECIPIENT, AMOUNT, expected_sender=SENDER.upper())
+        assert info.confirmed and info.amount == AMOUNT and info.block_time == 0x64
+        assert info.sender == SENDER.lower()
+
+    def test_wrong_sender_rejected(self, provider):
+        rpc_stub(provider, mined())
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT, expected_sender=RECIPIENT) is None
+
+    def test_below_min_confs_unconfirmed(self, provider):
+        rpc_stub(provider, mined(tip=1_000_030))  # 31 confs of the 32 required
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT).confirmed is False
+
+    def test_reverted_rejected(self, provider):
+        # Inclusion is not settlement: a reverted tx moved no funds.
+        rpc_stub(provider, mined(status='0x0'))
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+    def test_underpay_by_one_wei_rejected(self, provider):
+        # 18 decimals: the shortfall a 6-decimal token could not even express.
+        rpc_stub(provider, mined(logs=[transfer_log(amount=AMOUNT - 1)]))
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+    def test_wrong_recipient_rejected(self, provider):
+        rpc_stub(provider, mined(logs=[transfer_log(recipient=SENDER)]))
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+    def test_delegation_logs_alongside_the_transfer_are_ignored(self, provider):
+        # A UNI transfer also moves voting power, emitting DelegateVotesChanged from the SAME
+        # contract. Only topic0 == Transfer may settle a leg.
+        votes = dict(transfer_log(), topics=['0x' + 'de' * 32, topic(SENDER), topic(RECIPIENT)])
+        rpc_stub(provider, mined(logs=[votes, transfer_log()]))
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT).amount == AMOUNT
+
+    def test_pending_transfer_matches_off_calldata(self, provider):
+        calldata = SEL_TRANSFER + topic(RECIPIENT).removeprefix('0x') + f'{AMOUNT:064x}'
+        pending = {'hash': TX, 'from': SENDER, 'to': CONTRACT, 'input': calldata, 'blockNumber': None}
+        rpc_stub(provider, {'eth_getTransactionByHash': pending})
+        info = provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT)
+        assert info.confirmed is False and info.sender == SENDER.lower() and info.amount == AMOUNT
+
+    def test_absent_tx_is_absent(self, provider):
+        rpc_stub(provider, {'eth_getTransactionByHash': None})
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+    def test_receipt_unavailable_is_unknown_not_absent(self, provider):
+        # 'unknown' must never read as 'no such payment' — that verdict slashes a paying miner.
+        with pytest.raises(ProviderUnreachableError):
+            rpc_stub(provider, dict(mined(), eth_getTransactionReceipt=None)).fetch_matching_tx(
+                TX, RECIPIENT.lower(), AMOUNT
+            )
+
+    def test_missing_block_timestamp_is_unknown_not_absent(self, provider):
+        with pytest.raises(ProviderUnreachableError):
+            rpc_stub(provider, mined(block={'hash': BLOCK_HASH})).fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT)
+
+    def test_counterfeit_token_log_never_matches_even_on_the_cache_path(self, provider):
+        """A fake token emitting a well-formed Transfer must not settle the leg, and must not
+        settle it on the re-verify either: the cache is only written from a pinned-contract match."""
+        rpc_stub(provider, mined(logs=[transfer_log(contract=COUNTERFEIT)]))
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+        assert provider._settled_cache == {}
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+
+class TestSendGuards:
+    SEND = {
+        'eth_blockNumber': hex(100),
+        'eth_getBlockByNumber': {'baseFeePerGas': hex(10**9)},
+        'eth_maxPriorityFeePerGas': hex(10**9),
+        'eth_getTransactionCount': '0x0',
+        'eth_getBalance': hex(10**18),
+        'eth_estimateGas': hex(90_000),  # UNI's transfer also writes delegation checkpoints
+        'eth_call': f'0x{AMOUNT:064x}',  # balanceOf
+    }
+
+    def test_no_key_refused(self, provider):
+        assert provider.send_amount(RECIPIENT, AMOUNT) is None
+        assert 'ETH_PRIVATE_KEY' in provider.last_send_error
+
+    def test_key_mismatch_refused(self, provider, monkeypatch):
+        monkeypatch.setenv('ETH_PRIVATE_KEY', TEST_KEY)
+        assert provider.send_amount(RECIPIENT, AMOUNT, from_address=RECIPIENT) is None
+        assert 'key mismatch' in provider.last_send_error
+
+    def test_insufficient_token_balance_refused(self, provider, monkeypatch):
+        monkeypatch.setenv('ETH_PRIVATE_KEY', TEST_KEY)
+        rpc_stub(provider, dict(self.SEND, eth_call=f'0x{AMOUNT - 1:064x}'))
+        assert provider.send_amount(RECIPIENT, AMOUNT) is None
+        assert 'insufficient balance' in provider.last_send_error
+
+    def test_gas_poor_miner_refuses_before_broadcasting(self, provider, monkeypatch):
+        # Token-rich but ETH-poor: refuse here rather than burn a revert on L1.
+        monkeypatch.setenv('ETH_PRIVATE_KEY', TEST_KEY)
+        rpc_stub(provider, dict(self.SEND, eth_getBalance=hex(10**9)))
+        assert provider.send_amount(RECIPIENT, AMOUNT) is None
+        assert 'Insufficient gas balance' in provider.last_send_error
+
+    def test_broadcast_returns_a_hash(self, provider, monkeypatch):
+        monkeypatch.setenv('ETH_PRIVATE_KEY', TEST_KEY)
+        rpc_stub(provider, dict(self.SEND, eth_sendRawTransaction=TX))
+        assert provider.send_amount(RECIPIENT, AMOUNT) == (TX, 0)
+
+
+class TestDepositScanner:
+    def test_getlogs_hit_is_bounded_to_the_lookback_window(self, provider):
+        seen = {}
+
+        def logs(params):
+            seen.update(params[0])
+            return [transfer_log()]
+
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getLogs': logs})
+        assert provider.find_recent_outgoing(SENDER, RECIPIENT, AMOUNT) == TX
+        assert int(seen['fromBlock'], 16) == 10_000 - provider.SCAN_LOOKBACK_BLOCKS + 1
+        assert seen['address'] == CONTRACT
+
+    def test_failed_range_parks_the_cursor(self, provider):
+        def boom(params):
+            raise ConnectionError('down')
+
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getLogs': boom})
+        assert provider.find_recent_outgoing(SENDER, RECIPIENT, AMOUNT) is None
+        # Never leap a range the scan could not read — the deposit in it must stay reachable.
+        key = (SENDER.lower(), RECIPIENT.lower(), AMOUNT)
+        assert provider.scan_cursors[key] == 10_000 - provider.SCAN_LOOKBACK_BLOCKS


### PR DESCRIPTION
Adds UNI (Uniswap, ERC-20 on Ethereum) as a launch spoke: one `ChainDefinition`, one `Erc20` binding, one `LAUNCH_SPOKES` entry, one `TESTNET_TOKEN_CONTRACTS` row, tests.

**Base branch is `refactor/erc20-refusal-interface` (#647), not `test`.** UNI implements no `isBlacklisted`/`paused` — probing them **reverts**, and before #647 that revert propagated out of `delivery_refused` and the caller deferred every slash on the pair forever. Rebased onto `422d93d` (the post-red-team head, which renames the declaration to `unfreezable` and adds the boot falsifier). Retarget this PR to `test` once #647 merges.

das twin: **entrius/das-allways#99**. Merge this first — das's drift gate reads `allways/chains.py` from `test` and stays red until it lands.

## Registry row

| Field | Value | Why |
|---|---|---|
| `host_chain` / `env_prefix` | `ethereum` / `ETH` | Third asset on Ethereum's identity (eth, ethusdc, uni). One `ETH_NETWORK`/`ETH_RPC_URLS`/`ETH_PRIVATE_KEY` serves all three, so they can never disagree about which Ethereum they are on. |
| `networks` | `()` | `CHAIN_ETH` already declares Ethereum's network names. A second declaration renders a duplicate CLI row writing the same var. |
| `decimals` | 18 | Verified on-chain. Already-covered precision (eth, hype, bnb, avax) — `tests/test_rate.py` needs no new cases. |
| `min_confirmations` / `seconds_per_block` | 32 / 12 | **Identical to `CHAIN_ETH`.** Two assets on one chain must not disagree about that chain's reorg depth. 32 x 12s = 384s, inside the program's 600s default fulfillment grace. |
| `replay_grace_secs` | 0 | **Identical to `CHAIN_ETH`.** This absorbs hub-vs-spoke clock skew; two assets on one chain disagreeing about that chain's clock would be indefensible. |
| `asset_locator` | `0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984` | Uniswap's own published UNI address, re-verified on-chain (below). |
| `issuer_controls` | `unfreezable` | Both halves proven below: no freeze surface, and it cannot gain one. |

### `min_onchain_amount` = 3 UNI (`3_000_000_000_000_000_000`)

A rate-sanity input to `is_executable_rate`, **not an enforced minimum** (the enforced bounds are the program's `min_swap_amount`/`max_swap_amount` in SOL lamports). Sized at realistic-high L1 gas, not quiet-day gas:

- Real dest-leg gas, 23 direct `transfer()` calls sampled on mainnet: **35,294 – 57,218**. Budget **90,000** for the worst case, since a UNI transfer also writes up to two delegation checkpoints that FiatToken's does not. (Still far under `MAX_TOKEN_TRANSFER_GAS` = 150,000.)
- Live UNI/WETH price from the Uniswap V3 0.3% pool `0x1d42064F…d801` (`slot0`, token0=UNI, token1=WETH): **1 UNI = 0.00186539 ETH**.
- 3 UNI covers a 90,000-gas leg up to **~62 gwei**; at the observed typical 57k it covers **~98 gwei**. Mainnet basefee while writing this was **0.098 gwei**, so this is deliberately ~630x above a quiet day.
- Worth **2.12x** `CHAIN_ETHUSDC`'s floor. That gap is **not** all gas: the gas-budget ratio is only **1.38x** (90k vs 65k); the remaining **1.51x** is a deliberately higher assumed gas price (**62.5 vs 40.8 gwei**). Assumed gwei is per-asset economics and a judgement call, unlike `min_confirmations`, which is a chain fact and therefore pinned identical to `CHAIN_ETH`.
- Explicitly **not** `arbusdc`'s `1`: an 18-decimal token at L1 gas is nothing like a 6-decimal stablecoin on an L2.

## Token diligence — evidence, not docs links

All probed live 2026-08-12 against `ethereum-rpc.publicnode.com`.

| Property | Verdict | Evidence |
|---|---|---|
| **Not fee-on-transfer** | PASS | tx `0x6770b72da889dd8f5d330616ad33159da188143ebf44cc676077def26875d59c`, block 25740646. `Transfer` log value `210603000000000000000`. Recipient `0x6e71…fd62` `balanceOf` @25740645 = `0` → @25740646 = `210603000000000000000`; **delta == log value exactly**. Sender `0x58b7…5023` delta = `-210603000000000000000`, also exact. Both sides balance. |
| **Not rebasing** | PASS | `totalSupply()` = `1000000000000000000000000000` (1e27) at blocks 25740645 / 25740646 / 25740686 — constant. Balances are plain storage (`balances[src]`/`balances[dst]` in `_transferTokens`), never scaled. |
| **No freeze surface** (half 1 of `unfreezable`) | PASS | **PUSH-aware selector dispatch-table extraction** of the deployed runtime bytecode: **31** unique `PUSH4` constants, of which **27 are exactly Uni.sol's complete ABI** — every declared function found, **0 unaccounted selectors**. The remaining 4 are not selectors: `0x01e13380` (= 31,536,000, the `minimumTimeBetweenMints` literal), `0x65556e69` / `0x65656473` (ASCII `"eUni"` / `"eeds"`, revert-string fragments), and `0xffffffff` (the uint32 mask). A sweep of 24 freeze-capable selectors (`isBlacklisted`, `isBlackListed`, `blacklist`, `paused`, `pause`, `freeze`, `frozen`, `pauser`, `blacklister`, `owner`, `transferOwnership`, `upgradeTo`, `implementation`, `admin`, `initialize`, …) dispatches **NONE**. Identical on both networks. Live: `isBlacklisted(address)` and `paused()` both raise `EvmRpcError` with `is_execution_revert=True` on both networks. |
| **Cannot gain one** (half 2 of `unfreezable`) | PASS | EIP-1967 implementation slot `0x360894…2bbc` = **zero**; admin slot `0xb53127…6103` = zero; beacon slot `0xa3f0ad…3d50` = zero; OZ legacy impl slot = zero. `owner()`, `admin()`, `implementation()` all **revert**. No `upgrad`/`proxy`/`implementation`/`admin` string in the bytecode. Runtime code **12,567 bytes**, keccak `0xdeba17f16fdba566b45d8019575e068625403cc6986fa17ceadd6edf08aa0868`. Immutable bytecode, no admin path to new code. |
| **Standard `Transfer` event** | PASS | Decoded real log above: `address` = pinned UNI, `topic0` = `0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef`, exactly **3 topics** (from/to indexed), value in `data`. |
| **`transfer` return convention** | PASS | Same tx: `tx.to` = UNI, selector `0xa9059cbb`, `tx.value` = 0, receipt **`status = 0x1`**, `gasUsed` 57,218, exactly one UNI `Transfer` log. No revert-on-false. |

**Both halves matter and were checked separately.** Non-upgradeability alone is not sufficient — an immutable contract can ship a hardcoded blacklist from day one. The **dispatch-table** extraction is what rules that out; the empty proxy slots are what rule out acquiring one later. The boot falsifier (`Erc20._falsify_declaration`) then re-checks the first half against whatever contract actually resolved, on every start.

*Why the dispatch table and not a string scan.* An earlier revision of this PR argued from printable strings. That method is too weak to carry the claim, for two reasons: the "complete" 32-string figure was only the revert-message subset (a ≥6-char sweep finds ~101), and — decisively — **a stringless `require(!blacklisted[x])` emits a bare `REVERT` with no string at all**, so absence of blacklist *strings* proves nothing. The dispatch table does carry it: any externally reachable freeze or admin function must have an entry point, every `PUSH4` in the contract is accounted for, and 27 of 27 are Uni.sol's own. The conclusion is unchanged; the evidence is now the kind that actually establishes it.

**Source ↔ bytecode correspondence.** The deployed string table is exactly `Uniswap/governance` `Uni.sol`'s, which is how the source reasoning below is tied to the code that actually runs. Complete transfer-path revert set, read out of the deployed bytecode:

```
Uni::transfer: amount exceeds 96 bits
Uni::_transferTokens: cannot transfer from the zero address
Uni::_transferTokens: cannot transfer to the zero address
Uni::_transferTokens: transfer amount exceeds balance
Uni::_transferTokens: transfer amount overflows
Uni::_moveVotes: vote amount underflows
Uni::_moveVotes: vote amount overflows
Uni::_writeCheckpoint: block number exceeds 32 bits
```
(`_writeCheckpoint` is reached via `_moveDelegates`; it needs a block height ≥ 2^32 to fire, so it is unreachable in practice — but the list is labelled complete, so it belongs in it.)
Byte-identical on mainnet and Sepolia (same 12,567 bytes, same keccak, same 32 strings).

**One honest qualification on `issuer_controls='unfreezable'`.** UNI is not admin-free in every sense: `minter()` returns the Uniswap governance Timelock `0x1a9C8182C09F50C8318d769245beA52c32BE35BC`, with `mintCap()` = 2 (%), `minimumTimeBetweenMints()` = 31,536,000s (365 days), `mintingAllowedAfter()` = 1704067200. That power is **supply inflation only** — it cannot freeze an address, pause transfers, alter a transfer's amount, or change the code (`setMinter` only rotates who may mint). `issuer_controls` declares the *freeze/pause surface*, and Uni.sol has none, on immutable bytecode. `totalSupply` is still exactly 1e27, so no mint has ever occurred.

### UNI-specific hazard: governance delegation

A UNI transfer moves voting power (`_transferTokens` → `_moveDelegates`). Checked against `Uniswap/governance` `Uni.sol`:

- **No hook we do not model.** `_moveDelegates` only writes checkpoints and emits `DelegateVotesChanged` — a different `topic0` from the same contract. `_transfer_log` (`erc20.py:306`) filters on pinned address **and** `len(topics) == 3` **and** `topic0 == Transfer`, so the extra log can never settle a leg. Covered by `test_delegation_logs_alongside_the_transfer_are_ignored`.
- **No reachable revert.** The transfer path can revert on: `safe96` (amount ≥ 2^96 ≈ 7.92e28 — 79x total supply, unreachable), zero address, insufficient balance, and `_moveVotes` under/overflow. The last two cannot fire on an honest leg: votes move in lockstep with balances, so `srcRepOld >= balances[src] >= amount`, and `dstRepNew <= totalSupply = 1e27 < 2^96`.
- **Gas.** Delegation checkpoints are why the floor budgets 90k rather than the observed 57k; still well under the 150k cap.

## Live read-only verification

**Mainnet** (`ETH_NETWORK=mainnet`):
```
describe            Ethereum JSON-RPC (mainnet): ethereum-rpc.publicnode.com, eth.drpc.org
                    — token 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984
check_connection(require_send=False)   OK   <- runs the boot falsifier
  isBlacklisted(addr)   EvmRpcError is_execution_revert=True   (absence confirmed)
  paused()              EvmRpcError is_execution_revert=True   (absence confirmed)
tip                 25740760
settled transfer    0xb0cd5dd761d7378b4b9c707c47908b3c6875a70146c10412f0e0660c66d02ff4
  verify(mixed-case recipient 0X6e71…fd62, sender pinned)
                    confirmed=True amount=210604000000000000000 confs=71 block_time=1786558907
  underpayment +1 wei     None
  wrong sender            None
  wrong recipient         None
  unknown tx              None
get_balance(0x1a9C8182…BE35BC)   267247996305835021033106178
can_deliver_to      True     delivery_refused   False     (declared unfreezable — zero RPC calls)
```

**Sepolia** (`ETH_NETWORK=sepolia`):
```
describe            Ethereum JSON-RPC (sepolia): ethereum-sepolia-rpc.publicnode.com,
                    sepolia.gateway.tenderly.co — token 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984
check_connection(require_send=False)   OK   <- runs the boot falsifier
  isBlacklisted(addr)   EvmRpcError is_execution_revert=True   (absence confirmed)
  paused()              EvmRpcError is_execution_revert=True   (absence confirmed)
tip                 11474994
settled transfer    0xb6a4795e918b9a7cb56c64ab1e2e47f99365efc082b2ae0adc2edf41723bf5a7
  verify(mixed-case recipient 0X6e81…6299, sender pinned)
                    confirmed=True amount=40913978677132 confs=54 block_time=1786559232
  underpayment +1 wei     None
  wrong sender            None
  wrong recipient         None
  unknown tx              None
get_balance(0x6e81f4a9…6299)     94744025098838155
can_deliver_to      True     delivery_refused   False
ALL LIVE CHECKS PASSED
```

**Sepolia pin.** `TESTNET_TOKEN_CONTRACTS['uni']['sepolia']` is the *same address as mainnet*, and the runtime bytecode is **byte-identical** — keccak `0xdeba17f1…0868`, 12,567 bytes on both. `symbol`=UNI, `decimals`=18, `totalSupply`=1e27 match too. Only storage differs (`minter()` is a Sepolia-specific address), which is expected for a separate deployment of the same code and touches nothing on the verification path.

**Operational note, pre-existing and not introduced here.** On Ethereum *mainnet*, `eth.drpc.org`'s free tier intermittently answers HTTP 408 (`"Request timeout on the free tier"`). Two consequences, both benign:

- An absent tx needs quorum on the null, so `fetch_matching_tx` intermittently raises `ProviderUnreachableError` instead of returning `None` — the **fail-safe** direction (defer, never a false slash), correct by design. Both outcomes were observed live.
- The falsifier is **not** weakened by it: `eth_rpc` remembers a revert and raises it ahead of any later transport error (`evm.py:270`), so publicnode's revert still reaches `_falsify_declaration` as `is_execution_revert=True` even when drpc 408s. Verified explicitly, output above.

This is a property of the shared `ETHEREUM` ladder, identical for `eth` and `ethusdc`; operators should set `ETH_RPC_URLS`.

## Tests, lint, CLI

- `ruff format --check .` → `183 files already formatted`; `ruff check .` → `All checks passed!`
- `pytest tests/ -q` → **1562 passed, 6 deselected**
- New `tests/test_uni_provider.py` (36 cases, fully offline): shared env identity, network/token-contract resolution, wrong-network + codeless-contract startup rejection, the `unfreezable` path proving the gates make **zero** RPC calls plus a boot falsifier pair (a contract that reverts both probes boots; one that *answers* either probe fails boot), settled/underpaid-by-1-wei/wrong-recipient/wrong-sender/reverted/pending/absent verification, receipt- and timestamp-unavailable **raising**, counterfeit-contract logs never matching (incl. the cache path), send guards, deposit-scanner bounds and cursor parking — plus the sibling-log guards below.
- **`_transfer_log`'s shape check is now covered.** Nothing in the repo guarded `erc20.py:341`, so it was mutation-tested rather than assumed. The real hazard is **`Approval`**, not delegation: same pinned contract, **exactly 3 topics**, spender in `topics[2]`, value in `data` — structurally identical to `Transfer`, separated only by topic0. An `approve()`-only receipt settling a destination leg would confirm a swap in which **no funds moved**. Also covered: an **ERC-721-style `Transfer`**, whose topic0 is *byte-identical* to the ERC-20 one (indexed-ness is not hashed), leaving arity as the only separator. Topic0 constants are computed with `keccak`, not transcribed.

  | Mutation of `erc20.py:341` | Before | After |
  |---|---|---|
  | drop the `topic0` check | 1559 passed (undetected) | **2 failed** (`test_approval_alone_never_settles_a_leg`, `test_approval_never_outranks_the_real_transfer`) |
  | loosen arity `!= 3` → `< 3` | 1559 passed (undetected) | **1 failed** (`…wrong_arity…[four_topics]`) |
  | drop the guard entirely (`if False`) | — | **4 failed** |

  `erc20.py` is **unchanged** — the code was correct, only the guard was missing.
- **`decimals` / `native_unit` are now pinned** (`(18, 'wei')`), matching every sibling suite. Previously a typo shipped green through allways CI and was caught only by the das drift gate, which runs *after* allways merges. Mutation-checked both ways: `decimals` 18→6 and `native_unit` `wei`→`gwei` each fail the suite.
- `tests/test_chains.py`: `get_chain_def('uni')`, and #643's one-declaration-per-network assertion **generalised from a hardcoded ethusdc line into a loop over every Ethereum rider** — so it now covers uni (and qnt, when it lands) with no further edits.
- `tests/test_cli_chain_networks.py` **needed no change, and that is the correct outcome.** `NAME_SELECTED_CHAINS` filters on `c.networks`, so a `networks=()` row is excluded by construction. Verified directly: `alw config` renders `btc/eth/arb/hype/bnb/avax/base-network` and **no `uni-network` row** — adding one would be the bug.
- CLI flags derived, not written: `alw miner quotes --help` shows `--uni-price` (`UNI per 1 hub unit`) and `--uni-address`.
- `run-suites.sh --list` shows `sol-uni` and `uni-sol` with **zero harness edits** (derived from `LAUNCH_SPOKES`; `alw-utils#123` is merged, so `eth`/`ethusdc`/`uni` correctly share one `ETH_*` env block). **The suite was not executed** — it needs the full local stack, and this box's `/tmp` is under quota pressure.

## Multi-hub and emission dilution

Multi-hub is live (`HUB_CHAINS = ('sol', 'tao')`), so **`uni` creates TWO pairs, not one**: `('sol','uni')` and `('tao','uni')`. **Miners are expected to quote the TAO leg as well as the SOL leg.**

Dilution is per **PAIR**: `MINER_POOL_SHARE / (2 x len(LAUNCH_PAIRS))`.

| | spokes | pairs | directions | zero-volume floor |
|---|---|---|---|---|
| before | 9 | 17 | 34 | 0.294118% |
| after this PR | 10 | **19** | 38 | **0.263158%** |

Volume weighting (`POOL_VOLUME_ALPHA` = 0.66) lets a busy pair recover most of that; a pair with no volume does not.