### PR TITLE
Compare the attested epoch's vault half in the activation gate

### DIFF
--- a/allways/validator/activation.py
+++ b/allways/validator/activation.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 
 from allways.cli.swap_commands.swap_intake import floors_from_config
 from allways.solana import pdas
+from allways.solana.layouts import split_attestation_epoch
 from allways.validator.relay.wiring import axon_vault_client
 
 
@@ -91,10 +92,10 @@ def _attested(validator, miner_hotkey: str, miner_pk, backing: str, floor: int, 
             f'Bond below the {unit} floor: {attestation.effective_balance} < {floor} (the attested figure '
             f'is your gross bond net of accrued fees and voted slashes).'
         )
-    return _vault(validator, miner_hotkey, backing, attestation, floor)
+    return _vault(validator, miner_hotkey, backing, attestation, floor, config)
 
 
-def _vault(validator, miner_hotkey: str, backing: str, attestation, floor: int) -> Eligibility:
+def _vault(validator, miner_hotkey: str, backing: str, attestation, floor: int, config) -> Eligibility:
     """Verify the attestation against the bond it asserts. A stale mirror is the dangerous direction:
     it can only ever say a withdrawn bond is still there, never the reverse."""
     unit = backing.upper()
@@ -110,9 +111,19 @@ def _vault(validator, miner_hotkey: str, backing: str, attestation, floor: int) 
     locked, epoch = lock
     if not locked:
         return _no(f'Bond is not locked on the {unit} vault (the attestation has yet to catch up).')
-    if int(epoch) != int(attestation.epoch):
+    # The attested epoch carries the vault generation in its high half, so compare like for like —
+    # and require the CURRENT generation, or an attestation mirrored from a retired vault could
+    # authorise activation whenever its lock epoch happened to collide with the live vault's.
+    attested_generation, attested_epoch = split_attestation_epoch(attestation.epoch)
+    generation = int(getattr(config, 'vault_generation', 0) or 0)
+    if attested_generation != generation:
         return _no(
-            f'Bond attestation is stale — it asserts lock epoch {attestation.epoch}, the {unit} vault is at '
+            f'Bond attestation was mirrored from a retired {unit} vault (generation {attested_generation}, '
+            f'now {generation}). Retry once validators have re-mirrored your bond.'
+        )
+    if int(epoch) != attested_epoch:
+        return _no(
+            f'Bond attestation is stale — it asserts lock epoch {attested_epoch}, the {unit} vault is at '
             f'{epoch}. Retry once validators have re-mirrored your bond.'
         )
     if int(gross) < floor:

--- a/tests/test_axon_solana_handlers.py
+++ b/tests/test_axon_solana_handlers.py
@@ -41,6 +41,7 @@ class FakeSolanaClient:
         attestation=None,
         tao_min_collateral=TAO_FLOOR,
         heartbeat=NOW,
+        vault_generation=0,
     ):
         self.binding = SimpleNamespace(miner=MINER_PK) if binding else None
         self.full_binding = (
@@ -52,6 +53,7 @@ class FakeSolanaClient:
         self.attestation = attestation
         self._tao_min_collateral = tao_min_collateral
         self._heartbeat = heartbeat
+        self._vault_generation = vault_generation
         self.calls = []
 
     def get_hotkey_binding(self, hotkey_bytes):
@@ -69,6 +71,7 @@ class FakeSolanaClient:
             tao_min_collateral=self._tao_min_collateral,
             last_attest_heartbeat=self._heartbeat,
             attest_max_age_secs=86_400,
+            vault_generation=self._vault_generation,
         )
 
     def get_bond_attestation(self, miner, chain='tao'):
@@ -409,3 +412,31 @@ def test_reserve_bad_hotkey_rejects_at_info_not_error(monkeypatch):
     assert out.accepted is False
     assert 'Invalid SS58' in out.rejection_reason
     assert errors == []  # a garbage caller must not land on the validator's ERROR log
+
+
+def test_activate_tao_accepts_an_attestation_from_the_current_vault_generation(monkeypatch):
+    """After a vault swap the attested epoch carries the generation in its high half; the vault
+    still reports the bare lock epoch, so the check must compare like for like."""
+    from allways.solana.layouts import compose_attestation_epoch
+
+    client = FakeSolanaClient(
+        miner_state=miner_state(),
+        attestation=attested(epoch=compose_attestation_epoch(1, EPOCH)),
+        vault_generation=1,
+    )
+    v = with_vault(monkeypatch, make_validator(client, vault=FakeVault(locked=True, epoch=EPOCH)))
+    assert activation.check(v, HOTKEY, MINER_PK, miner_state(), 'tao', NOW).ok
+
+
+def test_activate_tao_refuses_an_attestation_from_a_retired_vault(monkeypatch):
+    """A retired vault's mirror must not authorise activation just because its lock epoch happens
+    to collide with the live vault's — the generation is what tells them apart."""
+    client = FakeSolanaClient(
+        miner_state=miner_state(),
+        attestation=attested(epoch=EPOCH),  # generation 0, i.e. the retired vault
+        vault_generation=1,
+    )
+    v = with_vault(monkeypatch, make_validator(client, vault=FakeVault(locked=True, epoch=EPOCH)))
+    result = activation.check(v, HOTKEY, MINER_PK, miner_state(), 'tao', NOW)
+    assert not result.ok
+    assert 'retired' in result.reason.lower(), result.reason


### PR DESCRIPTION
#656 composed the vault generation into the attestation epoch, but missed the **validator's
activation pre-check** — the one place outside the relay that compares an attested epoch to the
vault's. Found trying to activate the testnet miner on the new vault:

```
V1: no  Bond attestation is stale — it asserts lock epoch 4294967297,
        the TAO vault is at 1. Retry once validators have re-mirrored your bond.
0/1 validators accepted
```

That is the deadlock #656 removed, reappearing one layer up: the relay attested correctly
(`epoch=1 (gen 1)`), and then the gate refused it because it compared the composed value against
the vault's bare lock epoch.

## Fix

`activation.py:_vault` splits the composed epoch and compares the **vault half**, and additionally
requires the **current** generation. That second check is not incidental — without it an
attestation mirrored from a *retired* vault would authorise activation whenever its lock epoch
happened to collide with the live vault's, which is exactly the confusion the generation exists to
prevent. `config` was already threaded into `_attested`, so it only needed passing one level down.

I grepped every other `.epoch` comparison in the package: this was the only remaining site.

## Tests

Two new, both through the real `activation.check` path: a composed attestation from the current
generation activates, and one from a retired generation is refused with the generation named. The
`FakeSolanaClient` config now carries `vault_generation` (defaulting to 0, so every existing case is
unchanged — all 24 handler tests still pass untouched).

Python **1564 passed**; the single failure (`test_uppercase_bech32_matches_derived_address`) is
pre-existing on `test` and reproduces with these changes stashed. ruff clean.

Off-chain only — no program change, no upgrade. Validator redeploy picks it up.