### PR TITLE
Scope the accrued-fee ledger to the vault generation

### DIFF
--- a/allways/validator/relay/attestation.py
+++ b/allways/validator/relay/attestation.py
@@ -80,18 +80,20 @@ def compute(relay, miner: str, hotkey: str) -> Optional[Attested]:
     if gross is None or settled is None or lock is None:
         bt.logging.warning(f'relay: vault reads unavailable for {hotkey[:8]}… — leaving its attestation alone')
         return None
-    accrued = relay.store.accrued_fee_total(miner, relay.backing)
+    generation = relay.vault_generation()
+    if generation is None:
+        return None
+    # Scoped to THIS vault: the retired one's settled counter is gone, so summing its accruals
+    # against a fresh `settled` would re-charge fees it already collected.
+    accrued = relay.store.accrued_fee_total(miner, relay.backing, vault_generation=generation)
     # Fees the miner has earned the protocol but the vault has not yet booked. The vault debits at
     # settle time; Solana's guards must see the miner clipped from the moment the fee is earned.
     unsettled = max(0, accrued - settled)
     pending = sum(int(row['penalty']) for row in relay.store.open_relay_slashes(relay.backing, miner))
     locked, epoch = lock
     # A replacement vault restarts its lock epochs at 0, which the on-chain monotonic guard would
-    # read as stale forever. Compose the config's vault generation into the high half so epochs stay
-    # globally monotonic across the swap.
-    generation = relay.vault_generation()
-    if generation is None:
-        return None
+    # read as stale forever. Compose the generation into the high half so epochs stay globally
+    # monotonic across the swap.
     return Attested(
         max(0, gross - unsettled - pending),
         bool(locked),

--- a/allways/validator/relay/engine.py
+++ b/allways/validator/relay/engine.py
@@ -220,8 +220,14 @@ class BondRelay:
             # Absolute rao figure (the confirm-events seam W2b landed): Solana moved nothing, the
             # fee is owed on the vault and nets off the effective bond until it settles there.
             miner = str(fields['miner'])
+            # The fee is owed to the vault in service NOW. Refuse to record it under a guessed
+            # generation — ingest holds the cursor and replays, so an unreadable config costs a
+            # retry, while a mis-tagged accrual would be charged against the wrong vault forever.
+            generation = self.vault_generation()
+            if generation is None:
+                raise RuntimeError('vault generation unreadable — cannot tag the fee accrual')
             self.store.record_relay_fee(
-                _hex(fields['swap_key']), miner, self.backing, int(fields['fee']), int(block_time)
+                _hex(fields['swap_key']), miner, self.backing, int(fields['fee']), int(block_time), generation
             )
             self.mark_dirty(miner)
         elif name == 'SwapTimedOut':

--- a/allways/validator/relay/exit_relay.py
+++ b/allways/validator/relay/exit_relay.py
@@ -69,7 +69,10 @@ def _advance(relay, miner: str, now: int) -> bool:
         bt.logging.debug(f'relay: {miner[:8]} exit waiting — {why}')
         return True  # waiting is a healthy state, not an outstanding obligation
 
-    total = relay.store.accrued_fee_total(miner, relay.backing)
+    generation = relay.vault_generation()
+    if generation is None:
+        return False
+    total = relay.store.accrued_fee_total(miner, relay.backing, vault_generation=generation)
     settled = relay.vault.get_settled_total(hotkey)
     if settled is None:
         return False
@@ -189,7 +192,12 @@ def cadence_entries(relay, boundary: int) -> List[Tuple[str, int]]:
     AccountId. Membership is derived from the Solana event stream ALONE — deliberately not
     filtered against the vault — because the vector is hashed into the round key and must be
     byte-identical across validators; the vault's monotonic totals no-op any stale entry."""
-    totals: Dict[str, int] = relay.store.accrued_fee_totals(relay.backing, at_time=boundary)
+    generation = relay.vault_generation()
+    if generation is None:
+        return []
+    totals: Dict[str, int] = relay.store.accrued_fee_totals(
+        relay.backing, at_time=boundary, vault_generation=generation
+    )
     entries: List[Tuple[bytes, str, int]] = []
     for miner, total in totals.items():
         if total <= 0:

--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -562,34 +562,49 @@ class ValidatorStateStore:
             (cutoff_time,),
         )
 
-    def record_relay_fee(self, swap_key: str, miner: str, backing: str, fee: int, block_time: int) -> None:
-        """One completed off-chain-backed swap's absolute protocol fee (rao). Keyed by swap_key so a
-        re-ingested event can never double-count the accrual."""
+    def record_relay_fee(
+        self, swap_key: str, miner: str, backing: str, fee: int, block_time: int, vault_generation: int = 0
+    ) -> None:
+        """One completed off-chain-backed swap's absolute protocol fee (rao), tagged with the vault
+        generation that will collect it. Keyed by swap_key so a re-ingested event can never
+        double-count the accrual."""
         self._execute(
             """
-            INSERT INTO relay_fees (swap_key, miner, backing, fee, block_time)
-            VALUES (?, ?, ?, ?, ?)
+            INSERT INTO relay_fees (swap_key, miner, backing, fee, block_time, vault_generation)
+            VALUES (?, ?, ?, ?, ?, ?)
             ON CONFLICT(swap_key) DO NOTHING
             """,
-            (swap_key, miner, backing, int(fee), block_time),
+            (swap_key, miner, backing, int(fee), block_time, int(vault_generation)),
         )
 
-    def accrued_fee_total(self, miner: str, backing: str, at_time: Optional[int] = None) -> int:
-        """Cumulative fees this miner has earned the protocol on ``backing``, optionally as of a
-        boundary. The cadence batch reads at the aligned boundary so every validator derives the
-        identical vector."""
+    def accrued_fee_total(
+        self, miner: str, backing: str, at_time: Optional[int] = None, vault_generation: Optional[int] = None
+    ) -> int:
+        """Cumulative fees this miner owes THIS vault generation on ``backing``, optionally as of a
+        boundary. Scoped by generation because the vault's settled counter restarts at 0 on a
+        replacement — an unscoped sum re-charges what the retired vault already collected. The
+        cadence batch reads at the aligned boundary so every validator derives the identical vector."""
         sql = 'SELECT COALESCE(SUM(fee), 0) AS total FROM relay_fees WHERE miner = ? AND backing = ?'
         params: Tuple = (miner, backing)
+        if vault_generation is not None:
+            sql += ' AND vault_generation = ?'
+            params += (int(vault_generation),)
         if at_time is not None:
             sql += ' AND block_time <= ?'
             params += (at_time,)
         row = self._fetchone(sql, params)
         return int(row['total']) if row is not None else 0
 
-    def accrued_fee_totals(self, backing: str, at_time: Optional[int] = None) -> Dict[str, int]:
-        """``{miner: cumulative_fee}`` for every miner with an accrual on ``backing``."""
+    def accrued_fee_totals(
+        self, backing: str, at_time: Optional[int] = None, vault_generation: Optional[int] = None
+    ) -> Dict[str, int]:
+        """``{miner: cumulative_fee}`` on ``backing``, scoped to one vault generation when given
+        (accounting) and across all of them when not (miner discovery)."""
         sql = 'SELECT miner, COALESCE(SUM(fee), 0) AS total FROM relay_fees WHERE backing = ?'
         params: Tuple = (backing,)
+        if vault_generation is not None:
+            sql += ' AND vault_generation = ?'
+            params += (int(vault_generation),)
         if at_time is not None:
             sql += ' AND block_time <= ?'
             params += (at_time,)
@@ -854,6 +869,14 @@ class ValidatorStateStore:
             cols = [row[1] for row in conn.execute('PRAGMA table_info(relay_slashes)')]
             if cols and 'hotkey' not in cols:
                 conn.execute('ALTER TABLE relay_slashes ADD COLUMN hotkey TEXT')
+            # A fee is owed to the vault in service when it was earned, and a replacement vault
+            # restarts its settled counter at 0 — so an accrual must never be summed against a vault
+            # that did not collect it. Pre-existing rows default to generation 0, which is exactly
+            # where they were earned (the generation only exists from the first swap onward).
+            cols = [row[1] for row in conn.execute('PRAGMA table_info(relay_fees)')]
+            if cols and 'vault_generation' not in cols:
+                conn.execute('ALTER TABLE relay_fees ADD COLUMN vault_generation INTEGER NOT NULL DEFAULT 0')
+                conn.execute('DROP INDEX IF EXISTS idx_relay_fees_miner')
             # F4: the crown must score each direction against its OWN backing. rate_events gains the
             # quote's collateral_chain and collateral_events a backing, so a tao-hub quote/purse is
             # never confused with the sol one. Pre-F4 rows were all sol-backed by construction.
@@ -1006,10 +1029,14 @@ class ValidatorStateStore:
                     miner       TEXT NOT NULL,
                     backing     TEXT NOT NULL,
                     fee         INTEGER NOT NULL,
-                    block_time  INTEGER NOT NULL
+                    block_time  INTEGER NOT NULL,
+                    -- Which vault the fee is owed to. The vault's settled counter restarts at 0 on a
+                    -- replacement, so summing across generations re-charges fees the retired vault
+                    -- already collected.
+                    vault_generation INTEGER NOT NULL DEFAULT 0
                 );
                 CREATE INDEX IF NOT EXISTS idx_relay_fees_miner
-                    ON relay_fees(backing, miner);
+                    ON relay_fees(backing, miner, vault_generation);
 
                 CREATE TABLE IF NOT EXISTS relay_slashes (
                     swap_key      TEXT PRIMARY KEY,

--- a/tests/test_bond_relay.py
+++ b/tests/test_bond_relay.py
@@ -968,3 +968,40 @@ def test_a_fresh_vault_is_still_empty_whatever_the_generation():
 
     assert attestation_job.Attested(0, False, compose(4, 0)).is_empty
     assert not attestation_job.Attested(0, False, compose(4, 1)).is_empty
+
+
+def test_fees_are_scoped_to_the_vault_generation_that_will_collect_them():
+    """A replacement vault restarts its settled counter at 0. If accruals were summed across
+    generations, fees the retired vault already collected would be charged a second time."""
+    store = _store()
+    store.record_relay_fee('aa', MINER, 'tao', 1_800_000, NOW - 100, vault_generation=0)
+    store.record_relay_fee('bb', MINER, 'tao', 500_000, NOW, vault_generation=1)
+
+    assert store.accrued_fee_total(MINER, 'tao', vault_generation=0) == 1_800_000
+    assert store.accrued_fee_total(MINER, 'tao', vault_generation=1) == 500_000
+    # Unscoped stays the whole history — that read is miner discovery, not accounting.
+    assert store.accrued_fee_total(MINER, 'tao') == 2_300_000
+    assert set(store.accrued_fee_totals('tao', vault_generation=1)) == {MINER}
+
+
+def test_attestation_does_not_recharge_fees_the_retired_vault_settled():
+    """The live bug: 0.8 τ posted to a fresh vault was attested as 0.7982 τ because 1.8M rao of
+    already-settled fees came along from the retired vault."""
+    vault = FakeVault()
+    vault.lock[HOTKEY] = (True, 1)
+    vault.collateral[HOTKEY] = 800_000_000
+    vault.settled[HOTKEY] = 0  # a fresh vault has collected nothing yet
+    store = _store()
+    store.record_relay_fee('old', MINER, 'tao', 1_800_000, NOW - 500, vault_generation=0)
+    solana = FakeSolana(
+        miner_states={MINER: _miner_state()},
+        config=SimpleNamespace(last_attest_heartbeat=0, vault_generation=1),
+    )
+    relay = _relay(vault=vault, solana=solana, store=store)
+
+    desired = attestation_job.compute(relay, MINER, HOTKEY)
+    assert desired.effective_balance == 800_000_000, 'the retired vault already collected that fee'
+
+    # A fee earned under the CURRENT generation still nets off, exactly as before.
+    store.record_relay_fee('new', MINER, 'tao', 2_000_000, NOW, vault_generation=1)
+    assert attestation_job.compute(relay, MINER, HOTKEY).effective_balance == 798_000_000


### PR DESCRIPTION
Third and last member of the vault-swap family (after #656 and #658): per-miner state outliving a
per-vault counter.

## The bug

The attested bond is `gross − (accrued − settled)`. `accrued` is the validator's own running total
of fees a miner has earned the protocol; `settled` is what the vault has actually collected. A
**replacement vault restarts `settled` at 0**, while `accrued` keeps its whole history — so fees the
retired vault already collected read as unpaid and get charged a second time.

Seen live on testnet: 0.8 τ posted to the new vault attested as **0.798 τ**, short by exactly the
`1,800,000` rao that the retired vault's `settled_total` already showed.

## Fix

`relay_fees` rows carry the `vault_generation` that will collect them, and the three **accounting**
reads scope to the current generation:

- `attestation.compute` — the double-charge itself
- `exit_relay._advance` — the residual settle before an unlock
- `exit_relay.cadence_entries` — the fee batch. This one mattered as much as the attestation: it
  would have tried to re-settle already-collected fees against a vault that never owed them.

**Miner discovery** (`_bonded_miners`) deliberately keeps reading across all generations — a miner
whose only accruals predate the swap still has a bond to reconcile — so the scope is an explicit
argument rather than a default.

Ingest **refuses to record an accrual it cannot tag**: `ingest_events` already holds the cursor and
replays on failure (F3), so an unreadable config costs a retry, whereas a mis-tagged fee would be
charged against the wrong vault forever.

Pre-existing rows default to generation 0 — where they were genuinely earned, since the generation
only exists from the first bump onward. On mainnet the generation is still 0, so the migration is a
no-op there.

## Tests

Two new: generation-scoped vs unscoped totals, and the live scenario end to end (0.8 τ attesting as
0.8 τ despite a retired-generation accrual, while a current-generation fee still nets off normally).

Python **1566 passed**; the one failure (`test_uppercase_bech32_matches_derived_address`) is
pre-existing on `test` and reproduces with these changes stashed. ruff clean.

**Off-chain only — no program change, no upgrade.** Validator redeploy picks it up; the sqlite
column is added on open, like the per-hub columns before it.