### PR TITLE
Add POL on Polygon PoS as a launch spoke

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,7 +109,7 @@ BASE_PRIVATE_KEY=
 # ─── Chain: Polygon PoS (POL pairs) ────────────────────────
 POL_NETWORK=mainnet                 # mainnet | amoy
 # OPTIONAL ordered JSON-RPC endpoints (keyed providers embed the key in the URL);
-# unset = public (publicnode, drpc); publicnode leads as the rung that serves wide log ranges
+# unset = public (drpc, publicnode); drpc leads as the only rung serving archive state reads
 # POL_RPC_URLS=https://polygon-mainnet.infura.io/v3/your_key,https://polygon-bor-rpc.publicnode.com
 # 32-byte hex key — required for miners; optional local signing for `alw swap`
 POL_PRIVATE_KEY=

--- a/.env.example
+++ b/.env.example
@@ -106,6 +106,13 @@ BASE_NETWORK=mainnet                # mainnet | sepolia (Base Sepolia)
 BASE_PRIVATE_KEY=
 # OPTIONAL token contract override (dev/e2e fakes) — per ASSET, unset = Circle's canonical deployment
 # BASEUSDC_TOKEN_CONTRACT=
+# ─── Chain: Polygon PoS (POL pairs) ────────────────────────
+POL_NETWORK=mainnet                 # mainnet | amoy
+# OPTIONAL ordered JSON-RPC endpoints (keyed providers embed the key in the URL);
+# unset = public (publicnode, drpc); publicnode leads as the rung that serves wide log ranges
+# POL_RPC_URLS=https://polygon-mainnet.infura.io/v3/your_key,https://polygon-bor-rpc.publicnode.com
+# 32-byte hex key — required for miners; optional local signing for `alw swap`
+POL_PRIVATE_KEY=
 
 # ─── Chain: Cronos (CRO pairs) ─────────────────────────────
 CRO_NETWORK=mainnet                 # mainnet | testnet

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbit
 Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, SOL ↔ USDC-on-Base, SOL ↔ USDC-on-Ethereum, and SOL ↔ ASTER (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
 Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, SOL ↔ USDC-on-Base, SOL ↔ USDC-on-Ethereum, and SOL ↔ UNI (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
 Currently live with SOL and TAO as hubs, each paired against BTC, ETH, USDC-on-Arbitrum, HYPE, BNB, AVAX, USDC-on-Base, USDC-on-Ethereum, and QNT — plus SOL ↔ TAO itself (hub-and-spoke: every pair has a SOL or TAO leg). Designed to scale to any verifiable asset.
+Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, SOL ↔ USDC-on-Base, SOL ↔ USDC-on-Ethereum, and SOL ↔ POL (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
 
 ## Miner Risk Disclaimer
 
@@ -130,6 +131,7 @@ needs to persist across restarts.
 - `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `BNB_PRIVATE_KEY`, `AVAX_PRIVATE_KEY`, `BASE_PRIVATE_KEY`, `{ETH,ARB,HYPE,BNB,AVAX,BASE}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config (ETH and ethusdc both ride the `ETH_*` vars; BNB and aster both ride the `BNB_*` vars). See `.env.example`.
 - `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `BNB_PRIVATE_KEY`, `AVAX_PRIVATE_KEY`, `BASE_PRIVATE_KEY`, `{ETH,ARB,HYPE,BNB,AVAX,BASE}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config (ETH, ethusdc and uni all ride the `ETH_*` vars). See `.env.example`.
 - `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `BNB_PRIVATE_KEY`, `AVAX_PRIVATE_KEY`, `BASE_PRIVATE_KEY`, `{ETH,ARB,HYPE,BNB,AVAX,BASE}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config (ETH, ethusdc and qnt all ride the `ETH_*` vars). See `.env.example`.
+- `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `BNB_PRIVATE_KEY`, `AVAX_PRIVATE_KEY`, `BASE_PRIVATE_KEY`, `POL_PRIVATE_KEY`, `{ETH,ARB,HYPE,BNB,AVAX,BASE,POL}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config (ETH and ethusdc both ride the `ETH_*` vars). See `.env.example`.
 
 ## Running a Local Subtensor Lite Node (Validators)
 

--- a/allways/assets/__init__.py
+++ b/allways/assets/__init__.py
@@ -16,6 +16,7 @@ from allways.assets.eth import Ether
 from allways.assets.ethusdc import EthUsdc
 from allways.assets.evm_coin import EvmCoin
 from allways.assets.hype import Hype
+from allways.assets.pol import Pol
 from allways.assets.qnt import Qnt
 from allways.assets.sol import Sol
 from allways.assets.tao import Tao
@@ -36,6 +37,7 @@ __all__ = [
     'Bnb',
     'Avax',
     'Cro',
+    'Pol',
     'Erc20',
     'ArbUsdc',
     'BaseUsdc',
@@ -71,6 +73,7 @@ ASSET_REGISTRY: Tuple[AssetSpec, ...] = (
     AssetSpec('aster', Aster, ()),
     AssetSpec('uni', Uni, ()),
     AssetSpec('qnt', Qnt, ()),
+    AssetSpec('pol', Pol, ()),
 )
 
 

--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -363,6 +363,9 @@ class Erc20(EvmAsset):
                 tip_fee = int(self.chain.eth_rpc('eth_maxPriorityFeePerGas', []), 16)
             except Exception:
                 tip_fee = FALLBACK_PRIORITY_FEE_WEI
+            # A chain that enforces a tip floor rejects anything under it outright, and the failure
+            # repeats identically on every retry — clamp rather than sign an unbroadcastable tx.
+            tip_fee = max(tip_fee, self.chain.network_def.min_priority_fee_wei)
             max_fee = 2 * base_fee + tip_fee
 
             # Token balance BEFORE the gas estimate: an underfunded transfer reverts in the

--- a/allways/assets/evm.py
+++ b/allways/assets/evm.py
@@ -156,6 +156,19 @@ CRONOS = EvmNetwork(
     },
 )
 
+POLYGON = EvmNetwork(
+    label='Polygon',
+    chain_ids={'mainnet': 137, 'amoy': 80_002},
+    rpc_urls={
+        # Both rungs serve receipts and historical eth_getCode at the 120-block depth the slash
+        # gate probes. publicnode leads on the one method they differ on: it answers the
+        # address-pinned eth_getLogs span a token scanner would issue, where drpc's free tier
+        # refuses anything past ~100 blocks (under a misleading "over 10000 blocks" message).
+        'mainnet': ('https://polygon-bor-rpc.publicnode.com', 'https://polygon.drpc.org'),
+        'amoy': ('https://polygon-amoy-bor-rpc.publicnode.com', 'https://polygon-amoy.drpc.org'),
+    },
+)
+
 # ChainDefinition.host_chain → the EvmNetwork that hosts the asset.
 EVM_NETWORKS: Mapping[str, EvmNetwork] = {
     'ethereum': ETHEREUM,
@@ -165,6 +178,7 @@ EVM_NETWORKS: Mapping[str, EvmNetwork] = {
     'avalanche': AVALANCHE,
     'base': BASE,
     'cronos': CRONOS,
+    'polygon': POLYGON,
 }
 
 

--- a/allways/assets/evm.py
+++ b/allways/assets/evm.py
@@ -160,10 +160,11 @@ POLYGON = EvmNetwork(
     label='Polygon',
     chain_ids={'mainnet': 137, 'amoy': 80_002},
     rpc_urls={
-        # Both rungs serve receipts and historical eth_getCode at the 120-block depth the slash
-        # gate probes. publicnode leads on the one method they differ on: it answers the
-        # address-pinned eth_getLogs span a token scanner would issue, where drpc's free tier
-        # refuses anything past ~100 blocks (under a misleading "over 10000 blocks" message).
+        # A native coin's deepest read here is historical eth_getCode at tip-120 (the slash gate),
+        # and both rungs serve receipts and that depth — so this order costs pol nothing. It is
+        # pinned for the token that will ride this row: only publicnode answers the address-pinned
+        # eth_getLogs span a deposit scanner issues, drpc's free tier refusing past 100 blocks
+        # (measured; the "ranges over 10000 blocks" message it answers with is misleading).
         'mainnet': ('https://polygon-bor-rpc.publicnode.com', 'https://polygon.drpc.org'),
         'amoy': ('https://polygon-amoy-bor-rpc.publicnode.com', 'https://polygon-amoy.drpc.org'),
     },

--- a/allways/assets/evm.py
+++ b/allways/assets/evm.py
@@ -33,7 +33,9 @@ class EvmRpcError(RuntimeError):
 
 
 # eth_maxPriorityFeePerGas fallback when an endpoint doesn't serve it (1 gwei clears
-# comfortably in normal conditions without meaningfully overpaying a transfer).
+# comfortably in normal conditions without meaningfully overpaying a transfer). A chain that
+# REJECTS a tip below some floor declares it as EvmNetwork.min_priority_fee_wei; both send
+# paths clamp up to that, so this value is a default and never the final word.
 FALLBACK_PRIORITY_FEE_WEI = 1_000_000_000
 
 # Send-dedup / deposit-scan window in wall seconds (≈5 min); each chain derives its block
@@ -64,6 +66,9 @@ class EvmNetwork:
     label: str
     chain_ids: Mapping[str, int]
     rpc_urls: Mapping[str, Tuple[str, ...]]
+    # Protocol-enforced floor on maxPriorityFeePerGas. A tx under it is refused at intake, not
+    # merely slow, so both send paths clamp up to it. 0 = the chain enforces no floor.
+    min_priority_fee_wei: int = 0
 
 
 ETHEREUM = EvmNetwork(
@@ -159,14 +164,19 @@ CRONOS = EvmNetwork(
 POLYGON = EvmNetwork(
     label='Polygon',
     chain_ids={'mainnet': 137, 'amoy': 80_002},
+    # Bor refuses any tx under this at intake ('gas price below minimum'), verified live against
+    # mainnet: the generic 1 gwei fallback signs a tx no Polygon node will ever accept.
+    min_priority_fee_wei=25_000_000_000,
     rpc_urls={
-        # A native coin's deepest read here is historical eth_getCode at tip-120 (the slash gate),
-        # and both rungs serve receipts and that depth — so this order costs pol nothing. It is
-        # pinned for the token that will ride this row: only publicnode answers the address-pinned
-        # eth_getLogs span a deposit scanner issues, drpc's free tier refusing past 100 blocks
-        # (measured; the "ranges over 10000 blocks" message it answers with is misleading).
-        'mainnet': ('https://polygon-bor-rpc.publicnode.com', 'https://polygon.drpc.org'),
-        'amoy': ('https://polygon-amoy-bor-rpc.publicnode.com', 'https://polygon-amoy.drpc.org'),
+        # drpc leads as the only archive rung, the same rule AVALANCHE states: delivery_refused
+        # probes historical eth_getCode at tip-120 on every overdue swap and that gate decides a
+        # slash, while publicnode prunes right at the edge of it (measured deepest served tip-128
+        # mainnet / tip-126 amoy, and it is a pool whose boundary moves between requests).
+        # The cost lands on a token riding this row, not on pol: drpc's free tier refuses an
+        # address-pinned eth_getLogs span past 100 blocks, so a deposit scanner spends one
+        # failover per call reaching publicnode.
+        'mainnet': ('https://polygon.drpc.org', 'https://polygon-bor-rpc.publicnode.com'),
+        'amoy': ('https://polygon-amoy.drpc.org', 'https://polygon-amoy-bor-rpc.publicnode.com'),
     },
 )
 

--- a/allways/assets/evm_coin.py
+++ b/allways/assets/evm_coin.py
@@ -219,6 +219,9 @@ class EvmCoin(EvmAsset):
                 tip_fee = int(self.chain.eth_rpc('eth_maxPriorityFeePerGas', []), 16)
             except Exception:
                 tip_fee = FALLBACK_PRIORITY_FEE_WEI
+            # A chain that enforces a tip floor rejects anything under it outright, and the failure
+            # repeats identically on every retry — clamp rather than sign an unbroadcastable tx.
+            tip_fee = max(tip_fee, self.chain.network_def.min_priority_fee_wei)
             # 2× base fee absorbs six consecutive maximally-full blocks before the cap binds.
             max_fee = 2 * base_fee + tip_fee
 

--- a/allways/assets/pol.py
+++ b/allways/assets/pol.py
@@ -1,0 +1,11 @@
+from allways.assets.evm_coin import EvmCoin
+from allways.chains import CHAIN_POL
+
+
+class Pol(EvmCoin):
+    """POL on Polygon PoS — a config-row binding of the generic EvmCoin (see chains.CHAIN_POL).
+
+    Polygon speaks plain JSON-RPC, so nothing here is chain-specific beyond the pairing."""
+
+    def __init__(self):
+        super().__init__(CHAIN_POL)

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -408,8 +408,9 @@ CHAIN_POL = ChainDefinition(
     # whole unfinalized span. 100 blocks = 150s real, >=20x the deepest lag seen, and inside the
     # program's 600s fulfillment grace.
     min_confirmations=100,
-    # Rate sanity floor, not an economic guarantee: 0.05 POL covers a 21k-gas transfer below
-    # ~2380 gwei, ~9x the 230-260 gwei base fee Polygon has held for weeks. Miners price real gas.
+    # Rate sanity floor, not an economic guarantee: 0.05 POL covers a 21k-gas transfer up to
+    # ~2380 gwei — 8.4x the ~282 gwei a transfer actually costs today (249 base + 30 tip), and
+    # 4.5x the ~534 gwei ceiling a send authorises (2x base + tip). Miners price real gas.
     min_onchain_amount=50_000_000_000_000_000,
     # Producer-stamped timestamps vs the hub clock, as on Arbitrum — and under VEBloP a single
     # elected producer stamps a whole span, so its clock offset never averages out across proposers.

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -397,14 +397,16 @@ CHAIN_POL = ChainDefinition(
     networks=('mainnet', 'amoy'),
     testnet_network='amoy',
     # Measured 1.5000s over 50k mainnet blocks (2026-08-12); Amoy runs 1.0000s. 1 is the integer
-    # floor, and unlike the sub-second chains here it UNDER-states real time, so every block-derived
-    # bound spans 1.5x the wall seconds its intent reads — longer than it looks, never shorter.
+    # floor, and unlike the sub-second chains here it UNDER-states real time. Bounds that DIVIDE by
+    # it (scan lookback, the delivery_refused span) cover 1.5x the wall seconds they read; the one
+    # that MULTIPLIES, compute_extension_target_secs, under-counts by 50s — inside its 120s padding.
     seconds_per_block=1,
-    # Heimdall v2 milestones finalize deterministically but BEHIND the tip (the finalized tag ran
-    # 1-4 blocks back over 30 samples, matching the docs' 2-5s), so unlike Snowman/HyperBFT there
-    # is a reorg window to outrun. Its depth is set by how long a milestone can stall, not by a
-    # producer turn as on BSC: under VEBloP one elected producer builds the whole unfinalized span.
-    # 100 blocks = 150s real, 25x the deepest lag seen, inside the program's 600s fulfillment grace.
+    # Heimdall v2 milestones finalize deterministically but BEHIND the tip (the finalized tag has
+    # trailed by 1-5 blocks across repeated 40-sample runs, matching the docs' 2-5s), so unlike
+    # Snowman/HyperBFT there is a reorg window to outrun. Its depth is set by how long a milestone
+    # can stall, not by a producer turn as on BSC: under VEBloP one elected producer builds the
+    # whole unfinalized span. 100 blocks = 150s real, >=20x the deepest lag seen, and inside the
+    # program's 600s fulfillment grace.
     min_confirmations=100,
     # Rate sanity floor, not an economic guarantee: 0.05 POL covers a 21k-gas transfer below
     # ~2380 gwei, ~9x the 230-260 gwei base fee Polygon has held for weeks. Miners price real gas.

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -387,6 +387,33 @@ CHAIN_QNT = ChainDefinition(
     refusal_checks=(),
 )
 
+CHAIN_POL = ChainDefinition(
+    id='pol',
+    name='Polygon',
+    native_unit='wei',
+    decimals=18,
+    env_prefix='POL',
+    host_chain='polygon',
+    networks=('mainnet', 'amoy'),
+    testnet_network='amoy',
+    # Measured 1.5000s over 50k mainnet blocks (2026-08-12); Amoy runs 1.0000s. 1 is the integer
+    # floor, and unlike the sub-second chains here it UNDER-states real time, so every block-derived
+    # bound spans 1.5x the wall seconds its intent reads — longer than it looks, never shorter.
+    seconds_per_block=1,
+    # Heimdall v2 milestones finalize deterministically but BEHIND the tip (the finalized tag ran
+    # 1-4 blocks back over 30 samples, matching the docs' 2-5s), so unlike Snowman/HyperBFT there
+    # is a reorg window to outrun. Its depth is set by how long a milestone can stall, not by a
+    # producer turn as on BSC: under VEBloP one elected producer builds the whole unfinalized span.
+    # 100 blocks = 150s real, 25x the deepest lag seen, inside the program's 600s fulfillment grace.
+    min_confirmations=100,
+    # Rate sanity floor, not an economic guarantee: 0.05 POL covers a 21k-gas transfer below
+    # ~2380 gwei, ~9x the 230-260 gwei base fee Polygon has held for weeks. Miners price real gas.
+    min_onchain_amount=50_000_000_000_000_000,
+    # Producer-stamped timestamps vs the hub clock, as on Arbitrum — and under VEBloP a single
+    # elected producer stamps a whole span, so its clock offset never averages out across proposers.
+    replay_grace_secs=60,
+)
+
 SUPPORTED_CHAINS = {
     'btc': CHAIN_BTC,
     'tao': CHAIN_TAO,
@@ -402,6 +429,7 @@ SUPPORTED_CHAINS = {
     'aster': CHAIN_ASTER,
     'uni': CHAIN_UNI,
     'qnt': CHAIN_QNT,
+    'pol': CHAIN_POL,
 }
 
 

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -115,6 +115,7 @@ LAUNCH_SPOKES = (
     'aster',
     'uni',
     'qnt',
+    'pol',
 )
 # Every launch pair as (hub, spoke): each hub pairs against every spoke except itself. sol↔tao
 # lands exactly once (under SOL, its anchor) because sol never appears in LAUNCH_SPOKES.

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -240,9 +240,16 @@ class TestComputeExtensionTargetSecs:
         assert compute_extension_target_secs('cro', 0, self.NOW, self.CEILING) == 10_200
 
     def test_pol_remaining_confs(self):
-        # pol needs 100 confs at the stored 1s (1.5s real): raw = 10000 + 100 + 120 = 10220,
-        # bucket up to 10800 — the bucket swallows the 50s the integer floor under-counts.
+        # pol needs 100 confs at the stored 1s: raw = 10000 + 100 + 120 = 10220, bucket up to 10800.
         assert compute_extension_target_secs('pol', 0, self.NOW, self.CEILING) == 10_800
+        # What covers the 50s the integer floor under-counts is the 120s padding, NOT the bucket:
+        # the bucket's contribution is phase-dependent and is 0 at the `now` below. 220s of cover
+        # against a 150s real need is the whole margin, and it is what breaks first if
+        # min_confirmations is ever raised past 240 — the literal above would not notice.
+        worst_phase = 9_980  # now + remaining + padding lands exactly on a bucket boundary
+        cover = compute_extension_target_secs('pol', 0, worst_phase, self.CEILING) - worst_phase
+        assert cover == 220
+        assert cover >= CHAIN_POL.min_confirmations * 1.5
 
     def test_unsupported_chain_raises(self):
         with pytest.raises(KeyError):

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -18,6 +18,7 @@ from allways.chains import (
     CHAIN_ETH,
     CHAIN_ETHUSDC,
     CHAIN_HYPE,
+    CHAIN_POL,
     CHAIN_QNT,
     CHAIN_TAO,
     CHAIN_UNI,
@@ -68,6 +69,9 @@ class TestGetChain:
 
     def test_qnt(self):
         assert get_chain_def('qnt') is CHAIN_QNT
+
+    def test_pol(self):
+        assert get_chain_def('pol') is CHAIN_POL
 
     def test_unsupported_raises(self):
         with pytest.raises(KeyError):
@@ -234,6 +238,11 @@ class TestComputeExtensionTargetSecs:
     def test_cro_remaining_confs(self):
         # cro needs 2 confs, 1s each: remaining=2, raw = 10000 + 2 + 120 = 10122, bucket up to 10200.
         assert compute_extension_target_secs('cro', 0, self.NOW, self.CEILING) == 10_200
+
+    def test_pol_remaining_confs(self):
+        # pol needs 100 confs at the stored 1s (1.5s real): raw = 10000 + 100 + 120 = 10220,
+        # bucket up to 10800 — the bucket swallows the 50s the integer floor under-counts.
+        assert compute_extension_target_secs('pol', 0, self.NOW, self.CEILING) == 10_800
 
     def test_unsupported_chain_raises(self):
         with pytest.raises(KeyError):

--- a/tests/test_cli_chain_networks.py
+++ b/tests/test_cli_chain_networks.py
@@ -63,6 +63,7 @@ class TestPinnedContract:
             'avax-network',
             'base-network',
             'cro-network',
+            'pol-network',
             'router',
             'env',
         )
@@ -77,6 +78,7 @@ class TestPinnedContract:
             'avax-network',
             'base-network',
             'cro-network',
+            'pol-network',
         )
 
     def test_testnet_bundle(self):
@@ -91,6 +93,7 @@ class TestPinnedContract:
             'avax-network': 'fuji',
             'base-network': 'sepolia',
             'cro-network': 'testnet',
+            'pol-network': 'amoy',
             'netuid': '19',
             'router': '5HicmHG7fjbxrtx8FZNdv4xxS5jSN84KGpMnTHsKtKv9peao',
         }
@@ -107,6 +110,7 @@ class TestPinnedContract:
             'avax-network': 'mainnet',
             'base-network': 'mainnet',
             'cro-network': 'mainnet',
+            'pol-network': 'mainnet',
             'netuid': '7',
             'router': '',
         }
@@ -133,6 +137,7 @@ class TestPinnedContract:
             'avax': ('mainnet', 'fuji'),
             'baseusdc': ('mainnet', 'sepolia'),
             'cro': ('mainnet', 'testnet'),
+            'pol': ('mainnet', 'amoy'),
         }
 
 

--- a/tests/test_pol_provider.py
+++ b/tests/test_pol_provider.py
@@ -1,0 +1,304 @@
+"""Pol unit tests — all offline (RPC layer mocked, signing is pure crypto).
+
+The EVM behaviour itself is `EvmCoin`, proven by the Ether suite. What is Polygon-specific — and
+what a wrong value here would cost — lives in the binding: which network the env selects, the
+chain id every signed tx commits to, the 100-block confirmation depth that outruns a stalled
+Heimdall milestone, and the block time that drives the scanner. Polygon's own hazard is the same
+as BSC's — a destination that stops accepting a native transfer between reserve and payout
+(EIP-7702 delegation) — so the delivery gates are pinned too.
+"""
+
+import pytest
+from eth_account import Account
+
+from allways.assets import evm_coin
+from allways.assets.asset import ProviderUnreachableError
+from allways.assets.evm import POLYGON, EvmChain
+from allways.assets.evm_coin import MAX_WALK_BLOCKS
+from allways.assets.pol import Pol
+from allways.chains import CHAIN_POL, get_chain_def
+from allways.constants import LAUNCH_SPOKES
+
+TEST_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'  # hardhat account #0
+RECIPIENT = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+TX = '0x' + 'ab' * 32
+BLOCK_HASH = '0x' + 'cd' * 32
+DELEGATION = '0xef0100' + '11' * 20  # EIP-7702 delegation indicator
+MINED_BLOCK = 0xF4240  # 1_000_000
+CONFIRMED_TIP = MINED_BLOCK + CHAIN_POL.min_confirmations - 1
+
+SEND_RESPONSES = {
+    'eth_blockNumber': hex(100),
+    'eth_getBlockByNumber': {'baseFeePerGas': hex(10**9)},
+    'eth_maxPriorityFeePerGas': hex(10**9),
+    'eth_getTransactionCount': '0x0',
+    'eth_getBalance': hex(10**19),
+    'eth_estimateGas': hex(21_000),
+}
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    monkeypatch.setenv('POL_NETWORK', 'mainnet')
+    monkeypatch.delenv('POL_RPC_URLS', raising=False)
+    monkeypatch.delenv('POL_PRIVATE_KEY', raising=False)
+    return Pol()
+
+
+@pytest.fixture
+def frozen_now(monkeypatch):
+    """Pin the clock so delivery_refused's span arithmetic lands on exact block offsets."""
+    now = 1_800_000_000
+    monkeypatch.setattr(evm_coin.time, 'time', lambda: now)
+    return now
+
+
+def rpc_stub(provider, responses: dict):
+    """Replace eth_rpc with a method→response map. A callable value is invoked with params."""
+
+    def fake_rpc(method, params, timeout=15, **kw):
+        value = responses[method]
+        return value(params) if callable(value) else value
+
+    provider.chain.eth_rpc = fake_rpc
+    return provider
+
+
+def mined_responses(status='0x1', tip=CONFIRMED_TIP, value_hex=hex(10**18)):
+    return {
+        'eth_getTransactionByHash': {
+            'hash': TX,
+            'from': '0x' + '11' * 20,
+            # Lowercase on the wire against a checksummed expectation: EIP-55 is display-only,
+            # and a case-sensitive compare would reject an honest miner's payout.
+            'to': RECIPIENT.lower(),
+            'value': value_hex,
+            'blockNumber': hex(MINED_BLOCK),
+            'blockHash': BLOCK_HASH,
+        },
+        'eth_getTransactionReceipt': {'status': status, 'blockNumber': hex(MINED_BLOCK), 'blockHash': BLOCK_HASH},
+        'eth_blockNumber': hex(tip),
+        'eth_getBlockByNumber': {'hash': BLOCK_HASH, 'timestamp': '0x64'},
+    }
+
+
+class TestRegistryRow:
+    def test_is_a_launch_spoke_bound_to_its_registry_row(self, provider):
+        assert provider.chain_def is CHAIN_POL is get_chain_def('pol')
+        assert 'pol' in LAUNCH_SPOKES
+
+    def test_native_coin_composes_its_chain(self, provider):
+        # A native coin is an asset ON its network, not the network — so a second Polygon asset
+        # can land beside it on the same POL_* config without either claiming to be the chain.
+        assert isinstance(provider.chain, EvmChain) and provider.chain is not provider
+        assert provider.chain.env_prefix == CHAIN_POL.env_prefix
+
+    def test_decimals_and_prefix(self):
+        # decimals is the one row field with no other allways-side guard: das mirrors it and its
+        # drift gate only runs after this merges, so a typo would ship green without this line.
+        assert (CHAIN_POL.decimals, CHAIN_POL.env_prefix, CHAIN_POL.native_unit) == (18, 'POL', 'wei')
+
+    def test_confirmations_stay_inside_the_program_fulfillment_grace(self):
+        # An unlisted chain gets the program's 600s default grace. 100 × the stored 1s is 100s;
+        # real Polygon blocks are 1.5s, so the true leg wait is 150s — both well inside it.
+        assert CHAIN_POL.min_confirmations * CHAIN_POL.seconds_per_block < 600
+        assert CHAIN_POL.min_confirmations * 1.5 < 600
+
+
+class TestNetworkSelection:
+    def test_mainnet_chain_id(self, provider):
+        assert provider.chain.chain_id == 137
+
+    def test_testnet_chain_id(self, monkeypatch):
+        monkeypatch.setenv('POL_NETWORK', 'amoy')
+        assert Pol().chain.chain_id == 80_002
+
+    def test_unknown_network_raises(self, monkeypatch):
+        # A typo must never fall back to mainnet — that spends real POL against test swaps.
+        # 'mumbai' is the retired Polygon testnet Amoy replaced, so it is the likely typo.
+        monkeypatch.setenv('POL_NETWORK', 'mumbai')
+        with pytest.raises(ValueError, match='POL_NETWORK'):
+            Pol()
+
+    def test_unset_network_defaults_to_mainnet(self, monkeypatch):
+        monkeypatch.delenv('POL_NETWORK', raising=False)
+        assert Pol().chain.network == 'mainnet'
+
+    @pytest.mark.parametrize('network', tuple(POLYGON.chain_ids))
+    def test_every_network_has_a_keyless_default_ladder(self, monkeypatch, network):
+        monkeypatch.setenv('POL_NETWORK', network)
+        assert Pol().chain.rpc_bases == list(POLYGON.rpc_urls[network])
+
+    def test_rpc_urls_env_overrides_the_public_ladder(self, monkeypatch):
+        monkeypatch.setenv('POL_RPC_URLS', 'https://paid.example/key/,https://backup.example')
+        assert Pol().chain.rpc_bases == ['https://paid.example/key', 'https://backup.example']
+
+    def test_wrong_network_endpoint_fails_startup(self, monkeypatch):
+        # Amoy configured, a mainnet endpoint answering: the ladder must be rejected outright,
+        # never quietly used to verify legs against the wrong chain.
+        monkeypatch.setenv('POL_NETWORK', 'amoy')
+        p = rpc_stub(Pol(), {'eth_chainId': hex(137)})
+        with pytest.raises(ConnectionError, match='expected 80002'):
+            p.check_connection(require_send=False)
+
+
+class TestVerification:
+    def test_settled_transfer_matches(self, provider):
+        rpc_stub(provider, mined_responses())
+        info = provider.fetch_matching_tx(TX, RECIPIENT, 10**18)
+        assert info is not None and info.confirmed and info.amount == 10**18
+        assert info.block_time == 0x64
+
+    def test_one_hundred_confirmations_are_enough(self, provider):
+        rpc_stub(provider, mined_responses(tip=CONFIRMED_TIP))
+        assert provider.fetch_matching_tx(TX, RECIPIENT, 10**18).confirmed
+
+    def test_ninety_nine_confirmations_are_not(self, provider):
+        rpc_stub(provider, mined_responses(tip=CONFIRMED_TIP - 1))
+        assert provider.fetch_matching_tx(TX, RECIPIENT, 10**18).confirmed is False
+
+    def test_reverted_tx_rejected(self, provider):
+        # Inclusion is not settlement: a reverted tx still carries intact to/value fields.
+        rpc_stub(provider, mined_responses(status='0x0'))
+        assert provider.fetch_matching_tx(TX, RECIPIENT, 10**18) is None
+
+    def test_underpayment_rejected(self, provider):
+        rpc_stub(provider, mined_responses(value_hex=hex(10**17)))
+        assert provider.fetch_matching_tx(TX, RECIPIENT, 10**18) is None
+
+    def test_wrong_recipient_rejected(self, provider):
+        rpc_stub(provider, mined_responses())
+        assert provider.fetch_matching_tx(TX, '0x' + '22' * 20, 10**18) is None
+
+    def test_absent_tx_is_absent(self, provider):
+        rpc_stub(provider, {'eth_getTransactionByHash': None})
+        assert provider.fetch_matching_tx(TX, RECIPIENT, 10**18) is None
+
+    def test_unreadable_receipt_is_unknown_not_absent(self, provider):
+        # 'unknown' must never read as 'no such payment' — that verdict slashes a paying miner.
+        responses = mined_responses()
+        responses['eth_getTransactionReceipt'] = None
+        with pytest.raises(ProviderUnreachableError):
+            rpc_stub(provider, responses).fetch_matching_tx(TX, RECIPIENT, 10**18)
+
+    def test_unreadable_block_timestamp_is_unknown_not_absent(self, provider):
+        # is_tx_fresh fails closed on a missing block_time, so a stale-looking dest leg
+        # would ride to a TIMEOUT slash. Raise instead and let the caller retry.
+        responses = mined_responses()
+        responses['eth_getBlockByNumber'] = {'hash': BLOCK_HASH}
+        with pytest.raises(ProviderUnreachableError):
+            rpc_stub(provider, responses).fetch_matching_tx(TX, RECIPIENT, 10**18)
+
+
+class TestSending:
+    @pytest.fixture(autouse=True)
+    def _key(self, provider, monkeypatch):
+        monkeypatch.setenv('POL_PRIVATE_KEY', TEST_KEY)
+
+    def test_broadcasts_a_polygon_signed_transfer(self, provider):
+        # Pins the whole signed payload: chain id 137 (a tx signed for any other chain is simply
+        # invalid here), EIP-1559 fees off the stubbed base fee, and the estimated gas + 20%.
+        broadcast = {}
+
+        def capture(params):
+            broadcast['raw'] = params[0]
+            return TX
+
+        rpc_stub(provider, dict(SEND_RESPONSES, eth_sendRawTransaction=capture))
+        assert provider.send_amount(RECIPIENT, 10**16) == (TX, 0)
+
+        expected = Account.sign_transaction(
+            {
+                'chainId': 137,
+                'nonce': 0,
+                'to': RECIPIENT,
+                'value': 10**16,
+                'gas': 25_200,
+                'maxFeePerGas': 3 * 10**9,
+                'maxPriorityFeePerGas': 10**9,
+            },
+            TEST_KEY,
+        )
+        raw = getattr(expected, 'raw_transaction', None) or getattr(expected, 'rawTransaction')
+        assert broadcast['raw'].removeprefix('0x') == raw.hex().removeprefix('0x')
+
+    def test_no_key_refused(self, provider, monkeypatch):
+        monkeypatch.delenv('POL_PRIVATE_KEY', raising=False)
+        assert provider.send_amount(RECIPIENT, 10**16) is None
+        assert 'POL_PRIVATE_KEY' in provider.last_send_error
+
+    def test_key_mismatch_refused(self, provider):
+        assert provider.send_amount(RECIPIENT, 10**16, from_address=RECIPIENT) is None
+        assert 'key mismatch' in provider.last_send_error
+
+    def test_insufficient_balance_refused(self, provider):
+        rpc_stub(provider, dict(SEND_RESPONSES, eth_getBalance=hex(10**12)))
+        assert provider.send_amount(RECIPIENT, 10**18) is None
+        assert 'Insufficient POL' in provider.last_send_error
+
+
+class TestDeliveryGates:
+    """A Polygon dest can refuse a native transfer — a contract wallet, or an EOA that delegates
+    to one via EIP-7702 *after* the reservation pinned it. The reserve gate keeps such a swap from
+    starting; the slash gate keeps a miner who cannot pay from being punished for it."""
+
+    def test_reserve_gate_admits_an_eoa_and_blocks_a_reverting_dest(self, provider):
+        rpc_stub(provider, {'eth_getCode': '0x'})
+        assert provider.can_deliver_to(RECIPIENT, 10**16) is True
+
+        def refuse(params):
+            raise RuntimeError('rpc error execution reverted')
+
+        rpc_stub(provider, {'eth_getCode': '0x60806040', 'eth_estimateGas': refuse})
+        assert provider.can_deliver_to(RECIPIENT, 10**16) is False
+
+    def test_slash_gate_exempts_a_dest_that_gained_then_revoked_code(self, provider, frozen_now):
+        # The case only temporal sampling can catch, and the one a miner gets slashed over: the
+        # dest delegates via EIP-7702 after the reservation pinned it, the payout reverts, and the
+        # delegation is revoked before the slash check. 'latest' is clean by then — only the
+        # historical probes still see it. Code lives at the midpoint offset alone, so a passing
+        # run proves all three probe offsets were actually read.
+        probed = []
+
+        def code_at(params):
+            probed.append(params[1])
+            return DELEGATION if params[1] == hex(9_970) else '0x'
+
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getCode': code_at})
+        assert provider.delivery_refused(RECIPIENT, frozen_now - 60) is True
+        # now, then the window's far edge and its midpoint. The 60s window is 60 blocks at the
+        # stored 1s; the gate's 120-block span cap is ~180s of real Polygon history (1.5s blocks),
+        # so beyond that "the window since since_unix" stops being true — see tmp/todos/C7.
+        assert probed == ['latest', hex(9_940), hex(9_970)]
+
+    def test_slash_gate_does_not_exempt_a_dest_that_never_had_code(self, provider, frozen_now):
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getCode': '0x'})
+        assert provider.delivery_refused(RECIPIENT, frozen_now - 60) is False
+
+
+class TestDepositScanner:
+    def test_walk_is_bounded_for_a_fast_chain(self, provider):
+        # 5 min of Polygon blocks is 200 real blocks; the stored 1s block time floors the lookback
+        # at 300 instead, and each one costs a sequential eth_getBlockByNumber. The walk bound is
+        # what keeps a first scan inside a public endpoint's budget — a token asset on this same
+        # network has no such bound and would ask for the whole 300-block span (tmp/todos/C8).
+        assert provider.SCAN_LOOKBACK_BLOCKS == 300 > MAX_WALK_BLOCKS
+
+        scanned = []
+
+        def block(params):
+            scanned.append(int(params[0], 16))
+            return {'transactions': []}
+
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getBlockByNumber': block})
+        assert provider.find_recent_outgoing(RECIPIENT, RECIPIENT, 1) is None
+        assert len(scanned) == MAX_WALK_BLOCKS
+
+    def test_cursor_parks_below_an_unreadable_block(self, provider):
+        def boom(params):
+            raise ConnectionError('down')
+
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getBlockByNumber': boom})
+        assert provider.find_recent_outgoing(RECIPIENT, RECIPIENT, 1) is None
+        # Never leap a block the scan could not read — the deposit in it must stay reachable.
+        assert provider.scan_cursors[(RECIPIENT.lower(), RECIPIENT.lower(), 1)] == 10_000 - MAX_WALK_BLOCKS

--- a/tests/test_pol_provider.py
+++ b/tests/test_pol_provider.py
@@ -13,7 +13,7 @@ from eth_account import Account
 
 from allways.assets import evm_coin
 from allways.assets.asset import ProviderUnreachableError
-from allways.assets.evm import POLYGON, EvmChain
+from allways.assets.evm import FALLBACK_PRIORITY_FEE_WEI, POLYGON, EvmChain, EvmRpcError
 from allways.assets.evm_coin import MAX_WALK_BLOCKS
 from allways.assets.pol import Pol
 from allways.chains import CHAIN_POL, get_chain_def
@@ -27,14 +27,36 @@ DELEGATION = '0xef0100' + '11' * 20  # EIP-7702 delegation indicator
 MINED_BLOCK = 0xF4240  # 1_000_000
 CONFIRMED_TIP = MINED_BLOCK + CHAIN_POL.min_confirmations - 1
 
+# Polygon's real fee scale, not Ethereum's. A 1-gwei fixture would pin a transaction Bor
+# rejects at intake (25 gwei tip floor), so the fee values are the hazard, not scenery.
+BASE_FEE = 250_000_000_000  # 230-260 gwei sustained on mainnet
+TIP_FEE = 30_000_000_000  # eth_maxPriorityFeePerGas suggestion
 SEND_RESPONSES = {
     'eth_blockNumber': hex(100),
-    'eth_getBlockByNumber': {'baseFeePerGas': hex(10**9)},
-    'eth_maxPriorityFeePerGas': hex(10**9),
+    'eth_getBlockByNumber': {'baseFeePerGas': hex(BASE_FEE)},
+    'eth_maxPriorityFeePerGas': hex(TIP_FEE),
     'eth_getTransactionCount': '0x0',
     'eth_getBalance': hex(10**19),
     'eth_estimateGas': hex(21_000),
 }
+
+
+def signed_transfer(tip_fee):
+    """The exact payload send_amount must produce for a 0.01 POL transfer at the stubbed fees."""
+    signed = Account.sign_transaction(
+        {
+            'chainId': 137,
+            'nonce': 0,
+            'to': RECIPIENT,
+            'value': 10**16,
+            'gas': 25_200,
+            'maxFeePerGas': 2 * BASE_FEE + tip_fee,
+            'maxPriorityFeePerGas': tip_fee,
+        },
+        TEST_KEY,
+    )
+    raw = getattr(signed, 'raw_transaction', None) or getattr(signed, 'rawTransaction')
+    return raw.hex().removeprefix('0x')
 
 
 @pytest.fixture
@@ -51,6 +73,10 @@ def frozen_now(monkeypatch):
     now = 1_800_000_000
     monkeypatch.setattr(evm_coin.time, 'time', lambda: now)
     return now
+
+
+def _method_gone(params):
+    raise EvmRpcError('the method eth_maxPriorityFeePerGas does not exist', {'code': -32601})
 
 
 def rpc_stub(provider, responses: dict):
@@ -206,21 +232,31 @@ class TestSending:
 
         rpc_stub(provider, dict(SEND_RESPONSES, eth_sendRawTransaction=capture))
         assert provider.send_amount(RECIPIENT, 10**16) == (TX, 0)
+        assert broadcast['raw'].removeprefix('0x') == signed_transfer(TIP_FEE)
 
-        expected = Account.sign_transaction(
-            {
-                'chainId': 137,
-                'nonce': 0,
-                'to': RECIPIENT,
-                'value': 10**16,
-                'gas': 25_200,
-                'maxFeePerGas': 3 * 10**9,
-                'maxPriorityFeePerGas': 10**9,
-            },
-            TEST_KEY,
+    @pytest.mark.parametrize(
+        'fee_answer',
+        [_method_gone, hex(FALLBACK_PRIORITY_FEE_WEI)],
+        ids=['fee-method-absent', 'endpoint-suggests-below-the-floor'],
+    )
+    def test_tip_is_clamped_to_polygons_protocol_floor(self, provider, fee_answer):
+        # Bor refuses a tx under 25 gwei at intake, so the generic 1 gwei fallback signs something
+        # no Polygon node accepts. The failure is deterministic, not transient: no broadcast, no
+        # sent-cache entry, an identical retry next pass, and every live pol swap rides to a slash.
+        # An operator-supplied POL_RPC_URLS endpoint that omits the fee method reaches it directly.
+        assert FALLBACK_PRIORITY_FEE_WEI < POLYGON.min_priority_fee_wei
+        broadcast = {}
+
+        def capture(params):
+            broadcast['raw'] = params[0]
+            return TX
+
+        rpc_stub(
+            provider,
+            dict(SEND_RESPONSES, eth_maxPriorityFeePerGas=fee_answer, eth_sendRawTransaction=capture),
         )
-        raw = getattr(expected, 'raw_transaction', None) or getattr(expected, 'rawTransaction')
-        assert broadcast['raw'].removeprefix('0x') == raw.hex().removeprefix('0x')
+        assert provider.send_amount(RECIPIENT, 10**16) == (TX, 0)
+        assert broadcast['raw'].removeprefix('0x') == signed_transfer(POLYGON.min_priority_fee_wei)
 
     def test_no_key_refused(self, provider, monkeypatch):
         monkeypatch.delenv('POL_PRIVATE_KEY', raising=False)


### PR DESCRIPTION
Adds Polygon PoS as a network and its native coin `pol` as a launch spoke: one `EvmNetwork` row, one `ChainDefinition`, a 10-line `EvmCoin` binding, and the registry/spoke entries. No shared-code changes.

**Base note.** This targets `refactor/erc20-refusal-interface` (#647) only to keep the merge stack linear. `pol` is a native coin — it touches no token code and needs nothing from #647. Retarget to `test` once #647 lands.

**No CI runs at this base.** `test.yml` and `lint.yml` both fire on `pull_request: branches: [main, test]`, so GitHub reports no checks until this is retargeted. Both were run locally against the same venv — results under [Tests and lint](#tests-and-lint) below.

**Multi-hub.** `LAUNCH_PAIRS` is derived over `HUB_CHAINS = ('sol', 'tao')`, so this spoke creates **two** pairs, `sol-pol` and `tao-pol`. Miners are expected to quote the TAO leg as well as the SOL leg.

## Judgement calls

### `min_confirmations = 100`

Polygon PoS finality is **deterministic via Heimdall v2 milestones** — validators propose Bor block hashes through CometBFT vote extensions and a milestone finalizes the longest common prefix carrying ≥2/3 agreement; a finalized block is irreversible ([docs.polygon.technology](https://docs.polygon.technology/pos/concepts/finality/finality)). Finality is documented at 2–5s, and the reorg cap was reduced to 2 blocks by Heimdall v2 (July 2025); Rio/VEBloP (Oct 2025) reduced reorgs further.

Measured live, mainnet, 2026-08-12: the `finalized` tag has trailed `latest` by **1–5 blocks** across repeated 40-sample runs (my two runs: min 1, max 4, mean 2.33 on publicnode / 2.60 on drpc; an independent resample saw a max of 5). The deepest lag is sampling-dependent, so the registry comment states the range, not a single max. `safe` is not served (`safe block not found`).

But this is unlike Snowman or HyperBFT, where finality *is* inclusion — Polygon finalizes **behind** the tip, so there is a real window to outrun, and the code counts depth from the tip rather than asking for the `finalized` tag. What sets the depth is therefore **how long a milestone can stall**, not a bounded adversarial run: if Heimdall cannot reach 2/3, Bor keeps producing under longest-chain, and under VEBloP a *single* elected producer builds the whole unfinalized span — so unlike BSC there is no `turn_length` capping it.

100 blocks × 1.5s = **150s** real. That is ≥20× the deepest lag observed (worst case 5 blocks), 50× the documented 2-block cap, and tolerates a ~150s milestone stall. It sits inside the program's 600s default fulfillment grace with 450s left for detection, broadcast and inclusion — so no `constants.rs` grace-table arm is needed. In range with the registry's other fast chains (`arbusdc` 90, `baseusdc` 120).

### `seconds_per_block = 1` — and the integer floor runs the *other* way here

Measured **exactly 1.5000 s/block** on mainnet over 100 / 1,000 / 10,000 / 50,000-block windows (Amoy: exactly 1.0000). The field is an `int`, so 1.

Worth stating precisely, because it inverts the usual note: on the sub-second chains in this registry (`bnb` 0.45s, `arbusdc` ~0.25s) the floor **over**-states real block time, so a block-denominated bound covers *less* wall time than its seconds intent reads. Polygon at 1.5s is the first chain where the floor **under**-states it — but the direction then depends on whether the bound *divides by* or *multiplies by* `seconds_per_block`, so there is no blanket "longer, never shorter":

| derived bound | code reads | real wall time | direction |
|---|---|---|---|
| `SCAN_LOOKBACK_BLOCKS` = 300 (dedup / scan window) | divides — 300s | **450s** | longer ✅ |
| `delivery_refused` span cap, 120 blocks | divides — 120s | **180s** | longer ✅ |
| `compute_extension_target_secs`, 100 remaining confs | **multiplies** — 100s | 150s | **under-counts by 50s** |

The extension target is the only hazard — a short extension could time out an honest still-confirming leg. What covers the 50s is **`EXTENSION_PADDING_SECONDS = 120`, not the bucket**: the bucket's contribution is phase-dependent and is 0 at some `now`. The unconditional worst-phase cover is `remaining × 1 + 120 = 220s` against a `100 × 1.5 = 150s` real need. That margin holds only while `min_confirmations ≤ 240`; verified by mutation — 240 is exactly break-even, 241 fails. `tests/test_chains.py::test_pol_remaining_confs` pins the worst phase, not just the literal, so a future bump past 240 fails the test. Everywhere else the floor is the conservative direction (a *longer* dedup memory, a *deeper* slash-exemption probe).

### `min_onchain_amount = 5e16` (0.05 POL)

Priced at a realistic-high gas level, not today's. Measured via `eth_feeHistory` over 1,024-block windows at ~0h / 8h / 83h / 417h ago: **base fee has held 230–260 gwei** the whole time; priority-tip p50 78–165 gwei, p99 spiking to 20k–113k gwei. `eth_gasPrice` read 281 gwei, `eth_maxPriorityFeePerGas` 29.8 gwei at the time of writing. POL was $0.0745.

0.05 POL covers a 21,000-gas transfer up to **~2,380 gwei** — ~9× the sustained base fee and ~4× the `maxFeePerGas` the provider itself would set today (`2 × base + priority` ≈ 550 gwei). ≈ $0.0037. Much larger in POL terms than `bnb`'s 0.0002 or `avax`'s 0.001 because Polygon's gas is denominated in a $0.07 coin, and copying either would have been an order of magnitude short.

This is a rate-sanity input to `is_executable_rate` / `min_executable_sol_leg`, **not an enforced per-swap minimum** — the enforced bounds are the program's `min_swap_amount` / `max_swap_amount` in SOL lamports. A payout below this floor is still reachable. Miners price real gas into their quotes.

### `replay_grace_secs = 60`

Justified on hub-vs-spoke clock skew, not on timestamp monotonicity: the floor is Solana's `Clock.unix_timestamp` (itself an estimate) and Bor block timestamps are producer-stamped, so the two clocks can disagree regardless of how orderly either is on its own. 60s matches every other fast EVM spoke. Polygon has one extra reason for a grace rather than `eth`'s 0: under VEBloP a **single** elected producer stamps an entire span, so that producer's clock offset applies uniformly instead of averaging out across rotating proposers.

## RPC ladder — every rung, every method, both networks

`eth_chainId` alone is not enough (it is what let a disqualified rung through on Base and BSC), so each rung was probed on the full surface, including a real settled tx and an unknown tx.

Chain ids verified on both rungs of both ladders: mainnet **137** (`0x89`), Amoy **80002** (`0x13882`).

| method | mainnet publicnode | mainnet drpc | amoy publicnode | amoy drpc |
|---|---|---|---|---|
| `eth_chainId` | ✅ 0x89 | ✅ 0x89 | ✅ 0x13882 | ✅ 0x13882 |
| `eth_getTransactionReceipt` (real tx) | ✅ `status 0x1` | ✅ `status 0x1` | ✅ `status 0x1` | ✅ `status 0x1` |
| `eth_getTransactionReceipt` (unknown tx) | ✅ authoritative `null` | ✅ `null` | ✅ `null` | ✅ `null` |
| `eth_getTransactionByHash` (real tx) | ✅ | ✅ | ✅ | ✅ |
| `eth_getBlockByNumber` | ✅ | ✅ | ✅ | ✅ |
| `eth_getBalance` | ✅ | ✅ | ✅ | ✅ |
| `eth_estimateGas` | ✅ 0x5208 | ✅ 0x5208 | ✅ 0x5208 | ✅ 0x5208 |
| `eth_maxPriorityFeePerGas` | ✅ | ✅ | ✅ | ✅ |
| `eth_getCode` @ tip−120 (historical, contract) | ✅ 3706 chars | ✅ | ✅ 3598 chars | ✅ |
| `eth_getCode` deepest served (bisected) | **tip−128** | archive | **tip−126** | archive |
| `eth_getLogs` 300 blk, address-pinned | ✅ 5147 logs | ❌ refused | ✅ | ✅ |
| `eth_getLogs` 25 blk, address-pinned | ✅ 447 logs | ✅ 447 logs | ✅ | ✅ |

No rung is excluded: **both serve receipts on both networks** — the check that disqualified publicnode on Base and both candidates on BSC. Both also serve historical `eth_getCode` to tip−120, which is the deepest the slash-exemption gate probes; publicnode prunes state past ~tip−128, which does not reach any code path here.

**Ladder order — drpc leads (corrected in review round 2, see below).** It is the one method the rungs differ on: publicnode answers the address-pinned `eth_getLogs` span a token asset's deposit scanner would issue, while drpc's free tier refuses anything past ~100 blocks. Boundary **bisected** on mainnet drpc: 99 ✅, **100 blk ✅, 101 blk ❌** (first refusal), and 104 / 105 / 128 / 150 / 300 all ❌, all under the misleading message `ranges over 10000 blocks are not supported on free plan`. **`pol` itself never calls `eth_getLogs`** — its deepest read is historical `eth_getCode` at tip−120 for the slash gate. publicnode's retention ends right at that edge (bisected: deepest served **tip−128** mainnet / **tip−126** Amoy, and it is a load-balanced pool whose boundary moves between requests), so the money-bearing gate takes rung 1 and **drpc leads**, matching the rule `AVALANCHE` already states at `evm.py:114`. The cost falls on `polusdc`: its 300-block scan fails on drpc and falls through to publicnode — one wasted request per scan, and it works. (publicnode also refuses *address-less* log queries outright, `-32701`; the production filter always pins an address, so that never bites.)

Two independent providers reachable on each network — no escalation trigger hit.

## Naming — MATIC → POL

The native token was renamed. Confirmed current on-chain, not from docs: `symbol()` on Polygon's native-token system contract `0x…1010` returns **`POL`**, `name()` returns `Polygon Ecosystem Token`, `decimals()` returns **18**. PolygonScan renders "POL Price" on the transaction page. The das entry ships `symbol: "POL"` and `coingeckoId: "polygon-ecosystem-token"` (`matic-network` is the retired slug, now titled "MATIC (migrated to POL)").

## Live read-only verification

No funds moved. Full script output, both networks:

```
########## mainnet (Polygon JSON-RPC (mainnet): polygon-bor-rpc.publicnode.com, polygon.drpc.org)
  check_connection(require_send=False)   OK
  tip                                    91911775
  real settled transfer                  0x5527c9e3901a8fd89e57129f38aca6c9515a48f039b3e4ae0c07a273fb3c8e4b
    from 0x501c43b2510da0ca6572e05b479e530ce3985646  to 0x6806ADdffb50588e846c55E972B8045879F2E51d  value 67096995792698690 wei (0.067097 POL)
  verify (EIP-55 recipient, sender pinned) OK  confirmed=True confs=106 block_time=1786572532
  underpayment (expect value+1)            correctly rejected
  wrong sender                             correctly rejected
  wrong recipient                          correctly rejected
  unknown tx                               correctly absent (None)
  get_balance(0x6806ADdffb…)               87706346413755561 wei (0.087706 POL)
  rung chain-id checked                    https://polygon-bor-rpc.publicnode.com -> 137
  rung chain-id checked                    https://polygon.drpc.org -> 137

########## amoy (Polygon JSON-RPC (amoy): polygon-amoy-bor-rpc.publicnode.com, polygon-amoy.drpc.org)
  check_connection(require_send=False)   OK
  tip                                    44754250
  real settled transfer                  0x35d689a772ac6090efda353cced039f01c4c4d0ae2b09ef09b615fffea320793
    from 0xdf854a41900b9010e3bd12b31581c380f2d291b4  to 0x1Ad78c2C989a59c50120325BA323705ce10F7ec7  value 100000000000000000 wei (0.100000 POL)
  verify (EIP-55 recipient, sender pinned) OK  confirmed=True confs=125 block_time=1786572570
  underpayment (expect value+1)            correctly rejected
  wrong sender                             correctly rejected
  wrong recipient                          correctly rejected
  unknown tx                               correctly absent (None)
  get_balance(0x1Ad78c2C98…)               112183823217336032 wei (0.112184 POL)
  rung chain-id checked                    https://polygon-amoy-bor-rpc.publicnode.com -> 80002
  rung chain-id checked                    https://polygon-amoy.drpc.org -> 80002

ALL LIVE CHECKS PASSED
```

Both recipients were passed in **EIP-55 mixed case** against lowercase on the wire, so the compare went through `normalize_address` rather than string equality, and the sender was pinned on every call.

## Tests and lint

- `ruff format --check .` → `183 files already formatted`; `ruff check .` → `All checks passed!`
- `pytest tests/ -q` → **1565 passed**, 6 deselected
- New `tests/test_pol_provider.py`, fully offline (RPC stubbed with a method→response map): registry row, network selection + wrong-network startup rejection, keyless ladder per network, settled / 100th-vs-99th confirmation / reverted / underpaid / wrong-recipient / absent verification, receipt-unavailable and timestamp-unavailable both **raising**, signed-payload pin at chain id 137, send guards, both delivery gates, and the scanner's walk bound + cursor parking.
  - `decimals` and `native_unit` are pinned in the registry-row tuple. `decimals` is the one field with no other allways-side guard — das mirrors it, but das's drift gate only runs after this merges, so a typo would otherwise ship green.
- `tests/test_chains.py`: registry lookup + extension-target case.
- `tests/test_cli_chain_networks.py`: updated deliberately. A new network **does** add a CLI row, so this pinned-contract test failed until `pol-network` was added to the settable keys, the chain-network keys, both env bundles, and the accepted-names map — that failure is the guard working.
- `tests/test_rate.py`: no new cases. 18 decimals is already covered.

## CLI surfaces — derived, not written

```
alw miner quotes --help
  --pol-price    NUMBER   POL per 1 hub unit (0/omit to skip POL).
  --pol-address  TEXT     Your POL address.

alw config
  │ base-network   │ mainnet │ default │
  │ pol-network    │ mainnet │ default │
```

## e2e

`sol-pol` and `pol-sol` appear in `alw-utils` `run-suites.sh --list` with zero harness edits (verified: they vanish when this branch is off `PYTHONPATH`, so they are derived from `LAUNCH_SPOKES`, not written). **I did not run the suite** — it needs the full local Solana stack and several agents share this machine.

## Emission dilution — per PAIR

`MINER_POOL_SHARE / (2 × len(LAUNCH_PAIRS))`, computed from this branch:

| | spokes | pairs | directions | zero-volume floor per direction |
|---|---|---|---|---|
| base (#647) | 9 | 17 | 34 | 0.2941% |
| with `pol` | 10 | **19** | 38 | **0.2632%** |

A 10.5% cut to the equal-split floor, because `pol` costs two pairs, not one. `POOL_VOLUME_ALPHA = 0.66` means a busy pair recovers most of it; a pair with no volume does not. `DIRECTION_POOLS[('sol','pol')] == DIRECTION_POOLS[('tao','pol')] == 0.0026315…`. The number will move again as the sibling assets in this batch land.

## Two open shared-code bugs, as they apply here — reported, not fixed

**C8 — token deposit scanner asks for an unservable range.** `SCAN_LOOKBACK_BLOCKS = SCAN_LOOKBACK_SECS // seconds_per_block = 300 // 1 = **300**` on Polygon. That is exactly the range drpc refuses (measured boundary: serves ≤100, refuses ≥128). `pol` is **safe**: `EvmCoin` bounds its walk at `MAX_WALK_BLOCKS = 32` (`evm_coin.py:325`), pinned in `test_pol_provider.py::test_walk_is_bounded_for_a_fast_chain`, and it never calls `eth_getLogs` at all.

⚠️ **`polusdc` will not be safe.** `Erc20.find_recent_outgoing` (`erc20.py:466,585`) has no `MAX_WALK_BLOCKS` equivalent and issues **one** `eth_getLogs` across the full 300-block span. On rung 1 (publicnode) that is served — verified, 5,147 logs — so unlike `arbusdc` it will not be dead on arrival, but it will fail over on **every single call**, wasting a request per scan and leaving the pair single-rung for that method. Raising `seconds_per_block` to 2 would not rescue it either: 150 blocks is still past drpc's ~100-block boundary. The C8 span cap (`MAX_LOG_SPAN_BLOCKS = 25` + chunking) is the fix, and it should land before or with `polusdc`.

**C7 — slash-exemption lookback is measured in blocks.** The probe reaches `min(120, …)` blocks (`evm_coin.py:305`), which on a 1.5s chain is **~180s** of a 600s fulfillment window — **30% coverage**. Better than `bnb`'s 54s and `cro`'s 57s because Polygon's blocks are slower, still partial: a user can make delivery impossible, revoke it, wait ~3 minutes, and the evidence is gone before the slash check runs. The comment on `test_pol_provider.py::test_slash_gate_exempts_a_dest_that_gained_then_revoked_code` records the real number. Not fixed here — the fix is C7's live-observation ledger, and it is shared code.

## Merge order

Merge this before its das twin — [das-allways#101](https://github.com/entrius/das-allways/pull/101). That PR's chain-drift gate reads `allways/chains.py` from `test` and stays **red by design** until this lands (verified: `'pol' is served but not in chains.py SUPPORTED_CHAINS`; green against this branch locally). Nobody should "fix" it.



---

### Review round 1 — addressed in `d0d5a06`

| # | Fix |
|---|---|
| F1 | `chains.py` no longer claims "never shorter". The comment now splits divide-by bounds (longer) from `compute_extension_target_secs`, which multiplies and under-counts by 50s, inside its 120s padding — the inverse of the `CHAIN_BNB` blanket claim recorded in `tmp/todos/C7`. |
| F2 | `test_pol_remaining_confs` now pins the **worst phase** (`cover == 220`) and the property `cover ≥ min_confirmations × 1.5`, and credits the padding rather than the bucket. Mutation-checked: 240 break-even, 241 fails. |
| F3 | `evm.py` ladder comment now names the method `pol` itself depends on (historical `eth_getCode`, served by both rungs) before explaining the forward-looking publicnode-first choice for `polusdc`. |
| F4 | Re-measured, 80 fresh samples across both rungs: min 1, max 4, mean 2.33 / 2.60. An independent resample saw 5, so the comment now states 1–5 across repeated runs and ≥20× rather than a fragile single max. |
| F5 | Boundary bisected: last served **100**, first refused **101**. Body table corrected — `polusdc` should reuse 101, not 128. |

`ruff format --check .` + `ruff check .` clean; `pytest tests/ -q` → **1565 passed**.


---

### Review round 2 — red team, addressed in `39f068a`

**P2 (HIGH) — the fallback tip signed a transaction Polygon rejects at intake.** `FALLBACK_PRIORITY_FEE_WEI = 1 gwei` is below Bor's **25 gwei** protocol floor. Reproduced live with the same signed payload across three chains:

```
polygon : PRICE-GATE REJECT  "gas price below minimum: gas tip cap 1000000000, minimum needed 25000000000"
ethereum: price gate passed  (fails later on nonce)
bsc     : price gate passed  (fails later on nonce)
```

Polygon is the only chain in the registry that rejects it, so merging this row would make a previously-safe shared constant unsafe — and `erc20.py` carries it verbatim into `polusdc`. The failure is **deterministic, not transient**: broadcast refused → no `sent` entry → identical retry next pass → every live `pol` swap rides to a 1.1× slash. An operator pointing `POL_RPC_URLS` at an endpoint without `eth_maxPriorityFeePerGas` reaches it immediately.

Fix: `min_priority_fee_wei: int = 0` on `EvmNetwork`, `25_000_000_000` on the Polygon row, and one clamp line in **both** send paths (`evm_coin.py`, `erc20.py`) — `tip_fee = max(tip_fee, self.chain.network_def.min_priority_fee_wei)`. Clamped unconditionally, not only on the fallback, so an endpoint suggesting a too-low tip is covered too. The shared `FALLBACK_PRIORITY_FEE_WEI` comment no longer claims 1 gwei is universally adequate.

**End-to-end proof against live Polygon.** The real `Pol.send_amount` was driven with `eth_maxPriorityFeePerGas` unavailable, and the transaction it actually signed was handed to Bor:

```
FALLBACK_PRIORITY_FEE_WEI     =  1 gwei
POLYGON.min_priority_fee_wei  = 25 gwei

Bor verdict on the tx the CLAMPED provider signed:
  insufficient funds for gas * price + value: balance 0, tx cost 13375799685360001
  price gate: PASSED
```

It now fails only on the throwaway key's zero balance — the fee gate is cleared. Before the fix the identical path produced `gas tip cap 1000000000`.

**P2b — the test asserted the invalid transaction.** The fixture stubbed Ethereum-quiet fees (1 gwei base, 1 gwei tip) and pinned `maxPriorityFeePerGas: 10**9` — the one test that pins a whole Polygon transaction pinned one Polygon rejects, and it was green. Restubbed at real scale (`BASE_FEE = 250 gwei`, `TIP_FEE = 30 gwei`) and added a parametrised clamp test covering both routes to the floor (fee method absent / endpoint suggests below it). **Mutation-verified**: removing the clamp fails exactly those two tests and nothing else.

**P3 (MEDIUM) — ladder reordered, drpc first on both networks.** The old rationale cited `eth_getLogs`, which `EvmCoin` never calls. Bisected retention: publicnode's deepest served state is **tip−128** (mainnet) / **tip−126** (Amoy) against a slash gate that probes **tip−120** — a 6–8 block (9–12s) margin on a load-balanced pool, while `delivery_refused` makes 4 sequential RPCs after reading the tip. drpc serves tip−4096 on both. The money-bearing gate wins rung 1; the comment now states the measured retention and names the method `pol` itself depends on. `.env.example` updated to match.

**P7 (LOW) — `min_onchain_amount` comparison restated honestly.** The 2,380 gwei breakeven was right but "~9× the base fee" omitted the tip. Now: **8.4×** the ~282 gwei a transfer actually costs (249 base + 30 tip) and **4.5×** the ~534 gwei ceiling a send authorises (2 × base + tip). The value is unchanged.

**Re-verified after the change:** `ruff format --check .` + `ruff check .` clean; `pytest tests/ -q` → **1567 passed**; live read-only pass re-run on **both** networks with the new rung order — `check_connection`, a real settled transfer verified with an EIP-55 recipient and pinned sender (106 / 228 confs), historical `eth_getCode` at tip−120 served on rung 1, and `delivery_refused`'s full probe set returning `False` with no exception.