### PR TITLE
Add PAX Gold (PAXG) on Ethereum as a launch spoke

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,8 @@ BTC_PRIVATE_KEY=
 # Vars are per NETWORK, shared by every asset on it — ethusdc and uni add none of their own.
 # ─── Network: Ethereum (ETH + ethusdc + qnt pairs) ─────────
 # Vars are per NETWORK, shared by every asset on it — the tokens add no network vars of their own.
+# ─── Network: Ethereum (ETH + ethusdc + paxg pairs) ───────────────
+# Vars are per NETWORK, shared by every asset on it — ethusdc adds no network vars of its own.
 ETH_NETWORK=mainnet                 # mainnet | sepolia
 # OPTIONAL ordered JSON-RPC endpoints (keyed providers embed the key in the URL);
 # unset = public (publicnode, drpc)
@@ -54,6 +56,8 @@ ETH_PRIVATE_KEY=
 # OPTIONAL token contract overrides (dev/e2e fakes) — per ASSET, unset = the canonical deployment
 # ETHUSDC_TOKEN_CONTRACT=
 # QNT_TOKEN_CONTRACT=
+# PAX Gold rides the same ETH_* config. REQUIRED on testnet — Paxos publishes no Sepolia PAXG.
+# PAXG_TOKEN_CONTRACT=
 
 # ─── Network: Arbitrum (arbusdc pairs) ─────────────────────
 # Vars are per NETWORK, shared by every asset on it (ARB_ here, not ARBUSDC_).

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbit
 Currently live with SOL and TAO as hubs, each paired against BTC, ETH, USDC-on-Arbitrum, HYPE, BNB, AVAX, USDC-on-Base, USDC-on-Ethereum, and QNT — plus SOL ↔ TAO itself (hub-and-spoke: every pair has a SOL or TAO leg). Designed to scale to any verifiable asset.
 Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, SOL ↔ USDC-on-Base, SOL ↔ USDC-on-Ethereum, and SOL ↔ POL (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
 Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, SOL ↔ USDC-on-Base, SOL ↔ USDC-on-Ethereum, SOL ↔ POL, and SOL ↔ USDC-on-Polygon (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
+Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, SOL ↔ USDC-on-Base, SOL ↔ USDC-on-Ethereum, and SOL ↔ PAXG (hub-and-spoke: every pair has a SOL or TAO leg). Designed to scale to any verifiable asset.
 
 ## Miner Risk Disclaimer
 
@@ -133,6 +134,7 @@ needs to persist across restarts.
 - `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `BNB_PRIVATE_KEY`, `AVAX_PRIVATE_KEY`, `BASE_PRIVATE_KEY`, `{ETH,ARB,HYPE,BNB,AVAX,BASE}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config (ETH, ethusdc and uni all ride the `ETH_*` vars). See `.env.example`.
 - `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `BNB_PRIVATE_KEY`, `AVAX_PRIVATE_KEY`, `BASE_PRIVATE_KEY`, `{ETH,ARB,HYPE,BNB,AVAX,BASE}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config (ETH, ethusdc and qnt all ride the `ETH_*` vars). See `.env.example`.
 - `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `BNB_PRIVATE_KEY`, `AVAX_PRIVATE_KEY`, `BASE_PRIVATE_KEY`, `POL_PRIVATE_KEY`, `{ETH,ARB,HYPE,BNB,AVAX,BASE,POL}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config (ETH and ethusdc both ride the `ETH_*` vars). See `.env.example`.
+- `BTC_PRIVATE_KEY`, `ETH_PRIVATE_KEY`, `ARB_PRIVATE_KEY`, `HYPE_PRIVATE_KEY`, `BNB_PRIVATE_KEY`, `AVAX_PRIVATE_KEY`, `BASE_PRIVATE_KEY`, `{ETH,ARB,HYPE,BNB,AVAX,BASE}_RPC_URLS`, etc. — keyed by network, so assets sharing one share its config (ETH, ethusdc and paxg all ride the `ETH_*` vars). See `.env.example`.
 
 ## Running a Local Subtensor Lite Node (Validators)
 

--- a/allways/assets/__init__.py
+++ b/allways/assets/__init__.py
@@ -16,6 +16,7 @@ from allways.assets.eth import Ether
 from allways.assets.ethusdc import EthUsdc
 from allways.assets.evm_coin import EvmCoin
 from allways.assets.hype import Hype
+from allways.assets.paxg import Paxg
 from allways.assets.pol import Pol
 from allways.assets.polusdc import PolUsdc
 from allways.assets.qnt import Qnt
@@ -47,6 +48,7 @@ __all__ = [
     'Uni',
     'Qnt',
     'PolUsdc',
+    'Paxg',
     'create_assets',
 ]
 
@@ -77,6 +79,7 @@ ASSET_REGISTRY: Tuple[AssetSpec, ...] = (
     AssetSpec('qnt', Qnt, ()),
     AssetSpec('pol', Pol, ()),
     AssetSpec('polusdc', PolUsdc, ()),
+    AssetSpec('paxg', Paxg, ()),
 )
 
 

--- a/allways/assets/paxg.py
+++ b/allways/assets/paxg.py
@@ -1,0 +1,13 @@
+from allways.assets.erc20 import Erc20
+from allways.chains import CHAIN_PAXG
+
+
+class Paxg(Erc20):
+    """PAX Gold on Ethereum — a config-row binding of the generic Erc20 (see chains.CHAIN_PAXG).
+
+    Shares Ethereum's env identity with eth/ethusdc (ETH_NETWORK, ETH_RPC_URLS, ETH_PRIVATE_KEY),
+    adding only its own PAXG_TOKEN_CONTRACT override. Paxos freezes with isFrozen, not Circle's
+    isBlacklisted — the registry row declares which, so the provider never probes to find out."""
+
+    def __init__(self):
+        super().__init__(CHAIN_PAXG)

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -450,6 +450,41 @@ CHAIN_POLUSDC = ChainDefinition(
     refusal_checks=('isBlacklisted(address)', 'paused()'),
 )
 
+CHAIN_PAXG = ChainDefinition(
+    id='paxg',
+    name='PAX Gold',
+    # atto-PAXG. Not 'wei' — that is ETH's subunit, and this row is a token on Ethereum, not ETH.
+    native_unit='aPAXG',
+    decimals=18,
+    # Ethereum's prefix, shared with CHAIN_ETH and CHAIN_ETHUSDC: one ETH_NETWORK / ETH_RPC_URLS /
+    # ETH_PRIVATE_KEY serves every asset on it, so they can never disagree about which Ethereum.
+    env_prefix='ETH',
+    host_chain='ethereum',
+    # CHAIN_ETH already declares the ETH_NETWORK names; a second declaration would render a
+    # duplicate CLI row writing the same var.
+    networks=(),
+    seconds_per_block=12,
+    # CHAIN_ETH's finality, deliberately identical — assets on one chain must not disagree about
+    # its reorg depth. 32 x 12s = 384s, inside the program's 600s default fulfillment grace.
+    min_confirmations=32,
+    # Rate sanity floor, not an enforced minimum. One PAXG is a troy ounce of gold, so a token
+    # COUNT copied from another row would be absurd here: UNI's floor of 3 would mean three ounces,
+    # over $12,000, and the pair would silently never route. Derived instead from the gas the dest
+    # leg burns: 66,730 measured worst case (fresh recipient, cold slot) at 62 gwei is 0.0041 ETH,
+    # ~$7.74, ~0.0018 PAXG at $4,353/oz and $1,877/ETH (2026-08-13). Rounded up to 0.002.
+    min_onchain_amount=2_000_000_000_000_000,
+    # Ethereum's clock, as CHAIN_ETH: what this absorbs is hub-vs-spoke skew, and two assets on
+    # one chain disagreeing about that chain's clock would be indefensible.
+    replay_grace_secs=60,
+    # PAX Gold as published by Paxos (paxos.com/paxgold, contract verified on Etherscan, 2026-08-13).
+    asset_locator='0x45804880De22913dAFE09f4980848ECE6EcbAf78',
+    # Paxos freezes per address with isFrozen, NOT Circle's isBlacklisted — probed live 2026-08-13:
+    # isFrozen(address) and paused() both answer, isBlacklisted(address) reverts. Declaring Circle's
+    # surface here would make every probe raise, which defers each slash only as far as
+    # max_extend_at (~2.6h) and then times out anyway — slashing and striking an honest miner.
+    refusal_checks=('isFrozen(address)', 'paused()'),
+)
+
 SUPPORTED_CHAINS = {
     'btc': CHAIN_BTC,
     'tao': CHAIN_TAO,
@@ -467,6 +502,7 @@ SUPPORTED_CHAINS = {
     'qnt': CHAIN_QNT,
     'pol': CHAIN_POL,
     'polusdc': CHAIN_POLUSDC,
+    'paxg': CHAIN_PAXG,
 }
 
 

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -117,6 +117,7 @@ LAUNCH_SPOKES = (
     'qnt',
     'pol',
     'polusdc',
+    'paxg',
 )
 # Every launch pair as (hub, spoke): each hub pairs against every spoke except itself. sol↔tao
 # lands exactly once (under SOL, its anchor) because sol never appears in LAUNCH_SPOKES.

--- a/tests/test_paxg_provider.py
+++ b/tests/test_paxg_provider.py
@@ -1,0 +1,196 @@
+"""PAX Gold unit tests — all offline (RPC layer mocked, signing is pure crypto).
+
+Generic ERC-20 behaviour is proven by the arbusdc suite and the declared-refusal contract by
+tests/test_erc20_refusal_checks.py; this covers what is paxg-specific. Three things:
+
+  * PAXG is the first row to declare a NON-Circle freeze surface. Paxos uses isFrozen(address),
+    and isBlacklisted(address) reverts on its contract — declaring Circle's surface here would
+    make every probe revert and defer every slash on the pair forever.
+  * Its unit is a troy ounce of gold, ~1000x an ETH unit. A token COUNT copied from another row
+    makes the minimum leg absurd, and the pair silently never routes.
+  * It rides Ethereum's env identity alongside eth and ethusdc. One ETH_NETWORK must move all
+    of them.
+"""
+
+import pytest
+
+from allways.assets.erc20 import SEL_TRANSFER, TRANSFER_TOPIC0, _refusal_call
+from allways.assets.eth import Ether
+from allways.assets.ethusdc import EthUsdc
+from allways.assets.paxg import Paxg
+from allways.chains import CHAIN_ETH, CHAIN_PAXG, get_chain_def
+from allways.constants import LAUNCH_SPOKES
+
+SENDER = '0x' + '11' * 20
+RECIPIENT = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'  # mixed case on purpose
+CONTRACT = CHAIN_PAXG.asset_locator
+COUNTERFEIT = '0x' + '99' * 20
+TX = '0x' + 'ab' * 32
+BLOCK_HASH = '0x' + 'cd' * 32
+AMOUNT = 2_500_000_000_000_000_000  # 2.5 PAXG in wei — 18 decimals
+MAINNET_ID = 1
+
+SEL_IS_FROZEN, _ = _refusal_call('isFrozen(address)')
+SEL_PAUSED_, _ = _refusal_call('paused()')
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    monkeypatch.setenv('ETH_NETWORK', 'mainnet')
+    for var in ('ETH_RPC_URLS', 'ETH_PRIVATE_KEY', 'PAXG_TOKEN_CONTRACT'):
+        monkeypatch.delenv(var, raising=False)
+    return Paxg()
+
+
+def rpc_stub(provider, responses: dict):
+    def fake_rpc(method, params, timeout=15, **kw):
+        value = responses[method]
+        return value(params) if callable(value) else value
+
+    provider.chain.eth_rpc = fake_rpc
+    return provider
+
+
+def topic(address: str) -> str:
+    return '0x' + '00' * 12 + address.lower().removeprefix('0x')
+
+
+def transfer_log(contract=CONTRACT, recipient=RECIPIENT, amount=AMOUNT) -> dict:
+    return {
+        'address': contract,
+        'topics': [TRANSFER_TOPIC0, topic(SENDER), topic(recipient)],
+        'data': hex(amount),
+        'transactionHash': TX,
+    }
+
+
+def mined(logs=None, status='0x1', tip=1_000_100) -> dict:
+    return {
+        'eth_getTransactionByHash': {'hash': TX, 'blockNumber': '0xf4240', 'blockHash': BLOCK_HASH},
+        'eth_getTransactionReceipt': {
+            'status': status,
+            'blockNumber': '0xf4240',
+            'blockHash': BLOCK_HASH,
+            'logs': [transfer_log()] if logs is None else logs,
+        },
+        'eth_blockNumber': hex(tip),
+        'eth_getBlockByNumber': {'hash': BLOCK_HASH, 'timestamp': '0x64'},
+    }
+
+
+class TestSharedEnvIdentity:
+    def test_row_is_a_launch_spoke_on_ethereums_identity(self, provider):
+        assert provider.chain_def is CHAIN_PAXG is get_chain_def('paxg')
+        assert 'paxg' in LAUNCH_SPOKES
+        assert (CHAIN_PAXG.env_prefix, CHAIN_PAXG.host_chain) == (CHAIN_ETH.env_prefix, CHAIN_ETH.host_chain)
+        # Pinned here because nothing else on the allways side guards them: a typo'd decimals
+        # ships green through this CI and is only caught by the das drift gate, after merge.
+        assert (CHAIN_PAXG.decimals, CHAIN_PAXG.native_unit) == (18, 'aPAXG')
+        # CHAIN_ETH owns ETH_NETWORK; a second declaration renders a duplicate CLI row.
+        assert CHAIN_PAXG.networks == ()
+
+    def test_one_eth_network_moves_every_asset_on_it(self, monkeypatch):
+        monkeypatch.setenv('ETH_NETWORK', 'mainnet')
+        assert Paxg().chain.chain_id == EthUsdc().chain.chain_id == Ether().chain.chain_id == MAINNET_ID
+
+    def test_finality_and_clock_match_the_chain_it_shares(self):
+        assert (CHAIN_PAXG.min_confirmations, CHAIN_PAXG.seconds_per_block, CHAIN_PAXG.replay_grace_secs) == (
+            CHAIN_ETH.min_confirmations,
+            CHAIN_ETH.seconds_per_block,
+            CHAIN_ETH.replay_grace_secs,
+        )
+        # The implied leg stays inside the program's 600s default fulfillment grace.
+        assert CHAIN_PAXG.min_confirmations * CHAIN_PAXG.seconds_per_block < 600
+
+    def test_no_testnet_deployment_without_an_override(self, monkeypatch):
+        # Paxos publishes no Sepolia PAXG (verified 2026-08-13). Failing loudly is correct — the
+        # alternative is a testnet miner paying real mainnet PAXG against test swaps.
+        monkeypatch.setenv('ETH_NETWORK', 'sepolia')
+        monkeypatch.delenv('PAXG_TOKEN_CONTRACT', raising=False)
+        with pytest.raises(ValueError, match='PAXG_TOKEN_CONTRACT'):
+            Paxg()
+
+    def test_env_override_wins(self, monkeypatch):
+        monkeypatch.setenv('PAXG_TOKEN_CONTRACT', '0x' + '42' * 20)
+        assert Paxg().token_contract == '0x' + '42' * 20
+
+
+class TestPaxosFreezeSurface:
+    """Paxos freezes with isFrozen, not Circle's isBlacklisted. Declaring the wrong one would make
+    every probe revert, `delivery_refused` raise, and the caller defer every slash forever."""
+
+    def test_row_declares_the_paxos_surface(self):
+        assert CHAIN_PAXG.refusal_checks == ('isFrozen(address)', 'paused()')
+
+    @pytest.mark.parametrize('refusing', (SEL_IS_FROZEN, SEL_PAUSED_))
+    def test_each_declared_check_is_positive_evidence(self, provider, refusing):
+        def rpc(method, params, **kw):
+            if method == 'eth_blockNumber':
+                return hex(1000)
+            return hex(int(params[0]['data'].startswith(refusing)))
+
+        provider.chain.eth_rpc = rpc
+        assert provider.delivery_refused(RECIPIENT, since_unix=0) is True
+
+    def test_circles_selector_is_never_probed(self, provider):
+        # The regression guard for this whole row: PAXG reverts on isBlacklisted, so a probe for
+        # it would raise out of delivery_refused and defer every slash on the pair.
+        seen = []
+
+        def rpc(method, params, **kw):
+            if method == 'eth_blockNumber':
+                return hex(1000)
+            seen.append(params[0]['data'][:10])
+            return f'0x{0:064x}'
+
+        provider.chain.eth_rpc = rpc
+        provider.delivery_refused(RECIPIENT, since_unix=0)
+        assert set(seen) == {SEL_IS_FROZEN, SEL_PAUSED_}
+
+
+class TestGoldUnitEconomics:
+    """One PAXG is a troy ounce. Every constant that is a token COUNT elsewhere is a trap here."""
+
+    def test_the_minimum_leg_is_a_fraction_of_an_ounce(self):
+        # UNI's floor is 3 tokens; the same figure here would be three ounces of gold (>$12,000)
+        # and the pair would silently never route. The floor covers dest-leg gas, nothing more.
+        assert CHAIN_PAXG.min_onchain_amount == 2_000_000_000_000_000  # 0.002 PAXG
+
+
+class TestVerification:
+    def test_settled_transfer_matches_a_mixed_case_recipient_with_sender_pinned(self, provider):
+        rpc_stub(provider, mined())
+        info = provider.verify_transaction(TX, RECIPIENT, AMOUNT, expected_sender=SENDER)
+        assert info is not None and info.confirmed and info.amount == AMOUNT
+
+    def test_a_log_from_another_contract_never_matches(self, provider):
+        # Settlement truth is the PINNED contract's Transfer log — a counterfeit token emitting
+        # the same event must not pay a PAXG leg.
+        rpc_stub(provider, mined(logs=[transfer_log(contract=COUNTERFEIT)]))
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT, expected_sender=SENDER) is None
+
+    def test_a_reverted_tx_moved_no_funds(self, provider):
+        rpc_stub(provider, mined(status='0x0', logs=[]))
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT, expected_sender=SENDER) is None
+
+    def test_an_underpaying_transfer_is_rejected(self, provider):
+        rpc_stub(provider, mined(logs=[transfer_log(amount=AMOUNT - 1)]))
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT, expected_sender=SENDER) is None
+
+    def test_a_transfer_to_someone_else_is_rejected(self, provider):
+        rpc_stub(provider, mined(logs=[transfer_log(recipient=COUNTERFEIT)]))
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT, expected_sender=SENDER) is None
+
+    def test_the_pinned_sender_must_match(self, provider):
+        rpc_stub(provider, mined())
+        assert provider.verify_transaction(TX, RECIPIENT, AMOUNT, expected_sender=COUNTERFEIT) is None
+
+
+class TestSendGuards:
+    def test_send_without_a_key_refuses(self, provider):
+        assert provider.send_amount(RECIPIENT, AMOUNT) is None
+        assert 'ETH_PRIVATE_KEY' in provider.last_send_error
+
+    def test_calldata_targets_the_pinned_contract(self, provider):
+        assert SEL_TRANSFER.startswith('0xa9059cbb')
+        assert provider.token_contract == CHAIN_PAXG.asset_locator

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -473,6 +473,25 @@ class TestIsExecutableRate:
         """1e-9 µUSDC/SOL: even the 5 USDC floor overshoots max_swap — unroutable."""
         assert is_executable_rate(1e-9, 'ethusdc', 'sol', self.MIN, self.MAX) is False
 
+    def test_paxg_routes_at_its_gold_unit_floor(self):
+        """Canonical is spoke-per-1-hub, so paxg rates run ~1e-2 (0.017 PAXG per SOL at
+        $75.71/SOL, $4354/oz) — three orders off every other spoke. Below rate 0.02 the floor
+        is the BINDING term in min_source, so a later edit to it silently unroutes both pairs."""
+        assert get_chain_def('paxg').min_onchain_amount == 2_000_000_000_000_000
+        assert is_executable_rate(0.017, 'paxg', 'sol', self.MIN, self.MAX) is True
+        assert is_executable_rate(0.017, 'sol', 'paxg', self.MIN, self.MAX) is True
+
+    def test_paxg_routes_on_the_tao_hub_too(self):
+        """Multi-hub: a spoke is FOUR directions, and the TAO hub has its own bounds
+        (TAO_MAX_SWAP_AMOUNT_RAO = 1 tao). At 0.046 PAXG/TAO the lanes clear with ~22x
+        headroom; they stop routing below TAO ~$9, which is the number to watch."""
+        assert is_executable_rate(0.046, 'paxg', 'tao', self.MIN, self.MAX) is True
+        assert is_executable_rate(0.046, 'tao', 'paxg', self.MIN, self.MAX) is True
+
+    def test_crown_squat_low_paxg_rate_rejected(self):
+        """1e-9 PAXG/SOL: the gold-unit floor overshoots max_swap — unroutable."""
+        assert is_executable_rate(1e-9, 'paxg', 'sol', self.MIN, self.MAX) is False
+
     def test_arbusdc_survives_a_real_dust_floor(self):
         """What PR-E unlocks: with the orientation fixed, a real economic floor
         (0.01 USDC = 10_000 µUSDC) no longer kills the arbusdc→sol direction —


### PR DESCRIPTION
Adds PAX Gold as the tenth launch spoke. One troy ounce of allocated gold, tokenised by Paxos, on Ethereum.

Stacked on #647 — PAXG cannot ship without the declared refusal surface it adds. Rebase to `test` once #647 merges.

## Verified live, 2026-08-13 (mainnet, publicnode)

Contract `0x45804880De22913dAFE09f4980848ECE6EcbAf78`, implementation `0x7da4c5d9eca180a03765a6d27196f2a0380fa543`.

| Probe | Result |
|---|---|
| `symbol()` / `decimals()` | `PAXG` / 18 |
| `isFrozen(address)` | present, false |
| `paused()` | present, false |
| `isBlacklisted(address)` | **reverts — absent** |
| `feeRate()` / `feeParts()` / `getFeeFor(uint256)` | **absent from implementation bytecode** |

## The judgement calls

**Freeze surface.** Paxos freezes with `isFrozen`, not Circle's `isBlacklisted`. Declaring Circle's surface would make every probe revert, `delivery_refused` raise, and the caller defer every slash on the pair forever — miners unslashable. The row declares `refusal_checks=('isFrozen(address)', 'paused()')`; `test_circles_selector_is_never_probed` is the regression guard.

**`min_onchain_amount` — derived, never copied.** One PAXG is a troy ounce. UNI's floor of `3` would mean three ounces here, over $12,000, and the pair would silently never route. Derived from measured dest-leg gas instead:

```
66,550 gas (measured worst case: fresh recipient, cold slot) x 62 gwei
  = 0.004126 ETH = $7.74 = 0.00178 PAXG   ($4,353.51/PAXG, $1,876.89/ETH, coingecko 2026-08-13)
  -> rounded up to 0.002 PAXG = 2e15
```

Measured gas also confirms `MAX_TOKEN_TRANSFER_GAS` (150k) and the 120k estimator-down fallback are both sized correctly for this token.

**Upgradeable proxy — accepted, not coded against.** PAXG is a live zeppelinos proxy, which the batch rules call a hard stop. Overridden deliberately. Paxos can freeze an address (the row handles it, no slash), pause the token (same), or upgrade the proxy to restore the fee hooks that earlier PAX implementations shipped. That last one would make dest legs land short and slash miners. No guard is built for it: the hooks are absent today, restoring them takes a public upgrade to a multi-billion-dollar token, and the first failed leg surfaces it. Named here as knowingly accepted.

**No testnet.** Paxos publishes no Sepolia PAXG (`eth_getCode` returns `0x`). `alw config set env testnet` raises unless `PAXG_TOKEN_CONTRACT` is set, and a testnet validator will not boot without it — correct loud failure, but operators must know. Live testnet verification is deferred.

## Pair arithmetic (multi-hub)

Two pairs, four directions — `sol↔paxg` and `tao↔paxg`. Miners must quote TAO legs too.

```
before  9 spokes -> 17 pairs -> 34 directions -> floor 0.2941%
after  10 spokes -> 19 pairs -> 38 directions -> floor 0.2632%   (-10.5%)
```

Derived from `len(LAUNCH_PAIRS)` at this base; re-derive at merge time if other spokes land first. Volume weighting recovers most of it for a pair that trades; a quiet pair keeps the floor.

## Verification

- 1597 tests pass, `ruff check` and `ruff format --check` clean.
- 19 paxg-specific tests: shared ETH env identity, the Paxos freeze surface, the gold-unit floor, verification (pinned-contract log, reverted tx, underpay, wrong recipient, sender pin), send guards.
- `is_executable_rate` verified True in all four directions at realistic rates (~5e-5 sol, ~6e-5 tao).

Twin: das-allways#PENDING