### PR TITLE
Floor Arbitrum/Base USDC at 5 USDC (tighten the executable-rate gate)

### DIFF
--- a/allways/chains.py
+++ b/allways/chains.py
@@ -125,10 +125,10 @@ CHAIN_ARBUSDC = ChainDefinition(
     # math) — both far inside the 600s default program grace, so no grace-table arm.
     seconds_per_block=1,
     min_confirmations=90,
-    # ERC-20 transfers have no protocol minimum, so 1 is the honest floor. (The old
-    # F1 orientation defect that made this value load-bearing is fixed in utils/rate.py;
-    # raising it to an economic floor is now safe if ever wanted.)
-    min_onchain_amount=1,
+    # 5 USDC. min_onchain_amount floors the routable source amount inside is_executable_rate, so a
+    # floor of 1 (0.000001 USDC) leaves the crown-eligibility gate open to absurd rates routable only
+    # for dust — distorting emissions and the network's displayed rates. 5 USDC tightens that band.
+    min_onchain_amount=5_000_000,
     # Sequencer-stamped timestamps vs the hub clock — modest skew allowance (Arbitrum
     # timestamps are non-decreasing, but monotonicity says nothing about hub-spoke skew).
     replay_grace_secs=60,
@@ -221,9 +221,9 @@ CHAIN_BASEUSDC = ChainDefinition(
     # batch posts, so it needs far more depth than a fast-finality chain. 120 × 2s ≈ 240s,
     # well inside the program's 600s default fulfillment grace.
     min_confirmations=120,
-    # ERC-20 transfers have no protocol minimum and Base's L2 gas is negligible, so 1 is the
-    # honest floor — a rate sanity input, not an economic guarantee (as on Arbitrum).
-    min_onchain_amount=1,
+    # 5 USDC — matches Arbitrum/Ethereum USDC. As a rate-sanity input to is_executable_rate, a floor
+    # of 1 lets absurd rates pass the crown-eligibility gate routable only for dust; 5 USDC tightens it.
+    min_onchain_amount=5_000_000,
     # Sequencer-stamped timestamps vs the hub clock — modest skew allowance (monotonic
     # timestamps say nothing about how far the sequencer's clock sits from the hub's).
     replay_grace_secs=60,

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -454,11 +454,11 @@ class TestIsExecutableRate:
         rate = ((10 * self.DUST) / self.MAX) * 0.999
         assert is_executable_rate(rate, 'btc', 'sol', self.MIN, self.MAX) is False
 
-    def test_arbusdc_rates_executable_at_unit_floor(self):
-        """arbusdc regression guard (the F1 pin, kept): the pair must stay routable
-        BOTH ways at the honest unit floor. The orientation defect this guarded
-        against is fixed — the gate now inverts the canonical rate correctly."""
-        assert get_chain_def('arbusdc').min_onchain_amount == 1
+    def test_arbusdc_routes_at_its_five_dollar_floor(self):
+        """arbusdc's floor is now 5 USDC — a rate-sanity input to the crown gate (matching ethusdc),
+        tightening it against absurd rates routable only for dust. A real rate still routes BOTH ways
+        (0.1 SOL needs ~15 USDC at 150/SOL), which also keeps the F1 orientation-defect guard."""
+        assert get_chain_def('arbusdc').min_onchain_amount == 5_000_000
         assert is_executable_rate(150.0, 'arbusdc', 'sol', self.MIN, self.MAX) is True
         assert is_executable_rate(150.0, 'sol', 'arbusdc', self.MIN, self.MAX) is True
 


### PR DESCRIPTION
## What
`USDC (Arbitrum)` and `USDC (Base)` had `min_onchain_amount = 1` (0.000001 USDC). Raises both to `5_000_000` (5 USDC), matching `USDC (Ethereum)`. `chains.py` config only — **no redeploy.**

## Why (it's rate integrity, not dust)
`min_onchain_amount` is a direct input to **`is_executable_rate`**, the crown-eligibility gate:

```python
min_source = max(src.min_onchain_amount, math.ceil(lo))   # utils/rate.py:213
return min_source <= max_source
```

A floor of `1` lets `min_source` drop to almost nothing, so the `min_source <= max_source` test stays true for a **much wider band of rates** — including absurdly skewed ones that only "route" for a microscopic dust amount. Those ridiculous rates then pass the crown gate, which:
- **distorts emissions** — a rate routable only for 0.000001 USDC earns crown credit it shouldn't, and
- **distorts the displayed network rates** — the crown/leaderboard surfaces those extremes as if they were real quotes.

Raising the floor to 5 USDC lifts `min_source` and **shrinks the executable band**, rejecting dust-only rates. It's one of the known levers to tighten `is_executable_rate` against crown-squat.

The old "1 is the honest floor" comments were written for the dust/gas lens (and even named it "a rate sanity input" on Base) but drew the wrong conclusion — on cheap-gas L2s the floor isn't about gas economics, it's about not leaving the rate gate open at the low end. Comments rewritten to say so.

## Tests
`test_rate` + `test_chains` (105 passed), ruff clean. The `arbusdc` rate test was pinned to the unit floor (`== 1`); updated to the 5-USDC floor (mirrors the existing `ethusdc` test) — both directions still route (0.1 SOL needs ~15 USDC at 150/SOL, far above the floor), which keeps the F1 orientation-defect guard.
