### PR TITLE
v3.1 swap-testing fixes: EVM reserve-preflight parity, ETH replay grace, swap-now rejection reasons, hex swap_key

### DIFF
--- a/allways/assets/asset.py
+++ b/allways/assets/asset.py
@@ -185,8 +185,12 @@ class Asset(ABC):
     @abstractmethod
     def get_balance(self, address: str) -> int: ...
 
-    def can_deliver_to(self, address: str, amount: int) -> bool:
-        """Reserve-time gate: False only on positive evidence the destination cannot receive."""
+    def can_deliver_to(self, address: str, amount: int, from_address: Optional[str] = None) -> bool:
+        """Reserve-time gate: False only on positive evidence the destination cannot receive.
+
+        ``from_address`` is the committed sender the delivery would come from, when the caller
+        knows it — providers that simulate delivery should simulate from it, since a hostile
+        dest can accept from one sender and refuse another."""
         return True
 
     def delivery_refused(self, address: str, since_unix: int) -> bool:

--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -425,10 +425,11 @@ class Erc20(EvmAsset):
 
     # --- Delivery gates (F3: blacklist + pause, deliberately no getCode) ---
 
-    def can_deliver_to(self, address: str, amount: int) -> bool:
+    def can_deliver_to(self, address: str, amount: int, from_address: Optional[str] = None) -> bool:
         """Reserve-time gate: the issuer can freeze an address (blacklist) or the whole token
         (pause) — both make delivery impossible regardless of dest code and neither is the
-        miner's fault, so they must bounce the reservation. Fails open on RPC trouble."""
+        miner's fault, so they must bounce the reservation. Fails open on RPC trouble.
+        ``from_address`` is unused: FiatToken transfers gate on issuer state, not dest code."""
         try:
             return not self._eth_call(SEL_IS_BLACKLISTED, address) and not self._eth_call(SEL_PAUSED)
         except Exception:

--- a/allways/assets/evm_coin.py
+++ b/allways/assets/evm_coin.py
@@ -284,16 +284,18 @@ class EvmCoin(EvmAsset):
         gas = est + est // 5
         return None if gas > MAX_TRANSFER_GAS else gas
 
-    def can_deliver_to(self, address: str, amount: int) -> bool:
+    def can_deliver_to(self, address: str, amount: int, from_address: Optional[str] = None) -> bool:
         """Reserve-time gate: an EOA can never refuse a transfer; a code-bearing dest must pass
-        a simulated transfer. Fails open — only a positive revert blocks a reservation."""
+        the same simulation the miner's send runs — from the committed sender when known, with
+        the +20% headroom and MAX_TRANSFER_GAS cap. A dest the send path would refuse (revert
+        only for msg.sender != 0, or gas just under the cap from zero) must bounce here, not
+        ride the miner to a timeout slash. Fails open on RPC trouble."""
         try:
             if (self.chain.eth_rpc('eth_getCode', [address, 'latest']) or '0x') == '0x':
                 return True
-            self.chain.eth_rpc('eth_estimateGas', [{'from': ZERO_ADDRESS, 'to': address, 'value': hex(amount)}])
+        except Exception:
             return True
-        except Exception as e:
-            return 'revert' not in str(e).lower()
+        return self._transfer_gas(from_address or ZERO_ADDRESS, address, amount) is not None
 
     def delivery_refused(self, address: str, since_unix: int) -> bool:
         """Slash gate: code at the destination — now or sampled across the window since

--- a/allways/assets/sol.py
+++ b/allways/assets/sol.py
@@ -251,8 +251,9 @@ class Sol(Asset, Chain):
             bt.logging.error(f'SOL get_balance failed for {address}: {e}')
             return 0
 
-    def can_deliver_to(self, address: str, amount: int) -> bool:
-        """Reserve-time gate: bounce a reserved-key destination before any funds move."""
+    def can_deliver_to(self, address: str, amount: int, from_address: Optional[str] = None) -> bool:
+        """Reserve-time gate: bounce a reserved-key destination before any funds move.
+        System-account credits are sender-agnostic, so ``from_address`` plays no part here."""
         return address not in RESERVED_ACCOUNTS
 
     def delivery_refused(self, address: str, since_unix: int) -> bool:

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -105,9 +105,9 @@ CHAIN_ETH = ChainDefinition(
     # Rate sanity floor, not an economic guarantee: 0.00005 ETH covers a 21k-gas transfer
     # fee only below ~2.4 gwei — miners price real gas into their quotes.
     min_onchain_amount=50_000_000_000_000,
-    # Timestamps must strictly exceed the parent's, so a mined deposit can never stamp
-    # earlier than a reservation created before it — no BTC-style median-time lag.
-    replay_grace_secs=0,
+    # Monotonic slot timestamps don't help here: the freshness floor is stamped by the hub
+    # clock, so hub-vs-spoke skew needs the same modest allowance as the other EVM chains.
+    replay_grace_secs=60,
 )
 
 CHAIN_ARBUSDC = ChainDefinition(
@@ -251,7 +251,7 @@ CHAIN_ETHUSDC = ChainDefinition(
     min_onchain_amount=5_000_000,
     # Ethereum's clock, as CHAIN_ETH: what this absorbs is hub-vs-spoke skew, and two assets on
     # one chain disagreeing about that chain's clock would be indefensible.
-    replay_grace_secs=0,
+    replay_grace_secs=60,
     # Circle-verified native USDC on Ethereum (developers.circle.com, 2026-08-11).
     asset_locator='0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
 )

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -47,6 +47,7 @@ from allways.cli.swap_commands.swap_intake import (
     select_best_miner,
     swap_viable,
     to_smallest_units,
+    unviable_reason,
     viable_intakes,
 )
 from allways.cli.validator_rejections import render_and_aggregate
@@ -415,7 +416,8 @@ def swap_now_command(
     if miner_opt:
         viable = viable_intakes(candidates, from_chain, to_chain, from_amount, min_swap, max_swap, bounds)
         if not viable:
-            fail('No miner can fund an executable swap for that amount within bounds.')
+            reason = unviable_reason(candidates, from_chain, to_chain, from_amount, min_swap, max_swap, bounds)
+            fail(f'No miner can take this swap: {reason}.')
         best_to = max(p[1].to_amount for p in viable)
         if miner_opt == _MINER_PICK:
             cand, amts = _pick_intake(viable, from_chain, to_chain)
@@ -432,7 +434,8 @@ def swap_now_command(
     else:
         best = select_best_miner(candidates, from_chain, to_chain, from_amount, min_swap, max_swap, bounds)
         if best is None:
-            fail('No miner can fund an executable swap for that amount within bounds.')
+            reason = unviable_reason(candidates, from_chain, to_chain, from_amount, min_swap, max_swap, bounds)
+            fail(f'No miner can take this swap: {reason}.')
         cand, amts = best
 
     # Deliverability screens — before the fee-charging entry AND before sending into a doomed swap.
@@ -646,12 +649,15 @@ def _screen_deliverability(client, config, cand, from_chain, to_chain, receive_a
     courtesy warning only — a frozen source just means the deposit fails and the reservation
     lapses unclaimed. A leg whose provider can't be built read-only fails open, as before."""
     dest_provider = _gate_provider(to_chain, client, config)
+    quote = client.get_quote(cand.miner, from_chain, to_chain, cand.backing)
     if dest_provider is not None:
         # Format first — offline, and a malformed address can never be delivered to.
         if not dest_provider.chain.is_valid_address(receive_addr):
             fail(f'  {receive_addr!r} is not a valid {to_chain.upper()} address. No funds moved.')
         amts = compute_intake_amounts(from_chain, to_chain, from_amount, cand.rate_display, cand.backing)
-        if not dest_provider.can_deliver_to(receive_addr, amts.to_amount):
+        # Simulate from the miner's committed dest-side sender, as the validator gate does.
+        miner_to_addr = getattr(quote, 'miner_to_addr', '') if quote else ''
+        if not dest_provider.can_deliver_to(receive_addr, amts.to_amount, from_address=miner_to_addr or None):
             fail(
                 f'  Your receive address cannot accept {to_chain.upper()} right now '
                 '(frozen or transfers paused). No funds moved.'
@@ -659,7 +665,6 @@ def _screen_deliverability(client, config, cand, from_chain, to_chain, receive_a
     src_provider = _gate_provider(from_chain, client, config)
     if src_provider is None:
         return
-    quote = client.get_quote(cand.miner, from_chain, to_chain, cand.backing)
     miner_addr = getattr(quote, 'miner_from_addr', '') if quote else ''
     if miner_addr and (
         not src_provider.chain.is_valid_address(miner_addr) or not src_provider.can_deliver_to(miner_addr, from_amount)

--- a/allways/solana/client.py
+++ b/allways/solana/client.py
@@ -229,7 +229,8 @@ class AllwaysSolanaClient:
     def get_pool(self, miner, backing: str = 'sol'):
         return self._get('Pool', pdas.pool_pda(miner, backing, self.program_id))
 
-    def get_swap(self, swap_key: bytes):
+    def get_swap(self, swap_key: bytes | str):
+        """``swap_key`` in either circulating form — 32 raw bytes or the hex string (0x or bare)."""
         return self._get('Swap', pdas.swap_pda(swap_key, self.program_id))
 
     def get_quote(self, miner, from_chain: str, to_chain: str, backing: str = 'sol'):

--- a/allways/solana/pdas.py
+++ b/allways/solana/pdas.py
@@ -108,8 +108,16 @@ def legacy_initiate_round_pda(miner, program_id: Optional[Pubkey] = None) -> Pub
     return _derive([b'vote', bytes([REQ_INITIATE]), _pk_bytes(miner)], program_id)
 
 
-def swap_pda(swap_key: bytes, program_id: Optional[Pubkey] = None) -> Pubkey:
-    return _derive([b'swap', bytes(swap_key)], program_id)
+def swap_key_bytes(swap_key) -> bytes:
+    """The 32-byte swap_key from either form it circulates in: raw bytes, or the hex string
+    (0x or bare) the CLI, API, and logs surface."""
+    if isinstance(swap_key, str):
+        return bytes.fromhex(swap_key.removeprefix('0x'))
+    return bytes(swap_key)
+
+
+def swap_pda(swap_key: bytes | str, program_id: Optional[Pubkey] = None) -> Pubkey:
+    return _derive([b'swap', swap_key_bytes(swap_key)], program_id)
 
 
 def quote_pda(

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -172,16 +172,19 @@ def reserve_on_behalf(
     # later. Format first: it's offline and a malformed address can never be delivered to.
     providers = getattr(validator, 'axon_assets', {})
     provider = providers.get(to_chain)
+    miner_quote = quote or client.get_quote(miner_pk, from_chain, to_chain, backing)
     if provider is not None:
         if not provider.chain.is_valid_address(user_to_addr):
             return ReserveResult(False, f'destination is not a valid {to_chain} address')
-        if not provider.can_deliver_to(user_to_addr, amts.to_amount):
+        # Simulate delivery from the miner's committed dest-side sender: confirm pins
+        # sender == miner_to_addr, so a dest that refuses only THAT sender must bounce here too.
+        miner_to_addr = getattr(miner_quote, 'miner_to_addr', '') if miner_quote else ''
+        if not provider.can_deliver_to(user_to_addr, amts.to_amount, from_address=miner_to_addr or None):
             return ReserveResult(False, 'destination address rejects incoming transfers')
     # Same gate, source side (T18): the miner's receive address must accept the user's funds —
     # a miner quoting a malformed/rejecting/blacklisted address griefs takers into a burned fee.
     src_provider = providers.get(from_chain)
     if src_provider is not None:
-        miner_quote = quote or client.get_quote(miner_pk, from_chain, to_chain, backing)
         miner_from_addr = getattr(miner_quote, 'miner_from_addr', '') if miner_quote else ''
         if miner_from_addr and (
             not src_provider.chain.is_valid_address(miner_from_addr)

--- a/tests/test_bnb_provider.py
+++ b/tests/test_bnb_provider.py
@@ -247,6 +247,21 @@ class TestDeliveryGates:
         rpc_stub(provider, {'eth_getCode': '0x60806040', 'eth_estimateGas': refuse})
         assert provider.can_deliver_to(RECIPIENT, 10**16) is False
 
+    def test_reserve_gate_runs_the_send_paths_simulation(self, provider):
+        # Sender-gated refusal (accepts from address(0), reverts for the committed miner) and an
+        # estimate the +20% headroom pushes over MAX_TRANSFER_GAS must both bounce at reserve —
+        # exactly what the miner's _transfer_gas would refuse to pay at delivery.
+        miner = Account.from_key(TEST_KEY).address
+
+        def gas(params):
+            if params[0]['from'] == miner:
+                raise RuntimeError('rpc error execution reverted')
+            return hex(90_000)  # 90k raw → 108k with headroom → over the 100k cap
+
+        rpc_stub(provider, {'eth_getCode': '0x60806040', 'eth_estimateGas': gas})
+        assert provider.can_deliver_to(RECIPIENT, 10**16, from_address=miner) is False
+        assert provider.can_deliver_to(RECIPIENT, 10**16) is False
+
     def test_slash_gate_exempts_a_dest_that_gained_then_revoked_code(self, provider, frozen_now):
         # The case only temporal sampling can catch, and the one a miner gets slashed over: the
         # dest delegates via EIP-7702 after the reservation pinned it, the payout reverts, and the

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -194,3 +194,28 @@ class TestComputeExtensionTargetSecs:
     def test_unsupported_chain_raises(self):
         with pytest.raises(KeyError):
             compute_extension_target_secs('doge', 0, self.NOW, self.CEILING)
+
+
+class TestReplayGrace:
+    """Freshness gates on block_time >= floor - grace, where the floor is stamped by the HUB
+    clock. Spoke timestamps — however well-behaved on their own chain — say nothing about
+    hub-vs-spoke skew, so a zero grace strands an honest deposit stamped just behind the floor."""
+
+    def test_every_evm_chain_carries_the_skew_grace(self):
+        # Ethereum's monotonic slot timestamps once justified 0 here; the floor is hub-stamped,
+        # so ETH (and ethusdc with it) need the same allowance as every other EVM row.
+        for chain in SUPPORTED_CHAINS.values():
+            if chain.host_chain is not None:
+                assert chain.replay_grace_secs == 60, chain.id
+
+    def test_freshness_consumer_absorbs_the_eth_grace(self):
+        # The validator reads grace off chain_def (solana_swap_loop._is_fresh) — a deposit
+        # stamped inside the grace window is fresh; one predating it is still a replay.
+        from types import SimpleNamespace
+
+        from allways.validator.solana_swap_loop import is_tx_fresh
+
+        floor = 1_755_000_000
+        grace = CHAIN_ETH.replay_grace_secs
+        assert is_tx_fresh(SimpleNamespace(block_time=floor - grace), floor, grace)
+        assert not is_tx_fresh(SimpleNamespace(block_time=floor - grace - 1), floor, grace)

--- a/tests/test_ethereum_provider.py
+++ b/tests/test_ethereum_provider.py
@@ -728,6 +728,24 @@ class TestDeliveryGates:
         rpc_stub(provider, {'eth_getCode': down})
         assert provider.can_deliver_to(RECIPIENT, 10**15)
 
+    def test_can_deliver_to_simulates_from_committed_sender(self, provider):
+        # A dest can accept from address(0) yet revert for the miner's actual sender (e.g.
+        # `receive()` gated on msg.sender) — the reserve gate must run the send's simulation.
+        def gas(params):
+            if params[0]['from'] == TEST_ADDR:
+                raise RuntimeError('rpc error execution reverted')
+            return '0xb000'
+
+        rpc_stub(provider, {'eth_getCode': '0x6080', 'eth_estimateGas': gas})
+        assert provider.can_deliver_to(RECIPIENT, 10**15)  # sender unknown: from-zero still passes
+        assert not provider.can_deliver_to(RECIPIENT, 10**15, from_address=TEST_ADDR)
+
+    def test_can_deliver_to_applies_send_path_gas_cap(self, provider):
+        # 90k estimates under MAX_TRANSFER_GAS raw, but the send path's +20% headroom puts it
+        # at 108k — the miner would refuse to pay, so the reservation must never start.
+        rpc_stub(provider, {'eth_getCode': '0x6080', 'eth_estimateGas': hex(90_000)})
+        assert not provider.can_deliver_to(RECIPIENT, 10**15)
+
     def test_delivery_refused_code_at_latest(self, provider):
         rpc_stub(
             provider, {'eth_blockNumber': hex(1000), 'eth_getCode': lambda p: '0xef0100' if p[1] == 'latest' else '0x'}

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -115,7 +115,10 @@ def test_open_happy_path_persists_routed_request():
 
 def _gate_asset(can_deliver, valid=lambda addr: True):
     """Duck-typed asset for the reserve deliverability gates (can_deliver_to + chain format check)."""
-    return SimpleNamespace(can_deliver_to=can_deliver, chain=SimpleNamespace(is_valid_address=valid))
+    return SimpleNamespace(
+        can_deliver_to=lambda addr, amt, from_address=None: can_deliver(addr, amt),
+        chain=SimpleNamespace(is_valid_address=valid),
+    )
 
 
 def test_undeliverable_destination_rejects_before_any_bid():

--- a/tests/test_solana_client.py
+++ b/tests/test_solana_client.py
@@ -188,3 +188,28 @@ def test_pda_derivation():
     # backings never collide, and the round shares the same composite target.
     assert pdas.bond_attestation_pda(miner, 'tao') != pdas.bond_attestation_pda(miner, 'eth')
     assert isinstance(pdas.attestation_round_pda(miner, 'tao'), Pubkey)
+
+
+def test_swap_pda_accepts_hex_string_forms():
+    # The swap_key circulates as bytes on-chain but as a hex string in the CLI, API, and logs
+    # (F-12) — every surface form must derive the same PDA, so a pasted key just works.
+    key = bytes(range(32))
+    from_bytes = pdas.swap_pda(key)
+    assert pdas.swap_pda(key.hex()) == from_bytes
+    assert pdas.swap_pda('0x' + key.hex()) == from_bytes
+
+
+def test_get_swap_accepts_hex_string(monkeypatch):
+    # get_swap is the reader users actually hit with a pasted hex key — pin the boundary end-to-end.
+    from unittest.mock import MagicMock
+
+    from allways.solana.client import AllwaysSolanaClient
+
+    client = AllwaysSolanaClient.__new__(AllwaysSolanaClient)
+    client.program_id = pdas.resolve_program_id()
+    client.rpc = MagicMock()
+    client.rpc.get_account_info.return_value = None
+
+    key = bytes(range(32))
+    assert client.get_swap('0x' + key.hex()) is None  # no TypeError — reaches the RPC read
+    client.rpc.get_account_info.assert_called_once_with(pdas.swap_pda(key, client.program_id))

--- a/tests/test_swap_now_reservation.py
+++ b/tests/test_swap_now_reservation.py
@@ -485,7 +485,7 @@ class _Gate:
         self.checked = []
         self.chain = types.SimpleNamespace(is_valid_address=lambda addr: addr not in set(malformed))
 
-    def can_deliver_to(self, addr, amount):
+    def can_deliver_to(self, addr, amount, from_address=None):
         self.checked.append(addr)
         return addr not in self.reject
 

--- a/tests/test_swap_now_unviable_reason.py
+++ b/tests/test_swap_now_unviable_reason.py
@@ -1,0 +1,46 @@
+"""`alw swap now` must name the failing bound (F-2), not a generic "within bounds" shrug.
+
+``unviable_reason`` existed for exactly these branches and was never called: both no-viable-miner
+fail paths printed the same generic line, leaving the taker guessing WHICH bound (min/max swap,
+collateral, executable rate) refused them. Same stubbed-client harness as the disclosure tests,
+but the real selection/intake path runs so the reason is genuinely computed, not injected.
+"""
+
+import types
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from allways.cli.swap_commands.swap import swap_now_command
+from allways.cli.swap_commands.swap_intake import MinerCandidate
+
+USER = '68ToGUYjjYpqi7Atx7QyhbybR2RCfo2tkmgcoNR3DxYF'
+
+
+def _run(argv_extra=()):
+    client = MagicMock()
+    client.keypair.pubkey.return_value = USER
+    # min_swap 10 SOL: the 0.00005 BTC intake's hub leg lands far below it → GATE_BELOW_MIN.
+    client.get_config.return_value = types.SimpleNamespace(
+        min_swap_amount=10**10, max_swap_amount=0, pool_window_secs=60, finalize_window_secs=150
+    )
+    cand = MinerCandidate(miner='miner-pk', rate_display='0.0021', collateral=10**12, backing='sol')
+    argv = ['--from', 'btc', '--to', 'sol', '--amount', '0.00005', '--from-address', 'tb1qsource']
+    argv += ['--receive-address', USER, *argv_extra]
+    with (
+        patch('allways.cli.swap_commands.swap.get_solana_cli_context', return_value=({}, client)),
+        patch('allways.cli.swap_commands.swap.candidate_miners', return_value=[cand]),
+    ):
+        return CliRunner().invoke(swap_now_command, argv)
+
+
+def test_auto_select_failure_names_the_bound():
+    r = _run()
+    assert 'below min swap' in r.output
+    assert 'within bounds' not in r.output
+
+
+def test_named_miner_failure_names_the_bound():
+    r = _run(argv_extra=['--miner', 'miner-pk'])
+    assert 'below min swap' in r.output
+    assert 'within bounds' not in r.output


### PR DESCRIPTION
Fixes #661 and fixes #662 and fixes #663 and fixes #664.

Code-only fixes for four findings from v3.1 testnet swap testing. No contract/IDL/client-regen changes and no redeploy — the contract-side work (no-fault timeout terminal) is a separate, held PR.

## 1. Native-EVM reserve preflight now matches the miner send path (#661)

`EvmCoin.can_deliver_to` simulated a transfer from `ZERO_ADDRESS` and checked only for a revert, while the actual send path (`_transfer_gas`) estimates from the miner's signer, adds 20% headroom, and refuses above `MAX_TRANSFER_GAS`. A hostile taker could deploy a dest contract that passes the reserve gate but refuses the real delivery (sender-gated `receive()`, or gas under the cap raw but over it with headroom), riding an honest miner to a timeout slash.

- `can_deliver_to` now reuses `_transfer_gas` — same cap, same headroom, same fail-open-on-RPC-trouble semantics — and takes an optional `from_address`.
- The validator reserve engine and the CLI self-represented screen thread the miner's committed dest-side sender (`MinerQuote.miner_to_addr` — the address confirm pins `sender ==` against) into the gate.
- `delivery_refused` (the slash gate) is deliberately untouched: getCode-only, simulation is gameable by either side.

This closes a miner-griefing vector on the native EVM spokes (`eth`, `hype`, `bnb`, `avax`) — not yet on mainnet.

## 2. Ethereum replay grace 0 → 60s (#662)

`CHAIN_ETH` and `CHAIN_ETHUSDC` had `replay_grace_secs=0` (every other EVM chain: 60; BTC: 300). The freshness floor is stamped by the hub clock, so Ethereum's monotonic slot timestamps don't remove hub-vs-spoke skew — with zero grace an honest deposit stamped slightly behind the floor is judged a replay and the taker's funds strand. Both rows now carry 60, and the consumer (`solana_swap_loop._is_fresh` reading `chain_def.replay_grace_secs`) picks it up unchanged.

## 3. `swap now` names the failing bound (#663)

Both no-viable-miner fail branches printed the generic "within bounds" line while `unviable_reason()` — written precisely for this branch — was never called. Both branches now surface the computed reason (min/max swap with the bound figure, collateral, executable rate).

## 4. `get_swap` / `swap_pda` accept the hex swap_key (#664)

The swap_key circulates as a hex string in the CLI, API, and logs, but the readers required raw bytes and raised `TypeError`. Both now accept hex (`0x` or bare) via a `swap_key_bytes` normalizer at the boundary.

## Tests

- `test_ethereum_provider.py` / `test_bnb_provider.py`: dest that passes from-zero but reverts from the committed sender; estimate under the cap raw but over it after +20% headroom.
- `test_chains.py`: every EVM chain carries the 60s skew grace; `is_tx_fresh` boundary at exactly `floor - grace`.
- `test_swap_now_unviable_reason.py` (new): both CLI fail branches name the bound through the real selection path (no injected reason).
- `test_solana_client.py`: hex/`0x`-hex/bytes swap_key derive the same PDA; `get_swap` with a pasted hex key reaches the RPC read.
- Test doubles in `test_reserve_engine.py` / `test_swap_now_reservation.py` updated for the new `from_address` kwarg.

Full suite: 1575 passed; the one failure (`test_bitcoin_signing` uppercase-bech32) is a pre-existing full-suite ordering flake that reproduces identically on a clean `test` checkout and passes in isolation.