### PR TITLE
Revert strike decay — strikes are permanent until re-registration

### DIFF
--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/confirm_swap.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/confirm_swap.rs
@@ -150,11 +150,6 @@ pub fn handler(
             .release_reserved(bit, crate::constants::required_collateral(collateral_amount));
         ctx.accounts.miner_state.successful_swaps =
             ctx.accounts.miner_state.successful_swaps.saturating_add(1);
-        // Strike decay: a completed swap forgives one prior failure, so a transient fault (a dead
-        // Esplora, a slow chain) can't permanently strike-out an otherwise-healthy miner. The
-        // strike gate still bites a miner that fails faster than it succeeds.
-        ctx.accounts.miner_state.failed_swaps =
-            ctx.accounts.miner_state.failed_swaps.saturating_sub(1);
 
         // Accrue the miner's realized per-direction track record (count saturates; volume totals use
         // checked_add so a saturated sum can never silently corrupt the VWAP the validator reads).

--- a/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
@@ -135,9 +135,8 @@ pub struct MinerState {
     /// Lifetime swaps completed (confirm_swap quorum). Monotonic. Off-chain emissions warm-up gate:
     /// a miner earns nothing until `successful_swaps >= 2`.
     pub successful_swaps: u32,
-    /// Lifetime swaps failed (timeout_swap quorum), less one per completed swap (confirm_swap decays
-    /// it by 1, floored at 0). Off-chain strike-out gate: `failed_swaps > 2` => no emissions. Decay
-    /// means a healthy miner recovers by completing swaps, not only by re-registering.
+    /// Lifetime swaps failed (timeout_swap quorum). Monotonic, never resets. Off-chain strike-out gate:
+    /// `failed_swaps > 2` => no emissions (recover by re-registering).
     pub failed_swaps: u32,
     /// Stored PDA bump.
     pub bump: u8,


### PR DESCRIPTION
Reverts `2e4f155` ("P1: decay failed_swaps on a completed swap", merged inside #669).

## Why

Owner decision (Alex, 2026-08-14): the strike-out gate is meant to read a **lifetime** counter — a miner that accrues 3 slashes is permanently ineligible until it re-registers/rebinds. The decay (each completed swap forgives one strike) changed that to a net counter, and it shipped inside the cancel_swap PR where it was easy to miss.

What stays, deliberately:
- **cancel_swap remains no-fault** — it never touches `failed_swaps` (that was #669's actual purpose and is unchanged).
- Strikes still come **only from slash verdicts** (`timeout_swap` / legacy close), never from user-caused rejections or cancels.

This restores the pre-decay `state.rs` doc as written: *"Monotonic, never resets… recover by re-registering."*

## Deploy note

The decay **is live on the testnet program** (last deploy slot 483580250 = 2026-08-13 20:39Z, after #669 merged), so this needs a program upgrade after merge — same program id, in-place, no PDA wipe. Strikes already forgiven on-chain during the ~1-day window can't be restored; testnet-only impact.

`cargo check -p allways_swap_manager` clean.