### PR TITLE
Add USDC on Polygon as a launch spoke

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,7 +106,8 @@ BASE_NETWORK=mainnet                # mainnet | sepolia (Base Sepolia)
 BASE_PRIVATE_KEY=
 # OPTIONAL token contract override (dev/e2e fakes) — per ASSET, unset = Circle's canonical deployment
 # BASEUSDC_TOKEN_CONTRACT=
-# ─── Chain: Polygon PoS (POL, polusdc pairs) ───────────────
+# ─── Network: Polygon PoS (pol, polusdc pairs) ─────────────
+# Vars are per NETWORK, shared by every asset on it (POL_ here, not POLUSDC_).
 POL_NETWORK=mainnet                 # mainnet | amoy
 # OPTIONAL ordered JSON-RPC endpoints (keyed providers embed the key in the URL);
 # unset = public (drpc, publicnode); drpc leads as the only rung serving archive state reads

--- a/.env.example
+++ b/.env.example
@@ -106,13 +106,16 @@ BASE_NETWORK=mainnet                # mainnet | sepolia (Base Sepolia)
 BASE_PRIVATE_KEY=
 # OPTIONAL token contract override (dev/e2e fakes) — per ASSET, unset = Circle's canonical deployment
 # BASEUSDC_TOKEN_CONTRACT=
-# ─── Chain: Polygon PoS (POL pairs) ────────────────────────
+# ─── Chain: Polygon PoS (POL, polusdc pairs) ───────────────
 POL_NETWORK=mainnet                 # mainnet | amoy
 # OPTIONAL ordered JSON-RPC endpoints (keyed providers embed the key in the URL);
 # unset = public (drpc, publicnode); drpc leads as the only rung serving archive state reads
 # POL_RPC_URLS=https://polygon-mainnet.infura.io/v3/your_key,https://polygon-bor-rpc.publicnode.com
-# 32-byte hex key — required for miners; optional local signing for `alw swap`
+# 32-byte hex key — required for miners (fund POL for the POL legs, USDC + POL-for-gas for
+# the polusdc legs); optional local signing for `alw swap`
 POL_PRIVATE_KEY=
+# OPTIONAL token contract override (dev/e2e fakes) — per ASSET, unset = Circle's canonical deployment
+# POLUSDC_TOKEN_CONTRACT=
 
 # ─── Chain: Cronos (CRO pairs) ─────────────────────────────
 CRO_NETWORK=mainnet                 # mainnet | testnet

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbit
 Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, SOL ↔ USDC-on-Base, SOL ↔ USDC-on-Ethereum, and SOL ↔ UNI (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
 Currently live with SOL and TAO as hubs, each paired against BTC, ETH, USDC-on-Arbitrum, HYPE, BNB, AVAX, USDC-on-Base, USDC-on-Ethereum, and QNT — plus SOL ↔ TAO itself (hub-and-spoke: every pair has a SOL or TAO leg). Designed to scale to any verifiable asset.
 Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, SOL ↔ USDC-on-Base, SOL ↔ USDC-on-Ethereum, and SOL ↔ POL (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
+Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, SOL ↔ USDC-on-Base, SOL ↔ USDC-on-Ethereum, SOL ↔ POL, and SOL ↔ USDC-on-Polygon (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
 
 ## Miner Risk Disclaimer
 

--- a/allways/assets/__init__.py
+++ b/allways/assets/__init__.py
@@ -17,6 +17,7 @@ from allways.assets.ethusdc import EthUsdc
 from allways.assets.evm_coin import EvmCoin
 from allways.assets.hype import Hype
 from allways.assets.pol import Pol
+from allways.assets.polusdc import PolUsdc
 from allways.assets.qnt import Qnt
 from allways.assets.sol import Sol
 from allways.assets.tao import Tao
@@ -45,6 +46,7 @@ __all__ = [
     'Aster',
     'Uni',
     'Qnt',
+    'PolUsdc',
     'create_assets',
 ]
 
@@ -74,6 +76,7 @@ ASSET_REGISTRY: Tuple[AssetSpec, ...] = (
     AssetSpec('uni', Uni, ()),
     AssetSpec('qnt', Qnt, ()),
     AssetSpec('pol', Pol, ()),
+    AssetSpec('polusdc', PolUsdc, ()),
 )
 
 

--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -49,6 +49,8 @@ TESTNET_TOKEN_CONTRACTS = {
     # Same address as mainnet and byte-identical runtime bytecode (keccak
     # 0xdeba17f1…0868, 12567 bytes) — verified symbol UNI, 18 decimals, 1e27 supply.
     'uni': {'sepolia': '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984'},
+    # Circle-verified native USDC on Polygon Amoy (developers.circle.com, 2026-08-12).
+    'polusdc': {'amoy': '0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582'},
 }
 
 

--- a/allways/assets/polusdc.py
+++ b/allways/assets/polusdc.py
@@ -1,0 +1,12 @@
+from allways.assets.erc20 import Erc20
+from allways.chains import CHAIN_POLUSDC
+
+
+class PolUsdc(Erc20):
+    """USDC on Polygon PoS — a config-row binding of the generic Erc20 (see chains.CHAIN_POLUSDC).
+
+    Rides Polygon's env identity alongside native POL (POL_NETWORK, POL_RPC_URLS,
+    POL_PRIVATE_KEY), adding only its own POLUSDC_TOKEN_CONTRACT override."""
+
+    def __init__(self):
+        super().__init__(CHAIN_POLUSDC)

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -434,10 +434,11 @@ CHAIN_POLUSDC = ChainDefinition(
     # 600s default fulfillment grace. Pinned against CHAIN_POL by test, so neither can drift.
     seconds_per_block=1,
     min_confirmations=100,
-    # Rate sanity floor, not an economic guarantee: 0.01 USDC covers FiatToken's measured 61k-gas
-    # transfer below ~2200 gwei — ~9x the 230-260 gwei base fee Polygon has held for weeks, and ~4x
-    # the maxFeePerGas the provider would set today. Far under ethusdc's 5 USDC because Polygon gas
-    # costs cents, far over arbusdc's unit floor because it is not free either.
+    # Rate sanity floor, not an economic guarantee: 0.01 USDC covers FiatToken's measured 79k-gas
+    # transfer below ~1700 gwei — ~7x the 230-260 gwei base fee Polygon has held for weeks. Priced
+    # on the COLD recipient (79k; a warm one is 61k), since a payout goes to a user's address that
+    # usually holds no USDC yet. Far under ethusdc's 5 USDC because Polygon gas costs cents, far
+    # over arbusdc's unit floor because it is not free either.
     min_onchain_amount=10_000,
     # CHAIN_POL's clock, for the same reason its finality is: what this absorbs is hub-vs-spoke
     # skew, and two assets on one chain disagreeing about that chain's clock would be indefensible.

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -417,6 +417,38 @@ CHAIN_POL = ChainDefinition(
     replay_grace_secs=60,
 )
 
+CHAIN_POLUSDC = ChainDefinition(
+    id='polusdc',
+    name='USDC (Polygon)',
+    native_unit='µUSDC',
+    decimals=6,
+    # Polygon's prefix, shared with CHAIN_POL: one POL_NETWORK / POL_RPC_URLS / POL_PRIVATE_KEY
+    # serves both assets, so they can never disagree about which Polygon they are on.
+    env_prefix='POL',
+    host_chain='polygon',
+    # CHAIN_POL already declares the POL_NETWORK names; a second declaration would render a
+    # duplicate CLI row writing the same var.
+    networks=(),
+    # CHAIN_POL's clock and finality, deliberately identical — two assets on one chain must not
+    # disagree about its reorg depth. 100 blocks = 150s of real 1.5s blocks, inside the program's
+    # 600s default fulfillment grace. Pinned against CHAIN_POL by test, so neither can drift.
+    seconds_per_block=1,
+    min_confirmations=100,
+    # Rate sanity floor, not an economic guarantee: 0.01 USDC covers FiatToken's measured 61k-gas
+    # transfer below ~2200 gwei — ~9x the 230-260 gwei base fee Polygon has held for weeks, and ~4x
+    # the maxFeePerGas the provider would set today. Far under ethusdc's 5 USDC because Polygon gas
+    # costs cents, far over arbusdc's unit floor because it is not free either.
+    min_onchain_amount=10_000,
+    # CHAIN_POL's clock, for the same reason its finality is: what this absorbs is hub-vs-spoke
+    # skew, and two assets on one chain disagreeing about that chain's clock would be indefensible.
+    replay_grace_secs=60,
+    # Circle-verified native USDC on Polygon PoS (developers.circle.com, 2026-08-12) — NOT the
+    # bridged USDC.e at 0x2791Bca1f2de4661eD88A30C99A7a9449Aa84174, which also answers
+    # symbol() == 'USDC' and the FiatToken freeze surface, so only this pin tells them apart.
+    asset_locator='0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
+    refusal_checks=('isBlacklisted(address)', 'paused()'),
+)
+
 SUPPORTED_CHAINS = {
     'btc': CHAIN_BTC,
     'tao': CHAIN_TAO,
@@ -433,6 +465,7 @@ SUPPORTED_CHAINS = {
     'uni': CHAIN_UNI,
     'qnt': CHAIN_QNT,
     'pol': CHAIN_POL,
+    'polusdc': CHAIN_POLUSDC,
 }
 
 

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -116,6 +116,7 @@ LAUNCH_SPOKES = (
     'uni',
     'qnt',
     'pol',
+    'polusdc',
 )
 # Every launch pair as (hub, spoke): each hub pairs against every spoke except itself. sol↔tao
 # lands exactly once (under SOL, its anchor) because sol never appears in LAUNCH_SPOKES.

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -19,6 +19,7 @@ from allways.chains import (
     CHAIN_ETHUSDC,
     CHAIN_HYPE,
     CHAIN_POL,
+    CHAIN_POLUSDC,
     CHAIN_QNT,
     CHAIN_TAO,
     CHAIN_UNI,
@@ -72,6 +73,9 @@ class TestGetChain:
 
     def test_pol(self):
         assert get_chain_def('pol') is CHAIN_POL
+
+    def test_polusdc(self):
+        assert get_chain_def('polusdc') is CHAIN_POLUSDC
 
     def test_unsupported_raises(self):
         with pytest.raises(KeyError):
@@ -250,6 +254,12 @@ class TestComputeExtensionTargetSecs:
         cover = compute_extension_target_secs('pol', 0, worst_phase, self.CEILING) - worst_phase
         assert cover == 220
         assert cover >= CHAIN_POL.min_confirmations * 1.5
+
+    def test_polusdc_matches_the_chain_it_shares(self):
+        # A token and its host coin must extend identically — same confs, same stored block time.
+        assert compute_extension_target_secs('polusdc', 0, self.NOW, self.CEILING) == compute_extension_target_secs(
+            'pol', 0, self.NOW, self.CEILING
+        )
 
     def test_unsupported_chain_raises(self):
         with pytest.raises(KeyError):

--- a/tests/test_polusdc_provider.py
+++ b/tests/test_polusdc_provider.py
@@ -1,0 +1,299 @@
+"""PolUsdc unit tests — all offline (RPC layer mocked, signing is pure crypto).
+
+Generic ERC-20 behaviour is proven by the arbusdc and ethusdc suites; this covers what is
+polusdc-specific. Two things, chiefly:
+
+- **The shared env identity.** polusdc rides Polygon's row alongside native POL, so ONE
+  POL_NETWORK moves both. A second prefix here would leave polusdc reading an unset var,
+  silently defaulting to mainnet, and a testnet miner would pay real USDC against test swaps.
+- **The pin.** Bridged USDC.e on Polygon answers ``symbol() == 'USDC'`` and the whole FiatToken
+  freeze surface, so the boot probe cannot tell it from Circle's native deployment — only the
+  registry's asset_locator does. The address is the safety property; it is pinned here.
+"""
+
+import pytest
+
+from allways.assets.asset import ProviderUnreachableError
+from allways.assets.erc20 import SEL_IS_BLACKLISTED, SEL_TRANSFER, TESTNET_TOKEN_CONTRACTS, TRANSFER_TOPIC0
+from allways.assets.pol import Pol
+from allways.assets.polusdc import PolUsdc
+from allways.chains import CHAIN_POL, CHAIN_POLUSDC, get_chain_def
+from allways.constants import LAUNCH_SPOKES
+
+TEST_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'  # hardhat account #0
+SENDER = '0x' + '11' * 20
+RECIPIENT = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+CONTRACT = TESTNET_TOKEN_CONTRACTS['polusdc']['amoy']
+# Bridged USDC.e — real, live, and symbol-identical to the native token. Pinning it would make
+# miners pay in an asset nobody quoted, so it stands in for the counterfeit here.
+BRIDGED = '0x2791Bca1f2de4661eD88A30C99A7a9449Aa84174'
+TX = '0x' + 'ab' * 32
+BLOCK_HASH = '0x' + 'cd' * 32
+AMOUNT = 150_000_000  # 150 USDC in µUSDC
+AMOY_ID = 80_002
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    monkeypatch.setenv('POL_NETWORK', 'amoy')
+    for var in ('POL_RPC_URLS', 'POL_PRIVATE_KEY', 'POLUSDC_TOKEN_CONTRACT'):
+        monkeypatch.delenv(var, raising=False)
+    return PolUsdc()
+
+
+def rpc_stub(provider, responses: dict):
+    """Replace eth_rpc with a method→response map. A callable value is invoked with params."""
+
+    def fake_rpc(method, params, timeout=15, **kw):
+        value = responses[method]
+        return value(params) if callable(value) else value
+
+    provider.chain.eth_rpc = fake_rpc  # the asset talks through its chain (composed seam)
+    return provider
+
+
+def topic(address: str) -> str:
+    return '0x' + '00' * 12 + address.lower().removeprefix('0x')
+
+
+def transfer_log(contract=CONTRACT, recipient=RECIPIENT, amount=AMOUNT) -> dict:
+    return {
+        'address': contract,
+        'topics': [TRANSFER_TOPIC0, topic(SENDER), topic(recipient)],
+        'data': hex(amount),
+        'transactionHash': TX,
+    }
+
+
+def mined(logs=None, status='0x1', tip=1_000_100, block=None) -> dict:
+    return {
+        'eth_getTransactionByHash': {'hash': TX, 'blockNumber': '0xf4240', 'blockHash': BLOCK_HASH},
+        'eth_getTransactionReceipt': {
+            'status': status,
+            'blockNumber': '0xf4240',
+            'blockHash': BLOCK_HASH,
+            'logs': [transfer_log()] if logs is None else logs,
+        },
+        'eth_blockNumber': hex(tip),
+        'eth_getBlockByNumber': {'hash': BLOCK_HASH, 'timestamp': '0x64'} if block is None else block,
+    }
+
+
+class TestRegistryRow:
+    def test_row_is_a_launch_spoke_on_polygons_identity(self, provider):
+        assert provider.chain_def is CHAIN_POLUSDC is get_chain_def('polusdc')
+        assert 'polusdc' in LAUNCH_SPOKES
+        assert (CHAIN_POLUSDC.env_prefix, CHAIN_POLUSDC.host_chain) == (CHAIN_POL.env_prefix, CHAIN_POL.host_chain)
+        # CHAIN_POL owns POL_NETWORK; a second declaration renders a duplicate CLI row.
+        assert CHAIN_POLUSDC.networks == ()
+
+    def test_denomination_is_pinned(self):
+        # decimals is the only row field with no other allways-side guard: das mirrors it, but
+        # das's drift gate runs only after this merges, so a typo would otherwise ship green.
+        assert (CHAIN_POLUSDC.decimals, CHAIN_POLUSDC.native_unit) == (6, 'µUSDC')
+
+    def test_the_pinned_contract_is_circles_native_deployment(self):
+        # The bridged token is symbol-identical and answers the same freeze surface, so nothing
+        # downstream can tell them apart — this pin is the whole defence.
+        assert CHAIN_POLUSDC.asset_locator == '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359'
+        assert CHAIN_POLUSDC.asset_locator.lower() != BRIDGED.lower()
+        assert CHAIN_POLUSDC.refusal_checks == ('isBlacklisted(address)', 'paused()')
+
+    def test_finality_and_clock_match_the_chain_it_shares(self):
+        # Two assets on one chain must not disagree about its reorg depth or its clock. Compared
+        # against CHAIN_POL rather than against literals, so restating a number cannot drift it.
+        assert (
+            CHAIN_POLUSDC.min_confirmations,
+            CHAIN_POLUSDC.seconds_per_block,
+            CHAIN_POLUSDC.replay_grace_secs,
+        ) == (CHAIN_POL.min_confirmations, CHAIN_POL.seconds_per_block, CHAIN_POL.replay_grace_secs)
+        # 100 confs x 1.5s real = 150s, inside the program's 600s default fulfillment grace.
+        assert CHAIN_POLUSDC.min_confirmations * 1.5 < 600
+
+
+class TestSharedEnvIdentity:
+    @pytest.mark.parametrize('network,chain_id', (('mainnet', 137), ('amoy', AMOY_ID)))
+    def test_one_pol_network_moves_both_assets(self, monkeypatch, network, chain_id):
+        monkeypatch.setenv('POL_NETWORK', network)
+        assert PolUsdc().chain.chain_id == Pol().chain.chain_id == chain_id
+
+    def test_token_contract_follows_the_shared_network(self, provider, monkeypatch):
+        assert provider.token_contract == CONTRACT  # amoy deployment, off POL_NETWORK
+        monkeypatch.setenv('POL_NETWORK', 'mainnet')
+        assert PolUsdc().token_contract == CHAIN_POLUSDC.asset_locator
+
+    def test_env_override_wins(self, monkeypatch):
+        monkeypatch.setenv('POLUSDC_TOKEN_CONTRACT', '0x' + '42' * 20)
+        assert PolUsdc().token_contract == '0x' + '42' * 20
+
+    def test_unknown_network_raises(self, monkeypatch):
+        monkeypatch.setenv('POL_NETWORK', 'amoi')
+        with pytest.raises(ValueError, match='POL_NETWORK'):
+            PolUsdc()
+
+    def test_wrong_network_endpoint_fails_startup(self, provider):
+        # Amoy configured, a mainnet endpoint answering: reject outright rather than quietly
+        # verify legs against the wrong chain.
+        rpc_stub(provider, {'eth_chainId': '0x89'})
+        with pytest.raises(ConnectionError, match=f'expected {AMOY_ID}'):
+            provider.check_connection(require_send=False)
+
+    def test_codeless_contract_fails_startup(self, provider):
+        rpc_stub(provider, {'eth_chainId': hex(AMOY_ID), 'eth_blockNumber': '0x10', 'eth_getCode': '0x'})
+        with pytest.raises(ConnectionError, match='no code'):
+            provider.check_connection(require_send=False)
+
+
+class TestVerification:
+    def test_settled_transfer_matches_with_sender_pinned(self, provider):
+        rpc_stub(provider, mined())
+        info = provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT)
+        assert info.confirmed and info.amount == AMOUNT and info.block_time == 0x64
+        assert info.sender == SENDER.lower()
+
+    def test_below_min_confs_unconfirmed(self, provider):
+        rpc_stub(provider, mined(tip=1_000_098))  # 99 confs of the 100 required
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT).confirmed is False
+
+    def test_reverted_rejected(self, provider):
+        # Inclusion is not settlement: a reverted tx moved no funds.
+        rpc_stub(provider, mined(status='0x0'))
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+    def test_underpay_rejected(self, provider):
+        rpc_stub(provider, mined(logs=[transfer_log(amount=AMOUNT - 1)]))
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+    def test_wrong_recipient_rejected(self, provider):
+        rpc_stub(provider, mined(logs=[transfer_log(recipient=SENDER)]))
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+    def test_absent_tx_is_absent(self, provider):
+        rpc_stub(provider, {'eth_getTransactionByHash': None})
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+    def test_receipt_unavailable_is_unknown_not_absent(self, provider):
+        # 'unknown' must never read as 'no such payment' — that verdict slashes a paying miner.
+        with pytest.raises(ProviderUnreachableError):
+            rpc_stub(provider, dict(mined(), eth_getTransactionReceipt=None)).fetch_matching_tx(
+                TX, RECIPIENT.lower(), AMOUNT
+            )
+
+    def test_missing_block_timestamp_is_unknown_not_absent(self, provider):
+        with pytest.raises(ProviderUnreachableError):
+            rpc_stub(provider, mined(block={'hash': BLOCK_HASH})).fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT)
+
+    def test_a_bridged_usdc_transfer_never_settles_the_leg(self, provider):
+        """USDC.e pays the right recipient the right amount and logs a well-formed Transfer.
+        Only the pinned address rejects it — and the reject must survive the re-verify, since
+        the settled cache is written from a pinned-contract match alone."""
+        rpc_stub(provider, mined(logs=[transfer_log(contract=BRIDGED)]))
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+        assert provider._settled_cache == {}
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+    def test_pending_transfer_to_bridged_usdc_rejected(self, provider):
+        calldata = SEL_TRANSFER + topic(RECIPIENT).removeprefix('0x') + f'{AMOUNT:064x}'
+        pending = {'hash': TX, 'from': SENDER, 'to': BRIDGED, 'input': calldata, 'blockNumber': None}
+        rpc_stub(provider, {'eth_getTransactionByHash': pending})
+        assert provider.fetch_matching_tx(TX, RECIPIENT.lower(), AMOUNT) is None
+
+
+class TestIssuerGates:
+    """USDC is Circle's FiatToken, so isBlacklisted/paused answer — verified live on both networks."""
+
+    def views(self, provider, blacklisted=False, paused=False):
+        def call(params):
+            hit = blacklisted if params[0]['data'].startswith(SEL_IS_BLACKLISTED) else paused
+            return f'0x{int(hit):064x}'
+
+        return rpc_stub(provider, {'eth_call': call, 'eth_blockNumber': hex(1_000_000)})
+
+    def test_clean_dest_passes_reserve(self, provider):
+        assert self.views(provider).can_deliver_to(RECIPIENT, AMOUNT) is True
+
+    @pytest.mark.parametrize('gate', ('blacklisted', 'paused'))
+    def test_issuer_freeze_bounces_reserve_and_defers_the_slash(self, provider, gate):
+        # Freezing the payout address after reserve makes delivery impossible through no fault
+        # of the miner — positive evidence, never a slash.
+        p = self.views(provider, **{gate: True})
+        assert p.can_deliver_to(RECIPIENT, AMOUNT) is False
+        assert p.delivery_refused(RECIPIENT, 0) is True
+
+    def test_slash_gate_raises_on_rpc_trouble(self, provider):
+        def boom(params):
+            raise ConnectionError('down')
+
+        rpc_stub(provider, {'eth_call': boom})
+        with pytest.raises(ConnectionError):  # a flaky RPC postpones a slash, never falsifies one
+            provider.delivery_refused(RECIPIENT, 0)
+
+
+class TestSendGuards:
+    SEND = {
+        'eth_blockNumber': hex(100),
+        'eth_getBlockByNumber': {'baseFeePerGas': hex(250 * 10**9)},  # Polygon's sustained base fee
+        'eth_maxPriorityFeePerGas': hex(30 * 10**9),
+        'eth_getTransactionCount': '0x0',
+        'eth_getBalance': hex(10**18),
+        'eth_estimateGas': hex(61_000),  # measured on a real mainnet USDC transfer
+        'eth_call': f'0x{AMOUNT:064x}',  # balanceOf
+    }
+
+    def test_no_key_refused(self, provider):
+        assert provider.send_amount(RECIPIENT, AMOUNT) is None
+        assert 'POL_PRIVATE_KEY' in provider.last_send_error
+
+    def test_key_mismatch_refused(self, provider, monkeypatch):
+        monkeypatch.setenv('POL_PRIVATE_KEY', TEST_KEY)
+        assert provider.send_amount(RECIPIENT, AMOUNT, from_address=RECIPIENT) is None
+        assert 'key mismatch' in provider.last_send_error
+
+    def test_insufficient_token_balance_refused(self, provider, monkeypatch):
+        monkeypatch.setenv('POL_PRIVATE_KEY', TEST_KEY)
+        rpc_stub(provider, dict(self.SEND, eth_call=f'0x{AMOUNT - 1:064x}'))
+        assert provider.send_amount(RECIPIENT, AMOUNT) is None
+        assert 'insufficient balance' in provider.last_send_error
+
+    def test_gas_poor_miner_refuses_before_broadcasting(self, provider, monkeypatch):
+        # USDC-rich but POL-poor: refuse here rather than burn a revert. Polygon's gas is cheap
+        # in dollars and expensive in POL units, so this is a live failure mode, not a theory.
+        monkeypatch.setenv('POL_PRIVATE_KEY', TEST_KEY)
+        rpc_stub(provider, dict(self.SEND, eth_getBalance=hex(10**15)))
+        assert provider.send_amount(RECIPIENT, AMOUNT) is None
+        assert 'Insufficient gas balance' in provider.last_send_error
+
+    def test_broadcast_returns_a_hash(self, provider, monkeypatch):
+        monkeypatch.setenv('POL_PRIVATE_KEY', TEST_KEY)
+        rpc_stub(provider, dict(self.SEND, eth_sendRawTransaction=TX))
+        assert provider.send_amount(RECIPIENT, AMOUNT) == (TX, 0)
+
+
+class TestDepositScanner:
+    def test_scan_window_is_the_full_unbounded_lookback(self, provider):
+        """C8: Erc20 has no MAX_WALK_BLOCKS, so this whole span goes out as ONE eth_getLogs.
+
+        300 blocks is served by publicnode on both Polygon networks and refused by mainnet drpc
+        past ~100, so the scanner fails over on every call and runs effectively single-rung.
+        Pinned so C8's span cap has a test to change rather than a silent behaviour to break."""
+        seen = {}
+
+        def logs(params):
+            seen.update(params[0])
+            return [transfer_log()]
+
+        assert provider.SCAN_LOOKBACK_BLOCKS == 300  # 300s // 1s-per-block
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getLogs': logs})
+        assert provider.find_recent_outgoing(SENDER, RECIPIENT, AMOUNT) == TX
+        assert int(seen['fromBlock'], 16) == 10_000 - 300 + 1
+        assert seen['address'] == CONTRACT
+
+    def test_failed_range_parks_the_cursor(self, provider):
+        def boom(params):
+            raise ConnectionError('down')
+
+        rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getLogs': boom})
+        assert provider.find_recent_outgoing(SENDER, RECIPIENT, AMOUNT) is None
+        # Never leap a range the scan could not read — the deposit in it must stay reachable.
+        key = (SENDER.lower(), RECIPIENT.lower(), AMOUNT)
+        assert provider.scan_cursors[key] == 10_000 - provider.SCAN_LOOKBACK_BLOCKS

--- a/tests/test_polusdc_provider.py
+++ b/tests/test_polusdc_provider.py
@@ -273,9 +273,11 @@ class TestDepositScanner:
     def test_scan_window_is_the_full_unbounded_lookback(self, provider):
         """C8: Erc20 has no MAX_WALK_BLOCKS, so this whole span goes out as ONE eth_getLogs.
 
-        300 blocks is served by publicnode on both Polygon networks and refused by mainnet drpc
-        past ~100, so the scanner fails over on every call and runs effectively single-rung.
-        Pinned so C8's span cap has a test to change rather than a silent behaviour to break."""
+        publicnode leads the mainnet ladder and serves all 300 blocks, and eth_rpc returns on the
+        first success — so nothing fails over and nothing is wasted. The cost is that drpc cannot
+        serve this span at all (it caps at 101 blocks), leaving the scanner with no working
+        fallback rung on mainnet. Pinned so C8's span cap has a test to change rather than a
+        silent behaviour to break."""
         seen = {}
 
         def logs(params):


### PR DESCRIPTION
Adds Circle's native USDC on Polygon PoS as a launch spoke: one `ChainDefinition`, a 12-line `Erc20` binding, one `TESTNET_TOKEN_CONTRACTS` row, and the registry/spoke entries. No shared-code logic changes.

Requested by a real user: Polymarket settles in USDC on Polygon, so this is the leg with actual demand.

**Base note.** This targets `feat/pol-spoke` ([#655](https://github.com/entrius/allways/pull/655)), which itself targets `refactor/erc20-refusal-interface` ([#647](https://github.com/entrius/allways/pull/647)). The stack is **#647 → #655 → this**, kept linear on purpose. Both dependencies are real, not cosmetic: #647 gives the `issuer_controls` declaration this row uses, and #655 creates the Polygon `EvmNetwork` row and owns the `POL_*` env identity this asset rides. The head engineer retargets each PR to `test` as the one below it lands.

**No CI runs at this base.** `test.yml` and `lint.yml` both fire on `pull_request: branches: [main, test]`, so GitHub reports **no checks** until this is retargeted. Local verification is therefore the only verification; every result below is a real run, pasted verbatim.

**Multi-hub.** `LAUNCH_PAIRS` is derived over `HUB_CHAINS = ('sol', 'tao')`, so this spoke creates **two** pairs, `sol-polusdc` and `tao-polusdc`. Miners are expected to quote the TAO leg as well as the SOL leg.

## Wiring — it rides Polygon, it does not redeclare it

`polusdc` is the second asset on the network #655 added, exactly as `ethusdc` rides `CHAIN_ETH` and `aster` rides `CHAIN_BNB`.

| field | value | why |
|---|---|---|
| `host_chain` | `polygon` | the `EvmNetwork` row #655 added |
| `env_prefix` | `POL` | one `POL_NETWORK` / `POL_RPC_URLS` / `POL_PRIVATE_KEY` moves both assets, so they can never disagree about which Polygon they are on |
| `networks` | `()` | `CHAIN_POL` already declares the network names; a second declaration renders a **duplicate CLI row writing the same var** |
| `decimals` | 6 | `decimals()` read live on both networks |
| `issuer_controls` | `fiattoken` | Circle FiatToken — `isBlacklisted` / `paused` both answer, verified live on both rungs of both networks |
| `min_confirmations`<br>`seconds_per_block`<br>`replay_grace_secs` | 100 / 1 / 60 | **`CHAIN_POL`'s exactly.** Two assets on one chain disagreeing about its reorg depth or its clock is indefensible. Inherited from #655's rationale, not re-derived. |

Because `networks=()`, `NAME_SELECTED_CHAINS = tuple(c for c in SUPPORTED_CHAINS.values() if c.networks)` excludes this row **structurally** — so `tests/test_cli_chain_networks.py` needed **no change**, and `alw config` grows **no** `polusdc-network` row. Both verified below rather than assumed.

The finality/clock equality is pinned **against `CHAIN_POL` itself**, not against restated literals, so neither row can drift away from the other:

```python
tests/test_polusdc_provider.py::TestRegistryRow::test_finality_and_clock_match_the_chain_it_shares
assert (CHAIN_POLUSDC.min_confirmations, CHAIN_POLUSDC.seconds_per_block, CHAIN_POLUSDC.replay_grace_secs) == (
    CHAIN_POL.min_confirmations, CHAIN_POL.seconds_per_block, CHAIN_POL.replay_grace_secs)
```

`decimals` and `native_unit` are pinned too. `decimals` is the one row field with no other allways-side guard — das mirrors it, but das's drift gate only runs *after* this merges, so a typo would otherwise ship green.

## ⚠️ The pin is the safety property — native USDC vs bridged USDC.e

Polygon carries **two** live tokens that both answer `symbol() == "USDC"`. Probed live, mainnet, same block:

| | pinned (Circle native) | bridged USDC.e |
|---|---|---|
| address | `0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359` | `0x2791Bca1f2de4661eD88A30C99A7a9449Aa84174` |
| `symbol()` | `USDC` | **`USDC`** — identical |
| `name()` | `USD Coin` | `USD Coin (PoS)` |
| `decimals()` | 6 | 6 |
| `totalSupply()` | 614,487,487.88 | 990,400,823.53 |
| `isBlacklisted(0x0)` | answers `0x00…0` | **answers `0x00…0`** |
| `paused()` | answers `0x00…0` | **answers `0x00…0`** |
| CoinGecko slug (by contract) | `usd-coin` | `bridged-usdc-polygon-pos-bridge` |

The bridged token answers the **entire FiatToken freeze surface**, so #647's boot-time `_falsify_declaration` probe passes on it just as happily. Nothing downstream can tell the two apart — **only `asset_locator` does**. Pinning the wrong one would make miners pay in an asset nobody quoted. The contrast is written into the registry comment (`CHAIN_BASEUSDC`'s USDbC comment is the precedent) and pinned by `test_the_pinned_contract_is_circles_native_deployment`, and the bridged address stands in for the counterfeit in the verification tests rather than a made-up `0x99…` — a real, live, symbol-identical near-miss is the sharper fixture.

**Both addresses come from Circle's own published list** ([developers.circle.com/stablecoins/usdc-contract-addresses](https://developers.circle.com/stablecoins/usdc-contract-addresses)), not a block-explorer search:

| network | address | verified |
|---|---|---|
| Polygon PoS mainnet | `0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359` | Circle's list; code present (3706 chars), `decimals()` = 6, `symbol()` = `USDC` |
| Polygon Amoy | `0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582` | Circle's list; code present (3598 chars), `decimals()` = 6, `symbol()` = `USDC` |

## Token diligence

`issuer_controls='fiattoken'` is declared, **not** `unfreezable` — so there is **no immutability burden** here. USDC is an upgradeable proxy with a live admin, and for a Circle token that is correct and expected. No bytecode disassembly or proxy-slot proof is claimed or needed.

Everything below is a real transaction, not a docs link.

### Not fee-on-transfer — recipient balance delta equals the `Transfer` log value exactly

Recipients chosen so they are touched **exactly once** in their block, so the delta is attributable to the one transfer and nothing else. Historical `balanceOf` read from the archive rung.

```
mainnet  tx 0x4611fcb9763ec066141e433fcde75502a2867266e560dafe29e3453798bf5ad0
  Transfer log value                     82723040 µUSDC
  balanceOf(0x6ae8…2b5D) @91912485 = 0
  balanceOf(0x6ae8…2b5D) @91912486 = 82723040
  DELTA 82723040 == 82723040   ->  True

amoy     tx 0xee5e57179d9809dedc87aa426483b2d72020675ab880ae7c235a36a0a2f6fc2b
  Transfer log value                     9973 µUSDC
  balanceOf(0xa150…13f0) @44754805 = 100558677
  balanceOf(0xa150…13f0) @44754806 = 100568650
  DELTA 9973 == 9973           ->  True
```

A second independent mainnet sample earlier in the pass matched the same way (`0x34ae4708…8736d`, delta 2120000 == log 2120000).

### Standard `Transfer` event — topic0 recomputed, not transcribed

```python
'0x' + keccak(text='Transfer(address,address,uint256)').hex()
  = 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef
```

Decoded from the real mainnet log above, 3 topics, value in `data`:

```
log.address  0x3c499c542cef5e3811e1192ce70d8cc03d5c3359   == pinned contract: True
log.topics[0] 0xddf252ad…3b3ef                            == recomputed keccak: True
decoded      0xf70da97812CB96acDF810712Aa562db8dfA3dbEF -> 0x6ae8d7E7eA9F0A4E62535440180F41b3Cf732b5D
             value 82723040 µUSDC
```

### `transfer` return convention — no revert-on-false weirdness

Both sampled transfers carry `receipt.status == 0x1` with the `Transfer` log present. `tx.value == 0` and `tx.to == <token contract>`, i.e. an ordinary `transfer(address,uint256)` call, settled. Measured `gasUsed` on a real mainnet transfer: **60,179**; `eth_estimateGas` for the same shape: **60,977** — comfortably under `MAX_TOKEN_TRANSFER_GAS = 150_000`, so the miner's estimate is never clipped by the cap.

### Not rebasing

FiatToken mints and burns against a plain `balances` mapping; there is no supply-rescaling path, and the balance deltas above are exactly the transferred amounts at two different blocks on two different networks. No drift between reserve and confirm.

## Judgement call — `min_onchain_amount = 10_000` (0.01 USDC)

The one genuine decision here. Neither `arbusdc`'s `1` nor `ethusdc`'s 5 USDC is right, and both would be wrong by roughly two orders of magnitude in opposite directions.

Priced off a real FiatToken transfer, not a 21k-gas native send:

| input | measured |
|---|---|
| gas for a Polygon USDC `transfer` | **61k warm / 79k cold** — `gasUsed` 60,179 on a real mainnet tx and `eth_estimateGas` 60,977 to an existing holder, but **79,000** to an address that has never held USDC (cold balance slot) |
| base fee, sustained | 230–260 gwei (250.6 gwei at head this run; #655 measured the same band over 417h of `eth_feeHistory`) |
| `eth_gasPrice` / `eth_maxPriorityFeePerGas` | 279 gwei / 30 gwei |
| `maxFeePerGas` the provider would set today | `2 × base + priority` ≈ **530 gwei** |
| POL | $0.074518 |

**Derived from the cold case, not the warm one.** A miner's payout goes to a *user's* address, which on this workload is frequently a first-time USDC-on-Polygon recipient — so 79k is the common case here, not the exception.

```
realistic-high 1500 gwei (≈6x sustained base):  79k × 1500 gwei = 0.1185 POL = $0.0088
floor chosen                                    0.01 USDC       = $0.0100
=> 0.01 USDC covers a 79k-gas cold transfer up to ~1700 gwei
   ≈ 6.8x the sustained base fee   (warm 61k would read ~2200 gwei / ~8.8x)
```

The floor still clears a realistic-high cold transfer ($0.0088 < $0.0100) with room to spare, so `10_000` stands unchanged — only the stated headroom moves, from ~9x to ~6.8x. That is the same standard `ethusdc` sets (its 5 USDC covers 65k gas up to ~41 gwei, likewise ~1x a realistic-high L1 transfer), applied to a chain where gas costs a third of a cent instead of five dollars. It lands 500x under `ethusdc` and four orders of magnitude over `arbusdc`'s unit floor, which is exactly the spread between L1 gas, Polygon gas, and free.

**This is a rate-sanity input to `is_executable_rate` / `min_executable_sol_leg`, not an enforced per-swap minimum.** The enforced bounds are the program's `min_swap_amount` / `max_swap_amount` in SOL lamports. A payout below this floor is still reachable. Miners price real gas into their quotes.

## Live read-only verification — both networks

No funds moved. Full script output, driving the real `PolUsdc` provider:

```
########## mainnet (Polygon JSON-RPC (mainnet): polygon-bor-rpc.publicnode.com, polygon.drpc.org — token 0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359)
  check_connection(require_send=False)     OK  (boot probe falsified the fiattoken declaration)
  tip                                      91912586
  real settled USDC transfer               0x4611fcb9763ec066141e433fcde75502a2867266e560dafe29e3453798bf5ad0
    from 0xf70da97812CB96acDF810712Aa562db8dfA3dbEF  to 0x6ae8d7E7eA9F0A4E62535440180F41b3Cf732b5D  value 82723040 µUSDC (82.723040 USDC)
    log.address 0x3c499c542cef5e3811e1192ce70d8cc03d5c3359 == pinned 0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359: True
    topic0 == keccak(Transfer(address,address,uint256)): True
    receipt.status 0x1  (transfer returned true, no revert-on-false)
  verify (EIP-55 recipient, sender pinned) OK  confirmed=True block_time=1786573756
  underpayment (expect value+1)            correctly rejected
  wrong sender                             correctly rejected
  wrong recipient                          correctly rejected
  unknown tx                               correctly absent (None)
  get_balance(0x6ae8d7E7eA…)       82723040 µUSDC
  fee-on-transfer proof                    balanceOf@91912485=0 → @91912486=82723040
    delta 82723040 == Transfer log value 82723040: True  (NOT fee-on-transfer)
  rung chain-id checked                    https://polygon-bor-rpc.publicnode.com -> 137
  rung chain-id checked                    https://polygon.drpc.org -> 137

########## amoy (Polygon JSON-RPC (amoy): polygon-amoy-bor-rpc.publicnode.com, polygon-amoy.drpc.org — token 0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582)
  check_connection(require_send=False)     OK  (boot probe falsified the fiattoken declaration)
  tip                                      44755471
  real settled USDC transfer               0xee5e57179d9809dedc87aa426483b2d72020675ab880ae7c235a36a0a2f6fc2b
    from 0x7FE91b0dEdF5F37cdee43bd15605fD9fB3c5c372  to 0xa150C6674E5e3Aa0bF3E56bd69F9a97A414713f0  value 9973 µUSDC (0.009973 USDC)
    log.address 0x41e94eb019c0762f9bfcf9fb1e58725bfb0e7582 == pinned 0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582: True
    topic0 == keccak(Transfer(address,address,uint256)): True
    receipt.status 0x1  (transfer returned true, no revert-on-false)
  verify (EIP-55 recipient, sender pinned) OK  confirmed=True block_time=1786573247
  underpayment (expect value+1)            correctly rejected
  wrong sender                             correctly rejected
  wrong recipient                          correctly rejected
  unknown tx                               correctly absent (None)
  get_balance(0xa150C6674E…)       100568650 µUSDC
  fee-on-transfer proof                    balanceOf@44754805=100558677 → @44754806=100568650
    delta 9973 == Transfer log value 9973: True  (NOT fee-on-transfer)
  rung chain-id checked                    https://polygon-amoy-bor-rpc.publicnode.com -> 80002
  rung chain-id checked                    https://polygon-amoy.drpc.org -> 80002

ALL LIVE CHECKS PASSED
```

Both recipients were passed in **EIP-55 mixed case** against lowercase on the wire, so the compare went through `normalize_address` rather than string equality, and the sender was pinned on every call. Both transfers are past `min_confirmations`, so `confirmed=True` is proven rather than assumed. `check_connection` exercises #647's `_falsify_declaration`, which confirms on the live contract that the declared FiatToken surface is really there.

### Issuer surface, both rungs, both networks

```
                        isBlacklisted(addr)                 paused()
mainnet publicnode      0x…01 (answered)                    0x…00 (answered)
mainnet drpc            0x…01 (answered)                    0x…00 (answered)
amoy    publicnode      0x…01 (answered)                    0x…00 (answered)
amoy    drpc            0x…01 (answered)                    0x…00 (answered)
```

The `01` is real: Circle blacklists the token's own address (the probe's argument), which is why `_falsify_declaration` only asks *whether the call was answered*, never what it answered. `fiattoken` is the right declaration on all four rungs.

## Tests and lint

```
$ ruff format --check .   ->  185 files already formatted
$ ruff check .            ->  All checks passed!
$ pytest tests/ -q        ->  1599 passed, 6 deselected, 3 warnings in 11.34s
```

- New `tests/test_polusdc_provider.py`, fully offline (RPC stubbed with a method→response map): registry row incl. pinned `decimals`/`native_unit`/`asset_locator`, the `CHAIN_POL` equality, shared env identity across both networks, token-contract resolution + `POLUSDC_TOKEN_CONTRACT` override, wrong-network and codeless-contract startup rejection, settled / 100th-vs-99th confirmation / reverted / underpaid / wrong-recipient / absent verification, receipt-unavailable and timestamp-unavailable both **raising**, the bridged-USDC.e reject on both the log path and the pending-calldata path (and across the settled cache), both issuer gates plus the RPC-trouble raise, send guards, and the scanner's window + cursor parking.
- `tests/test_chains.py`: registry lookup, plus an extension-target case asserting `polusdc` extends **identically to `pol`** rather than to a literal.
- `tests/test_cli_chain_networks.py`: **no change needed**, as predicted — `networks=()` excludes this row structurally. Confirmed, not assumed:
  ```
  polusdc in NAME_SELECTED_CHAINS: False
  polusdc-network in CHAIN_NETWORK_KEYS: False
  CHAIN_NETWORK_KEYS: ('btc-network', 'eth-network', 'arb-network', 'hype-network',
                       'bnb-network', 'avax-network', 'base-network', 'pol-network')
  ```
- `tests/test_rate.py`: no new cases. 6 decimals is already covered by the USDC family.
- The id is **7 characters**, under the `VARCHAR(10)` limit every chain column in `allways-db` carries; `test_ids_are_lowercase_and_fit_the_wire` covers it automatically.

## CLI surfaces — derived, not written

```
$ alw miner quotes --help
  --polusdc-price     NUMBER   POLUSDC per 1 hub unit (0/omit to skip POLUSDC).
  --polusdc-address   TEXT     Your POLUSDC address.

$ alw config
  │ base-network   │ mainnet │ default │
  │ pol-network    │ mainnet │ default │      <- no polusdc-network row, by design
```

Adding this asset touched **no** CLI file.

## e2e

`sol-polusdc` and `polusdc-sol` appear in `alw-utils` `run-suites.sh --list` with **zero harness edits**:

```
$ PYTHONPATH=<this branch> ./run-suites.sh --list
  sol-pol
  pol-sol
  sol-polusdc
  polusdc-sol

$ ./run-suites.sh --list          # branch off PYTHONPATH
  (0 polusdc rows)
```

They vanish without the branch, so they are derived from `LAUNCH_SPOKES`, not written. **I did not run the suite** — it needs the full local Solana stack and several agents share this machine.

## Emission dilution — per PAIR

`MINER_POOL_SHARE / (2 × len(LAUNCH_PAIRS))`, computed from this branch. Not the dead single-hub `2 × len(LAUNCH_SPOKES)` formula.

| | spokes | pairs | directions | zero-volume floor per direction |
|---|---|---|---|---|
| base (#655, with `pol`) | 10 | 19 | 38 | 0.2632% |
| with `polusdc` | 11 | **21** | 42 | **0.2381%** |

A 9.5% cut to the equal-split floor, because `polusdc` costs **two** pairs, not one. `DIRECTION_POOLS[('sol','polusdc')] == DIRECTION_POOLS[('tao','polusdc')] == 0.00238095…`. `POOL_VOLUME_ALPHA = 0.66` means a busy pair recovers most of it; a pair with no volume does not. The number moves again as the sibling assets in this batch land.

## Two open shared-code bugs, as they apply here — reported, not fixed

### C8 — the token deposit scanner asks for a range one rung refuses

`SCAN_LOOKBACK_BLOCKS = SCAN_LOOKBACK_SECS // seconds_per_block = 300 // 1 = 300`, and `Erc20.find_recent_outgoing` issues **one** `eth_getLogs` across that whole span. It has **no walk bound** — `EvmCoin`'s `MAX_WALK_BLOCKS = 32` (`evm_coin.py:325`) does not apply to tokens, and that asymmetry is the bug.

Measured live with the production filter (address-pinned + topic0), this run:

| span | mainnet publicnode | mainnet drpc | amoy publicnode | amoy drpc |
|---|---|---|---|---|
| 25 blk | ✅ 284 logs | ✅ 269 logs | ✅ | ✅ |
| 100 blk | ✅ 1533 | ✅ 1516 | ✅ | ✅ |
| **101 / 102 blk** | ✅ | ✅ 101 / ❌ **102** | ✅ | ✅ |
| 150 blk | ✅ 2506 | ❌ refused | ✅ | ✅ |
| **300 blk (what ships)** | ✅ **5148** | ❌ refused | ✅ | ✅ |

drpc's refusal message is misleading — `ranges over 10000 blocks are not supported on free plan` — but the real boundary was bisected exactly: **an inclusive range of 101 blocks is served, 102 is refused** (equivalently, a `toBlock - fromBlock` delta of 100 is the last that works). The `pol` sibling reports the same limit in delta terms.

**So `polusdc` is *not* dead on arrival**, unlike `arbusdc` (C8's headline case, where *both* rungs refuse). Mainnet publicnode serves the full 300-block span, and the ladder in #655 already leads with publicnode for exactly this reason, so the shipped order is correct as-is.

**To be precise about the mechanism — there is no failover here.** `EvmChain.eth_rpc` (`assets/evm.py:240-255`) walks the ladder in order and **returns on the first success**, and publicnode leads for Polygon mainnet (`evm.py:152`). On a healthy day it answers the 300-block filter directly, so nothing fails over and no request is wasted. The real exposure is the opposite shape: **drpc cannot serve this span at all, so the scanner has no working fallback rung on mainnet.** `find_recent_outgoing` is effectively **single-rung** — one endpoint outage away from `arbusdc`'s permanently-dead scanner, with no redundancy behind it. Amoy is unaffected: both rungs serve 300.

Raising `seconds_per_block` to 2 would **not** rescue it — 150 blocks is still past drpc's boundary. The C8 fix (`MAX_LOG_SPAN_BLOCKS = 25` + chunking) is the real answer, and it should land before or with the next token on a sub-second chain. Pinned here as `test_scan_window_is_the_full_unbounded_lookback`, so the fix has a test to change rather than a silent behaviour to break.

### C7 — the slash-exemption lookback is measured in blocks, and tokens get half the coins' span

```python
assets/erc20.py:568   span = min(60, ... // self.chain_def.seconds_per_block)     # tokens
assets/evm_coin.py:305 ... min(self.SCAN_LOOKBACK_BLOCKS, 120) ...                # native coins
```

That 60-vs-120 split is undocumented drift, tracked separately. For `polusdc` the historical probe reaches **60 blocks = ~90s of real 1.5s blocks**, i.e. **15% of the program's 600s fulfillment window** — where native `pol` on the same chain gets 180s (30%). A user can make delivery impossible, revoke it, wait ~90 seconds, and the historical evidence is gone before the slash check runs.

The `latest` probe is the load-bearing signal and is unaffected — freezes persist for months — so this is a coverage gap on the historical backstop, not a live hole. Not fixed here; the fix is C7's live-observation ledger, and it is shared code.

### No action — flagged so it is not later read as a Polygon regression

`POL_PRIVATE_KEY` now signs two assets, so a `pol` leg and a `polusdc` leg share a nonce surface. That is the identical situation `eth`+`ethusdc` and `bnb`+`aster` already carry: it is the intended consequence of one env identity per network, and the fix (local nonce tracking) is shared code in `evm.py`, out of scope here.

## Merge order

Merge this before its das twin — [das-allways#102](https://github.com/entrius/das-allways/pull/102), which is stacked on das#101 the same way this is stacked on #655:

```
allways #647  (erc20 refusal interface)
  └─ allways #655  (pol spoke)          ─── das #101  (pol chain)
       └─ allways #660  (THIS PR)        ─── das #102  (polusdc chain)
```

das#102's chain-drift gate reads `allways/chains.py` from `test`, so it stays **red by design** until this lands. Verified both directions against the real branches, with no local patching:

```
$ node scripts/check-chain-drift.mjs                          # vs test
  'pol' is served but not in chains.py SUPPORTED_CHAINS       # red, expected
  'polusdc' is served but not in chains.py SUPPORTED_CHAINS

$ ALLWAYS_PY_ROOT=<this branch> node scripts/check-chain-drift.mjs
  chain drift gate: 12 chains, hubs (sol, tao) in lockstep    # green
```

Nobody should "fix" the red gate.