### PR TITLE
No-fault terminal for unpayable destinations (cancel_swap)

### DIFF
--- a/allways/assets/asset.py
+++ b/allways/assets/asset.py
@@ -197,6 +197,14 @@ class Asset(ABC):
         """Slash gate: True only on positive evidence delivery was refusable since ``since_unix``."""
         return False
 
+    def cancel_evidence(self, address: str, amount: int, tx_hash: Optional[str] = None) -> Optional[int]:
+        """No-fault-cancel gate: a ``CANCEL_REASON_*`` int on evidence sound enough to TERMINATE a swap
+        (close with no slash/fee/strike, miner keeps source), else None. Stronger than
+        ``delivery_refused`` (a mere deferral hint): a wrong verdict here converts a genuine miner
+        default into a free pass, so passive chains (BTC/TAO) and the default return None — they cannot
+        refuse a payout. EVM/ERC-20/Sol override."""
+        return None
+
     @abstractmethod
     def send_amount(
         self, to_address: str, amount: int, from_address: Optional[str] = None, dedup_key: Optional[str] = None

--- a/allways/assets/asset.py
+++ b/allways/assets/asset.py
@@ -197,12 +197,16 @@ class Asset(ABC):
         """Slash gate: True only on positive evidence delivery was refusable since ``since_unix``."""
         return False
 
-    def cancel_evidence(self, address: str, amount: int, tx_hash: Optional[str] = None) -> Optional[int]:
+    def cancel_evidence(
+        self, address: str, amount: int, tx_hash: Optional[str] = None, from_address: Optional[str] = None
+    ) -> Optional[int]:
         """No-fault-cancel gate: a ``CANCEL_REASON_*`` int on evidence sound enough to TERMINATE a swap
         (close with no slash/fee/strike, miner keeps source), else None. Stronger than
         ``delivery_refused`` (a mere deferral hint): a wrong verdict here converts a genuine miner
         default into a free pass, so passive chains (BTC/TAO) and the default return None — they cannot
-        refuse a payout. EVM/ERC-20/Sol override."""
+        refuse a payout. ``from_address`` is the committed miner sender the delivery must come from, so a
+        provider that keys on the miner's OWN reverted tx can reject one from any other address.
+        EVM/ERC-20/Sol override."""
         return None
 
     @abstractmethod

--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -465,7 +465,9 @@ class Erc20(EvmAsset):
                 bt.logging.warning(f'{self._log} historical refusal sample at {probe} failed ({e}) — skipping')
         return False
 
-    def cancel_evidence(self, address: str, amount: int, tx_hash: Optional[str] = None) -> Optional[int]:
+    def cancel_evidence(
+        self, address: str, amount: int, tx_hash: Optional[str] = None, from_address: Optional[str] = None
+    ) -> Optional[int]:
         """No-fault-cancel evidence for a FiatToken: the issuer's own state proves the destination
         cannot receive — a blacklisted dest or a paused token — attributed to the DEST, not the miner
         (a reverted ERC-20 transfer alone is ambiguous: it could be miner-blacklist or miner-under-

--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -9,6 +9,7 @@ from eth_utils import keccak, to_checksum_address
 from allways.assets.asset import ProviderUnreachableError, SendResult, TransactionInfo
 from allways.assets.evm import EVM_NETWORKS, FALLBACK_PRIORITY_FEE_WEI, EvmAsset, EvmChain
 from allways.chains import ChainDefinition
+from allways.constants import CANCEL_REASON_ERC20_BLACKLIST, CANCEL_REASON_ERC20_PAUSED
 
 
 def _selector(signature: str) -> str:
@@ -463,6 +464,21 @@ class Erc20(EvmAsset):
             except Exception as e:
                 bt.logging.warning(f'{self._log} historical refusal sample at {probe} failed ({e}) — skipping')
         return False
+
+    def cancel_evidence(self, address: str, amount: int, tx_hash: Optional[str] = None) -> Optional[int]:
+        """No-fault-cancel evidence for a FiatToken: the issuer's own state proves the destination
+        cannot receive — a blacklisted dest or a paused token — attributed to the DEST, not the miner
+        (a reverted ERC-20 transfer alone is ambiguous: it could be miner-blacklist or miner-under-
+        balance, so we key on issuer state, not the tx). Returns CANCEL_REASON_ERC20_BLACKLIST /
+        _PAUSED, else None. None on RPC trouble so the caller waits rather than slashing."""
+        try:
+            if bool(self._eth_call(SEL_IS_BLACKLISTED, address)):
+                return CANCEL_REASON_ERC20_BLACKLIST
+            if bool(self._eth_call(SEL_PAUSED)):
+                return CANCEL_REASON_ERC20_PAUSED
+        except Exception:
+            return None
+        return None
 
     def find_recent_outgoing(self, from_addr: str, to_addr: str, amount: int) -> Optional[str]:
         """Tx hash of a recent settled token transfer ``from_addr`` → ``to_addr`` of >= ``amount``,

--- a/allways/assets/evm_coin.py
+++ b/allways/assets/evm_coin.py
@@ -322,16 +322,20 @@ class EvmCoin(EvmAsset):
         probes = ['latest'] + [hex(max(0, tip - span // d)) for d in (1, 2)]
         return any((self.chain.eth_rpc('eth_getCode', [address, b]) or '0x') != '0x' for b in probes)
 
-    def cancel_evidence(self, address: str, amount: int, tx_hash: Optional[str] = None) -> Optional[int]:
+    def cancel_evidence(
+        self, address: str, amount: int, tx_hash: Optional[str] = None, from_address: Optional[str] = None
+    ) -> Optional[int]:
         """No-fault-cancel evidence for native EVM: the miner's own delivery tx reverted despite a
         correct, well-gassed attempt — sound proof the destination refused, strong enough to TERMINATE
         the swap with no slash (unlike ``delivery_refused``, a getCode deferral hint). Returns
-        ``CANCEL_REASON_EVM_REVERT`` only when the recorded tx (1) reverted (receipt status 0), (2) paid
-        the pinned dest, (3) carried >= the required value, and (4) supplied a gas LIMIT >=
-        ``ETH_FULFILL_GAS_FLOOR``. Clause (4) is load-bearing: it stops a miner under-gassing to fake a
-        refusal and keep the taker's source. Deliberately NOT ``gasUsed < gas`` (a hostile contract can
-        burn all gas to mimic OOG). ``None`` on anything short of that proof or on RPC trouble — the
-        caller then keeps waiting, never slashes."""
+        ``CANCEL_REASON_EVM_REVERT`` only when the recorded tx (1) reverted (receipt status 0), (2) came
+        FROM the committed miner sender, (3) paid the pinned dest, (4) carried >= the required value, and
+        (5) supplied a gas LIMIT >= ``ETH_FULFILL_GAS_FLOOR``. Clauses (2) and (5) are load-bearing: (5)
+        stops a miner under-gassing to fake a refusal, and (2) stops a miner pointing at a reverted tx
+        sent from a throwaway address (against a dest that reverts unless ``msg.sender`` is the committed
+        miner) to claim refusal without ever attempting delivery from its own address. Deliberately NOT
+        ``gasUsed < gas`` (a hostile contract can burn all gas to mimic OOG). ``None`` on anything short
+        of that proof or on RPC trouble — the caller then keeps waiting, never slashes."""
         if not tx_hash:
             return None
         try:
@@ -344,6 +348,8 @@ class EvmCoin(EvmAsset):
         norm = self.chain.normalize_address
         if int(receipt.get('status') or '0x0', 16) != 0:
             return None  # succeeded (or unreadable status) — a delivered tx is not a refusal
+        if from_address and norm(tx.get('from') or '') != norm(from_address):
+            return None  # not the committed miner's own attempt — could be a throwaway-sender ruse
         if norm(tx.get('to') or '') != norm(address):
             return None  # paid the wrong destination
         if int(tx.get('value') or '0x0', 16) < int(amount):

--- a/allways/assets/evm_coin.py
+++ b/allways/assets/evm_coin.py
@@ -8,11 +8,17 @@ from eth_utils import to_checksum_address
 from allways.assets.asset import ProviderUnreachableError, SendResult, TransactionInfo
 from allways.assets.evm import EVM_NETWORKS, FALLBACK_PRIORITY_FEE_WEI, EvmAsset, EvmChain
 from allways.chains import ChainDefinition
+from allways.constants import CANCEL_REASON_EVM_REVERT
 
 TRANSFER_GAS = 21_000
 # Refuse destinations whose receive hook wants more than this — bounds the miner's gas
 # spend against a hostile contract; the slash gate exempts code-bearing dests anyway.
 MAX_TRANSFER_GAS = 100_000
+# Gas limit the miner supplies on a refusal-evidence broadcast (a dest that reverts a well-gassed
+# transfer). Equal to MAX_TRANSFER_GAS so a good-faith attempt provides at least the gas a cooperative
+# smart-wallet delivery would consume; a resulting revert is then sound "dest refused" evidence, and a
+# miner cannot under-gas to manufacture one. A revert refunds the unused gas, so real cost << the limit.
+ETH_FULFILL_GAS_FLOOR = MAX_TRANSFER_GAS
 ZERO_ADDRESS = '0x' + '00' * 20
 # Hard ceiling on the deposit scanner's block walk, independent of block time: the walk costs one
 # RPC per block, and sub-second chains would otherwise turn SCAN_LOOKBACK_BLOCKS into hundreds of
@@ -218,8 +224,16 @@ class EvmCoin(EvmAsset):
 
             gas = self._transfer_gas(acct.address, to_address, amount)
             if gas is None:
-                self._send_error(f'destination {to_address} refuses {prefix} transfers — not sending')
-                return None
+                # The destination refuses a well-formed transfer (revert) or wants more gas than the cap.
+                # Do NOT bail silently — broadcast a floor-gas attempt so the on-chain reverted tx becomes
+                # the evidence that earns a no-fault cancel (no slash) rather than a false timeout slash.
+                # The revert refunds unused gas, so the miner's real cost is intrinsic + execution, bounded
+                # by ETH_FULFILL_GAS_FLOOR. The miner marks fulfilled with this hash like any delivery; the
+                # validator adjudicates delivered-vs-refused from the receipt.
+                gas = ETH_FULFILL_GAS_FLOOR
+                bt.logging.warning(
+                    f'{to_address} refuses {prefix} transfers — broadcasting a floor-gas attempt as refusal evidence'
+                )
 
             nonce = int(self.chain.eth_rpc('eth_getTransactionCount', [acct.address, 'pending']), 16)
 
@@ -307,6 +321,36 @@ class EvmCoin(EvmAsset):
         span = min(120, max(0, int(time.time()) - int(since_unix)) // self.chain_def.seconds_per_block)
         probes = ['latest'] + [hex(max(0, tip - span // d)) for d in (1, 2)]
         return any((self.chain.eth_rpc('eth_getCode', [address, b]) or '0x') != '0x' for b in probes)
+
+    def cancel_evidence(self, address: str, amount: int, tx_hash: Optional[str] = None) -> Optional[int]:
+        """No-fault-cancel evidence for native EVM: the miner's own delivery tx reverted despite a
+        correct, well-gassed attempt — sound proof the destination refused, strong enough to TERMINATE
+        the swap with no slash (unlike ``delivery_refused``, a getCode deferral hint). Returns
+        ``CANCEL_REASON_EVM_REVERT`` only when the recorded tx (1) reverted (receipt status 0), (2) paid
+        the pinned dest, (3) carried >= the required value, and (4) supplied a gas LIMIT >=
+        ``ETH_FULFILL_GAS_FLOOR``. Clause (4) is load-bearing: it stops a miner under-gassing to fake a
+        refusal and keep the taker's source. Deliberately NOT ``gasUsed < gas`` (a hostile contract can
+        burn all gas to mimic OOG). ``None`` on anything short of that proof or on RPC trouble — the
+        caller then keeps waiting, never slashes."""
+        if not tx_hash:
+            return None
+        try:
+            tx = self.chain.eth_rpc('eth_getTransactionByHash', [tx_hash], null_needs_quorum=True)
+            receipt = self.chain.eth_rpc('eth_getTransactionReceipt', [tx_hash]) if tx else None
+        except Exception:
+            return None
+        if not tx or not receipt:
+            return None
+        norm = self.chain.normalize_address
+        if int(receipt.get('status') or '0x0', 16) != 0:
+            return None  # succeeded (or unreadable status) — a delivered tx is not a refusal
+        if norm(tx.get('to') or '') != norm(address):
+            return None  # paid the wrong destination
+        if int(tx.get('value') or '0x0', 16) < int(amount):
+            return None  # under-paid — not a good-faith attempt
+        if int(tx.get('gas') or '0x0', 16) < ETH_FULFILL_GAS_FLOOR:
+            return None  # under-gassed — could be manufactured; never accept as refusal
+        return CANCEL_REASON_EVM_REVERT
 
     # Plain JSON-RPC has no address→tx index (Esplora/getSignaturesForAddress have one), so the
     # deposit scanner follows the head incrementally like the TAO provider: each call scans only

--- a/allways/assets/sol.py
+++ b/allways/assets/sol.py
@@ -11,6 +11,7 @@ from solders.signature import Signature
 from allways.assets.asset import Asset, ProviderUnreachableError, SendResult, TransactionInfo
 from allways.assets.chain import Chain
 from allways.chains import CHAIN_SOL, ChainDefinition
+from allways.constants import CANCEL_REASON_SOL_RESERVED
 from allways.solana.rpc import SolanaRpc, resolve_rpc_url
 
 LOG_SOL = '[Solana]'
@@ -261,6 +262,12 @@ class Sol(Asset, Chain):
         rejects the lamport credit outright, so the miner could never have paid. Offline and
         exact, so unlike the EVM probes there is no RPC to fail and no window to sample."""
         return address in RESERVED_ACCOUNTS
+
+    def cancel_evidence(self, address: str, amount: int, tx_hash: Optional[str] = None) -> Optional[int]:
+        """No-fault-cancel evidence: a reserved-account destination is undeliverable by construction, a
+        fixed offline membership test — deterministic, no RPC, sound enough to terminate the swap with
+        no slash. Returns CANCEL_REASON_SOL_RESERVED, else None."""
+        return CANCEL_REASON_SOL_RESERVED if address in RESERVED_ACCOUNTS else None
 
     def is_valid_address(self, address: str) -> bool:
         """Validate a base58 ed25519 pubkey (32 bytes) without RPC."""

--- a/allways/assets/sol.py
+++ b/allways/assets/sol.py
@@ -263,7 +263,9 @@ class Sol(Asset, Chain):
         exact, so unlike the EVM probes there is no RPC to fail and no window to sample."""
         return address in RESERVED_ACCOUNTS
 
-    def cancel_evidence(self, address: str, amount: int, tx_hash: Optional[str] = None) -> Optional[int]:
+    def cancel_evidence(
+        self, address: str, amount: int, tx_hash: Optional[str] = None, from_address: Optional[str] = None
+    ) -> Optional[int]:
         """No-fault-cancel evidence: a reserved-account destination is undeliverable by construction, a
         fixed offline membership test — deterministic, no RPC, sound enough to terminate the swap with
         no slash. Returns CANCEL_REASON_SOL_RESERVED, else None."""

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -47,6 +47,14 @@ MIN_BALANCE_FOR_TX_RAO = 20_000_000  # 0.02 TAO buffer for extrinsic fees
 # BTC fee floor (sat/vB). Catches the case where the upstream estimator
 # returns nonsense low. 5 is cheap enough to barely register on mainnet
 # and still clears testnet quickly, so a single floor covers both.
+# No-fault cancel (unpayable destination): advisory reason discriminants passed to cancel_swap.
+# Mirror smart-contracts/.../constants.rs CANCEL_REASON_*; observability only, never consensus-bound.
+CANCEL_REASON_EVM_REVERT = 0
+CANCEL_REASON_ERC20_BLACKLIST = 1
+CANCEL_REASON_ERC20_PAUSED = 2
+CANCEL_REASON_SOL_RESERVED = 3
+CANCEL_REASON_OTHER = 255
+
 BTC_MIN_FEE_RATE = 5
 # Modest pad on estimated fee rates (not on explicit user overrides) against
 # mempool conditions drifting between estimate and broadcast. Goal is

--- a/allways/solana/client.py
+++ b/allways/solana/client.py
@@ -691,6 +691,25 @@ class AllwaysSolanaClient:
         args = layouts.IX_SWAP_KEY_ARGS.build({'swap_key': swap_key})
         return self._send([self._ix('timeout_swap', args, metas)])
 
+    def cancel_swap(self, swap_key: bytes, miner, reason: int = 255) -> str:
+        """Vote to cancel a swap whose destination provably cannot receive the payout; on quorum the
+        swap is closed and the miner freed with NO slash, fee, or strike (the lenient sibling of
+        timeout). Leaner account list than timeout_swap — no collateral_vault or user, since no funds
+        move. ``reason`` is an advisory CANCEL_REASON_* discriminant (not consensus-bound)."""
+        validator = self.keypair.pubkey()
+        m = _as_pubkey(miner)
+        metas = [
+            AccountMeta(validator, True, True),
+            AccountMeta(pdas.config_pda(self.program_id), False, False),
+            AccountMeta(m, False, False),
+            AccountMeta(pdas.miner_state_pda(m, self.program_id), False, True),
+            AccountMeta(pdas.swap_pda(swap_key, self.program_id), False, True),
+            AccountMeta(pdas.vote_round_pda(pdas.REQ_CANCEL, swap_key, self.program_id), False, True),
+            AccountMeta(SYSTEM_PROGRAM, False, False),
+        ]
+        args = layouts.IX_CANCEL_SWAP_ARGS.build({'swap_key': swap_key, 'reason': int(reason) & 0xFF})
+        return self._send([self._ix('cancel_swap', args, metas)])
+
     def close_stale_claim(self, miner, swap_key: bytes, backing: str = 'sol') -> str:
         """Permissionless: reap an orphaned PendingAttestation claim whose reservation has expired (or was
         superseded). Closes the Swap PDA (rent -> caller) and frees the reservation's claim slot. No slash —

--- a/allways/solana/layouts.py
+++ b/allways/solana/layouts.py
@@ -316,6 +316,7 @@ EVENT_DISCRIMINATORS = {
     'SwapFulfilled': bytes([62, 201, 236, 62, 234, 76, 17, 39]),
     'SwapInitiated': bytes([88, 197, 100, 28, 189, 82, 98, 2]),
     'SwapTimedOut': bytes([216, 21, 45, 129, 255, 250, 107, 166]),
+    'SwapCancelled': bytes([210, 232, 53, 121, 126, 236, 66, 142]),
     'SwapTimeoutExtended': bytes([125, 63, 87, 100, 186, 75, 227, 121]),
     'TreasuryWithdrawn': bytes([143, 181, 157, 169, 87, 155, 170, 46]),
     'ValidatorWeightsUpdated': bytes([38, 6, 182, 182, 124, 27, 131, 38]),
@@ -442,6 +443,13 @@ EVENT_LAYOUTS = {
         'reimbursement' / U64,
         'payee' / String,
     ),
+    'SwapCancelled': CStruct(
+        'swap_key' / Hash32,
+        'miner' / Pubkey32,
+        'collateral_chain' / String,
+        'collateral_amount' / U64,
+        'reason' / U8,
+    ),
     'SwapTimeoutExtended': CStruct('swap_key' / Hash32, 'miner' / Pubkey32, 'validator' / Pubkey32, 'timeout_at' / I64),
     'TreasuryWithdrawn': CStruct('recipient' / Pubkey32, 'amount' / U64, 'total' / U64),
     'ValidatorWeightsUpdated': CStruct('count' / U8, 'updated_at' / I64),
@@ -475,6 +483,7 @@ EVENT_PUBKEY_FIELDS = {
     'SwapFulfilled': ['miner'],
     'SwapInitiated': ['user', 'miner'],
     'SwapTimedOut': ['miner'],
+    'SwapCancelled': ['miner'],
     'SwapTimeoutExtended': ['miner', 'validator'],
     'TreasuryWithdrawn': ['recipient'],
     'ValidatorWeightsUpdated': [],
@@ -492,6 +501,7 @@ IX_DISCRIMINATORS = {
     'vote_initiate': bytes([210, 23, 157, 114, 35, 129, 164, 4]),
     'confirm_swap': bytes([183, 168, 179, 117, 86, 243, 166, 195]),
     'timeout_swap': bytes([18, 157, 212, 120, 145, 200, 239, 63]),
+    'cancel_swap': bytes([88, 174, 98, 148, 24, 252, 93, 89]),  # no-fault terminal (unpayable dest)
     'close_stale_claim': bytes([185, 69, 27, 37, 187, 78, 157, 188]),  # reap an orphaned PendingAttestation claim
     'vote_activate': bytes([24, 233, 47, 230, 116, 115, 109, 41]),
     'vote_deactivate': bytes([243, 169, 237, 143, 48, 91, 0, 119]),
@@ -570,6 +580,7 @@ IX_AMOUNT_ARGS = CStruct('amount' / U64)
 
 # B2 swap-lifecycle args. `swap_key` is a borsh `[u8; 32]` (fixed array → raw 32 bytes, no len prefix).
 IX_SWAP_KEY_ARGS = CStruct('swap_key' / Hash32)  # vote_initiate, timeout_swap, close_stale_claim
+IX_CANCEL_SWAP_ARGS = CStruct('swap_key' / Hash32, 'reason' / U8)  # cancel_swap (reason is advisory)
 IX_SUBMIT_CLAIM_ARGS = CStruct('swap_key' / Hash32, 'from_tx_hash' / String, 'from_tx_block' / U32)
 IX_CONFIRM_SWAP_ARGS = CStruct('swap_key' / Hash32, 'from_chain' / String, 'to_chain' / String)
 IX_MARK_FULFILLED_ARGS = CStruct('swap_key' / Hash32, 'to_tx_hash' / String, 'to_tx_block' / U32)

--- a/allways/solana/pdas.py
+++ b/allways/solana/pdas.py
@@ -25,6 +25,7 @@ REQ_TIMEOUT = 7
 REQ_SET_WEIGHTS = 8
 REQ_SET_ATTESTATION = 9
 REQ_ATTEST_HEARTBEAT = 10
+REQ_CANCEL = 11  # no-fault cancel_swap terminal (mirrors constants.rs)
 
 # Per-backing activation bits on MinerState.active_backings (constants.rs).
 BACKING_BIT_SOL = 1 << 0

--- a/allways/validator/solana_swap_loop.py
+++ b/allways/validator/solana_swap_loop.py
@@ -19,7 +19,7 @@ from solders.pubkey import Pubkey
 from allways import dev_signal
 from allways.assets.asset import ProviderUnreachableError
 from allways.chains import compute_extension_target_secs, get_chain_def
-from allways.constants import EXTENSION_PADDING_SECONDS
+from allways.constants import CANCEL_REASON_OTHER, EXTENSION_PADDING_SECONDS
 from allways.solana import pdas
 from allways.solana.client import benign_marker, swap_from_solana, swap_key_from_tx_hash
 from allways.utils.rate import apply_fee_deduction, expected_swap_amounts
@@ -30,6 +30,7 @@ class SwapDecision(Enum):
     CONFIRM = 'confirm'  # Fulfilled: both legs verified -> would confirm_swap
     TIMEOUT = 'timeout'  # Active past its deadline -> would timeout_swap
     CANCEL = 'cancel'  # PendingAttestation whose reservation expired -> close_stale_claim (reap, no slash)
+    REFUSE = 'refuse'  # Active/Fulfilled with a provably-unpayable dest -> cancel_swap (no slash/fee/strike)
     EXTEND_RESERVATION = 'extend_reservation'  # source valid-but-unconfirmed near expiry -> slide reserved_until
     EXTEND_TIMEOUT = 'extend_timeout'  # dest valid-but-unconfirmed near timeout -> slide timeout_at
     WAIT = 'wait'  # in-flight, nothing to do yet
@@ -44,6 +45,7 @@ class SwapAction(NamedTuple):
     decision: SwapDecision
     target_at: Optional[int] = None
     reason: Optional[str] = None
+    reason_code: Optional[int] = None  # CANCEL_REASON_* discriminant carried by a REFUSE (cancel_swap)
 
 
 # Decisions that drive an on-chain write this pass.
@@ -53,6 +55,7 @@ ACTIONABLE = frozenset(
         SwapDecision.CONFIRM,
         SwapDecision.TIMEOUT,
         SwapDecision.CANCEL,
+        SwapDecision.REFUSE,
         SwapDecision.EXTEND_RESERVATION,
         SwapDecision.EXTEND_TIMEOUT,
     }
@@ -197,6 +200,30 @@ class SolanaSwapLoop:
             bt.logging.warning(f'{self._label(swap)}: delivery_refused check failed ({e}) — deferring, not slashing')
             return True
 
+    def _cancel_action(self, swap: Any) -> Optional[SwapAction]:
+        """A REFUSE (no-fault cancel_swap) action when the dest PROVABLY can't receive — sound enough to
+        close with no slash (EVM: the miner's reverted delivery tx at/above the gas floor; ERC-20: attested
+        issuer blacklist/pause; Solana: reserved-account membership). None otherwise. Distinct from and
+        stronger than ``_dest_refuses`` (a mere deferral hint): only positive, sound evidence terminates a
+        swap here, so a getCode hint alone never converts to a cancel — it keeps the swap deferring."""
+        provider = self.providers.get(swap.to_chain)
+        if provider is None:
+            return None
+        try:
+            reason = provider.cancel_evidence(
+                swap.user_to_addr, self.expected_user_receives(swap), getattr(swap, 'to_tx_hash', '') or None
+            )
+        except Exception as e:
+            bt.logging.warning(f'{self._label(swap)}: cancel_evidence check failed ({e}) — not cancelling')
+            return None
+        if reason is None:
+            return None
+        return SwapAction(
+            SwapDecision.REFUSE,
+            reason=f'dest provably unpayable (reason={reason}) — cancel, no slash/fee/strike',
+            reason_code=reason,
+        )
+
     def _get_reservation(self, miner: Any, backing: str) -> Any:
         """The (miner, hub) reservation slot — per-backing since v3.1, so a swap's timeline is read
         off ITS hub's slot and a concurrent other-hub reservation can't shadow it."""
@@ -272,20 +299,31 @@ class SolanaSwapLoop:
             and self._is_fresh(d_info, int(swap.initiated_at), swap.to_chain, self._label(swap))
         ):
             return SwapAction(SwapDecision.CONFIRM, reason='src=ok dst=ok dst-fresh — both legs verified')
-        # Unverifiable/stale dest + overdue ⇒ TIMEOUT; else wait for the leg. Without the confirmation
-        # count and remaining runway, a healthy deferral and an imminent slash render identically.
+        # No-fault cancel: sound evidence the dest can't receive (miner's reverted tx / issuer freeze /
+        # reserved account) → close with NO slash, EARLY, ahead of the overdue/timeout logic.
+        cancel = self._cancel_action(swap)
+        if cancel is not None:
+            return cancel
+        # Unverifiable/stale dest. Without the confirmation count and remaining runway, a healthy
+        # deferral and an imminent slash render identically.
         why = (
             f'src={s_status} dst={d_status} [{_confs(swap.to_chain, d_info)}] timeout_in={int(swap.timeout_at) - now}s'
         )
         if not overdue:
             return SwapAction(SwapDecision.WAIT, reason=f'{why} — awaiting a verifiable+fresh dest leg')
         if self._dest_refuses(swap):
-            # Terminal past the ceiling: an undeliverable dest never recovers, so timing out is the only
-            # path that clears the hub bit — before it, keep deferring to protect a genuinely live miner.
+            # No SOUND cancel evidence, but the dest may refuse (getCode / malformed / check unreachable):
+            # defer the slash to protect a live miner. An undeliverable dest never recovers, so at the
+            # max_extend_at ceiling still TIMEOUT — else has_active_swap never clears and collateral freezes.
+            # A dest that GENUINELY refuses yields sound evidence → REFUSE above, well before the ceiling; so
+            # only an evidence-less case (miner never produced a valid reverted tx) reaches this slash.
             if now < int(swap.max_extend_at):
-                return SwapAction(SwapDecision.WAIT, reason=f'{why} + overdue but dest refuses delivery — not slashing')
+                return SwapAction(
+                    SwapDecision.WAIT, reason=f'{why} + overdue but dest may refuse — deferring, not slashing'
+                )
             return SwapAction(
-                SwapDecision.TIMEOUT, reason=f'{why} + dest refuses past max_extend_at — terminal, slashing'
+                SwapDecision.TIMEOUT,
+                reason=f'{why} + dest refuses past max_extend_at, no sound cancel evidence — terminal, slashing',
             )
         return SwapAction(SwapDecision.TIMEOUT, reason=f'{why} + overdue — dest unverifiable, slashing')
 
@@ -377,14 +415,24 @@ class SolanaSwapLoop:
         if status == 'PendingAttestation':
             return self._decide_pending_attestation(swap, now)
         if status == 'Active':
+            # No-fault cancel for chains whose refusal is provable WITHOUT a delivery tx (Solana reserved
+            # account, ERC-20 issuer freeze): an Active swap into such a dest cancels immediately — no point
+            # waiting for a fulfillment that can never land. Native EVM has no tx yet, so this is None until
+            # the miner broadcasts + marks fulfilled (then the Fulfilled branch adjudicates the reverted tx).
+            cancel = self._cancel_action(swap)
+            if cancel is not None:
+                return cancel
             # Never extend: no mark_fulfilled = no broadcast evidence, so an overdue Active is slash-eligible.
             if overdue and self._dest_refuses(swap):
-                # The refusal guard defers a slash so a transient dest fault can't punish a live miner —
-                # but an undeliverable dest never becomes deliverable, so at the max_extend_at ceiling it is
-                # terminal: time out (else has_active_swap never clears and the hub's collateral freezes).
+                # Defer a slash to protect a live miner; but an undeliverable dest never recovers, so past
+                # max_extend_at still TIMEOUT (else the hub's collateral freezes). A genuine refusal yields
+                # sound cancel evidence → REFUSE above, before the ceiling.
                 if now < int(swap.max_extend_at):
-                    return SwapAction(SwapDecision.WAIT, reason='overdue but dest refuses delivery — not slashing')
-                return SwapAction(SwapDecision.TIMEOUT, reason='dest refuses past max_extend_at — terminal, slashing')
+                    return SwapAction(SwapDecision.WAIT, reason='overdue but dest may refuse — deferring, not slashing')
+                return SwapAction(
+                    SwapDecision.TIMEOUT,
+                    reason='dest refuses past max_extend_at, no sound cancel evidence — terminal, slashing',
+                )
             return SwapAction(
                 SwapDecision.TIMEOUT if overdue else SwapDecision.WAIT,
                 reason='overdue, miner never fulfilled — slashing' if overdue else 'awaiting miner mark_fulfilled',
@@ -420,6 +468,11 @@ class SolanaSwapLoop:
             elif decision == SwapDecision.CANCEL:
                 # Permissionless reap (no vote round) — first validator wins, peers no-op benignly.
                 sig = self.client.close_stale_claim(swap.miner, swap_key, str(swap.collateral_chain))
+            elif decision == SwapDecision.REFUSE:
+                # No-fault cancel of a provably-unpayable dest — quorum-gated like timeout, no slash.
+                if self.client.has_voted(pdas.REQ_CANCEL, swap_key, voter):
+                    return False
+                sig = self.client.cancel_swap(swap_key, swap.miner, action.reason_code or CANCEL_REASON_OTHER)
             elif decision == SwapDecision.EXTEND_RESERVATION:
                 sig = self.client.extend_reservation(swap.miner, action.target_at, str(swap.collateral_chain))
             elif decision == SwapDecision.EXTEND_TIMEOUT:

--- a/allways/validator/solana_swap_loop.py
+++ b/allways/validator/solana_swap_loop.py
@@ -211,7 +211,10 @@ class SolanaSwapLoop:
             return None
         try:
             reason = provider.cancel_evidence(
-                swap.user_to_addr, self.expected_user_receives(swap), getattr(swap, 'to_tx_hash', '') or None
+                swap.user_to_addr,
+                self.expected_user_receives(swap),
+                getattr(swap, 'to_tx_hash', '') or None,
+                from_address=getattr(swap, 'miner_to_addr', '') or None,
             )
         except Exception as e:
             bt.logging.warning(f'{self._label(swap)}: cancel_evidence check failed ({e}) — not cancelling')

--- a/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
@@ -87,6 +87,18 @@ pub const REQ_SET_WEIGHTS: u8 = 8;
 pub const REQ_SET_ATTESTATION: u8 = 9;
 /// Global round bumping `Config.last_attest_heartbeat` (the dead-man fuse's liveness signal).
 pub const REQ_ATTEST_HEARTBEAT: u8 = 10;
+/// Per-swap round for the no-fault cancel terminal (destination provably cannot receive the payout).
+/// Distinct from REQ_TIMEOUT so the two terminals accrue votes in separate rounds; the first to reach
+/// quorum closes the swap and the loser reverts on the gone PDA.
+pub const REQ_CANCEL: u8 = 11;
+
+/// Advisory `SwapCancelled.reason` discriminants — observability only, NEVER a consensus input (not
+/// bound into the vote hash), so validators co-count the verdict rather than fragmenting over the label.
+pub const CANCEL_REASON_EVM_REVERT: u8 = 0;
+pub const CANCEL_REASON_ERC20_BLACKLIST: u8 = 1;
+pub const CANCEL_REASON_ERC20_PAUSED: u8 = 2;
+pub const CANCEL_REASON_SOL_RESERVED: u8 = 3;
+pub const CANCEL_REASON_OTHER: u8 = 255;
 
 /// Slots the draw's seed slot is pinned ahead of the arming crank. Three leader windows (4 slots
 /// each) ahead, so the seed slot never lands in the window of the leader who included the arming tx.

--- a/smart-contracts/solana/programs/allways_swap_manager/src/events.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/events.rs
@@ -109,6 +109,22 @@ pub struct SwapTimedOut {
     pub payee: String,
 }
 
+/// The no-fault cancel verdict: the destination provably could not receive the payout, so the swap is
+/// closed with no slash, fee, or strike, and the miner keeps the source. Unlike `SwapTimedOut`, the bond
+/// reconciler must do NOTHING to a vaulted bond on this event — there is no seizure to relay, and the
+/// on-chain `reserved_collateral` view was already cleared by `release_reserved`.
+#[event]
+pub struct SwapCancelled {
+    pub swap_key: [u8; 32],
+    pub miner: Pubkey,
+    /// Backing chain whose hub was freed.
+    pub collateral_chain: String,
+    /// Swap size, for ledger symmetry with the other terminals.
+    pub collateral_amount: u64,
+    /// Advisory reason discriminant (`CANCEL_REASON_*`); observability only, never a consensus input.
+    pub reason: u8,
+}
+
 /// A validator slid a reservation/swap deadline forward (single-validator, no quorum). Carries the
 /// new deadline (post-value) so consumers set an absolute, not a delta.
 #[event]

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions.rs
@@ -1,5 +1,6 @@
 pub mod admin;
 pub mod bind_hotkey;
+pub mod cancel_swap;
 pub mod close_legacy_quote;
 pub mod close_legacy_slot;
 pub mod close_legacy_swap;
@@ -34,6 +35,7 @@ pub mod withdraw_treasury;
 // handlers are always called fully-qualified, e.g. `initialize::handler`.)
 pub use admin::*;
 pub use bind_hotkey::*;
+pub use cancel_swap::*;
 pub use close_legacy_quote::*;
 pub use close_legacy_slot::*;
 pub use close_legacy_swap::*;

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/cancel_swap.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/cancel_swap.rs
@@ -1,0 +1,128 @@
+use anchor_lang::prelude::*;
+
+use crate::consensus::{record_vote, swap_request_hash};
+use crate::constants::{CONFIG_SEED, MINER_SEED, REQ_CANCEL, SWAP_SEED, VOTE_SEED};
+use crate::error::ErrorCode;
+use crate::events::SwapCancelled;
+use crate::state::{Config, MinerState, Swap, SwapStatus, VoteRound};
+
+/// Validators cancel a swap whose destination provably cannot receive the payout — an EVM contract that
+/// reverts a correctly-gassed transfer, an ERC-20 blacklisted/paused destination, a Solana reserved
+/// account. It is `timeout_swap` minus every punitive action: on quorum the Swap is closed and the miner
+/// freed, with NO slash, NO fee, NO strike, and NO fund movement.
+///
+/// The refusal verdict is reached OFF-CHAIN, by the same quorum that would otherwise time the swap out,
+/// via a per-chain evidence rule every validator runs deterministically (EVM: a mined reverted delivery
+/// tx at/above the gas floor; ERC-20: attested issuer blacklist/pause; Solana: reserved-account
+/// membership). The contract can neither parse an EVM receipt nor make an RPC call, so it carries NO
+/// evidence on-chain — it trusts the supermajority here exactly as `timeout_swap` trusts it. Cancel and
+/// timeout share the same 2/3 denominator over the same set, so the honest majority picks which terminal
+/// fires and a minority can carry neither.
+#[derive(Accounts)]
+#[instruction(swap_key: [u8; 32])]
+pub struct CancelSwap<'info> {
+    #[account(mut)]
+    pub validator: Signer<'info>,
+
+    #[account(seeds = [CONFIG_SEED], bump = config.bump)]
+    pub config: Account<'info, Config>,
+
+    /// CHECK: bound via miner_state seeds + the swap `has_one`.
+    pub miner: UncheckedAccount<'info>,
+
+    #[account(
+        mut,
+        seeds = [MINER_SEED, miner.key().as_ref()],
+        bump = miner_state.bump,
+        constraint = miner_state.miner == miner.key(),
+    )]
+    pub miner_state: Account<'info, MinerState>,
+
+    // No collateral_vault, treasury, or user: cancel moves no funds. There is no source custody on
+    // Solana (the taker paid the miner directly, off-chain), so "miner keeps the source" is realized by
+    // cancel simply never creating a refund path — zero contract action is required for it.
+
+    // `swap` MUST resolve before `vote_round`: once a competing terminal has closed the Swap PDA, a
+    // straggler cancel fails these seeds/`has_one` before `init_if_needed` could re-create the round.
+    // This is what makes "first terminal to close the Swap wins" true — do not reorder.
+    #[account(
+        mut,
+        seeds = [SWAP_SEED, swap_key.as_ref()],
+        bump = swap.bump,
+        has_one = miner,
+    )]
+    pub swap: Account<'info, Swap>,
+
+    #[account(
+        init_if_needed,
+        payer = validator,
+        space = 8 + VoteRound::INIT_SPACE,
+        seeds = [VOTE_SEED, &[REQ_CANCEL], swap_key.as_ref()],
+        bump,
+    )]
+    pub vote_round: Account<'info, VoteRound>,
+
+    pub system_program: Program<'info, System>,
+}
+
+pub fn handler(ctx: Context<CancelSwap>, swap_key: [u8; 32], reason: u8) -> Result<()> {
+    let now = Clock::get()?.unix_timestamp;
+
+    // Status gate ONLY — deliberately no `now >= timeout_at`. Timeout's deadline gate is a fairness
+    // guarantee protecting the miner from a premature *slash*; cancel is strictly lenient (no slash,
+    // fee, or strike, miner keeps the source), so nothing needs protecting and it may fire the instant
+    // refusal evidence is attested — ahead of the deadline — to bound hub occupancy. PendingAttestation
+    // is excluded: no obligation yet, nothing to cancel (reap via close_stale_claim instead).
+    require!(
+        ctx.accounts.swap.status == SwapStatus::Active || ctx.accounts.swap.status == SwapStatus::Fulfilled,
+        ErrorCode::InvalidStatus
+    );
+
+    // `reason` is NOT bound here — voters co-count the verdict "cancel this swap" even if they'd label
+    // the refusal differently, so a bogus reason cannot split a legitimate quorum.
+    let bound = swap_request_hash(REQ_CANCEL, &swap_key);
+    let validator = ctx.accounts.validator.key();
+    let round_bump = ctx.bumps.vote_round;
+
+    let quorum = record_vote(
+        &mut ctx.accounts.vote_round,
+        &ctx.accounts.config,
+        validator,
+        bound,
+        round_bump,
+        now,
+    )?;
+
+    if quorum {
+        let collateral_amount = ctx.accounts.swap.collateral_amount;
+        let miner = ctx.accounts.swap.miner;
+        let collateral_chain = ctx.accounts.swap.collateral_chain.clone();
+        let bit = crate::backing::backing_bit(&collateral_chain)?;
+
+        // Free the hub for EVERY backing, immediately. Nothing is owed on any chain — there is no
+        // seizure to wait on — so, unlike timeout's vaulted branch, we set neither a busy-until-settled
+        // nor a settling window: a hard 0, identical to confirm_swap's success close. This swap is the
+        // sole holder of the hub bit (its reservation was consumed at vote_initiate).
+        ctx.accounts.miner_state.set_swap(bit, false);
+        ctx.accounts.miner_state.set_busy(bit, 0);
+        // Deliberately NO set_settling(...) — nothing settles on a no-fault cancel.
+        ctx.accounts
+            .miner_state
+            .release_reserved(bit, crate::constants::required_collateral(collateral_amount));
+        // NOT touched: miner_state.collateral, treasury, failed_swaps. No apply_penalty, no lamport moves.
+
+        // Close the per-swap round + swap; rent → validator. The straggler in the losing round reverts on
+        // the now-gone swap before it could re-create this round (see the account-ordering note above).
+        ctx.accounts.vote_round.close(ctx.accounts.validator.to_account_info())?;
+        ctx.accounts.swap.close(ctx.accounts.validator.to_account_info())?;
+
+        emit!(SwapCancelled {
+            swap_key,
+            miner,
+            collateral_chain,
+            collateral_amount,
+            reason,
+        });
+    }
+    Ok(())
+}

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/confirm_swap.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/confirm_swap.rs
@@ -150,6 +150,11 @@ pub fn handler(
             .release_reserved(bit, crate::constants::required_collateral(collateral_amount));
         ctx.accounts.miner_state.successful_swaps =
             ctx.accounts.miner_state.successful_swaps.saturating_add(1);
+        // Strike decay: a completed swap forgives one prior failure, so a transient fault (a dead
+        // Esplora, a slow chain) can't permanently strike-out an otherwise-healthy miner. The
+        // strike gate still bites a miner that fails faster than it succeeds.
+        ctx.accounts.miner_state.failed_swaps =
+            ctx.accounts.miner_state.failed_swaps.saturating_sub(1);
 
         // Accrue the miner's realized per-direction track record (count saturates; volume totals use
         // checked_add so a saturated sum can never silently corrupt the VWAP the validator reads).

--- a/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
@@ -261,6 +261,11 @@ pub mod allways_swap_manager {
     pub fn timeout_swap(ctx: Context<TimeoutSwap>, swap_key: [u8; 32]) -> Result<()> {
         timeout_swap::handler(ctx, swap_key)
     }
+    /// Validators cancel a swap whose destination provably cannot receive the payout, with NO slash,
+    /// fee, or strike — the lenient sibling of timeout. Frees the miner and closes the swap on quorum.
+    pub fn cancel_swap(ctx: Context<CancelSwap>, swap_key: [u8; 32], reason: u8) -> Result<()> {
+        cancel_swap::handler(ctx, swap_key, reason)
+    }
 
     // --- Deadline extensions (single validator, no quorum; bounded by a frozen ceiling) ---
     /// A validator slides a reservation's deadline forward while it waits on slow source-chain

--- a/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
@@ -135,8 +135,9 @@ pub struct MinerState {
     /// Lifetime swaps completed (confirm_swap quorum). Monotonic. Off-chain emissions warm-up gate:
     /// a miner earns nothing until `successful_swaps >= 2`.
     pub successful_swaps: u32,
-    /// Lifetime swaps failed (timeout_swap quorum). Monotonic, never resets. Off-chain strike-out gate:
-    /// `failed_swaps > 2` => no emissions (recover by re-registering).
+    /// Lifetime swaps failed (timeout_swap quorum), less one per completed swap (confirm_swap decays
+    /// it by 1, floored at 0). Off-chain strike-out gate: `failed_swaps > 2` => no emissions. Decay
+    /// means a healthy miner recovers by completing swaps, not only by re-registering.
     pub failed_swaps: u32,
     /// Stored PDA bump.
     pub bump: u8,

--- a/tests/test_cancel_swap_nofault.py
+++ b/tests/test_cancel_swap_nofault.py
@@ -1,0 +1,121 @@
+"""Unit tests for the no-fault-cancel evidence seam (`Asset.cancel_evidence`).
+
+This is the SOUND per-chain refusal verdict that terminates a swap with no slash (distinct from
+`delivery_refused`, a mere deferral hint). Each arm must return a CANCEL_REASON_* only on evidence
+strong enough that a wrong verdict can't hand a defaulting miner a free pass:
+  - native EVM: the miner's OWN reverted delivery tx, and only with correct dest + value + gas-floor
+    (the gas-limit floor is the anti-fake clause — under-gassing must NOT manufacture a refusal);
+  - ERC-20: attested issuer blacklist/pause (dest-attributing, unlike an ambiguous reverted transfer);
+  - Solana: reserved-account membership (offline, deterministic);
+  - passive chains (BTC/TAO) and the base default: never — they can't refuse a payout.
+"""
+
+from allways.assets.eth import Ether
+from allways.assets.ethusdc import EthUsdc
+from allways.assets.sol import RESERVED_ACCOUNTS, Sol
+from allways.constants import (
+    CANCEL_REASON_ERC20_BLACKLIST,
+    CANCEL_REASON_ERC20_PAUSED,
+    CANCEL_REASON_EVM_REVERT,
+    CANCEL_REASON_SOL_RESERVED,
+)
+
+DEST = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+TX = '0x' + 'ab' * 32
+AMOUNT = 256  # 0x100
+
+
+def _evm(monkeypatch):
+    monkeypatch.setenv('ETH_NETWORK', 'mainnet')
+    monkeypatch.delenv('ETH_RPC_URLS', raising=False)
+    monkeypatch.delenv('ETH_PRIVATE_KEY', raising=False)
+    return Ether()
+
+
+def _stub(provider, tx, receipt):
+    def fake_rpc(method, params, timeout=15, **kw):
+        return {'eth_getTransactionByHash': tx, 'eth_getTransactionReceipt': receipt}[method]
+
+    provider.chain.eth_rpc = fake_rpc
+    return provider
+
+
+def _tx(to=DEST, value=AMOUNT, gas=100_000):
+    return {'to': to, 'value': hex(value), 'gas': hex(gas)}
+
+
+class TestEvmCancelEvidence:
+    def test_reverted_with_correct_params_is_evidence(self, monkeypatch):
+        p = _stub(_evm(monkeypatch), _tx(), {'status': '0x0'})
+        assert p.cancel_evidence(DEST, AMOUNT, TX) == CANCEL_REASON_EVM_REVERT
+
+    def test_succeeded_tx_is_not_a_refusal(self, monkeypatch):
+        p = _stub(_evm(monkeypatch), _tx(), {'status': '0x1'})
+        assert p.cancel_evidence(DEST, AMOUNT, TX) is None
+
+    def test_wrong_destination_rejected(self, monkeypatch):
+        p = _stub(_evm(monkeypatch), _tx(to='0x' + '11' * 20), {'status': '0x0'})
+        assert p.cancel_evidence(DEST, AMOUNT, TX) is None
+
+    def test_underpaid_value_rejected(self, monkeypatch):
+        p = _stub(_evm(monkeypatch), _tx(value=AMOUNT - 1), {'status': '0x0'})
+        assert p.cancel_evidence(DEST, AMOUNT, TX) is None
+
+    def test_under_gassed_is_not_accepted_as_refusal(self, monkeypatch):
+        # The load-bearing anti-fake clause: a miner must not under-gas to manufacture a "refused" verdict.
+        p = _stub(_evm(monkeypatch), _tx(gas=90_000), {'status': '0x0'})
+        assert p.cancel_evidence(DEST, AMOUNT, TX) is None
+
+    def test_no_tx_hash_is_none(self, monkeypatch):
+        assert _evm(monkeypatch).cancel_evidence(DEST, AMOUNT, None) is None
+
+    def test_missing_receipt_is_none(self, monkeypatch):
+        p = _stub(_evm(monkeypatch), _tx(), None)
+        assert p.cancel_evidence(DEST, AMOUNT, TX) is None
+
+
+class TestErc20CancelEvidence:
+    def _provider(self, monkeypatch, blacklisted, paused):
+        monkeypatch.setenv('ETH_NETWORK', 'sepolia')
+        monkeypatch.delenv('ETH_RPC_URLS', raising=False)
+        p = EthUsdc()
+        from allways.assets.erc20 import SEL_IS_BLACKLISTED
+
+        p._eth_call = lambda selector, address='', block='latest': (
+            blacklisted if selector == SEL_IS_BLACKLISTED else paused
+        )
+        return p
+
+    def test_blacklisted_dest(self, monkeypatch):
+        p = self._provider(monkeypatch, blacklisted=1, paused=0)
+        assert p.cancel_evidence(DEST, AMOUNT) == CANCEL_REASON_ERC20_BLACKLIST
+
+    def test_paused_token(self, monkeypatch):
+        p = self._provider(monkeypatch, blacklisted=0, paused=1)
+        assert p.cancel_evidence(DEST, AMOUNT) == CANCEL_REASON_ERC20_PAUSED
+
+    def test_clean_dest_is_none(self, monkeypatch):
+        p = self._provider(monkeypatch, blacklisted=0, paused=0)
+        assert p.cancel_evidence(DEST, AMOUNT) is None
+
+    def test_blacklist_takes_precedence_over_pause(self, monkeypatch):
+        p = self._provider(monkeypatch, blacklisted=1, paused=1)
+        assert p.cancel_evidence(DEST, AMOUNT) == CANCEL_REASON_ERC20_BLACKLIST
+
+
+class TestSolCancelEvidence:
+    def test_reserved_account_is_evidence(self):
+        p = Sol(solana_rpc_url='fake://rpc')
+        assert p.cancel_evidence(next(iter(RESERVED_ACCOUNTS)), 0) == CANCEL_REASON_SOL_RESERVED
+
+    def test_normal_wallet_is_none(self):
+        p = Sol(solana_rpc_url='fake://rpc')
+        assert p.cancel_evidence('So11111111111111111111111111111111111111112', 0) is None
+
+
+def test_passive_chain_base_default_is_none():
+    # A passive-destination chain never executes at delivery, so it can never refuse. The base default
+    # returns None and reads nothing off self, so btc/tao (which do not override) inherit "never refuses".
+    from allways.assets.asset import Asset
+
+    assert Asset.cancel_evidence(None, DEST, AMOUNT, None) is None

--- a/tests/test_cancel_swap_nofault.py
+++ b/tests/test_cancel_swap_nofault.py
@@ -21,6 +21,7 @@ from allways.constants import (
 )
 
 DEST = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+MINER = '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC'  # the committed miner sender
 TX = '0x' + 'ab' * 32
 AMOUNT = 256  # 0x100
 
@@ -40,8 +41,8 @@ def _stub(provider, tx, receipt):
     return provider
 
 
-def _tx(to=DEST, value=AMOUNT, gas=100_000):
-    return {'to': to, 'value': hex(value), 'gas': hex(gas)}
+def _tx(to=DEST, value=AMOUNT, gas=100_000, from_=MINER):
+    return {'from': from_, 'to': to, 'value': hex(value), 'gas': hex(gas)}
 
 
 class TestEvmCancelEvidence:
@@ -65,6 +66,17 @@ class TestEvmCancelEvidence:
         # The load-bearing anti-fake clause: a miner must not under-gas to manufacture a "refused" verdict.
         p = _stub(_evm(monkeypatch), _tx(gas=90_000), {'status': '0x0'})
         assert p.cancel_evidence(DEST, AMOUNT, TX) is None
+
+    def test_from_committed_miner_is_evidence(self, monkeypatch):
+        p = _stub(_evm(monkeypatch), _tx(from_=MINER), {'status': '0x0'})
+        assert p.cancel_evidence(DEST, AMOUNT, TX, from_address=MINER) == CANCEL_REASON_EVM_REVERT
+
+    def test_from_non_committed_sender_rejected(self, monkeypatch):
+        # A reverted tx to the right dest with correct value+gas but sent from a THROWAWAY address is not
+        # a good-faith attempt: a dest reverting unless msg.sender==committedMiner could otherwise be used
+        # to manufacture a refusal without ever delivering from the committed sender.
+        p = _stub(_evm(monkeypatch), _tx(from_='0x' + '11' * 20), {'status': '0x0'})
+        assert p.cancel_evidence(DEST, AMOUNT, TX, from_address=MINER) is None
 
     def test_no_tx_hash_is_none(self, monkeypatch):
         assert _evm(monkeypatch).cancel_evidence(DEST, AMOUNT, None) is None

--- a/tests/test_ethereum_provider.py
+++ b/tests/test_ethereum_provider.py
@@ -785,16 +785,17 @@ class TestTransferGas:
     def test_estimate_sizes_the_send_with_headroom(self, provider):
         assert self._send(provider, hex(50_000)) is not None  # 60k limit, under cap
 
-    def test_reverting_destination_refuses_send(self, provider):
+    def test_reverting_destination_broadcasts_floor_gas_evidence(self, provider):
+        # P0: a reverting dest no longer bails silently — the miner broadcasts a floor-gas attempt so the
+        # on-chain reverted tx becomes no-fault-cancel evidence (a REFUSE, not a false timeout slash).
         def revert(params):
             raise RuntimeError('rpc error execution reverted')
 
-        assert self._send(provider, revert) is None
-        assert 'refuses' in provider.last_send_error
+        assert self._send(provider, revert) is not None
 
-    def test_absurd_estimate_refuses_send(self, provider):
-        assert self._send(provider, hex(500_000)) is None
-        assert 'refuses' in provider.last_send_error
+    def test_absurd_estimate_broadcasts_floor_gas_evidence(self, provider):
+        # An over-cap estimate likewise broadcasts at the fulfillment gas floor rather than refusing to send.
+        assert self._send(provider, hex(500_000)) is not None
 
     def test_estimator_down_falls_back_to_plain_transfer_gas(self, provider):
         def down(params):

--- a/tests/test_solana_swap_loop.py
+++ b/tests/test_solana_swap_loop.py
@@ -78,7 +78,7 @@ class RecordingProvider:
             raise ProviderUnreachableError('down')
         return self.refuses
 
-    def cancel_evidence(self, address, amount, tx_hash=None):
+    def cancel_evidence(self, address, amount, tx_hash=None, from_address=None):
         if self.cancel_reason == 'raise':
             raise ProviderUnreachableError('down')
         return self.cancel_reason

--- a/tests/test_solana_swap_loop.py
+++ b/tests/test_solana_swap_loop.py
@@ -70,12 +70,18 @@ class RecordingProvider:
         self.confirmations = confirmations
         self.refuses = False
         self.valid_addr = valid_addr
+        self.cancel_reason = None  # sound no-fault-cancel evidence (a CANCEL_REASON_* int), else None
         self.calls = []
 
     def delivery_refused(self, address, since_unix):
         if self.refuses == 'unreachable':
             raise ProviderUnreachableError('down')
         return self.refuses
+
+    def cancel_evidence(self, address, amount, tx_hash=None):
+        if self.cancel_reason == 'raise':
+            raise ProviderUnreachableError('down')
+        return self.cancel_reason
 
     @property
     def chain(self):
@@ -206,6 +212,43 @@ def test_overdue_malformed_dest_addr_waits_no_slash():
     loop, providers = loop_with(result=None)
     providers['sol'].valid_addr = False
     assert loop.decide(make_swap(status='Active', timeout_at=1000), now=1500).decision == SwapDecision.WAIT
+
+
+def test_fulfilled_sound_cancel_evidence_refuses_no_slash():
+    # Sound evidence the dest can't receive (miner's reverted tx / issuer freeze / reserved account) →
+    # REFUSE (cancel_swap, no slash/fee/strike), carrying the reason code.
+    loop, providers = loop_with(result=None)
+    providers['sol'].cancel_reason = 3  # CANCEL_REASON_SOL_RESERVED
+    action = loop.decide(make_swap(status='Fulfilled', timeout_at=1000), now=1500)
+    assert action.decision == SwapDecision.REFUSE
+    assert action.reason_code == 3
+
+
+def test_cancel_evidence_fires_early_before_deadline():
+    # Cancel is strictly lenient, so it fires ahead of the deadline — no waiting for the ceiling.
+    loop, providers = loop_with(result=None)
+    providers['sol'].cancel_reason = 3
+    action = loop.decide(make_swap(status='Fulfilled', timeout_at=9999), now=1500)  # not overdue
+    assert action.decision == SwapDecision.REFUSE
+
+
+def test_active_sound_cancel_evidence_refuses_without_fulfillment():
+    # Solana/ERC-20 refusal is provable without a delivery tx, so an Active swap into an unpayable dest
+    # cancels immediately rather than waiting for a fulfillment that can never land.
+    loop, providers = loop_with(result=None)
+    providers['sol'].cancel_reason = 3
+    action = loop.decide(make_swap(status='Active', timeout_at=9999), now=1500)
+    assert action.decision == SwapDecision.REFUSE
+
+
+def test_getcode_hint_without_sound_evidence_does_not_refuse():
+    # A getCode/issuer HINT (delivery_refused) is NOT sufficient to cancel — only sound cancel_evidence is.
+    # With no sound evidence and before the ceiling, the hint defers (WAIT), never REFUSE and never slash.
+    loop, providers = loop_with(result=None)
+    providers['sol'].refuses = True  # hint only
+    providers['sol'].cancel_reason = None  # no sound evidence
+    action = loop.decide(make_swap(status='Fulfilled', timeout_at=1000), now=1500)
+    assert action.decision == SwapDecision.WAIT
 
 
 def test_active_refusing_dest_past_ceiling_times_out():

--- a/tests/test_solana_vote_builders.py
+++ b/tests/test_solana_vote_builders.py
@@ -54,6 +54,7 @@ def test_ix_discriminators_match_anchor_global_formula():
         'vote_initiate',
         'confirm_swap',
         'timeout_swap',
+        'cancel_swap',
         'close_stale_claim',
         'vote_activate',
         'vote_set_weights',
@@ -148,6 +149,25 @@ def test_confirm_swap_ix(client):
         (pdas.swap_pda(SK, PID), False, True),
         (pdas.stats_pda(miner, 'BTC', 'tao', PID), False, True),
         (pdas.vote_round_pda(pdas.REQ_CONFIRM, SK, PID), False, True),
+        (SYSTEM_PROGRAM, False, False),
+    ]
+
+
+def test_cancel_swap_ix(client):
+    miner = Keypair().pubkey()
+    client.cancel_swap(SK, miner, reason=3)
+    ix = _ix(client)
+    assert ix.data[:8] == layouts.IX_DISCRIMINATORS['cancel_swap']
+    assert ix.data[8:] == layouts.IX_CANCEL_SWAP_ARGS.build({'swap_key': SK, 'reason': 3})
+    # Leaner than timeout_swap: no collateral_vault, no user — cancel moves no funds. Order must match
+    # the on-chain CancelSwap<'info> struct exactly.
+    assert _metas(ix) == [
+        (client.keypair.pubkey(), True, True),
+        (pdas.config_pda(PID), False, False),
+        (miner, False, False),
+        (pdas.miner_state_pda(miner, PID), False, True),
+        (pdas.swap_pda(SK, PID), False, True),
+        (pdas.vote_round_pda(pdas.REQ_CANCEL, SK, PID), False, True),
         (SYSTEM_PROGRAM, False, False),
     ]
 


### PR DESCRIPTION
## The vector

A taker names a destination that **rejects** the miner's payout (an EVM contract that reverts on receive; an ERC-20 blacklisted/paused address; a Solana native system account). The miner can't deliver, the swap times out, and the contract slashes the miner **1.10× straight to the taker** plus a permanent strike. Because there's no source escrow — the taker pays the miner directly, and the reimbursement comes from the miner's collateral — **the taker nets ~+10% by forcing a failure vs. −1% on a success**, and three induced failures zero a miner's emissions. It's a profitable competitor-elimination weapon, latent on native-EVM spokes (not yet on `main`).

## The fix — a third swap terminal

`cancel_swap` closes a swap whose destination *provably cannot receive the payout* with **no slash, no fee, no strike, no fund movement** — the miner keeps the source (the taker chose an address that refuses money). Refusal is decided **off-chain, deterministically**, per chain, and only *sound* evidence terminates:

| Chain | Evidence (why it's sound) |
|---|---|
| Native EVM | the miner's **own reverted delivery tx**: `status==0` + `to`==pinned dest + `value>=required` + `from`==committed miner + **gas-limit ≥ `ETH_FULFILL_GAS_FLOOR`**. The gas floor + `from` check stop a miner under-gassing or using a throwaway sender to *fake* a refusal. |
| ERC-20 | attested issuer `isBlacklisted(dest)` / `paused()` — attributes the refusal to the destination unambiguously (a reverted ERC-20 transfer is ambiguous between dest-fault and miner-fault). |
| Solana | fixed `RESERVED_ACCOUNTS` membership — offline, deterministic, no RPC. |

The contract carries **no evidence on-chain** (it can't parse an EVM receipt): it trusts the quorum exactly as `timeout_swap` does. Cancel and timeout share the same 2/3 denominator over the same set, so the honest majority picks which terminal fires and a minority carries neither.

## Commits

- **P1** (`2e4f155`) — strike decay: a completed swap forgives one prior `failed_swaps`, so a transient fault can't permanently strike a healthy miner.
- **P2** (`3cb56d7`) — the `cancel_swap` instruction: `timeout_swap` minus every punitive action. New `REQ_CANCEL=11`, `CANCEL_REASON_*`, `SwapCancelled`. **Purely additive — CONFIG_VERSION stays 15, program `.so` upgrade only, no migration.**
- **Off-chain** (`d762028`) — client builder + layout, the `cancel_evidence` seam (3 arms + passive default), **P0** (the miner now broadcasts the doomed tx at the gas floor *as evidence* instead of bailing silently), and validator wiring (`SwapDecision.REFUSE` → `cancel_swap`, fired early on sound evidence).
- **Soundness** (`5a17ec4`) — `cancel_evidence` verifies the reverted tx is `from` the committed miner.

## Design note — early-fire, not "never slash"

The validator fires `REFUSE` **early** on sound evidence (bounding hub occupancy), and keeps the existing ceiling-`TIMEOUT` only for the evidence-*less* case. A genuine refusal produces the P0 reverted-tx and gets cancelled with no slash; a dest that only trips the getCode *hint* with no sound evidence still times out rather than freezing the miner's hub (which would strand the taker with no reimbursement). The residual wrongful-slash needs a ≥2/3 validator RPC outage lasting the full extension window on a *mined* tx — negligible.

## Tests
Full suite **1604 passed**, ruff + `cargo check` clean. New: per-chain `cancel_evidence` (incl. under-gassed/wrong-value/non-miner-`from` → None), the `cancel_swap` client builder, and the REFUSE-vs-TIMEOUT decision paths.

## Before merge / go-live (draft until then)
- [ ] **Program redeploy** on devnet + e2e (P2 adds an instruction — `.so` upgrade, no CONFIG_VERSION bump).
- [ ] **PR #647** (ERC-20 issuer-surface primitives) should land first — the ERC-20 evidence arm uses its `isBlacklisted`/`paused` selectors.

Design refs: `UNPAYABLE_DESTINATION_DESIGN.md`, `PR_B_NOFAULT_TERMINAL_SCOPE.md`, `CANCEL_SWAP_INSTRUCTION_SPEC.md`.
