### PR TITLE
Read the declared refusal surface for cancel evidence

### DIFF
--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -485,16 +485,20 @@ class Erc20(EvmAsset):
     def cancel_evidence(
         self, address: str, amount: int, tx_hash: Optional[str] = None, from_address: Optional[str] = None
     ) -> Optional[int]:
-        """No-fault-cancel evidence for a FiatToken: the issuer's own state proves the destination
-        cannot receive — a blacklisted dest or a paused token — attributed to the DEST, not the miner
-        (a reverted ERC-20 transfer alone is ambiguous: it could be miner-blacklist or miner-under-
-        balance, so we key on issuer state, not the tx). Returns CANCEL_REASON_ERC20_BLACKLIST /
-        _PAUSED, else None. None on RPC trouble so the caller waits rather than slashing."""
+        """No-fault-cancel evidence: the issuer's own state proves the destination cannot receive —
+        a frozen dest or a stopped token — attributed to the DEST, not the miner (a reverted ERC-20
+        transfer alone is ambiguous: it could be miner-frozen or miner-under-balance, so we key on
+        issuer state, not the tx).
+
+        Reads the surface the ROW declares, exactly as ``_refused_at`` does. Hardcoding one issuer's
+        selectors here would revert on every other token and silently yield no evidence — which
+        slashes a miner for a destination its issuer froze. Returns CANCEL_REASON_ERC20_BLACKLIST
+        for a per-address freeze, _PAUSED for a token-wide stop, else None. None on RPC trouble so
+        the caller waits rather than slashing."""
         try:
-            if bool(self._eth_call(SEL_IS_BLACKLISTED, address)):
-                return CANCEL_REASON_ERC20_BLACKLIST
-            if bool(self._eth_call(SEL_PAUSED)):
-                return CANCEL_REASON_ERC20_PAUSED
+            for selector, takes_address in self._checks:
+                if self._eth_call(selector, address if takes_address else ''):
+                    return CANCEL_REASON_ERC20_BLACKLIST if takes_address else CANCEL_REASON_ERC20_PAUSED
         except Exception:
             return None
         return None

--- a/tests/test_erc20_refusal_checks.py
+++ b/tests/test_erc20_refusal_checks.py
@@ -14,9 +14,10 @@ from dataclasses import replace
 
 import pytest
 
-from allways.assets.erc20 import Erc20
+from allways.assets.erc20 import SEL_IS_BLACKLISTED, Erc20, _refusal_call
 from allways.assets.evm import EvmRpcError
 from allways.chains import CHAIN_ETHUSDC
+from allways.constants import CANCEL_REASON_ERC20_BLACKLIST, CANCEL_REASON_ERC20_PAUSED
 
 RECIPIENT = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
 DECLARED = CHAIN_ETHUSDC  # ('isBlacklisted(address)', 'paused()')
@@ -111,3 +112,38 @@ class TestDeclaredChecks:
             raise ConnectionError('every endpoint is down')
 
         assert build(DECLARED, down).can_deliver_to(RECIPIENT, amount=1) is True
+
+
+class TestCancelEvidenceReadsTheDeclaredSurface:
+    """#669 added the no-fault cancel; it hardcoded Circle's selectors, so a token declaring any
+    other surface produced no evidence and rode to a TIMEOUT slash instead. No non-Circle token
+    existed in the registry then — paxg is the first, so this is the guard for every one after."""
+
+    PAXOS = replace(
+        CHAIN_ETHUSDC, id='paxos', name='Paxos-style token', refusal_checks=('isFrozen(address)', 'paused()')
+    )
+
+    @pytest.mark.parametrize(
+        'signature,expected',
+        (('isFrozen(address)', CANCEL_REASON_ERC20_BLACKLIST), ('paused()', CANCEL_REASON_ERC20_PAUSED)),
+    )
+    def test_a_non_circle_surface_still_yields_cancel_evidence(self, signature, expected):
+        answering, _ = _refusal_call(signature)
+
+        def rpc(method, params, **kw):
+            # A declared selector the contract really has answers; Circle's does not exist here
+            # (exactly as on real PAXG), and must never be reached.
+            assert not params[0]['data'].startswith(SEL_IS_BLACKLISTED), 'probed Circle on a Paxos-style row'
+            return f'0x{int(params[0]["data"].startswith(answering)):064x}'
+
+        provider = build(self.PAXOS, rpc)
+        assert provider.cancel_evidence(RECIPIENT, amount=1) == expected
+
+    def test_a_clean_destination_yields_no_evidence(self):
+        assert build(self.PAXOS, lambda m, p, **kw: f'0x{0:064x}').cancel_evidence(RECIPIENT, amount=1) is None
+
+    def test_rpc_trouble_yields_no_evidence_rather_than_a_false_cancel(self):
+        def down(*_a, **_kw):
+            raise ConnectionError('every endpoint is down')
+
+        assert build(self.PAXOS, down).cancel_evidence(RECIPIENT, amount=1) is None


### PR DESCRIPTION
`#647` made a token's issuer freeze surface a declared registry fact (`refusal_checks`) because hardcoding Circle's `isBlacklisted`/`paused` made every non-Circle token's probe revert — and a revert read as a verdict is how a miner becomes unslashable.

`#669` then added the no-fault `cancel_swap` path and hardcoded Circle's selectors again inside it:

```python
erc20.py:494   if bool(self._eth_call(SEL_IS_BLACKLISTED, address)):
erc20.py:498   except Exception:
erc20.py:499       return None
```

`_refused_at` reads `self._checks`; `cancel_evidence` did not. The two disagreed about what a token's freeze surface is.

## What it costs

On a token whose row declares any other surface, the hardcoded call reverts, the `except` swallows it, and `cancel_evidence` returns `None`. So:

```
dest genuinely frozen
  _refused_at      reads self._checks   -> True
  cancel_evidence  calls isBlacklisted  -> REVERTS -> None   (no evidence)
  _cancel_action                        -> None             (no no-fault cancel)
  loop             -> WAIT to max_extend_at, then TIMEOUT
                      solana_swap_loop.py:433-437
  timeout_swap.rs  -> collateral seized + failed_swaps += 1
```

The miner is slashed and permanently struck for a destination the **issuer** froze — silently, since the revert is swallowed and never logged. Exactly the outcome `#647` and `#669` were each built to prevent.

## The fix

Read the declared checks, as `_refused_at` already does. The `takes_address` flag already separates the two reason codes — a per-address freeze is a blacklist, a nullary check is a token-wide stop.

```python
for selector, takes_address in self._checks:
    if self._eth_call(selector, address if takes_address else ''):
        return CANCEL_REASON_ERC20_BLACKLIST if takes_address else CANCEL_REASON_ERC20_PAUSED
```

No behaviour change for the three Circle rows: their declared tuple is exactly `('isBlacklisted(address)', 'paused()')`, so they probe the same two selectors in the same order.

## Why nobody caught it

No non-Circle token existed in the registry when `#669` landed, so every row's declared surface happened to equal the hardcoded pair. `paxg` (allways#670) is the first that differs.

## Verification

- 1625 tests pass, ruff clean.
- New guard asserts a Paxos-style row (`isFrozen`/`paused`) yields cancel evidence for both a per-address freeze and a token-wide stop, and **asserts Circle's selector is never probed** on such a row.
- Confirmed the guard fails without the fix (2 failed) and passes with it.
- Clean destination and RPC-down both still yield `None`, so a flaky endpoint defers rather than producing a false cancel.