### PR TITLE
Disable spokes with no testnet deployment instead of failing neuron boot

### DIFF
--- a/allways/assets/__init__.py
+++ b/allways/assets/__init__.py
@@ -11,7 +11,7 @@ from allways.assets.bnb import Bnb
 from allways.assets.btc import Bitcoin
 from allways.assets.chain import Chain
 from allways.assets.cro import Cro
-from allways.assets.erc20 import Erc20
+from allways.assets.erc20 import Erc20, MissingTestnetDeployment
 from allways.assets.eth import Ether
 from allways.assets.ethusdc import EthUsdc
 from allways.assets.evm_coin import EvmCoin
@@ -116,6 +116,13 @@ def create_assets(
             if check:
                 provider.check_connection(require_send=require_send)
             providers[chain_id] = provider
+        except MissingTestnetDeployment as e:
+            # A spoke with no deployment on this test network can't exist here at all, so it
+            # disables rather than failing the boot. A miner that quotes the pair (explicitly
+            # in required_chains) still fails hard — it must not advertise what it can't serve.
+            if check and required_chains is not None and chain_id in required_chains:
+                raise RuntimeError(f'{cls.__name__} failed startup check: {e}') from e
+            bt.logging.warning(f'{cls.__name__} disabled on this network: {e} — {chain_id} pairs are unavailable here')
         except Exception as e:
             if check and required:
                 raise RuntimeError(f'{cls.__name__} failed startup check: {e}') from e

--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -49,6 +49,10 @@ TESTNET_TOKEN_CONTRACTS = {
     # Same address as mainnet and byte-identical runtime bytecode (keccak
     # 0xdeba17f1…0868, 12567 bytes) — verified symbol UNI, 18 decimals, 1e27 supply.
     'uni': {'sepolia': '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984'},
+    # Quant's official test QNT, dispensed by its documented getTestQNT faucet
+    # (0xCe8623CD…54825, docs.overledger.dev). Verified plain ERC20 — immutable, no
+    # pause/blacklist, probes revert — so the row's declared surface holds on Sepolia.
+    'qnt': {'sepolia': '0x81Dc68CB065ec6D9a4d24f6e2F442dc2A236D853'},
     # Circle-verified native USDC on Polygon Amoy (developers.circle.com, 2026-08-12).
     'polusdc': {'amoy': '0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582'},
 }

--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -54,14 +54,23 @@ TESTNET_TOKEN_CONTRACTS = {
 }
 
 
+class MissingTestnetDeployment(ValueError):
+    """The token has no pinned deployment on the configured test network (issuer-deployed
+    assets like QNT/PAXG often exist on mainnet only). Distinct so create_assets can disable
+    the spoke on testnet instead of failing the whole neuron's boot."""
+
+
 def _token_contract(chain_def: ChainDefinition, network: str) -> str:
     var = f'{chain_def.id.upper()}_TOKEN_CONTRACT'
     override = os.environ.get(var)
     if override:
         return override
-    contract = (
-        chain_def.asset_locator if network == 'mainnet' else TESTNET_TOKEN_CONTRACTS.get(chain_def.id, {}).get(network)
-    )
+    if network != 'mainnet':
+        contract = TESTNET_TOKEN_CONTRACTS.get(chain_def.id, {}).get(network)
+        if not contract:
+            raise MissingTestnetDeployment(f'No {chain_def.id} token contract for network {network!r} — set {var}')
+        return contract
+    contract = chain_def.asset_locator
     if not contract:
         raise ValueError(f'No {chain_def.id} token contract for network {network!r} — set {var}')
     return contract

--- a/tests/test_assets_optional.py
+++ b/tests/test_assets_optional.py
@@ -44,6 +44,29 @@ def test_none_means_all_required(registry):
         cp.create_assets(check=True)
 
 
+class _NoTestnet:
+    def __init__(self):
+        raise cp.MissingTestnetDeployment('No qnt token contract for network sepolia')
+
+
+@pytest.fixture
+def registry_with_missing_testnet(monkeypatch):
+    monkeypatch.setattr(cp, 'ASSET_REGISTRY', (('qnt', _NoTestnet, ()), ('sol', _Ok, ())))
+
+
+def test_missing_testnet_deployment_degrades_for_validators(registry_with_missing_testnet):
+    # required_chains=None (validator: all chains required) must still boot — the spoke
+    # simply doesn't exist on this network.
+    providers = cp.create_assets(check=True)
+    assert 'sol' in providers
+    assert 'qnt' not in providers
+
+
+def test_missing_testnet_deployment_still_fails_a_quoting_miner(registry_with_missing_testnet):
+    with pytest.raises(RuntimeError, match='failed startup check'):
+        cp.create_assets(check=True, required_chains={'qnt', 'sol'})
+
+
 def test_evm_network_names_match_the_rpc_registry():
     """chains.py names the networks the CLI accepts; assets/evm.py names the chain ids the
     provider dials. One fact in two files, so CI compares them — for the row that declares the

--- a/tests/test_qnt_provider.py
+++ b/tests/test_qnt_provider.py
@@ -5,9 +5,9 @@ qnt-specific. Two things: it is the third asset on Ethereum's env identity, and 
 ``refusal_checks=()`` — QNT implements neither isBlacklisted nor paused, and
 probing them REVERTS, which the slash gate would read as "defer" forever.
 
-Everything here builds on mainnet: QNT has no Sepolia deployment, so the row has no
-TESTNET_TOKEN_CONTRACTS entry and a testnet provider only constructs behind the
-QNT_TOKEN_CONTRACT override. That gap is why this spoke is not mergeable yet.
+Everything here builds on mainnet. On Sepolia the row pins Quant's official test QNT
+(dispensed by its documented getTestQNT faucet) in TESTNET_TOKEN_CONTRACTS, with the
+QNT_TOKEN_CONTRACT override still available for pointing elsewhere.
 """
 
 import pytest
@@ -134,18 +134,16 @@ class TestSharedEnvIdentity:
             provider.check_connection(require_send=False)
 
 
-class TestNoTestnetDeployment:
-    """QNT is issuer-deployed on Ethereum only. Until a project-deployed test token is pinned —
-    immutable AND with no pause or blacklist, or the row's declaration stops being true on
-    testnet — a testnet provider cannot be built. create_assets disables the spoke on testnet
-    (MissingTestnetDeployment) so a testnet validator still boots without it."""
+class TestTestnetDeployment:
+    """The Sepolia pin is Quant's own test QNT — a verified plain ERC20 (immutable, no pause
+    or blacklist; probing reverts like mainnet), so the row's declared surface stays true on
+    testnet. A spoke without such a pin (e.g. paxg) degrades via MissingTestnetDeployment
+    instead of failing the neuron's boot."""
 
-    def test_sepolia_has_no_pinned_contract(self, monkeypatch):
-        assert 'qnt' not in TESTNET_TOKEN_CONTRACTS
+    def test_sepolia_pin_builds_the_provider(self, monkeypatch):
         monkeypatch.setenv('ETH_NETWORK', 'sepolia')
         monkeypatch.delenv('QNT_TOKEN_CONTRACT', raising=False)
-        with pytest.raises(ValueError, match='QNT_TOKEN_CONTRACT'):
-            Qnt()
+        assert Qnt().token_contract == TESTNET_TOKEN_CONTRACTS['qnt']['sepolia']
 
     def test_override_restores_the_shared_network_identity(self, monkeypatch):
         # What pinning a test token buys: the same one-ETH_NETWORK guarantee, on Sepolia.

--- a/tests/test_qnt_provider.py
+++ b/tests/test_qnt_provider.py
@@ -137,8 +137,8 @@ class TestSharedEnvIdentity:
 class TestNoTestnetDeployment:
     """QNT is issuer-deployed on Ethereum only. Until a project-deployed test token is pinned —
     immutable AND with no pause or blacklist, or the row's declaration stops being true on
-    testnet — a testnet provider cannot be built, and validators build every provider at boot,
-    so this row must not reach a testnet validator's LAUNCH_SPOKES."""
+    testnet — a testnet provider cannot be built. create_assets disables the spoke on testnet
+    (MissingTestnetDeployment) so a testnet validator still boots without it."""
 
     def test_sepolia_has_no_pinned_contract(self, monkeypatch):
         assert 'qnt' not in TESTNET_TOKEN_CONTRACTS


### PR DESCRIPTION
## Problem

The testnet validator on `:test` crash-loops at startup:

```
RuntimeError: Qnt failed startup check: No qnt token contract for network 'sepolia' — set QNT_TOKEN_CONTRACT
```

QNT (#652) and PAXG (#670) are issuer-deployed on mainnet only — neither has a `TESTNET_TOKEN_CONTRACTS` entry (deliberately: QNT's test docstring notes a pinned test token must be immutable with no pause/blacklist, or the row's declared surface stops being true). But validators build every registry asset (`required_chains=None`), so the documented gap became a fleet-wide testnet boot crash. Fixing QNT alone just crashes on PAXG next.

## Fix

- `_token_contract` raises a typed `MissingTestnetDeployment` (a `ValueError` subclass) when a non-mainnet network has no pinned contract and no env override.
- `create_assets` catches it and **disables the spoke with a warning** instead of failing the boot — a spoke with no deployment on the network can't exist there at all, so failing the neuron over it protects nothing.
- A miner that **explicitly quotes the pair** (`chain_id in required_chains`) still fails hard — it must not advertise a pair it can't serve.
- `{ID}_TOKEN_CONTRACT` env override still works for pinning a mock; mainnet path (registry `asset_locator`) unchanged.

## Tests

- New: validator-style `create_assets(check=True)` boots and excludes the spoke; a quoting miner still raises.
- `test_qnt_provider.py` guard tests unchanged and passing (constructor still raises; the subclass keeps the `ValueError` contract); docstring updated to the new behavior.
- Full suite: 1857 passed; the one failure (`test_uppercase_bech32_matches_derived_address`) is a pre-existing ordering flake that reproduces on clean `test`.

## Deploy note

aw-vali does not auto-deploy (watchtower disabled) — after the `:test` image rebuilds, roll it manually. Until then the testnet vali can boot via the `QNT_TOKEN_CONTRACT`/`PAXG_TOKEN_CONTRACT` stand-ins already in its `.env`.