### PR TITLE
Drop the reserve-time destination deliverability prediction

### DIFF
--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -651,17 +651,10 @@ def _screen_deliverability(client, config, cand, from_chain, to_chain, receive_a
     dest_provider = _gate_provider(to_chain, client, config)
     quote = client.get_quote(cand.miner, from_chain, to_chain, cand.backing)
     if dest_provider is not None:
-        # Format first — offline, and a malformed address can never be delivered to.
+        # Validity only — deliverability is NOT predicted at reserve time (not a boundary; the sound
+        # check is the delivery-time reverted-tx proof). A malformed address can never be delivered to.
         if not dest_provider.chain.is_valid_address(receive_addr):
             fail(f'  {receive_addr!r} is not a valid {to_chain.upper()} address. No funds moved.')
-        amts = compute_intake_amounts(from_chain, to_chain, from_amount, cand.rate_display, cand.backing)
-        # Simulate from the miner's committed dest-side sender, as the validator gate does.
-        miner_to_addr = getattr(quote, 'miner_to_addr', '') if quote else ''
-        if not dest_provider.can_deliver_to(receive_addr, amts.to_amount, from_address=miner_to_addr or None):
-            fail(
-                f'  Your receive address cannot accept {to_chain.upper()} right now '
-                '(frozen or transfers paused). No funds moved.'
-            )
     src_provider = _gate_provider(from_chain, client, config)
     if src_provider is None:
         return

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -174,13 +174,11 @@ def reserve_on_behalf(
     provider = providers.get(to_chain)
     miner_quote = quote or client.get_quote(miner_pk, from_chain, to_chain, backing)
     if provider is not None:
+        # Validity only: NOT a deliverability prediction. Reserve-time deliverability isn't a security
+        # boundary (a dest can pass here then revert later via 7702/conditional code); the sound check is
+        # the delivery-time reverted-tx proof (cancel_swap). Fat-finger UX belongs in the client app.
         if not provider.chain.is_valid_address(user_to_addr):
             return ReserveResult(False, f'destination is not a valid {to_chain} address')
-        # Simulate delivery from the miner's committed dest-side sender: confirm pins
-        # sender == miner_to_addr, so a dest that refuses only THAT sender must bounce here too.
-        miner_to_addr = getattr(miner_quote, 'miner_to_addr', '') if miner_quote else ''
-        if not provider.can_deliver_to(user_to_addr, amts.to_amount, from_address=miner_to_addr or None):
-            return ReserveResult(False, 'destination address rejects incoming transfers')
     # Same gate, source side (T18): the miner's receive address must accept the user's funds —
     # a miner quoting a malformed/rejecting/blacklisted address griefs takers into a burned fee.
     src_provider = providers.get(from_chain)

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -121,15 +121,15 @@ def _gate_asset(can_deliver, valid=lambda addr: True):
     )
 
 
-def test_undeliverable_destination_rejects_before_any_bid():
-    # B-lite reserve gate: a dest that provably refuses transfers bounces before funds move.
+def test_reserve_does_not_predict_dest_deliverability():
+    # Reserve-time deliverability is NOT a security boundary (a dest can pass here then revert later),
+    # so a dest that WOULD refuse is no longer bounced here — the sound check is the delivery-time
+    # reverted-tx proof (cancel_swap). Validity is still screened (see the malformed test below).
     client = FakeClient()
     validator = _validator(client)
     validator.axon_assets = {'btc': _gate_asset(lambda addr, amt: False)}
     result = reserve_on_behalf(validator, HOTKEY, 'sol', 'btc', USER_PK, str(USER_PK), 'userBTCaddr', 10**9)
-    assert not result.ok
-    assert 'rejects incoming transfers' in result.reason
-    assert client.calls == []  # bounced before the on-chain bid
+    assert 'rejects incoming transfers' not in (result.reason or '')
 
 
 def test_malformed_destination_address_rejects_before_any_bid():

--- a/tests/test_swap_now_reservation.py
+++ b/tests/test_swap_now_reservation.py
@@ -499,12 +499,12 @@ def _screen(gate, from_chain, to_chain, client=None):
     return gate
 
 
-def test_screen_blocks_undeliverable_receive_address():
-    # F7: self-represented takers have no validator to bounce a blacklisted dest for them.
-    import pytest
-
-    with pytest.raises(SystemExit):
-        _screen(_Gate(reject={'recvaddr'}), 'sol', 'arbusdc')
+def test_screen_does_not_probe_or_block_undeliverable_receive_address():
+    # Reserve-time deliverability is no longer predicted (not a boundary; the sound check is the
+    # delivery-time reverted-tx proof). A dest that would refuse is neither probed nor blocked here —
+    # fat-finger UX moved to the client app. Validity is still screened (test below).
+    gate = _screen(_Gate(reject={'recvaddr'}), 'sol', 'arbusdc')
+    assert 'recvaddr' not in gate.checked
 
 
 def test_screen_blocks_rejecting_miner_receive_address():
@@ -547,8 +547,10 @@ def test_screen_blocks_malformed_miner_receive_address():
 
 
 def test_screen_rejection_aborts_swap_now_before_any_bid():
-    # Placement guard: the screen fires inside `swap now` BEFORE the resume/bid machinery —
-    # a doomed dest aborts the flow with no bid placed and no reservation touched.
+    # Placement guard: the SOURCE-side screen (which stays — it protects takers) fires inside
+    # `swap now` BEFORE the resume/bid machinery, so a miner whose receive address rejects the source
+    # aborts the flow with no bid placed. (The dest-side deliverability screen was removed — a refusing
+    # DEST is no longer probed here; see test_screen_does_not_probe_or_block_undeliverable_receive_address.)
     from click.testing import CliRunner
 
     from allways.cli.swap_commands.swap import swap_now_command
@@ -559,12 +561,13 @@ def test_screen_rejection_aborts_swap_now_before_any_bid():
     client.get_config.return_value = types.SimpleNamespace(
         min_swap_amount=1, max_swap_amount=10**18, pool_window_secs=60
     )
+    client.get_quote.return_value = types.SimpleNamespace(miner_from_addr='minerSOLaddr', miner_to_addr='')
     amts = types.SimpleNamespace(collateral_amount=10**9, from_amount=5000, to_amount=10**9)
     cand = types.SimpleNamespace(miner='miner-pk', rate_display='0.0021', collateral=10**10, backing='sol')
     argv = ['--from', 'sol', '--to', 'btc', '--amount', '0.001', '--receive-address', 'userBTCaddr', '--yes']
     with (
         patch('allways.cli.swap_commands.swap.get_solana_cli_context', return_value=(None, client)),
-        patch('allways.cli.swap_commands.swap._gate_provider', return_value=_Gate(reject={'userBTCaddr'})),
+        patch('allways.cli.swap_commands.swap._gate_provider', return_value=_Gate(reject={'minerSOLaddr'})),
         patch('allways.cli.swap_commands.swap.candidate_miners', return_value=[cand]),
         patch('allways.cli.swap_commands.swap.select_best_miner', return_value=(cand, amts)),
         patch('allways.cli.swap_commands.swap._save_pending'),


### PR DESCRIPTION
## What

Removes the **reserve-time destination deliverability prediction** (`can_deliver_to` on the taker's dest) from the validator reserve engine and the CLI screen. Pure validator/CLI Python — **no contract change, no redeploy.**

## Why

Reserve-time deliverability is **not a security boundary**. A deliberate actor makes their destination receivable at reserve, passes the check, then trivially makes it unreceivable afterward (EIP-7702 delegation, or a contract that flips a flag / conditional revert). It protected against nothing intentional, added machinery to the validator loop, and — worst — *looked* like a boundary, which is a liability (someone later leans on it).

The **sound** check now lives at delivery time: the `cancel_swap` no-fault terminal (#669) proves refusal from the miner's actual reverted delivery tx (correct dest/value/gas, from the committed miner). An honest miner facing a genuinely-unpayable dest gets a no-fault cancel; nobody is falsely slashed.

## Kept

- **Address validity** (`is_valid_address`) — a format check, not a prediction; a malformed address genuinely can never receive. Offline, free.
- **The source-side miner-receive check** — different dynamics: it protects *takers* from a miner quoting a bad receive address, and the miner's address is committed. Left untouched.

## The honest-mistake gap

The one useful thing the dest check did was catch a user fat-fingering an unreceivable address. That's a **UX concern**, and under the cancel model the stakes are real (sending to an unreceivable dest → no-fault cancel → the user loses their funds). It's moved to the client app as a best-effort warning: **LandynDev/ventura-labs-allways-app#78**.

## Tests
`test_reserve_engine` + `test_swap_now_reservation` (84 passed), ruff clean. The two dest-rejection tests are flipped to assert the new contract (a refusing dest is no longer probed or bounced at reserve); the placement-guard test now exercises the source-side screen that stays.
