### PR TITLE
Add Quant (QNT) on Ethereum as a launch spoke

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,8 @@ BTC_PRIVATE_KEY=
 
 # ─── Network: Ethereum (ETH + ethusdc + uni pairs) ─────────
 # Vars are per NETWORK, shared by every asset on it — ethusdc and uni add none of their own.
+# ─── Network: Ethereum (ETH + ethusdc + qnt pairs) ─────────
+# Vars are per NETWORK, shared by every asset on it — the tokens add no network vars of their own.
 ETH_NETWORK=mainnet                 # mainnet | sepolia
 # OPTIONAL ordered JSON-RPC endpoints (keyed providers embed the key in the URL);
 # unset = public (publicnode, drpc)
@@ -46,6 +48,12 @@ ETH_PRIVATE_KEY=
 # OPTIONAL token contract overrides (dev/e2e fakes) — per ASSET, unset = the canonical deployment
 # ETHUSDC_TOKEN_CONTRACT=
 # UNI_TOKEN_CONTRACT=
+# 32-byte hex key — required for miners (fund ETH for the ETH legs, USDC/QNT + ETH-for-gas for
+# the token legs); optional local signing for `alw swap`
+ETH_PRIVATE_KEY=
+# OPTIONAL token contract overrides (dev/e2e fakes) — per ASSET, unset = the canonical deployment
+# ETHUSDC_TOKEN_CONTRACT=
+# QNT_TOKEN_CONTRACT=
 
 # ─── Network: Arbitrum (arbusdc pairs) ─────────────────────
 # Vars are per NETWORK, shared by every asset on it (ARB_ here, not ARBUSDC_).

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Allways creates a verification layer above independent systems. Assets move nati
 Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, SOL ↔ USDC-on-Base, SOL ↔ USDC-on-Ethereum, and SOL ↔ CRO (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
 Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, SOL ↔ USDC-on-Base, SOL ↔ USDC-on-Ethereum, and SOL ↔ ASTER (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
 Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, SOL ↔ USDC-on-Base, SOL ↔ USDC-on-Ethereum, and SOL ↔ UNI (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
+Currently live with SOL and TAO as hubs, each paired against BTC, ETH, USDC-on-Arbitrum, HYPE, BNB, AVAX, USDC-on-Base, USDC-on-Ethereum, and QNT — plus SOL ↔ TAO itself (hub-and-spoke: every pair has a SOL or TAO leg). Designed to scale to any verifiable asset.
 
 ## Miner Risk Disclaimer
 
@@ -128,6 +129,7 @@ needs to persist across restarts.
 - `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `BNB_PRIVATE_KEY`, `AVAX_PRIVATE_KEY`, `BASE_PRIVATE_KEY`, `CRO_PRIVATE_KEY`, `{ETH,ARB,HYPE,BNB,AVAX,BASE,CRO}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config (ETH and ethusdc both ride the `ETH_*` vars). See `.env.example`.
 - `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `BNB_PRIVATE_KEY`, `AVAX_PRIVATE_KEY`, `BASE_PRIVATE_KEY`, `{ETH,ARB,HYPE,BNB,AVAX,BASE}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config (ETH and ethusdc both ride the `ETH_*` vars; BNB and aster both ride the `BNB_*` vars). See `.env.example`.
 - `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `BNB_PRIVATE_KEY`, `AVAX_PRIVATE_KEY`, `BASE_PRIVATE_KEY`, `{ETH,ARB,HYPE,BNB,AVAX,BASE}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config (ETH, ethusdc and uni all ride the `ETH_*` vars). See `.env.example`.
+- `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `BNB_PRIVATE_KEY`, `AVAX_PRIVATE_KEY`, `BASE_PRIVATE_KEY`, `{ETH,ARB,HYPE,BNB,AVAX,BASE}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config (ETH, ethusdc and qnt all ride the `ETH_*` vars). See `.env.example`.
 
 ## Running a Local Subtensor Lite Node (Validators)
 

--- a/allways/assets/__init__.py
+++ b/allways/assets/__init__.py
@@ -16,6 +16,7 @@ from allways.assets.eth import Ether
 from allways.assets.ethusdc import EthUsdc
 from allways.assets.evm_coin import EvmCoin
 from allways.assets.hype import Hype
+from allways.assets.qnt import Qnt
 from allways.assets.sol import Sol
 from allways.assets.tao import Tao
 from allways.assets.uni import Uni
@@ -41,6 +42,7 @@ __all__ = [
     'EthUsdc',
     'Aster',
     'Uni',
+    'Qnt',
     'create_assets',
 ]
 
@@ -68,6 +70,7 @@ ASSET_REGISTRY: Tuple[AssetSpec, ...] = (
     AssetSpec('cro', Cro, ()),
     AssetSpec('aster', Aster, ()),
     AssetSpec('uni', Uni, ()),
+    AssetSpec('qnt', Qnt, ()),
 )
 
 

--- a/allways/assets/qnt.py
+++ b/allways/assets/qnt.py
@@ -1,0 +1,12 @@
+from allways.assets.erc20 import Erc20
+from allways.chains import CHAIN_QNT
+
+
+class Qnt(Erc20):
+    """Quant on Ethereum — a config-row binding of the generic Erc20 (see chains.CHAIN_QNT).
+
+    Rides Ethereum's env identity alongside native ETH and ethusdc (ETH_NETWORK, ETH_RPC_URLS,
+    ETH_PRIVATE_KEY), adding only its own QNT_TOKEN_CONTRACT override."""
+
+    def __init__(self):
+        super().__init__(CHAIN_QNT)

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -354,6 +354,39 @@ CHAIN_UNI = ChainDefinition(
     refusal_checks=(),
 )
 
+CHAIN_QNT = ChainDefinition(
+    id='qnt',
+    name='Quant',
+    # atto-QNT. Not 'wei' — that is ETH's subunit, and this row is a token on Ethereum, not ETH.
+    native_unit='aQNT',
+    decimals=18,
+    # Ethereum's prefix, shared with CHAIN_ETH: one ETH_NETWORK / ETH_RPC_URLS / ETH_PRIVATE_KEY
+    # serves every asset on it, so they can never disagree about which Ethereum they are on.
+    env_prefix='ETH',
+    host_chain='ethereum',
+    # CHAIN_ETH already declares the ETH_NETWORK names; a second declaration would render a
+    # duplicate CLI row writing the same var.
+    networks=(),
+    seconds_per_block=12,
+    # CHAIN_ETH's finality, deliberately identical — two assets on one chain must not disagree
+    # about its reorg depth. 32 × 12s = 384s, inside the program's 600s default fulfillment grace.
+    min_confirmations=32,
+    # Rate sanity floor, not an economic guarantee: 0.1 QNT covers this contract's ~65k-gas
+    # transfer only below ~48 gwei — miners price real gas into their quotes, and the per-swap
+    # lever is the contract's min_swap_amount. A fraction of a token, not whole units: QNT's
+    # unit value is ~60x a stablecoin's, so a floor of 1 QNT would price out honest small legs.
+    min_onchain_amount=100_000_000_000_000_000,
+    # Ethereum's clock, as CHAIN_ETH: what this absorbs is hub-vs-spoke skew, and two assets on
+    # one chain disagreeing about that chain's clock would be indefensible.
+    replay_grace_secs=60,
+    # Quant's ICO token, deployed 2018 by Quant and verified byte-for-byte on Sourcify (solc
+    # 0.4.21 StandardToken, not a proxy). mint is crowdsale-gated; nothing else is privileged.
+    asset_locator='0x4a220E6096B25EADb88358cb44068A3248254675',
+    # No freeze surface: the verified source has no blacklist, no pause and no owner. And none can
+    # be added: EIP-1967 slots empty, and the runtime holds no DELEGATECALL/SELFDESTRUCT/CREATE.
+    refusal_checks=(),
+)
+
 SUPPORTED_CHAINS = {
     'btc': CHAIN_BTC,
     'tao': CHAIN_TAO,
@@ -368,6 +401,7 @@ SUPPORTED_CHAINS = {
     'cro': CHAIN_CRO,
     'aster': CHAIN_ASTER,
     'uni': CHAIN_UNI,
+    'qnt': CHAIN_QNT,
 }
 
 

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -101,7 +101,21 @@ def declarable_backings(from_chain: str, to_chain: str) -> list[str]:
 
 
 # Chains paired against each hub; add a chain here to launch its pairs.
-LAUNCH_SPOKES = ('btc', 'tao', 'eth', 'arbusdc', 'hype', 'bnb', 'avax', 'baseusdc', 'ethusdc', 'cro', 'aster', 'uni')
+LAUNCH_SPOKES = (
+    'btc',
+    'tao',
+    'eth',
+    'arbusdc',
+    'hype',
+    'bnb',
+    'avax',
+    'baseusdc',
+    'ethusdc',
+    'cro',
+    'aster',
+    'uni',
+    'qnt',
+)
 # Every launch pair as (hub, spoke): each hub pairs against every spoke except itself. sol↔tao
 # lands exactly once (under SOL, its anchor) because sol never appears in LAUNCH_SPOKES.
 LAUNCH_PAIRS: tuple[tuple[str, str], ...] = tuple(

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -18,6 +18,7 @@ from allways.chains import (
     CHAIN_ETH,
     CHAIN_ETHUSDC,
     CHAIN_HYPE,
+    CHAIN_QNT,
     CHAIN_TAO,
     CHAIN_UNI,
     EXTENSION_BUCKET_SECONDS,
@@ -64,6 +65,9 @@ class TestGetChain:
 
     def test_uni(self):
         assert get_chain_def('uni') is CHAIN_UNI
+
+    def test_qnt(self):
+        assert get_chain_def('qnt') is CHAIN_QNT
 
     def test_unsupported_raises(self):
         with pytest.raises(KeyError):

--- a/tests/test_cli_chain_networks.py
+++ b/tests/test_cli_chain_networks.py
@@ -8,6 +8,7 @@ network, and a dropped key breaks a documented command.
 """
 
 import json
+import os
 
 import pytest
 from click.testing import CliRunner
@@ -24,6 +25,10 @@ def config_file(tmp_path, monkeypatch):
     monkeypatch.setattr(main, 'CONFIG_FILE', path)
     monkeypatch.setattr(helpers, 'CONFIG_FILE', path)
     monkeypatch.setattr(helpers, '_CLI_OVERRIDES', {})
+    # The shim writes {PREFIX}_NETWORK straight into os.environ, and monkeypatch cannot undo a
+    # write it did not make — isolate the process env so it can't follow the session into an
+    # asset constructor (a leaked ETH_NETWORK=sepolia builds every ETH asset on the wrong network).
+    monkeypatch.setattr(os, 'environ', os.environ.copy())
     for chain in SUPPORTED_CHAINS.values():
         monkeypatch.delenv(f'{chain.env_prefix}_NETWORK', raising=False)
     for var in ('SOLANA_RPC_URL', 'SOLANA_RPC_API_KEY', 'SOLANA_KEYPAIR_PATH', 'ALLWAYS_PROGRAM_ID'):
@@ -198,15 +203,11 @@ class TestProviderHandoff:
     """The config only matters because it reaches the providers through {PREFIX}_NETWORK."""
 
     def test_shim_feeds_every_chain(self, config_file, monkeypatch):
-        import os
-
         helpers.apply_chain_network_env({network_key(c): c.networks[1] for c in NAME_SELECTED_CHAINS})
         for chain in NAME_SELECTED_CHAINS:
             assert os.environ[f'{chain.env_prefix}_NETWORK'] == chain.networks[1]
 
     def test_shim_never_overrides_an_explicit_env(self, config_file, monkeypatch):
-        import os
-
         for chain in NAME_SELECTED_CHAINS:
             monkeypatch.setenv(f'{chain.env_prefix}_NETWORK', 'mainnet')
         helpers.apply_chain_network_env({network_key(c): c.networks[1] for c in NAME_SELECTED_CHAINS})

--- a/tests/test_qnt_provider.py
+++ b/tests/test_qnt_provider.py
@@ -1,0 +1,300 @@
+"""Qnt unit tests — all offline (RPC layer mocked, signing is pure crypto).
+
+Generic ERC-20 behaviour is proven by the arbusdc and ethusdc suites; this covers what is
+qnt-specific. Two things: it is the third asset on Ethereum's env identity, and it declares
+``refusal_checks=()`` — QNT implements neither isBlacklisted nor paused, and
+probing them REVERTS, which the slash gate would read as "defer" forever.
+
+Everything here builds on mainnet: QNT has no Sepolia deployment, so the row has no
+TESTNET_TOKEN_CONTRACTS entry and a testnet provider only constructs behind the
+QNT_TOKEN_CONTRACT override. That gap is why this spoke is not mergeable yet.
+"""
+
+import pytest
+
+from allways.assets.asset import ProviderUnreachableError
+from allways.assets.erc20 import SEL_TRANSFER, TESTNET_TOKEN_CONTRACTS, TRANSFER_TOPIC0
+from allways.assets.eth import Ether
+from allways.assets.evm import EvmRpcError
+from allways.assets.qnt import Qnt
+from allways.chains import CHAIN_ETH, CHAIN_QNT, get_chain_def
+from allways.constants import LAUNCH_SPOKES
+
+TEST_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'  # hardhat account #0
+SENDER = '0x' + '11' * 20
+RECIPIENT = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+CONTRACT = CHAIN_QNT.asset_locator
+COUNTERFEIT = '0x' + '99' * 20
+TX = '0x' + 'ab' * 32
+BLOCK_HASH = '0x' + 'cd' * 32
+AMOUNT = 5 * 10**18  # 5 QNT
+MAINNET_ID = 1
+SEPOLIA_ID = 11_155_111
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    monkeypatch.setenv('ETH_NETWORK', 'mainnet')
+    for var in ('ETH_RPC_URLS', 'ETH_PRIVATE_KEY', 'QNT_TOKEN_CONTRACT'):
+        monkeypatch.delenv(var, raising=False)
+    return Qnt()
+
+
+def rpc_stub(provider, responses: dict):
+    """Replace eth_rpc with a method→response map. A callable value is invoked with params."""
+
+    def fake_rpc(method, params, timeout=15, **kw):
+        value = responses[method]
+        return value(params) if callable(value) else value
+
+    provider.chain.eth_rpc = fake_rpc  # the asset talks through its chain (composed seam)
+    return provider
+
+
+def no_rpc(provider):
+    """Any RPC call fails the test: a declared 'none' surface must answer from the registry."""
+
+    def boom(method, params, timeout=15, **kw):
+        raise AssertionError(f'unexpected RPC {method} — QNT reverts on issuer probes')
+
+    provider.chain.eth_rpc = boom
+    return provider
+
+
+def topic(address: str) -> str:
+    return '0x' + '00' * 12 + address.lower().removeprefix('0x')
+
+
+def transfer_log(contract=CONTRACT, sender=SENDER, recipient=RECIPIENT, amount=AMOUNT) -> dict:
+    return {
+        'address': contract,
+        'topics': [TRANSFER_TOPIC0, topic(sender), topic(recipient)],
+        'data': hex(amount),
+        'transactionHash': TX,
+    }
+
+
+def mined(logs=None, status='0x1', tip=1_000_100, block=None) -> dict:
+    return {
+        'eth_getTransactionByHash': {'hash': TX, 'blockNumber': '0xf4240', 'blockHash': BLOCK_HASH},
+        'eth_getTransactionReceipt': {
+            'status': status,
+            'blockNumber': '0xf4240',
+            'blockHash': BLOCK_HASH,
+            'logs': [transfer_log()] if logs is None else logs,
+        },
+        'eth_blockNumber': hex(tip),
+        'eth_getBlockByNumber': {'hash': BLOCK_HASH, 'timestamp': '0x64'} if block is None else block,
+    }
+
+
+class TestSharedEnvIdentity:
+    """qnt names the NETWORK, not the asset — the third asset on one ETH_NETWORK."""
+
+    def test_row_is_a_launch_spoke_on_ethereums_identity(self, provider):
+        assert provider.chain_def is CHAIN_QNT is get_chain_def('qnt')
+        assert 'qnt' in LAUNCH_SPOKES
+        assert (CHAIN_QNT.env_prefix, CHAIN_QNT.host_chain) == (CHAIN_ETH.env_prefix, CHAIN_ETH.host_chain)
+        # CHAIN_ETH owns ETH_NETWORK; a second declaration renders a duplicate CLI row.
+        assert CHAIN_QNT.networks == ()
+
+    def test_one_eth_network_moves_both_assets(self, provider):
+        assert provider.chain.chain_id == Ether().chain.chain_id == MAINNET_ID
+        assert provider.token_contract == CHAIN_QNT.asset_locator
+
+    def test_env_override_wins(self, monkeypatch):
+        monkeypatch.setenv('QNT_TOKEN_CONTRACT', '0x' + '42' * 20)
+        assert Qnt().token_contract == '0x' + '42' * 20
+
+    def test_unknown_network_raises(self, monkeypatch):
+        monkeypatch.setenv('ETH_NETWORK', 'seplia')
+        with pytest.raises(ValueError, match='ETH_NETWORK'):
+            Qnt()
+
+    def test_finality_matches_the_chain_it_shares(self):
+        # Two assets on one chain must not disagree about its reorg depth, and the implied
+        # 384s leg stays inside the program's 600s default fulfillment grace.
+        assert (CHAIN_QNT.min_confirmations, CHAIN_QNT.seconds_per_block, CHAIN_QNT.replay_grace_secs) == (
+            CHAIN_ETH.min_confirmations,
+            CHAIN_ETH.seconds_per_block,
+            CHAIN_ETH.replay_grace_secs,
+        )
+        assert CHAIN_QNT.min_confirmations * CHAIN_QNT.seconds_per_block < 600
+
+    def test_wrong_network_endpoint_fails_startup(self, provider):
+        # Mainnet configured, a Sepolia endpoint answering: reject outright rather than
+        # quietly verify legs against the wrong chain.
+        rpc_stub(provider, {'eth_chainId': hex(SEPOLIA_ID)})
+        with pytest.raises(ConnectionError, match=f'expected {MAINNET_ID}'):
+            provider.check_connection(require_send=False)
+
+    def test_codeless_contract_fails_startup(self, provider):
+        rpc_stub(provider, {'eth_chainId': hex(MAINNET_ID), 'eth_blockNumber': '0x10', 'eth_getCode': '0x'})
+        with pytest.raises(ConnectionError, match='no code'):
+            provider.check_connection(require_send=False)
+
+
+class TestNoTestnetDeployment:
+    """QNT is issuer-deployed on Ethereum only. Until a project-deployed test token is pinned —
+    immutable AND with no pause or blacklist, or the row's declaration stops being true on
+    testnet — a testnet provider cannot be built, and validators build every provider at boot,
+    so this row must not reach a testnet validator's LAUNCH_SPOKES."""
+
+    def test_sepolia_has_no_pinned_contract(self, monkeypatch):
+        assert 'qnt' not in TESTNET_TOKEN_CONTRACTS
+        monkeypatch.setenv('ETH_NETWORK', 'sepolia')
+        monkeypatch.delenv('QNT_TOKEN_CONTRACT', raising=False)
+        with pytest.raises(ValueError, match='QNT_TOKEN_CONTRACT'):
+            Qnt()
+
+    def test_override_restores_the_shared_network_identity(self, monkeypatch):
+        # What pinning a test token buys: the same one-ETH_NETWORK guarantee, on Sepolia.
+        monkeypatch.setenv('ETH_NETWORK', 'sepolia')
+        monkeypatch.setenv('QNT_TOKEN_CONTRACT', '0x' + '42' * 20)
+        assert Qnt().chain.chain_id == Ether().chain.chain_id == SEPOLIA_ID
+
+
+class TestDeclaredUnfreezable:
+    """QNT reverts on isBlacklisted/paused. Probing them raises EvmRpcError, delivery_refused
+    propagates it, and the caller defers the slash — forever. The row declares the surface
+    instead, so both gates answer with ZERO RPC calls."""
+
+    def test_reserve_gate_passes_without_touching_the_chain(self, provider):
+        assert no_rpc(provider).can_deliver_to(RECIPIENT, AMOUNT) is True
+
+    def test_slash_gate_never_refuses_and_never_probes(self, provider):
+        assert no_rpc(provider).delivery_refused(RECIPIENT, 0) is False
+
+    def test_boot_falsifier_accepts_the_real_declaration(self, provider):
+        # Both probes reverting is the declaration holding — what QNT does live on mainnet.
+        # An ANSWER from either fails boot; that direction is proven in the PR-0 suite.
+        def reverts(_params):
+            raise EvmRpcError('execution reverted', {'code': 3, 'message': 'execution reverted'})
+
+        rpc_stub(
+            provider,
+            {'eth_chainId': hex(MAINNET_ID), 'eth_blockNumber': '0x10', 'eth_getCode': '0xbeef', 'eth_call': reverts},
+        )
+        provider.check_connection(require_send=False)
+
+
+class TestVerification:
+    def test_settled_transfer_matches_mixed_case_with_sender_pinned(self, provider):
+        # Expecteds arrive in EIP-55 casing while the RPC answers lowercase — comparison
+        # normalizes, and the on-chain sender is pinned to the reserved address.
+        rpc_stub(provider, mined())
+        info = provider.verify_transaction(TX, RECIPIENT, AMOUNT, expected_sender=SENDER.upper())
+        assert info.confirmed and info.amount == AMOUNT and info.block_time == 0x64
+        assert info.sender == SENDER.lower()
+
+    def test_wrong_sender_rejected(self, provider):
+        rpc_stub(provider, mined())
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT, expected_sender=COUNTERFEIT) is None
+
+    def test_below_min_confs_unconfirmed(self, provider):
+        rpc_stub(provider, mined(tip=1_000_030))  # 31 confs of the 32 required
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT).confirmed is False
+
+    def test_reverted_rejected(self, provider):
+        # Inclusion is not settlement: a reverted tx moved no funds.
+        rpc_stub(provider, mined(status='0x0'))
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+    def test_underpay_rejected(self, provider):
+        rpc_stub(provider, mined(logs=[transfer_log(amount=AMOUNT - 1)]))
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+    def test_wrong_recipient_rejected(self, provider):
+        rpc_stub(provider, mined(logs=[transfer_log(recipient=SENDER)]))
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+    def test_pending_transfer_matches_off_calldata(self, provider):
+        calldata = SEL_TRANSFER + topic(RECIPIENT).removeprefix('0x') + f'{AMOUNT:064x}'
+        pending = {'hash': TX, 'from': SENDER, 'to': CONTRACT, 'input': calldata, 'blockNumber': None}
+        rpc_stub(provider, {'eth_getTransactionByHash': pending})
+        info = provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT)
+        assert info.confirmed is False and info.sender == SENDER.lower() and info.amount == AMOUNT
+
+    def test_absent_tx_is_absent(self, provider):
+        rpc_stub(provider, {'eth_getTransactionByHash': None})
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+    @pytest.mark.parametrize('gap', ('eth_getTransactionReceipt', 'eth_getBlockByNumber'))
+    def test_unreadable_settlement_is_unknown_not_absent(self, provider, gap):
+        # 'unknown' must never read as 'no such payment' — that verdict slashes a paying miner.
+        blind = dict(mined())
+        blind[gap] = None if gap == 'eth_getTransactionReceipt' else {'hash': BLOCK_HASH}
+        with pytest.raises(ProviderUnreachableError):
+            rpc_stub(provider, blind).fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT)
+
+    def test_counterfeit_token_log_never_matches_even_on_the_cache_path(self, provider):
+        """A fake token emitting a well-formed Transfer must not settle the leg, and must not
+        settle it on the re-verify either: the cache is only written from a pinned-contract match."""
+        rpc_stub(provider, mined(logs=[transfer_log(contract=COUNTERFEIT)]))
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+        assert provider._settled_cache == {}
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+
+class TestSendGuards:
+    SEND = {
+        'eth_blockNumber': hex(100),
+        'eth_getBlockByNumber': {'baseFeePerGas': hex(10**9)},
+        'eth_maxPriorityFeePerGas': hex(10**9),
+        'eth_getTransactionCount': '0x0',
+        'eth_getBalance': hex(10**18),
+        'eth_estimateGas': hex(65_000),
+        'eth_call': f'0x{AMOUNT:064x}',  # balanceOf
+    }
+
+    def test_no_key_refused(self, provider):
+        assert provider.send_amount(RECIPIENT, AMOUNT) is None
+        assert 'ETH_PRIVATE_KEY' in provider.last_send_error
+
+    def test_key_mismatch_refused(self, provider, monkeypatch):
+        monkeypatch.setenv('ETH_PRIVATE_KEY', TEST_KEY)
+        assert provider.send_amount(RECIPIENT, AMOUNT, from_address=RECIPIENT) is None
+        assert 'key mismatch' in provider.last_send_error
+
+    def test_insufficient_token_balance_refused(self, provider, monkeypatch):
+        monkeypatch.setenv('ETH_PRIVATE_KEY', TEST_KEY)
+        rpc_stub(provider, dict(self.SEND, eth_call=f'0x{AMOUNT - 1:064x}'))
+        assert provider.send_amount(RECIPIENT, AMOUNT) is None
+        assert 'insufficient balance' in provider.last_send_error
+
+    def test_gas_poor_miner_refuses_before_broadcasting(self, provider, monkeypatch):
+        # QNT-rich but ETH-poor is the ordinary state of a high-unit-value token holder:
+        # refuse here rather than burn a revert on L1.
+        monkeypatch.setenv('ETH_PRIVATE_KEY', TEST_KEY)
+        rpc_stub(provider, dict(self.SEND, eth_getBalance=hex(10**9)))
+        assert provider.send_amount(RECIPIENT, AMOUNT) is None
+        assert 'Insufficient gas balance' in provider.last_send_error
+
+    def test_broadcast_returns_a_hash(self, provider, monkeypatch):
+        monkeypatch.setenv('ETH_PRIVATE_KEY', TEST_KEY)
+        rpc_stub(provider, dict(self.SEND, eth_sendRawTransaction=TX))
+        assert provider.send_amount(RECIPIENT, AMOUNT) == (TX, 0)
+
+
+class TestDepositScanner:
+    def test_getlogs_hit_is_bounded_to_the_lookback_window(self, provider):
+        seen = {}
+
+        def logs(params):
+            seen.update(params[0])
+            return [transfer_log()]
+
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getLogs': logs})
+        assert provider.find_recent_outgoing(SENDER, RECIPIENT, AMOUNT) == TX
+        assert int(seen['fromBlock'], 16) == 10_000 - provider.SCAN_LOOKBACK_BLOCKS + 1
+        assert seen['address'] == CONTRACT
+
+    def test_failed_range_parks_the_cursor(self, provider):
+        def boom(params):
+            raise ConnectionError('down')
+
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getLogs': boom})
+        assert provider.find_recent_outgoing(SENDER, RECIPIENT, AMOUNT) is None
+        # Never leap a range the scan could not read — the deposit in it must stay reachable.
+        key = (SENDER.lower(), RECIPIENT.lower(), AMOUNT)
+        assert provider.scan_cursors[key] == 10_000 - provider.SCAN_LOOKBACK_BLOCKS


### PR DESCRIPTION
## ⛔ blocked: awaiting testnet deployment — DO NOT MERGE

QNT has **no deployment on Sepolia** (`eth_getCode` at `0x4a220E60…4675` returns `0x` on both
configured endpoints). `Erc20._token_contract` raises when a non-mainnet network has no
`TESTNET_TOKEN_CONTRACTS` entry, and validators construct **every** provider at boot
(`neurons/validator.py`, `required_chains=None`). Merging this adds `qnt` to `LAUNCH_SPOKES`, and a
**testnet validator would then fail to start at all** — boot-blocking, not a coverage gap.

**What unparks it:** a project-deployed minimal ERC-20 on Sepolia — symbol `QNT`, 18 decimals,
**immutable, with no pause and no blacklist** (an OpenZeppelin `ERC20Pausable` mock is immutable and
still wrong: pausing it would slash every honest miner on the pair, and it would fail the boot
falsifier) — pinned in `erc20.py::TESTNET_TOKEN_CONTRACTS` with a comment stating plainly that it is
a **project-deployed test token, not an issuer deployment**. No mock was deployed here: that work is
deferred out of this batch by decision, and no fail-soft boot path was added in its place.

## Base branch

Opened against **`refactor/erc20-refusal-interface` (#647), not `test`** — QNT implements neither
`isBlacklisted` nor `paused`, both **revert**, and pre-#647 `_refused_at` would propagate that out of
`delivery_refused` and defer every slash on the pair forever. Retarget to `test` after #647 merges.

## What changed

| File | Change |
|---|---|
| `allways/chains.py` | `CHAIN_QNT` + `SUPPORTED_CHAINS` entry |
| `allways/assets/qnt.py` | `Erc20` binding — a docstring and one `super().__init__(CHAIN_QNT)` |
| `allways/assets/__init__.py` | import, `__all__`, `ASSET_REGISTRY` row |
| `allways/constants.py` | `'qnt'` appended to `LAUNCH_SPOKES` |
| `.env.example`, `README.md` | Ethereum block now names three assets; `QNT_TOKEN_CONTRACT` |
| `tests/test_qnt_provider.py` | new, fully offline |
| `tests/test_chains.py` | registry case + the shared-network assertion covers both ETH tokens |
| `tests/test_cli_chain_networks.py` | fixture isolates `os.environ` (see below) |

`tests/test_rate.py` needs no new cases — 18 decimals is already covered.

## Registry row

`host_chain='ethereum'`, `env_prefix='ETH'`, **`networks=()`** — `CHAIN_ETH` already declares
Ethereum's network names, and a second declaration would render a duplicate CLI row writing the same
var. One `ETH_NETWORK` / `ETH_RPC_URLS` / `ETH_PRIVATE_KEY` now serves `eth` + `ethusdc` + `qnt`, so
they can never disagree about which Ethereum they are on.

`min_confirmations=32`, `seconds_per_block=12`, `replay_grace_secs=0` — **identical to `CHAIN_ETH`
by construction**. Two assets on one chain disagreeing about its reorg depth or its clock is
indefensible; `tests/test_qnt_provider.py::test_finality_matches_the_chain_it_shares` pins all three
to `CHAIN_ETH`'s values rather than restating them. 32 × 12s = 384s, inside the program's 600s
default fulfillment grace.

### `min_onchain_amount = 100_000_000_000_000_000` (0.1 QNT)

The one genuine judgement call. Sized at **realistic-high L1 gas, not quiet-day gas** — mainnet base
fee was **0.095 gwei** while writing this, which is not a number to build a constant on.

```
observed transfer cost   30,069 gas (real mainnet tx, warm recipient) — 65,000 used as the
                         conservative ceiling, well under DEFAULT_TOKEN_TRANSFER_GAS (120k)
fee @ 60 gwei            65,000 × 60 gwei = 0.0039 ETH
prices (2026-08-12)      ETH $1,885.29 · QNT $58.33  →  1 QNT = 0.03094 ETH
fee in QNT               0.0039 / 0.03094 = 0.126 QNT
floor 0.1 QNT            = 0.003094 ETH → covers a 65k-gas transfer only below ~48 gwei
```

Deliberately **not** `arbusdc`'s `1`: that is an L2 stablecoin floor and this leg pays L1 gas.
Deliberately a **fraction of a token**, not whole units: QNT's unit value is ~60× a stablecoin's, so
a 1 QNT floor (~$58) would price out honest small legs. It lands at ~$5.83, the same order as
`ethusdc`'s 5 USDC — the right comparison, since both are L1 Ethereum legs paying the same gas.

This is a **rate-sanity input** to `is_executable_rate` / `min_executable_sol_leg`, **not an enforced
minimum** — the enforced trade bounds are the contract's `min_swap_amount` / `max_swap_amount` in SOL
lamports, and a spoke payout below this floor is still reachable.

## Token diligence

`Erc20` settles a leg by matching a `Transfer` log against an expected amount. Anything that makes
*amount sent ≠ amount logged ≠ balance delta* silently breaks verification and slashes an honest
miner. Evidence, not docs links.

**Verified source** (Sourcify, chain 1, `creationMatch: match`, `runtimeMatch: match`,
`proxyResolution.isProxy: false`, solc `0.4.21+commit.dfe3193c`, deployed block 5,392,950,
`StandardToken.sol:StandardToken`, deploy tx `0xae16f475…c337c` from `0xf5e38bbe…c4Bc`):

```solidity
uint256 totalSupply_ = 45467000000000000000000000;
function transfer(address _to, uint256 _value) public returns (bool) {
  require(_to != address(0));
  require(_value <= balances[msg.sender]);
  balances[msg.sender] = balances[msg.sender].sub(_value);
  balances[_to] = balances[_to].add(_value);
  emit Transfer(msg.sender, _to, _value);
  return true;
}
```

| Property | Evidence |
|---|---|
| **Not fee-on-transfer** | Real mainnet transfer `0x397792258bc8573f1ce8ccdbb90d55b851f0a74d2367dd611f2f25dd8af134ed` (block 25,740,697). `Transfer` log value `44960300700000000000`; recipient `balanceOf` `27868807822049596454902 → 27913768122749596454902`, delta **exactly** the log value; sender delta exactly `-`the log value. Calldata `to`/`amount` also match the log exactly. Source: `transfer` is a plain SafeMath balance move, no fee branch |
| **Not rebasing** | From source: balances change only in `transfer` / `transferFrom` / `mint`; there is no rebase, no share/index accounting, no supply hook. `totalSupply()` returns the storage variable `totalSupply_`, initialised to a compile-time constant and **never written again** — `mint` credits `balances` only. (This also resolves the apparent supply discrepancy: the contract reports the 45,467,000 ICO cap, while aggregators sum the 14,612,493 actually minted.) |
| **No freeze/pause surface** | Complete `PUSH4` dispatch table decoded from the deployed runtime bytecode — 14 selectors, the whole public interface: `name` `symbol` `decimals` `totalSupply` `balanceOf` `transfer` `transferFrom` `approve` `allowance` `increaseApproval` `decreaseApproval` `mint(address,uint256)` `crowdsale()` `DECIMAL_ZEROS()`. **No** `owner`, `pause`, `unpause`, `paused`, `isBlacklisted`, `blacklist`, `freeze`. Live probes: `isBlacklisted(addr)` and `paused()` both **revert** (`code 3`, `is_execution_revert=True`) |
| **Cannot GAIN one (non-upgradeable)** | EIP-1967 implementation / admin / beacon slots all `0x00…00`. Sourcify `isProxy: false`. Opcode-aware scan of the full 5,155-byte runtime finds **zero** `DELEGATECALL`, `CALLCODE`, `SELFDESTRUCT`, `CREATE`, `CREATE2` — there is no mechanism by which this code can change or be replaced. No `owner()`/`admin()`/`transferOwnership` exists to hold an admin. |
| **Standard `Transfer` event** | Decoded real log, `topic0 = 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef` = `keccak("Transfer(address,address,uint256)")`, 3 topics, value in `data` |
| **`transfer` return convention** | Successful mainnet receipt: `status 0x1`, exactly 1 log, `gasUsed 30069`. `eth_call transfer(to,1)` from a holder returns `0x…01` — returns `true` on success, reverts on failure, no revert-on-false weirdness |

Both halves of `issuer_controls='unfreezable'` are established separately above: **no freeze surface
today** (source + full selector table + live reverts) **and it can never gain one** (empty proxy
slots, no admin, no code-changing opcode). Neither half alone would justify the declaration.

**Not a hard stop:** not fee-on-transfer, not rebasing, not upgradeable, no active admin.

**Disclosed:** `mint(address,uint256)` exists, gated by `onlyCrowdsale` on `crowdsale()` =
`0x398e41ac3d5972b4bac2320cd130c7a25ca446f7`, set once in the constructor with **no setter**. It
reverts from any other caller (verified live). The crowdsale is a *constructor argument*, not the
deployer — the deploy tx has `to: null` and comes from `0xf5e38bbe…c4Bc`, whose `eth_getCode` is
`0x` (an EOA). It is a supply/dilution fact, not a verification or
slash fact — minting cannot decouple amount-sent from amount-logged, and it is not a freeze surface,
so it does not bear on `unfreezable`.

### Contract identity

`0x4a220E6096B25EADb88358cb44068A3248254675`. On-chain: `name() = "Quant"`, `symbol() = "QNT"`,
`decimals() = 18`. Corroborated off block-explorer search by CoinGecko's issuer-linked entry
(`detail_platforms.ethereum` = this address, 18 decimals, homepage `quant.network`), the **Uniswap
Labs Default** token list (checksummed exact match), and Trust Wallet's assets registry.
**Stated plainly:** Quant does not publish the contract address on a machine-fetchable page of their
own site (their FAQ contains no `0x…` address, and quant.network 403s automated fetches), so the
issuer-channel confirmation the brief asked for is not available in that form. What replaces it is
the verified 2018 source itself, deployed by Quant's own crowdsale contract.

## Verification

`ruff format --check .` and `ruff check .` clean. Full `pytest tests/ -q` → **1556 passed, 6
deselected**.

### Live read-only pass, Ethereum mainnet (2026-08-12)

```
describe        : Ethereum JSON-RPC (mainnet): ethereum-rpc.publicnode.com, eth.drpc.org
                  — token 0x4a220E6096B25EADb88358cb44068A3248254675
issuer_controls : unfreezable
check_connection: OK (require_send=False) — boot falsifier accepted the declaration
tip             : 25740777

sample tx       : 0x397792258bc8573f1ce8ccdbb90d55b851f0a74d2367dd611f2f25dd8af134ed
  sender        : 0x9625e9e2a41d8d61ff048b6f72ee07e3c4fff2c6
  recipient     : 0xa9d1e08c7793af67e9d92fe308d5697fb81d3e43
  amount        : 44960300700000000000 (44.9603007 QNT)

verify (mixed-case recipient, sender pinned): confirmed=True amount=44960300700000000000
  sender=0x9625e9e2a41d8d61ff048b6f72ee07e3c4fff2c6 confs=81 block_time=1786559135
underpaid (expect+1)      : None
wrong sender              : None
wrong recipient           : None
unknown tx                : None
balance(recipient)        : 26578104060469596454902 = 26578.10406 QNT

--- issuer controls: declared unfreezable ---
  raw isBlacklisted() probe -> EvmRpcError: execution reverted (is_execution_revert=True)
  raw paused() probe       -> EvmRpcError: execution reverted (is_execution_revert=True)
  can_deliver_to (zero RPC)  : True
  delivery_refused (zero RPC): False
```

`check_connection` succeeding is what proves the declaration holds against real bytecode: #647's
`_falsify_declaration` probes both selectors at boot and fails startup if an `unfreezable` row's
contract *answers* either one.

Worth recording: on a later run the unknown-tx probe raised `ProviderUnreachableError: null without
quorum` instead of returning `None`, because drpc was intermittently 408-ing. That is the
unknown ≠ absent guard working — a lone null is never a verdict — and it resolved to a clean `None`
once both endpoints answered.

**The testnet half of this evidence does not exist and is not faked.** There is no Sepolia
deployment to read; see the park note at the top.

### CLI surfaces — derived, not written

```
--qnt-price   NUMBER   QNT per 1 hub unit (0/omit to skip QNT).
--qnt-address TEXT     Your QNT address.
```

`alw config` shows **no** new network row (`btc-network`, `eth-network`, `arb-network`,
`hype-network`, `bnb-network`, `avax-network`, `base-network` — unchanged). qnt rides ETH's row;
adding one would be a bug.

### e2e

`alw-utils` derives its scenarios from `LAUNCH_SPOKES`, so `run-suites.sh --list` shows `sol-qnt` and
`qnt-sol` with zero harness edits (verified against this branch). Not run: the pair's suite needs a
network the asset has no testnet deployment on — the same blocker as the park. `alw-utils#123` is
merged, which matters here: `eth` + `ethusdc` + `qnt` all key their fake RPC, wallet and env block off
the shared `ETH` prefix, so `ETH_RPC_URLS` / `ETH_PRIVATE_KEY` are emitted once for the network
rather than once per asset.

### Review-pass fixes (2026-08-12)

Four LOW findings, all applied on this branch:

| # | Fix |
|---|---|
| Q1 | `chains.py` comment said QNT was "deployed 2018 by its crowdsale". It was not — deploy tx `0xae16f475…c337c` has `to: null` from `0xf5e38bbe…c4Bc`, an EOA (`eth_getCode` = `0x`); the crowdsale is a constructor argument. Independently re-verified; now reads "deployed 2018 by Quant … mint is crowdsale-gated" |
| Q2 | `native_unit` `'wei'` → `'aQNT'`. Wei is *ETH's* subunit; a token row must not borrow it |
| Q3 | Dropped the hand-enumerated `for token in (CHAIN_ETHUSDC, CHAIN_QNT)` assertion in `test_chains.py`. `test_assets_on_one_network_share_its_env_identity` already derives that guarantee for every row — the enumeration chipped at "one ChainDefinition + one binding + one LAUNCH_SPOKES entry" and would collide with the sibling branches on the same line |
| Q4 | `README.md`'s "every pair has a SOL leg" has been false since #638 made TAO a hub — `('tao','qnt')` has no SOL leg. Rewrote the sentence rather than just the clause I appended to it |

### One test-hygiene fix

`tests/test_cli_chain_networks.py`'s `config_file` fixture now isolates `os.environ`.
`helpers.apply_chain_network_env` writes `{PREFIX}_NETWORK` straight into the process env, and
`monkeypatch` cannot undo a write it did not make — so `ETH_NETWORK=sepolia` leaked out of that
module and into every later test's asset constructors. Latent until now (`ethusdc` has a Sepolia pin
and constructed fine); `qnt` has none, so it surfaced as a failure in `test_assets_optional.py`. The
leaking fixture is the bug; nothing in shared runtime code changed.

## Emission dilution — per PAIR

Multi-hub (#638) is live: **one spoke is TWO pairs.** `qnt` creates `('sol','qnt')` **and**
`('tao','qnt')`, and **miners are expected to quote the TAO leg too**, not just the SOL leg.

```
floor per direction = MINER_POOL_SHARE / (2 × len(LAUNCH_PAIRS))

before this PR   9 spokes → 17 pairs → 34 directions → 0.2941%
after this PR   10 spokes → 19 pairs → 38 directions → 0.2632%
```

Re-derive at merge time: three sibling assets in this batch move the same number, and the batch lands
at 13 spokes → 25 pairs → 50 directions → 0.2000%.

## Merge order

`#647` merges first, then this PR is retargeted to `test` — except it does not merge at all until the
testnet deployment above exists. Its das twin (`das-allways`) merges after it, and that repo's CI
drift gate stays red until then by design.

