### PR TITLE
Fix crown rate-lane liveness: per-backing prune anchors + live quote-book reconcile

### DIFF
--- a/allways/validator/event_index.py
+++ b/allways/validator/event_index.py
@@ -18,7 +18,7 @@ events drive FULFILL_START/END. The crown credits a miner only while its activit
 
 from __future__ import annotations
 
-from typing import Callable, Dict, List, Optional, Set
+from typing import Callable, Dict, List, Optional, Set, Tuple
 
 import bittensor as bt
 
@@ -63,7 +63,8 @@ class SolanaEventIndex:
     def ingest(self, records: List[EventRecord], attribution: Dict[str, str]) -> int:
         """Persist ``records`` (oldest-first) into the event tables, mapping each event's miner Solana
         pubkey → bound hotkey via ``attribution`` (B3.2 ``build_attribution``). Events from an unbound
-        pubkey are dropped (no UID to credit); ``reconcile_live_state`` later heals any state they carried.
+        pubkey are dropped (no UID to credit); the per-round reconciles (``reconcile_live_state`` for
+        active/collateral, ``reconcile_live_quotes`` for rates) later heal the state they carried.
         Records with no ``blockTime`` are skipped defensively — poll() already holds the cursor before
         unstamped txs, so none should reach here. Returns the count written."""
         written = 0
@@ -241,6 +242,42 @@ class SolanaEventIndex:
                 self.state_store.insert_collateral_event(now, hotkey, live_collateral, backing='sol')
                 bt.logging.warning(
                     f'reconcile {hotkey[:8]}: event-derived collateral ≠ chain, corrected to {live_collateral}'
+                )
+
+    def reconcile_live_quotes(self, live_quotes: Dict[Tuple[str, str, str, str], float], now: int) -> None:
+        """Rate-liveness backstop, the ``reconcile_live_state`` sibling for the rate stream.
+        Lane termination is otherwise event-driven only (``QuoteRemoved``/``MinerBackingChanged``),
+        so one lost removal would freeze a lane's last nonzero rate forever — the prune keeps it
+        as the per-lane anchor and every future window would keep crediting it. Once per round,
+        diff the event-derived positive-rate lanes against the live on-chain quote book
+        (``live_quotes``: ``{(hotkey, from, to, collateral_chain): display_rate}``): a lane with
+        no live quote is zeroed, a lane whose live rate differs is corrected to the chain's value.
+        Corrections are stamped ``now`` (credit already granted stands — error bounded at one
+        round) and per-lane quiet-window guarded, so a legitimately in-flight quote change is
+        never fought. An empty book is treated as a failed read and skipped — fail open, so an
+        RPC hiccup can never zero every lane at once."""
+        if not live_quotes:
+            bt.logging.warning('reconcile: MinerQuote read empty, skipping quote reconcile this round')
+            return
+        quiet_start = now - RECONCILE_QUIET_SECS
+        recent_lanes = self.state_store.rate_lanes_touched_in_range(quiet_start, now)
+        for lane, derived_rate in self.state_store.lanes_with_live_rate(now).items():
+            if lane in recent_lanes:
+                continue
+            hotkey, from_chain, to_chain, backing = lane
+            live_rate = live_quotes.get(lane)
+            if live_rate is None:
+                self.state_store.insert_rate_event(hotkey, from_chain, to_chain, 0.0, now, collateral_chain=backing)
+                bt.logging.warning(
+                    f'reconcile {hotkey[:8]}: {from_chain}->{to_chain} ({backing}) has no live quote, rate zeroed'
+                )
+            elif live_rate != derived_rate:
+                self.state_store.insert_rate_event(
+                    hotkey, from_chain, to_chain, live_rate, now, collateral_chain=backing
+                )
+                bt.logging.warning(
+                    f'reconcile {hotkey[:8]}: {from_chain}->{to_chain} ({backing}) event-derived rate '
+                    f'{derived_rate} ≠ chain, corrected to {live_rate}'
                 )
 
     @staticmethod

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -35,6 +35,7 @@ from allways.constants import (
     MINER_POOL_SHARE,
     POOL_VOLUME_ALPHA,
     POOL_VOLUME_WINDOW_SECS,
+    RATE_PRECISION,
     RECYCLE_UID,
     REWARD_MINER_STATES,
     SCORING_WINDOW_BLOCKS,
@@ -46,7 +47,7 @@ from allways.constants import (
 )
 from allways.solana.layouts import lock_max
 from allways.solana.pdas import BACKING_BITS
-from allways.utils.rate import is_executable_rate, min_executable_hub_leg
+from allways.utils.rate import is_executable_rate, min_executable_hub_leg, quantize_rate_fixed
 from allways.validator.binding import build_attribution
 from allways.validator.scoring_trace import WeightingTrace, log_scoring_trace
 from allways.validator.state_store import ValidatorStateStore
@@ -237,6 +238,27 @@ def live_miner_states(solana_client, metagraph, attribution: Optional[Dict[str, 
     return states
 
 
+def live_quote_rates(
+    solana_client, attribution: Optional[Dict[str, str]] = None
+) -> Dict[Tuple[str, str, str, str], float]:
+    """``{(hotkey, from_chain, to_chain, collateral_chain): display_rate}`` for every live
+    on-chain quote from a bound miner — the chain-truth side of the quote-existence
+    reconcile (``SolanaEventIndex.reconcile_live_quotes``). Rates pass through the same
+    quantize-then-scale transform as ``QuoteSet`` ingest so an unchanged quote compares
+    equal to its event-derived rate. Unbound miners are dropped, matching ingest: their
+    lanes never entered the event tables, so there is nothing to reconcile."""
+    if attribution is None:
+        attribution = build_attribution(solana_client)
+    quotes: Dict[Tuple[str, str, str, str], float] = {}
+    for _pda, q in solana_client.get_all('MinerQuote'):
+        hotkey = attribution.get(str(q.miner))
+        if hotkey is None:
+            continue
+        lane = (hotkey, str(q.from_chain).lower(), str(q.to_chain).lower(), str(q.collateral_chain).lower())
+        quotes[lane] = quantize_rate_fixed(int(q.rate)) / RATE_PRECISION
+    return quotes
+
+
 def build_eligibility(
     solana_client,
     metagraph,
@@ -402,8 +424,16 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
     # on-chain counters (B3.3, pubkey→hotkey via the sr25519 binding; absent hotkey → not
     # eligible), and the reconcile backstop that corrects event-derived active/collateral
     # state the ingest lost — before the replay below reads those tables.
-    live_states = live_miner_states(self.solana_client, self.metagraph)
+    attribution = build_attribution(self.solana_client)
+    live_states = live_miner_states(self.solana_client, self.metagraph, attribution)
     self.event_index.reconcile_live_state(live_states, now=current_time)
+    # Rate-liveness backstop: a lost QuoteRemoved would otherwise freeze a lane's crown
+    # credit forever (the prune keeps the last rate as the lane's anchor). Best-effort —
+    # the reconcile is a safety net, so a failed quote read never sinks the round.
+    try:
+        self.event_index.reconcile_live_quotes(live_quote_rates(self.solana_client, attribution), now=current_time)
+    except Exception as e:
+        bt.logging.warning(f'quote reconcile failed, skipping this round: {e}')
     # The global (strike) view feeds the trace log; rows gate per lane so a TAO settle zeroes
     # only tao-lane contributions while sol-lane rows keep earning (V-2, F4).
     eligibility = {hk: is_eligible(ms, current_time) for hk, ms in live_states.items()}

--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -178,6 +178,40 @@ class ValidatorStateStore:
         )
         return [(r['from_chain'], r['to_chain']) for r in rows]
 
+    def lanes_with_live_rate(self, block: int) -> Dict[Tuple[str, str, str, str], float]:
+        """Cross-hotkey variant of ``directions_with_live_rate``: every
+        ``(hotkey, from_chain, to_chain, collateral_chain)`` lane whose latest
+        rate at-or-before ``block`` is positive, mapped to that rate. This is
+        the event-derived side of the per-round quote-existence reconcile."""
+        rows = self._fetchall(
+            """
+            SELECT hotkey, from_chain, to_chain, collateral_chain, rate FROM (
+                SELECT hotkey, from_chain, to_chain, collateral_chain, rate,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY hotkey, from_chain, to_chain, collateral_chain
+                           ORDER BY block DESC, id DESC
+                       ) AS rn
+                FROM rate_events
+                WHERE block <= ?
+            ) WHERE rn = 1 AND rate > 0
+            """,
+            (block,),
+        )
+        return {(r['hotkey'], r['from_chain'], r['to_chain'], r['collateral_chain']): r['rate'] for r in rows}
+
+    def rate_lanes_touched_in_range(self, start_block: int, end_block: int) -> Set[Tuple[str, str, str, str]]:
+        """Lanes with any rate event in ``(start_block, end_block]`` — the
+        reconcile's per-lane quiet-window guard reads this so a stale live
+        view never overwrites a fresher real event."""
+        rows = self._fetchall(
+            """
+            SELECT DISTINCT hotkey, from_chain, to_chain, collateral_chain
+            FROM rate_events WHERE block > ? AND block <= ?
+            """,
+            (start_block, end_block),
+        )
+        return {(r['hotkey'], r['from_chain'], r['to_chain'], r['collateral_chain']) for r in rows}
+
     # ─── crown event tables (Solana-sourced via SolanaEventIndex) ───────
 
     def insert_active_event(self, block_num: int, hotkey: str, active: bool) -> None:
@@ -771,15 +805,20 @@ class ValidatorStateStore:
 
     def prune_events_older_than(self, cutoff_block: int) -> None:
         """Delete rate events older than ``cutoff_block``, preserving the
-        latest row per ``(hotkey, from_chain, to_chain)`` as a state-
-        reconstruction anchor for ``get_latest_rate_before(window_start)``."""
+        latest row per ``(hotkey, from_chain, to_chain, collateral_chain)``
+        lane as a state-reconstruction anchor for
+        ``get_latest_rate_before(window_start)``. The backing is part of the
+        anchor key (F4): on a dual-backing direction each backing's lane is
+        scored on its own rate stream, so keeping only the direction's newest
+        row would delete the sibling backing's anchor and silently drop that
+        lane out of the crown at window start."""
         self._execute(
             """
             DELETE FROM rate_events
             WHERE block < ?
               AND id NOT IN (
                   SELECT MAX(id) FROM rate_events
-                  GROUP BY hotkey, from_chain, to_chain
+                  GROUP BY hotkey, from_chain, to_chain, collateral_chain
               )
             """,
             (cutoff_block,),

--- a/tests/test_event_index.py
+++ b/tests/test_event_index.py
@@ -731,6 +731,108 @@ class TestReconcileLiveState:
         store.close()
 
 
+class TestReconcileLiveQuotes:
+    """Rate-liveness backstop: a lane whose event-derived rate is positive but
+    which has no matching live on-chain quote is zeroed once per round — the
+    safety net for a lost ``QuoteRemoved`` (which would otherwise freeze the
+    lane's last nonzero rate as its prune anchor forever). Quiet-window guarded
+    per lane; an empty quote book reads as a failed RPC and skips the sweep."""
+
+    NOW = 100_000
+
+    @staticmethod
+    def _seed_quote(
+        idx,
+        *,
+        block_time: int,
+        from_chain: str = 'btc',
+        to_chain: str = 'tao',
+        rate: int = 200,
+        collateral_chain: str = 'sol',
+    ):
+        idx.ingest(
+            [
+                rec(
+                    'QuoteSet',
+                    miner='pk_a',
+                    block_time=block_time,
+                    from_chain=from_chain,
+                    to_chain=to_chain,
+                    rate=rate * RATE_PRECISION,
+                    liquidity=0,
+                    collateral_chain=collateral_chain,
+                )
+            ],
+            ATTR,
+        )
+
+    def test_zeroes_lane_whose_quote_removed_was_dropped(self, tmp_path: Path):
+        # The quote died on-chain but its QuoteRemoved never reached ingest; the
+        # book still has an unrelated live quote, so the sweep runs and zeroes it.
+        store = make_store(tmp_path)
+        idx = SolanaEventIndex(store)
+        self._seed_quote(idx, block_time=100)
+        idx.reconcile_live_quotes({('hk_b', 'sol', 'tao', 'sol'): 1.0}, now=self.NOW)
+        assert store.get_latest_rate_before('hk_a', 'btc', 'tao', self.NOW, collateral_chain='sol') == (0.0, self.NOW)
+        store.close()
+
+    def test_zeroes_only_the_missing_backing_on_dual_lane(self, tmp_path: Path):
+        # Dual-backing direction: the sol-backed quote vanished, the tao-backed
+        # sibling is still live — only the sol lane is zeroed.
+        store = make_store(tmp_path)
+        idx = SolanaEventIndex(store)
+        self._seed_quote(idx, block_time=100, from_chain='sol', to_chain='tao', rate=1, collateral_chain='sol')
+        self._seed_quote(idx, block_time=200, from_chain='sol', to_chain='tao', rate=2, collateral_chain='tao')
+        idx.reconcile_live_quotes({('hk_a', 'sol', 'tao', 'tao'): 2.0}, now=self.NOW)
+        assert store.get_latest_rate_before('hk_a', 'sol', 'tao', self.NOW, collateral_chain='sol') == (0.0, self.NOW)
+        assert store.get_latest_rate_before('hk_a', 'sol', 'tao', self.NOW, collateral_chain='tao') == (2.0, 200)
+        store.close()
+
+    def test_quiet_guard_defers_to_recent_rate_event(self, tmp_path: Path):
+        # The lane's quote was set seconds ago; a stale (pre-set) book read that
+        # doesn't carry it yet must not zero the fresher event truth.
+        store = make_store(tmp_path)
+        idx = SolanaEventIndex(store)
+        self._seed_quote(idx, block_time=self.NOW - 60)
+        idx.reconcile_live_quotes({('hk_b', 'sol', 'tao', 'sol'): 1.0}, now=self.NOW)
+        assert store.get_latest_rate_before('hk_a', 'btc', 'tao', self.NOW, collateral_chain='sol') == (
+            200.0,
+            self.NOW - 60,
+        )
+        store.close()
+
+    def test_corrects_diverged_rate_to_chain_value(self, tmp_path: Path):
+        # A missed QuoteSet: the chain says 250, the event stream still says 200.
+        store = make_store(tmp_path)
+        idx = SolanaEventIndex(store)
+        self._seed_quote(idx, block_time=100, rate=200)
+        idx.reconcile_live_quotes({('hk_a', 'btc', 'tao', 'sol'): 250.0}, now=self.NOW)
+        assert store.get_latest_rate_before('hk_a', 'btc', 'tao', self.NOW, collateral_chain='sol') == (
+            250.0,
+            self.NOW,
+        )
+        store.close()
+
+    def test_empty_book_skips_the_sweep(self, tmp_path: Path):
+        # An empty bulk read is indistinguishable from a failed one — fail open
+        # rather than zeroing every lane at once.
+        store = make_store(tmp_path)
+        idx = SolanaEventIndex(store)
+        self._seed_quote(idx, block_time=100)
+        idx.reconcile_live_quotes({}, now=self.NOW)
+        assert store.get_latest_rate_before('hk_a', 'btc', 'tao', self.NOW, collateral_chain='sol') == (200.0, 100)
+        store.close()
+
+    def test_noop_when_consistent(self, tmp_path: Path):
+        store = make_store(tmp_path)
+        idx = SolanaEventIndex(store)
+        self._seed_quote(idx, block_time=100)
+        idx.reconcile_live_quotes({('hk_a', 'btc', 'tao', 'sol'): 200.0}, now=self.NOW)
+        events = store.get_rate_events_in_range('btc', 'tao', 0, self.NOW, collateral_chain='sol')
+        assert [e['block'] for e in events] == [100]
+        store.close()
+
+
 class TestSwapFulfillmentHash:
     def test_swap_fulfilled_persists_delivery_hash(self, tmp_path: Path):
         store = make_store(tmp_path)

--- a/tests/test_rate_state.py
+++ b/tests/test_rate_state.py
@@ -201,6 +201,24 @@ class TestPrune:
         assert store.get_latest_rate_before('hk1', 'btc', 'tao', block=10_000) == (6500.0, 100)
         store.close()
 
+    def test_prune_preserves_anchor_per_backing_on_dual_lane(self, tmp_path: Path):
+        """A dual-backing direction keeps BOTH backings' anchors — the anchor
+        key includes collateral_chain. Regression: grouping by direction only
+        deleted the older backing's newest row whenever the sibling backing
+        had a fresher one, silently dropping that lane out of the crown at
+        window start (observed live: tao-backed sol↔tao lanes on testnet)."""
+        store = make_store(tmp_path)
+        # tao-backed lane posted first, sol-backed sibling re-posted later —
+        # both older than the cutoff, so each survives only as its lane's anchor.
+        store.insert_rate_event('hk1', 'sol', 'tao', 0.361, block=100, collateral_chain='tao')
+        store.insert_rate_event('hk1', 'sol', 'tao', 0.360, block=200, collateral_chain='sol')
+
+        store.prune_events_older_than(cutoff_block=5_000)
+
+        assert store.get_latest_rate_before('hk1', 'sol', 'tao', block=10_000, collateral_chain='tao') == (0.361, 100)
+        assert store.get_latest_rate_before('hk1', 'sol', 'tao', block=10_000, collateral_chain='sol') == (0.360, 200)
+        store.close()
+
 
 class TestConcurrency:
     def test_concurrent_writes_threadsafe(self, tmp_path: Path):


### PR DESCRIPTION
Closes #666, closes #667. Follow-up to the F-4 crown-orphan spike (verdict: the dashboard's dead lanes are display-only, but the spike surfaced these two real validator bugs).

## 1. Prune anchor now keyed per backing (#666 — live emissions bug, verified on testnet)

`prune_events_older_than` kept `MAX(id)` per `(hotkey, from_chain, to_chain)`, missing `collateral_chain` — though F4 made the backing part of the lane key in the insert dedup and every reader. On a dual-backing direction the hourly prune deleted the older backing's newest rate row whenever the sibling had a fresher one; that lane's `get_latest_rates_before(window_start)` then found no anchor and the miner silently dropped out of the lane's crown. Same-rate inserts dedupe, so a standing quote never refreshes its own anchor — the lane never heals on its own.

**state.db evidence (isaiah, netuid 19, 2026-08-13):** on-chain, uid 2 (`ER9J…QhE5` / `5E7wEg…7n23`) has live tao-backed sol↔tao quotes (rate 1.0, updated 1786580353/54) plus sol-backed siblings re-posted later (1786587218). The validator's `rate_events` carries the sol-backed anchors at 1786587218 and **zero rows for `(sol,tao,tao)` / `(tao,sol,tao)`** — the tao-backed anchors were pruned because the sol-backed re-posts were newer. Single-backing directions (btc↔tao, eth↔tao) kept their anchors. Those two lanes are earning no crown credit today despite live nonzero quotes.

Fix: `GROUP BY hotkey, from_chain, to_chain, collateral_chain`. Regression test: a dual-backing direction retains both backings' anchors across a prune. The live lanes heal on the next quote re-post (or via the new reconcile below).

## 2. Per-round quote-existence reconcile (#667 — latent SPOF)

Lane termination was event-driven only (`QuoteRemoved` / `MinerBackingChanged` zeroing); `reconcile_live_state` healed active + collateral each round but never rates, so one missed `QuoteRemoved` would freeze a lane's last nonzero rate as its prune anchor forever — live view and rewarded replay agreeing with each other, both wrong.

New `SolanaEventIndex.reconcile_live_quotes`, called right after `reconcile_live_state` in `calculate_miner_rewards`: diffs the event-derived positive-rate lanes against the live `MinerQuote` book (pubkey→hotkey via the round's attribution, reused for both reconciles), zeroes lanes with no live quote, corrects lanes whose chain rate differs (rates pass through the same quantize-then-scale transform as ingest, so unchanged quotes compare equal). Same contract as the sibling reconciles: corrections stamped `now` (already-granted credit stands, error bounded at one round), per-lane `RECONCILE_QUIET_SECS` guard so an in-flight legitimate quote change is never fought. An empty book reads as a failed RPC and skips the sweep — fail open, an RPC hiccup can never zero every lane at once — and the whole reconcile is try/excepted so a failed read never sinks the scoring round.

This is the shipped descendant of the never-merged `terminate_orphaned_rates` sweep from the sentinel-commitment leak writeup.

## Tests

7 new (1 prune regression, 6 reconcile: dropped-removal zeroing, dual-backing selectivity, quiet-window guard, rate-divergence correction, empty-book skip, consistent no-op). Full suite: 1573 passed; the one failure (`test_bitcoin_signing.py::TestCanSendFromCase::test_uppercase_bech32_matches_derived_address`) is pre-existing on clean `origin/test` and order-dependent (passes in isolation), unrelated to this change.

The das-allways display fallback (the artifact the spike actually chased) is a separate PR in that repo.