### PR TITLE
Register bump_vault_generation and pin the migrate driver to CONFIG_VERSION

### DIFF
--- a/allways/solana/layouts.py
+++ b/allways/solana/layouts.py
@@ -535,6 +535,8 @@ IX_DISCRIMINATORS = {
     'set_tao_min_collateral': bytes([154, 196, 157, 5, 232, 196, 250, 217]),
     'set_settlement_grace': bytes([151, 0, 169, 67, 242, 17, 56, 40]),
     'set_attest_max_age': bytes([160, 215, 211, 57, 62, 246, 30, 80]),
+    # Retires the current vault's attestation-epoch namespace (see compose_attestation_epoch).
+    'bump_vault_generation': bytes([93, 192, 10, 149, 230, 255, 251, 27]),
     # W2b — reap a quote stranded at the pre-W2b four-seed derivation (no args).
     'close_legacy_quote': bytes([174, 62, 107, 15, 91, 39, 82, 249]),
     # v3 — reap the reused per-miner slots the upgrade left unreadable (no args each). Unlike the

--- a/smart-contracts/solana/migrate_devnet.py
+++ b/smart-contracts/solana/migrate_devnet.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""v10 → v14 migration driver (run AFTER `solana program deploy` upgrades the program).
+"""v10 → v15 migration driver (run AFTER `solana program deploy` upgrades the program).
 
 Signs with the Config admin (= dev-asm on devnet, which is also the upgrade authority). Order matters:
 migrate_config MUST run first (an unmigrated v10 Config can't deserialize under the new layout, so
@@ -28,6 +28,7 @@ from solders.pubkey import Pubkey
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 from allways.solana import pdas  # noqa: E402
 from allways.solana.client import AllwaysSolanaClient  # noqa: E402
+from allways.solana.layouts import CONFIG_VERSION  # noqa: E402
 
 SYSTEM = Pubkey.from_string('11111111111111111111111111111111')
 
@@ -81,8 +82,8 @@ def main():
     if not dry:
         v = c.get_config().version
         print(f'  Config.version now: {v}')
-        if v != 14:
-            print('  ABORT: config did not reach v14; not migrating miners.')
+        if v != CONFIG_VERSION:
+            print(f'  ABORT: config did not reach v{CONFIG_VERSION}; not migrating miners.')
             return
 
     # 2. migrate_miner_state per miner.


### PR DESCRIPTION
Two gaps #656 left behind, both surfaced running the real devnet v14 → v15 upgrade.

**`bump_vault_generation` was unreachable.** The client builds instructions from
`IX_DISCRIMINATORS`, and #656 added the program instruction, the client wrapper and the CLI command
but not the table entry — so the call raised `KeyError: 'bump_vault_generation'` instead of sending.
The existing builder tests re-derive every registered discriminator from `sha256("global:<name>")`,
so this entry is verified by them rather than taken on trust (confirmed against the IDL:
`[93, 192, 10, 149, 230, 255, 251, 27]`).

**`migrate_devnet.py` hardcoded the target version.** It asserted `version != 14` as a literal,
which would abort the run on every future schema bump — it aborted this one. Now reads
`CONFIG_VERSION` from layouts.

## Verified on devnet

```
program upgraded    3Xx7eZQa…      config 14 → 15
migrate_config + migrate_miner_state ×5   all ok
bump_vault_generation  3kmSsaNK…   vault_generation 0 → 1
```

The deadlock is broken: the stored attestation epoch is `2`, and a new-vault lock epoch of `1` now
composes to `4294967297`, which clears the monotonic guard. Entry resumed.