### PR TITLE
Let a bond lock into any validator set size

### DIFF
--- a/smart-contracts/ink-bond-vault/lib.rs
+++ b/smart-contracts/ink-bond-vault/lib.rs
@@ -492,15 +492,11 @@ mod allways_bond_vault {
 
         /// Miner-initiated lock — locking yourself is always safe, so no
         /// quorum. A locked bond ≥ min_collateral is what the mirror relays to
-        /// Solana as "eligible for vote_activate".
+        /// Solana as "eligible for vote_activate". Deliberately un-gated on set
+        /// size: unlock at n=1 is 1-of-1 and always live, so a small set is a
+        /// trust choice, not a stranding risk.
         #[ink(message)]
         pub fn lock_bond(&mut self) -> Result<(), Error> {
-            // No bond may be locked into a set too small to govern it: below the
-            // removal floor a locked bond can be stranded or exposed to n-of-n
-            // fragility, so gate the lock on the same MIN_VALIDATORS_TO_REMOVE.
-            if self.validators.len() < MIN_VALIDATORS_TO_REMOVE {
-                return Err(Error::InvalidValidatorSet);
-            }
             let caller = self.env().caller();
             let (locked, epoch) = self.lock_of(caller);
             if locked {
@@ -1266,20 +1262,28 @@ mod allways_bond_vault {
             assert_eq!(vault.lock_bond(), Err(Error::InsufficientCollateral));
         }
 
+        /// Launch runs a single validator for months, so locking must work at
+        /// n=1 — where unlock is 1-of-1 and the bond can never be stranded.
         #[ink::test]
-        fn lock_requires_min_validators() {
+        fn lone_validator_can_lock_and_unlock_a_bond() {
             let acc = accounts();
-            // new_vault seeds only two validators — below the removal floor.
-            let mut vault = new_vault();
+            let mut vault = seeded_vault(ink::prelude::vec![acc.django]);
             post(&mut vault, acc.bob, 5_000);
             set_caller(acc.bob);
-            assert_eq!(vault.lock_bond(), Err(Error::InvalidValidatorSet));
+            vault.lock_bond().unwrap();
+            assert_eq!(vault.get_lock_state(acc.bob), (true, 1));
+
+            set_caller(acc.django);
+            vault.vote_unlock(acc.bob, 1).unwrap();
+            assert_eq!(vault.get_lock_state(acc.bob), (false, 2));
         }
 
+        /// The set size a lock lands in is a trust choice, not a precondition:
+        /// n=2 is the ramp between launch and the removal floor.
         #[ink::test]
-        fn lock_succeeds_at_min_validators() {
+        fn lock_succeeds_below_the_removal_floor() {
             let acc = accounts();
-            let mut vault = seeded_vault(ink::prelude::vec![acc.django, acc.eve, acc.charlie]);
+            let mut vault = new_vault();
             post(&mut vault, acc.bob, 5_000);
             set_caller(acc.bob);
             vault.lock_bond().unwrap();


### PR DESCRIPTION
F12 (shipped in #648) gated `lock_bond` on `MIN_VALIDATORS_TO_REMOVE = 3`. That bars the
configuration we actually launch with — **a single validator for the first months** — and it
has the risk backwards.

## Why n=1 is the safe case

`get_required_votes` is `ceil(n × pct / 100)` (`lib.rs:206-213`). At our 66% threshold:

| n | money quorum | removal | reality |
|---|---|---|---|
| **1** | 1-of-1 | barred | fully live — the lone validator can always unlock/slash/collect |
| **2** | 2-of-2 | barred (`len < 3`) | the fragile size — one dark key strands every locked bond, and it can't be ejected |
| 3 | 2-of-3 | allowed | healthy |

A bond can never strand at n=1. The size F12's rationale describes is n=2, and banning `n < 3`
caught the safe configuration along with it.

The gate also didn't hold the invariant it claimed: it checks only at lock time, and removal
requires `len >= 3` *before* the call, leaving 2 after. So a bond locked into a healthy n=3 set
can end up governed by an n=2 set the next day regardless.

## What changed

- Dropped the `validators.len()` check from `lock_bond`; the doc comment now records why the
  lock is deliberately un-gated on set size.
- Replaced the two F12 tests with `lone_validator_can_lock_and_unlock_a_bond` (n=1 locks *and*
  unlocks — the liveness half of allowing it) and `lock_succeeds_below_the_removal_floor` (n=2,
  the ramp). n=3 stays covered by `lock_blocks_withdraw_until_quorum_unlock`.

**The removal floor is untouched.** At n=2 removal needs "everyone except the target" = one
vote, so unilateral ejection stays barred — that gate was correct, F12's mistake was reusing its
constant for a different question.

## Tests

ink! vault 34 passed / 0 failed. No Python or Solana surface touches this (`InvalidValidatorSet`
has no off-chain reader).

## Deploy

Vault-only, and the vault is **immutable** — this must land before the testnet re-instantiate,
which is itself blocked on it: the replacement vault would otherwise refuse `alw vault lock` at
our seeded n=1 set, dead-ending the TAO lifecycle walk at step 2.