### PR TITLE
Trim pre-window crown tails before the scoring-window wipe

### DIFF
--- a/allways/validator/storage/queries.py
+++ b/allways/validator/storage/queries.py
@@ -22,6 +22,21 @@ ON CONFLICT (started_at, from_chain, to_chain, backing, hotkey)
 DO UPDATE SET ended_at = EXCLUDED.ended_at, credit = EXCLUDED.credit, rate = EXCLUDED.rate
 """
 
+# Pre-window tail trim: the wipe above keys on started_at, so an interval
+# opened BEFORE the window that is still running into it survives the delete
+# and overlaps the recomputed rows — double-counting that lane's crown time
+# for every reader. Happens whenever the window anchor regresses behind
+# already-flushed rows, e.g. a restarted validator's initial round
+# (last_scored_time boots to now - SCORING_WINDOW_SECS, not to what the old
+# process last flushed). The recomputed window is authoritative, so clamp
+# such tails to its start; the pre-window portion stays as flushed.
+TRIM_CROWN_TAILS_AT = """
+UPDATE crown_holders
+SET ended_at = %s
+WHERE from_chain = %s AND to_chain = %s AND backing = %s
+  AND started_at < %s AND ended_at > %s
+"""
+
 # sync_cursor: bookkeeping watermarks. The validator advances these in the
 # same transaction as the data they describe, so a partial write never leaves
 # the cursor ahead of (or behind) the rows.

--- a/allways/validator/storage/repository.py
+++ b/allways/validator/storage/repository.py
@@ -18,6 +18,7 @@ from .queries import (
     DELETE_CURRENT_CROWN_BY_DIRECTION,
     DELETE_CURRENT_MINER_SCORES,
     SET_SYNC_CURSOR,
+    TRIM_CROWN_TAILS_AT,
 )
 
 
@@ -66,6 +67,23 @@ class Repository(BaseRepository):
         return self.execute_command(
             DELETE_CROWN_IN_RANGE,
             (from_chain, to_chain, backing, lo_ts, hi_ts),
+            commit=commit,
+        )
+
+    def trim_crown_tails(
+        self,
+        from_chain: str,
+        to_chain: str,
+        backing: str,
+        at_ts: int,
+        commit: bool = True,
+    ) -> bool:
+        """Clamp intervals that started before ``at_ts`` but run past it to end
+        at ``at_ts`` — they would overlap (and double-count against) the window
+        being rewritten from ``at_ts`` on."""
+        return self.execute_command(
+            TRIM_CROWN_TAILS_AT,
+            (at_ts, from_chain, to_chain, backing, at_ts, at_ts),
             commit=commit,
         )
 

--- a/allways/validator/storage/storage.py
+++ b/allways/validator/storage/storage.py
@@ -157,6 +157,7 @@ class DatabaseStorage:
                 for direction, rows in crown_rows_by_direction.items():
                     from_chain, to_chain, backing = direction
                     lo, hi = crown_window_bounds_by_direction[direction]
+                    self.repo.trim_crown_tails(from_chain, to_chain, backing, lo, commit=False)
                     self.repo.delete_crown_in_range(from_chain, to_chain, backing, lo, hi, commit=False)
                     crown_inserted += self.repo.store_crown_holders_bulk(rows, commit=False)
                 result.stored_counts['crown_holders'] = crown_inserted
@@ -205,6 +206,7 @@ class DatabaseStorage:
 
             with self.db_connection.pipeline():
                 for from_chain, to_chain, backing in directions:
+                    self.repo.trim_crown_tails(from_chain, to_chain, backing, window_start, commit=False)
                     self.repo.delete_crown_in_range(
                         from_chain, to_chain, backing, window_start, window_end, commit=False
                     )

--- a/tests/test_validator_storage.py
+++ b/tests/test_validator_storage.py
@@ -64,6 +64,9 @@ class FakeRepo:
     def delete_crown_in_range(self, from_chain, to_chain, backing, lo, hi, commit=False):
         self.conn._maybe_fail()
 
+    def trim_crown_tails(self, from_chain, to_chain, backing, at_ts, commit=False):
+        self.conn._maybe_fail()
+
     def set_sync_cursor(self, key, value, commit=False):
         self.conn._maybe_fail()
 
@@ -182,3 +185,32 @@ def test_halt_flush_clears_live_score_tip(monkeypatch):
     result = storage.flush_halt_window(directions=[('sol', 'btc', 'sol')], window_start=0, window_end=100, max_ts=100)
     assert result.success
     assert calls == [[]]
+
+
+def test_scoring_flush_trims_pre_window_tails(monkeypatch):
+    """flush_scoring_window clamps intervals that run into the window from
+    before its start. The started_at-keyed wipe can't reach them, and a
+    surviving tail overlaps the recomputed rows and double-counts crown time
+    (seen as /crown/time shareOfWindow > 1 after a validator restart, whose
+    initial round anchors behind what the old process last flushed)."""
+    conn = FakeConnection()
+    storage = make_storage(monkeypatch, [conn])
+    calls = []
+    storage.repo.trim_crown_tails = (
+        lambda f, t, b, at, commit=False: calls.append(('trim', f, t, b, at))
+    )
+    storage.repo.delete_crown_in_range = (
+        lambda f, t, b, lo, hi, commit=False: calls.append(('delete', f, t, b, lo, hi))
+    )
+    storage.repo.store_crown_holders_bulk = lambda rows, commit=False: len(rows)
+    storage.repo.store_miner_scores_bulk = lambda rows, commit=False: len(rows)
+    lane = ('sol', 'btc', 'sol')
+    result = storage.flush_scoring_window(
+        crown_rows_by_direction={lane: []},
+        crown_window_bounds_by_direction={lane: (1_000, 4_600)},
+        miner_score_rows=[],
+        crown_holders_max_ts=4_600,
+    )
+    assert result.success
+    # Trim runs before the wipe, clamped at the same window edge the wipe keys on.
+    assert calls == [('trim', 'sol', 'btc', 'sol', 1_000), ('delete', 'sol', 'btc', 'sol', 1_000, 4_600)]

--- a/tests/test_validator_storage.py
+++ b/tests/test_validator_storage.py
@@ -196,12 +196,8 @@ def test_scoring_flush_trims_pre_window_tails(monkeypatch):
     conn = FakeConnection()
     storage = make_storage(monkeypatch, [conn])
     calls = []
-    storage.repo.trim_crown_tails = (
-        lambda f, t, b, at, commit=False: calls.append(('trim', f, t, b, at))
-    )
-    storage.repo.delete_crown_in_range = (
-        lambda f, t, b, lo, hi, commit=False: calls.append(('delete', f, t, b, lo, hi))
-    )
+    storage.repo.trim_crown_tails = lambda f, t, b, at, commit=False: calls.append(('trim', f, t, b, at))
+    storage.repo.delete_crown_in_range = lambda f, t, b, lo, hi, commit=False: calls.append(('delete', f, t, b, lo, hi))
     storage.repo.store_crown_holders_bulk = lambda rows, commit=False: len(rows)
     storage.repo.store_miner_scores_bulk = lambda rows, commit=False: len(rows)
     lane = ('sol', 'btc', 'sol')


### PR DESCRIPTION
## Symptom

`GET /crown/time?direction=SOL-BTC` on test-api reported `crownSecs: 6790` inside a `windowSecs: 3599` window (`shareOfWindow: 1.89`) for uid 12 — crown seconds exceeding the window, which should be impossible.

## Root cause

`crown_holders` had two overlapping open intervals for the same (lane, hotkey):

```
[1786720798 → 1786724401]   last round flushed by the pre-restart validator process
[1786721178 → 1786724809]   initial round of the restarted process
```

On restart, `last_scored_time` boots to `now - SCORING_WINDOW_SECS` (neurons/validator.py), which can land **behind** what the old process last flushed. The round flush wipes `[window_start, window_end)` keyed on `started_at` — so the old round's row, which *started before* the new window but *runs into* it, survives the delete and overlaps the recomputed rows. Every duration-integrating reader (crown/time, leaderboard crown share) then double-counts the overlap. The ledger shows the same scar pattern from an earlier restart (~20h prior), so this reproduces on most restarts.

## Fix

Before the wipe, clamp any interval with `started_at < window_start AND ended_at > window_start` to end at `window_start`, per lane, in the same transaction. The recomputed window is authoritative; the pre-window portion of the old row stays exactly as flushed, so no history is lost. Applied to both `flush_scoring_window` and `flush_halt_window`.

Regression test added; `tests/test_validator_storage.py` passes (10/10).

## Note

Existing overlapping rows on the test DB need a one-time repair (trim old tails at the successor's start) — the fix only prevents new ones. Repair SQL is ready separately.

Related context: the restarted process also *re-scores* the overlap span (it was already paid by the old process's final flush) — that's an emissions duplication on restart, out of scope here but worth a look.