### PR TITLE
Fix the TAO-collateral testnet operator findings (F1/F2/F4 + log noise)

### DIFF
--- a/allways/cli/swap_commands/vault.py
+++ b/allways/cli/swap_commands/vault.py
@@ -19,7 +19,7 @@ import click
 
 from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import console, fail, get_cli_context, loading
-from allways.constants import TAO_TO_RAO
+from allways.constants import TAO_HUB_VAULT_ADDRESSES, TAO_TO_RAO
 from allways.vault import BondVaultClient, VaultConfigError, codec
 
 # Mirror the vault contract's floors — fail locally with a clear message rather
@@ -34,9 +34,23 @@ def _client(use_coldkey: bool = False) -> BondVaultClient:
 
     config, wallet, subtensor, _ = get_cli_context()
     try:
-        return BondVaultClient.from_config(subtensor, config, keypair=resolve_signer(wallet, use_coldkey))
+        client = BondVaultClient.from_config(subtensor, config, keypair=resolve_signer(wallet, use_coldkey))
     except (VaultConfigError, codec.VaultCodecError) as e:
         fail(str(e))
+    _warn_if_off_record(client.address, getattr(subtensor, 'network', None))
+    return client
+
+
+def _warn_if_off_record(address: str, network) -> None:
+    """A stale configured address posts bonds into a vault no validator watches — it reads back
+    healthy but nothing ever attests, so the miner silently never activates."""
+    expected = TAO_HUB_VAULT_ADDRESSES.get(str(network or ''))
+    if expected and address != expected:
+        console.print(
+            f'[yellow]⚠ Configured vault {address}\n  is not the of-record vault for "{network}" '
+            f'({expected}).\n  A bond posted to an unwatched vault is never attested — '
+            f'`alw config set vault-address` unless this is intentional.[/yellow]'
+        )
 
 
 def _account_bytes(ss58: str) -> bytes:
@@ -53,6 +67,13 @@ def _report(result, ok_msg: str):
         if result.reverted:
             console.print(
                 '[yellow]The vault rejected the call (contract reverted) — e.g. empty pot, locked bond, or insufficient balance.[/yellow]'
+            )
+        elif result.error == 'TransferFailed':
+            console.print(
+                '[yellow]The chain could not draw the funds (TransferFailed) — pallet-contracts '
+                'pre-charges the FULL gas limit (refunded after execution) plus the existential '
+                'deposit, so a transfer near the signer\'s whole balance fails even though the fee '
+                'actually charged is tiny. Leave ~0.3 τ of headroom or post a smaller amount.[/yellow]'
             )
         else:
             console.print(f'[red]Call failed[/red]{f" [dim]({result.error})[/dim]" if result.error else ""}')

--- a/allways/cli/swap_commands/vault.py
+++ b/allways/cli/swap_commands/vault.py
@@ -72,7 +72,7 @@ def _report(result, ok_msg: str):
             console.print(
                 '[yellow]The chain could not draw the funds (TransferFailed) — pallet-contracts '
                 'pre-charges the FULL gas limit (refunded after execution) plus the existential '
-                'deposit, so a transfer near the signer\'s whole balance fails even though the fee '
+                "deposit, so a transfer near the signer's whole balance fails even though the fee "
                 'actually charged is tiny. Leave ~0.3 τ of headroom or post a smaller amount.[/yellow]'
             )
         else:

--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -27,6 +27,7 @@ from allways.cli.swap_commands.helpers import (
     fail,
     freshest_reservation,
     from_lamports,
+    from_rao,
     get_solana_cli_context,
     load_miner_book,
     miner_runtime_status,
@@ -441,6 +442,10 @@ def _sol_or(amount: int, zero_label: str) -> str:
     return f'{from_lamports(amount):.4f} SOL' + (f' ({zero_label})' if amount == 0 else '')
 
 
+def _tao_or(rao: int, zero_label: str) -> str:
+    return f'{from_rao(rao):.4f} τ' + (f' ({zero_label})' if rao == 0 else '')
+
+
 def _votes_needed(cfg) -> int:
     """Votes required for consensus — mirrors the program's headcount check
     (consensus.rs: votes*100 >= threshold*total), i.e. ceil(threshold*total/100)."""
@@ -477,6 +482,11 @@ def view_config(as_json):
                 'max_collateral_sol': from_lamports(cfg.max_collateral),
                 'min_swap_amount_sol': from_lamports(cfg.min_swap_amount),
                 'max_swap_amount_sol': from_lamports(cfg.max_swap_amount),
+                'tao_min_collateral_tao': from_rao(int(getattr(cfg, 'tao_min_collateral', 0) or 0)),
+                'tao_min_swap_amount_tao': from_rao(int(getattr(cfg, 'tao_min_swap_amount', 0) or 0)),
+                'tao_max_swap_amount_tao': from_rao(int(getattr(cfg, 'tao_max_swap_amount', 0) or 0)),
+                'settlement_grace_secs': int(getattr(cfg, 'settlement_grace_secs', 0) or 0),
+                'attest_max_age_secs': int(getattr(cfg, 'attest_max_age_secs', 0) or 0),
                 'fulfillment_timeout_secs': cfg.fulfillment_timeout_secs,
                 'reservation_ttl_secs': cfg.reservation_ttl_secs,
                 'pool_window_secs': cfg.pool_window_secs,
@@ -496,6 +506,11 @@ def view_config(as_json):
     console.print(f'  Max collateral:       {_sol_or(cfg.max_collateral, "unlimited")}')
     console.print(f'  Min swap amount:      {_sol_or(cfg.min_swap_amount, "no minimum")}')
     console.print(f'  Max swap amount:      {_sol_or(cfg.max_swap_amount, "no maximum")}')
+    console.print(f'  TAO min collateral:   {_tao_or(int(getattr(cfg, "tao_min_collateral", 0) or 0), "none")}')
+    console.print(f'  TAO min swap:         {_tao_or(int(getattr(cfg, "tao_min_swap_amount", 0) or 0), "no minimum")}')
+    console.print(f'  TAO max swap:         {_tao_or(int(getattr(cfg, "tao_max_swap_amount", 0) or 0), "no maximum")}')
+    console.print(f'  Settlement grace:     {secs_str(int(getattr(cfg, "settlement_grace_secs", 0) or 0))}')
+    console.print(f'  Attest max age:       {secs_str(int(getattr(cfg, "attest_max_age_secs", 0) or 0))}')
     console.print(f'  Fulfillment timeout:  {secs_str(cfg.fulfillment_timeout_secs)}')
     console.print(f'  Reservation TTL:      {secs_str(cfg.reservation_ttl_secs)}')
     console.print(f'  Pool window:          {secs_str(cfg.pool_window_secs)}')

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -169,12 +169,15 @@ RELAY_SWAP_RETENTION_SECS = 7 * 86400
 
 # ─── TAO bond vault (ink!) — deployed contract address, of record ───
 # So a deployment isn't lost. The runtime resolves the ACTIVE vault via ALLWAYS_VAULT_ADDRESS /
-# `alw config set vault-address`; this constant is the reference record per network.
-# TESTNET (SN19, deployed 2026-08-12). Replaces 5GAE4JD8…BEcD, whose immutable code still carried the
+# `alw config set vault-address`; this map is the reference record, keyed by subtensor network,
+# and the vault CLI warns when a configured address strays from it — a bond posted to a vault no
+# validator watches reads back healthy but is never attested.
+# test: SN19, deployed 2026-08-12. Replaces 5GAE4JD8…BEcD, whose immutable code still carried the
 # lock_bond validator floor (#653) — it cannot lock a bond at our n=1 launch set, so it was re-instantiated.
-TAO_HUB_VAULT_ADDRESS = '5Fkn2rNGvWxZ3cMNWbbT3FVrsyBjWmpE5fU4yYGDCrKAfLhs'
-# MAINNET
-# TAO_HUB_VAULT_ADDRESS = ''  # fill when prod is deployed
+TAO_HUB_VAULT_ADDRESSES = {
+    'test': '5Fkn2rNGvWxZ3cMNWbbT3FVrsyBjWmpE5fU4yYGDCrKAfLhs',
+    # 'finney': '',  # fill when prod is deployed
+}
 
 # ─── Swap outcome retention ──────────────────────────────
 # Terminal completed/timed_out rows (seam stage truth after the swap PDA closes). Rows are

--- a/allways/validator/event_index.py
+++ b/allways/validator/event_index.py
@@ -26,6 +26,7 @@ from allways import dev_signal
 from allways.classes import ActivityTransition, MinerActivity
 from allways.constants import RATE_PRECISION, RECONCILE_QUIET_SECS
 from allways.solana.events import EventRecord
+from allways.solana.layouts import EVENT_PUBKEY_FIELDS
 from allways.utils.rate import quantize_rate_fixed
 from allways.validator.state_store import ValidatorStateStore
 
@@ -282,6 +283,10 @@ class SolanaEventIndex:
 
     @staticmethod
     def _miner_str(rec: EventRecord) -> Optional[str]:
+        # Some events (AttestHeartbeat, HaltSet, …) carry no miner by design — that's a skip,
+        # not a decode failure worth logging.
+        if 'miner' not in EVENT_PUBKEY_FIELDS.get(rec.name, ('miner',)):
+            return None
         try:
             return str(rec.fields['miner'])
         except (KeyError, TypeError) as e:

--- a/tests/test_cli_vault_admin.py
+++ b/tests/test_cli_vault_admin.py
@@ -114,3 +114,35 @@ def test_set_config_votes_exact_rao_and_prints_a_round_tripping_peer_command(mon
     assert m
     assert vault_cli._tao_flag_to_rao(m.group(1), 'min') == 1_000_000_007
     assert vault_cli._tao_flag_to_rao(m.group(2), 'max') == 9_000_000_023
+
+
+# ─── _report / vault-address guards (v3.1 testnet findings) ──────────────────
+
+
+def test_transfer_failed_names_the_gas_precharge(capsys):
+    """Posting near the signer's whole balance dies on the pallet's fee pre-charge; a bare
+    "Call failed (TransferFailed)" gives the operator nothing to act on."""
+    vault_cli._report(VaultCallResult(ok=False, error='TransferFailed'), 'unused')
+    out = capsys.readouterr().out
+    assert 'TransferFailed' in out
+    assert 'pre-charges' in out
+    assert 'headroom' in out
+
+
+def test_off_record_vault_address_warns(capsys):
+    """A stale configured vault reads back healthy but no validator attests bonds posted to it."""
+    from allways.constants import TAO_HUB_VAULT_ADDRESSES
+
+    vault_cli._warn_if_off_record('5GAE4JD8zpQUfYLKKqWifLMEpEo9YrqkkUUdxjsmHyogBEcD', 'test')
+    out = capsys.readouterr().out
+    assert 'of-record' in out
+    assert TAO_HUB_VAULT_ADDRESSES['test'][:8] in out
+
+
+def test_on_record_or_unknown_network_vault_address_stays_quiet(capsys):
+    from allways.constants import TAO_HUB_VAULT_ADDRESSES
+
+    vault_cli._warn_if_off_record(TAO_HUB_VAULT_ADDRESSES['test'], 'test')
+    vault_cli._warn_if_off_record('5AnyVault', 'finney')  # no of-record entry yet
+    vault_cli._warn_if_off_record('5AnyVault', None)
+    assert capsys.readouterr().out == ''

--- a/tests/test_cli_view_solana.py
+++ b/tests/test_cli_view_solana.py
@@ -20,6 +20,11 @@ def _config(**over):
         max_collateral=0,
         min_swap_amount=0,
         max_swap_amount=0,
+        tao_min_swap_amount=100_000_000,
+        tao_max_swap_amount=1_000_000_000,
+        tao_min_collateral=250_000_000,
+        settlement_grace_secs=900,
+        attest_max_age_secs=86_400,
         halted=False,
         reservation_fee_lamports=1_000_000,
         pool_window_secs=60,
@@ -49,6 +54,40 @@ def test_view_config_renders_every_field(monkeypatch):
     assert '0.001000 SOL' in result.output  # reservation fee in SOL
     assert 'On-chain Program Config' in result.output
     assert 'alw config' in result.output  # cross-link to the local CLI settings
+
+
+def test_view_config_renders_the_tao_hub_bounds(monkeypatch):
+    """Full TAO capacity needs 1.1 × tao_max_swap — an operator can't size a bond off
+    bounds the config view hides, so every TAO field must render."""
+    client = MagicMock()
+    client.get_config.return_value = _config()
+    _patch_client(monkeypatch, client)
+
+    result = CliRunner().invoke(view.view_group, ['config'])
+
+    assert result.exit_code == 0, result.output
+    for label in ('TAO min collateral:', 'TAO min swap:', 'TAO max swap:', 'Settlement grace:', 'Attest max age:'):
+        assert label in result.output
+    assert '0.2500' in result.output  # tao_min_collateral in TAO
+    assert '1.0000' in result.output  # tao_max_swap in TAO
+
+
+def test_view_config_json_carries_the_tao_hub_bounds(monkeypatch):
+    client = MagicMock()
+    client.get_config.return_value = _config()
+    _patch_client(monkeypatch, client)
+
+    result = CliRunner().invoke(view.view_group, ['config', '--json'])
+
+    assert result.exit_code == 0, result.output
+    import json as _json
+
+    payload = _json.loads(result.output)
+    assert payload['tao_min_collateral_tao'] == 0.25
+    assert payload['tao_min_swap_amount_tao'] == 0.1
+    assert payload['tao_max_swap_amount_tao'] == 1.0
+    assert payload['settlement_grace_secs'] == 900
+    assert payload['attest_max_age_secs'] == 86_400
 
 
 def test_votes_needed_mirrors_contract_headcount_math():

--- a/tests/test_event_index.py
+++ b/tests/test_event_index.py
@@ -942,3 +942,22 @@ def test_activity_events_hub_column_migrates_in_place(tmp_path: Path):
     assert state['hk_a']['sol'] == MinerActivity.FULFILLING
     assert state['hk_a']['tao'] == MinerActivity.RESERVED
     store.close()
+
+
+class TestMinerlessEvents:
+    def test_by_design_minerless_events_skip_without_debug_noise(self, tmp_path: Path, monkeypatch):
+        """AttestHeartbeat is {at} by construction — skipping it must not log the
+        'missing miner field' line that reads like a decode defect in validator logs."""
+        from allways.validator import event_index as ei
+
+        calls = []
+        monkeypatch.setattr(ei.bt.logging, 'debug', lambda *a, **k: calls.append(a))
+        heartbeat = EventRecord(
+            name='AttestHeartbeat', fields={'at': 1_000}, slot=1, block_time=1_000, signature='sig-hb'
+        )
+        halt = EventRecord(name='HaltSet', fields={'halted': True}, slot=2, block_time=1_001, signature='sig-halt')
+
+        written = make_index(make_store(tmp_path)).ingest([heartbeat, halt], ATTR)
+
+        assert written == 0
+        assert calls == []


### PR DESCRIPTION
Fixes the allways-side findings from the 2026-08-13 TAO-collateral testnet pass (SN19, program v15). All four are client/CLI/validator-side — no contract changes.

## F2 — `alw view config` hid every TAO bound
The deployed Config carries `tao_min_swap_amount`, `tao_max_swap_amount`, `tao_min_collateral`, `settlement_grace_secs`, and `attest_max_age_secs`, and they decode fine (`layouts.py` Config) — only the renderer was never extended. Full TAO capacity needs `1.1 × tao_max_swap`, so an operator sizing a bond had to read the account by hand. Both the text and `--json` outputs now render the TAO-hub half.

## F4 — opaque `TransferFailed` near the balance ceiling
`post-collateral` of ~the signer's whole balance fails because pallet-contracts pre-charges the FULL gas limit (`DEFAULT_GAS` ref_time 300e9, refunded after execution) plus the existential deposit — an affordability check against a number the operator never sees (measured headroom ~0.06–0.26 τ vs an actual fee of 0.00034 τ). `_report` previously explained only `ContractReverted`; it now names the pre-charge and suggests headroom. A dry-run-for-real-gas preflight is a possible follow-up but the message alone makes the failure actionable.

## F1 — of-record vault address: per-network map + drift warning
#654 already re-pointed the constant at the live testnet vault (the old `5GAE4JD8…` was re-instantiated away over the #653 lock_bond floor). What #654 could not fix: a box whose *configured* `vault-address` is stale posts bonds into a vault that reads back healthy but that no validator watches — nothing attests, the miner never activates, no error anywhere. This is exactly what happened during the testnet pass. `TAO_HUB_VAULT_ADDRESS` is now `TAO_HUB_VAULT_ADDRESSES` keyed by subtensor network (no runtime consumer read the scalar), and every `alw vault` command warns when the configured address differs from the of-record entry for the network it's on. Networks without an entry (mainnet, local) stay silent.

## Log noise — `AttestHeartbeat missing miner field`
`AttestHeartbeat` is `{at}` by design, but `_miner_str` debug-logged every skip, so validator logs carried a defect-looking line every 5 minutes. Events whose `EVENT_PUBKEY_FIELDS` entry has no `miner` are now skipped silently; the debug line remains for genuinely malformed miner-carrying events.

## Not in this PR (cross-repo)
F3 — TAO-backed `/miners` rows reporting the SOL purse (lamports) in `collateral` next to a rao-denominated `fundableUpTo` — is an alw-utils indexer / das-allways fix, tracked separately.

## Testing
- 6 new tests: TAO bounds in text + JSON config views, `TransferFailed` hint, off-record warning + quiet paths, miner-less event ingest without debug noise.
- Full suite: 1588 passed; the one failure (`test_bitcoin_signing` uppercase-bech32) is pre-existing on `test` and ordering-dependent (passes in isolation, fails in full runs on a clean checkout too).