### PR TITLE
Key the collateral prune anchor by backing + reconcile the tao purse live

### DIFF
--- a/allways/validator/event_index.py
+++ b/allways/validator/event_index.py
@@ -217,16 +217,24 @@ class SolanaEventIndex:
             return None
         return ttl if ttl > 0 else None
 
-    def reconcile_live_state(self, live_states: Dict[str, object], now: int) -> None:
+    def reconcile_live_state(
+        self, live_states: Dict[str, object], now: int, live_bonds: Optional[Dict[str, int]] = None
+    ) -> None:
         """Scoring-round backstop for lost events (unbound-at-ingest drops, abandoned unstamped
         txs, RPC gaps): diff each bound miner's live chain state against the event-derived view
         and write corrective events stamped ``now``. Corrections apply from now on — crown
         already credited over a divergent stretch stands, bounding the error at one round.
         A miner is corrected only while its event stream has been quiet for
-        ``RECONCILE_QUIET_SECS``, so a stale live read never fights an in-flight real event."""
+        ``RECONCILE_QUIET_SECS``, so a stale live read never fights an in-flight real event.
+
+        ``live_bonds`` is the tao purse's sibling to ``ms.collateral``: ``{hotkey: effective
+        tao collateral}`` (0 for an unlocked bond, matching the ``BondAttested`` ingest). It
+        exists because the tao stream has no live-read backstop of its own — a lost
+        ``BondAttested`` (or, before #-this, a mis-keyed prune deleting the tao anchor) leaves
+        the purse stuck at 0 and silently drops the miner off every tao lane's crown. Absent
+        (``None``) it is skipped, preserving the sol-only behaviour for callers that don't pass it."""
         derived_active = self.state_store.get_active_state_at(now)
-        # ms.collateral is the SOL local purse; reconcile only that stream (the TAO bond is fed by
-        # BondAttested, not this live read) so a tao-backing row can't be mistaken for a divergence.
+        # ms.collateral is the SOL local purse; the TAO bond rides ``live_bonds`` below.
         derived_collateral = self.state_store.get_collaterals_at(now, backing='sol')
         quiet_start = now - RECONCILE_QUIET_SECS
         recent_active = {e['hotkey'] for e in self.state_store.get_active_events_in_range(quiet_start, now)}
@@ -244,6 +252,17 @@ class SolanaEventIndex:
                 bt.logging.warning(
                     f'reconcile {hotkey[:8]}: event-derived collateral ≠ chain, corrected to {live_collateral}'
                 )
+        if live_bonds is not None:
+            derived_tao = self.state_store.get_collaterals_at(now, backing='tao')
+            recent_tao = {
+                e['hotkey'] for e in self.state_store.get_collateral_events_in_range(quiet_start, now, backing='tao')
+            }
+            for hotkey, bond in live_bonds.items():
+                if hotkey not in recent_tao and derived_tao.get(hotkey) != int(bond):
+                    self.state_store.insert_collateral_event(now, hotkey, int(bond), backing='tao')
+                    bt.logging.warning(
+                        f'reconcile {hotkey[:8]}: event-derived tao collateral ≠ chain, corrected to {int(bond)}'
+                    )
 
     def reconcile_live_quotes(self, live_quotes: Dict[Tuple[str, str, str, str], float], now: int) -> None:
         """Rate-liveness backstop, the ``reconcile_live_state`` sibling for the rate stream.

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -238,6 +238,28 @@ def live_miner_states(solana_client, metagraph, attribution: Optional[Dict[str, 
     return states
 
 
+def live_bond_balances(
+    solana_client, metagraph, attribution: Optional[Dict[str, str]] = None, chain: str = 'tao'
+) -> Dict[str, int]:
+    """``{hotkey: effective bond collateral}`` for bound, on-metagraph miners with a
+    ``BondAttestation`` on ``chain`` — the tao purse's live-read backstop, the sibling of
+    ``live_miner_states``' ``ms.collateral`` for the sol purse. An unlocked bond backs
+    nothing → 0, matching the ``BondAttested`` ingest. One ``get_all`` per round; feeds
+    ``reconcile_live_state`` so a lost/pruned tao anchor self-heals like the sol one."""
+    if attribution is None:
+        attribution = build_attribution(solana_client)
+    metagraph_hotkeys = set(metagraph.hotkeys)
+    bonds: Dict[str, int] = {}
+    for _pubkey, ba in solana_client.get_all('BondAttestation'):
+        if str(ba.chain).lower() != chain:
+            continue
+        hotkey = attribution.get(str(ba.miner))
+        if hotkey is None or hotkey not in metagraph_hotkeys:
+            continue
+        bonds[hotkey] = int(ba.effective_balance) if ba.locked else 0
+    return bonds
+
+
 def live_quote_rates(
     solana_client, attribution: Optional[Dict[str, str]] = None
 ) -> Dict[Tuple[str, str, str, str], float]:
@@ -426,7 +448,10 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
     # state the ingest lost — before the replay below reads those tables.
     attribution = build_attribution(self.solana_client)
     live_states = live_miner_states(self.solana_client, self.metagraph, attribution)
-    self.event_index.reconcile_live_state(live_states, now=current_time)
+    # The tao bond has no live field on MinerState, so read the attestations too — else a
+    # lost/pruned tao anchor leaves the purse stuck at 0 and drops the miner off every tao crown.
+    live_bonds = live_bond_balances(self.solana_client, self.metagraph, attribution)
+    self.event_index.reconcile_live_state(live_states, now=current_time, live_bonds=live_bonds)
     # Rate-liveness backstop: a lost QuoteRemoved would otherwise freeze a lane's crown
     # credit forever (the prune keeps the last rate as the lane's anchor). Best-effort —
     # the reconcile is a safety net, so a failed quote read never sinks the round.

--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -782,15 +782,21 @@ class ValidatorStateStore:
 
     def prune_collateral_events(self, cutoff_block: int) -> None:
         """Drop collateral events older than ``cutoff_block``, preserving the
-        latest row per hotkey as a reconstruction anchor (mirrors
-        ``prune_active_events``)."""
+        latest row per ``(hotkey, backing)`` as a reconstruction anchor.
+
+        The anchor MUST be keyed by backing: a dual-backing miner posts one
+        collateral stream per purse (sol local, tao bond), and grouping by
+        hotkey alone kept only the globally-newest row — so a fresher sol row
+        silently deleted the tao anchor, ``get_collaterals_at(backing='tao')``
+        found nothing, and the miner dropped off every tao lane's crown. Same
+        per-lane keying the rate prune uses (#668)."""
         if cutoff_block <= 0:
             return
         self._execute(
             """
             DELETE FROM collateral_events
             WHERE block_num < ?
-              AND id NOT IN (SELECT MAX(id) FROM collateral_events GROUP BY hotkey)
+              AND id NOT IN (SELECT MAX(id) FROM collateral_events GROUP BY hotkey, backing)
             """,
             (cutoff_block,),
         )

--- a/tests/test_event_index.py
+++ b/tests/test_event_index.py
@@ -730,6 +730,53 @@ class TestReconcileLiveState:
         assert len(store.load_all_collateral_events()) == 1
         store.close()
 
+    def test_reseeds_missing_tao_collateral_from_live_bond(self, tmp_path: Path):
+        # The tao anchor was lost (missed BondAttested, or a mis-keyed prune) so the purse
+        # reads 0 and the miner is off every tao crown — the live bond re-seeds it. Regression
+        # for the live divergence: 0.85 τ attested on-chain, no tao collateral row in the store.
+        store = make_store(tmp_path)
+        idx = SolanaEventIndex(store)
+        store.insert_collateral_event(100, 'hk_a', 2_000_000_000, backing='sol')  # sol purse intact
+        idx.reconcile_live_state(
+            {'hk_a': self._ms(active=True, collateral=2_000_000_000)},
+            now=self.NOW,
+            live_bonds={'hk_a': 850_000_000},
+        )
+        assert idx.get_miner_collaterals_at(self.NOW, backing='tao') == {'hk_a': 850_000_000}
+        assert idx.get_miner_collaterals_at(self.NOW, backing='sol') == {'hk_a': 2_000_000_000}  # untouched
+        store.close()
+
+    def test_tao_backstop_skipped_when_bonds_absent(self, tmp_path: Path):
+        # Default (no live_bonds) keeps the sol-only behaviour — no spurious tao rows.
+        store = make_store(tmp_path)
+        idx = SolanaEventIndex(store)
+        idx.reconcile_live_state({'hk_a': self._ms(active=True, collateral=42)}, now=self.NOW)
+        assert idx.get_miner_collaterals_at(self.NOW, backing='tao') == {}
+        store.close()
+
+    def test_tao_quiet_guard_defers_to_recent_bond_event(self, tmp_path: Path):
+        # A real BondAttested landed seconds ago; a stale live bond read must not overwrite it.
+        store = make_store(tmp_path)
+        idx = SolanaEventIndex(store)
+        store.insert_collateral_event(self.NOW - 60, 'hk_a', 900_000_000, backing='tao')
+        idx.reconcile_live_state(
+            {'hk_a': self._ms(active=True, collateral=0)}, now=self.NOW, live_bonds={'hk_a': 1}
+        )
+        assert idx.get_miner_collaterals_at(self.NOW, backing='tao') == {'hk_a': 900_000_000}
+        store.close()
+
+    def test_unlocked_bond_reconciles_to_zero(self, tmp_path: Path):
+        # An unlocked bond backs nothing → 0 (live_bond_balances maps it so); a stale nonzero
+        # tao anchor is corrected down, matching the BondAttested ingest.
+        store = make_store(tmp_path)
+        idx = SolanaEventIndex(store)
+        store.insert_collateral_event(100, 'hk_a', 850_000_000, backing='tao')
+        idx.reconcile_live_state(
+            {'hk_a': self._ms(active=True, collateral=0)}, now=self.NOW, live_bonds={'hk_a': 0}
+        )
+        assert idx.get_miner_collaterals_at(self.NOW, backing='tao') == {'hk_a': 0}
+        store.close()
+
 
 class TestReconcileLiveQuotes:
     """Rate-liveness backstop: a lane whose event-derived rate is positive but

--- a/tests/test_event_index.py
+++ b/tests/test_event_index.py
@@ -759,9 +759,7 @@ class TestReconcileLiveState:
         store = make_store(tmp_path)
         idx = SolanaEventIndex(store)
         store.insert_collateral_event(self.NOW - 60, 'hk_a', 900_000_000, backing='tao')
-        idx.reconcile_live_state(
-            {'hk_a': self._ms(active=True, collateral=0)}, now=self.NOW, live_bonds={'hk_a': 1}
-        )
+        idx.reconcile_live_state({'hk_a': self._ms(active=True, collateral=0)}, now=self.NOW, live_bonds={'hk_a': 1})
         assert idx.get_miner_collaterals_at(self.NOW, backing='tao') == {'hk_a': 900_000_000}
         store.close()
 
@@ -771,9 +769,7 @@ class TestReconcileLiveState:
         store = make_store(tmp_path)
         idx = SolanaEventIndex(store)
         store.insert_collateral_event(100, 'hk_a', 850_000_000, backing='tao')
-        idx.reconcile_live_state(
-            {'hk_a': self._ms(active=True, collateral=0)}, now=self.NOW, live_bonds={'hk_a': 0}
-        )
+        idx.reconcile_live_state({'hk_a': self._ms(active=True, collateral=0)}, now=self.NOW, live_bonds={'hk_a': 0})
         assert idx.get_miner_collaterals_at(self.NOW, backing='tao') == {'hk_a': 0}
         store.close()
 

--- a/tests/test_rate_state.py
+++ b/tests/test_rate_state.py
@@ -219,6 +219,25 @@ class TestPrune:
         assert store.get_latest_rate_before('hk1', 'sol', 'tao', block=10_000, collateral_chain='sol') == (0.360, 200)
         store.close()
 
+    def test_prune_collateral_preserves_anchor_per_backing(self, tmp_path: Path):
+        """A dual-backing miner keeps BOTH purses' collateral anchors — the
+        prune key includes backing. Regression: grouping by hotkey alone kept
+        only the globally-newest row, so a fresher sol row deleted the tao
+        anchor, get_collaterals_at(backing='tao') found nothing, and the miner
+        dropped off every tao lane's crown (observed live: uid 12's tao purse,
+        0.85 τ bond attested on-chain yet no tao collateral row in the store)."""
+        store = make_store(tmp_path)
+        # tao bond attested first, sol purse re-posted later — both older than
+        # the cutoff, so each survives only as its own purse's anchor.
+        store.insert_collateral_event(100, 'hk1', 850_000_000, backing='tao')
+        store.insert_collateral_event(200, 'hk1', 2_000_000_000, backing='sol')
+
+        store.prune_collateral_events(cutoff_block=5_000)
+
+        assert store.get_collaterals_at(10_000, backing='tao') == {'hk1': 850_000_000}
+        assert store.get_collaterals_at(10_000, backing='sol') == {'hk1': 2_000_000_000}
+        store.close()
+
 
 class TestConcurrency:
     def test_concurrent_writes_threadsafe(self, tmp_path: Path):


### PR DESCRIPTION
## The bug

`prune_collateral_events` preserved the newest anchor with `MAX(id) GROUP BY hotkey` — **not** `(hotkey, backing)`. This is the exact twin of the rate-anchor bug **#668** fixed for `rate_events`, but the collateral prune was left with hotkey-only grouping.

On a dual-backing miner the periodic prune **deleted the tao collateral row whenever a fresher sol row existed**, so `get_collaterals_at(backing='tao')` found no anchor → the crown's `can_fund` gate dropped the miner off **every** tao-backed lane → the tao pools recycled → **no tao-backed emissions to anyone**.

### Observed live (testnet, netuid 19)
UID 12 has an active tao backing with a **0.85 τ bond attested on-chain** and executable tao-hub quotes (`tao→hype 0.002`, `tao→arbusdc 55`), yet the validator's `collateral_events` carried **only sol rows** and `/crown` showed no holder on any tao lane (`tao->hype`, `tao->arbusdc`, `tao->btc`, …) — for every miner, every forward step. The indexer (`/miners`) was correct; the validator diverged.

## The fix

1. **Root cause** — key the prune anchor on `(hotkey, backing)`, matching the rate prune (`state_store.py`).
2. **Recovery/resilience** — the tao purse had no live-read backstop (the comment noted it "is fed by BondAttested, not this live read"), so once an anchor is lost/pruned it never returns (there's no periodic re-attestation). `reconcile_live_state` now takes `live_bonds` (`{hotkey: effective tao collateral}`, `0` for an unlocked bond) and re-seeds a missing tao anchor each round — the sibling of the sol `ms.collateral` path. `live_bond_balances` reads the `BondAttestation` accounts once per round; absent `live_bonds` preserves the sol-only behaviour.

## Impact
Emissions-affecting: without this, **no tao-backed miner earns** and tao pools recycle. Recovery is needed to observe correct tao emissions/crown interactions during the current split-collateral swap testing.

## Tests
- `test_prune_collateral_preserves_anchor_per_backing` — a dual-backing miner keeps **both** purses' collateral anchors through a prune.
- `test_reseeds_missing_tao_collateral_from_live_bond` — the backstop re-seeds a lost tao anchor from the live bond.
- `test_tao_quiet_guard_defers_to_recent_bond_event`, `test_unlocked_bond_reconciles_to_zero`, `test_tao_backstop_skipped_when_bonds_absent`.

226 passed across `test_rate_state`, `test_event_index`, `test_scoring_v1`.