### PR TITLE
Free the hub and record the outcome when a swap is cancelled

### DIFF
--- a/allways/classes.py
+++ b/allways/classes.py
@@ -25,7 +25,7 @@ class ActivityTransition(IntEnum):
     which opens before its initiation, and a reservation lapse applies last so an
     in-flight swap survives its synthetic ``RESERVE_EXPIRE``."""
 
-    FULFILL_END = 0  # SwapCompleted / SwapTimedOut
+    FULFILL_END = 0  # SwapCompleted / SwapTimedOut / SwapCancelled
     RESERVE_START = 1  # PoolResolved
     FULFILL_START = 2  # SwapInitiated
     RESERVE_EXPIRE = 3  # synthetic, at reserve block_time + reservation_ttl_secs

--- a/allways/validator/event_index.py
+++ b/allways/validator/event_index.py
@@ -7,8 +7,9 @@ this index persists them into the ``state_store`` event tables, attributing each
 its bound Bittensor hotkey at write time (B3.2). The crown math is unchanged — it consumes the same
 ``get_*_at`` / ``get_*_in_range`` shapes ``ContractEventWatcher`` exposed. ``SwapCompleted`` additionally
 persists its realized legs into ``clearing_rates``, the per-swap realized-volume history the dashboard and
-treasury reporting read. ``SwapCompleted``/``SwapTimedOut`` also record the swap's terminal outcome into
-``swap_outcomes``, the seam's post-close completed-vs-slashed truth (terminal swap PDAs are closed on-chain).
+treasury reporting read. ``SwapCompleted``/``SwapTimedOut``/``SwapCancelled`` also record the swap's terminal outcome into
+``swap_outcomes``, the seam's post-close completed-vs-slashed-vs-cancelled truth (terminal swap PDAs are
+closed on-chain).
 
 The axis is unix ``blockTime`` seconds (the ``block_num``/``block`` columns are repurposed), not substrate
 blocks. Reservation + swap lifecycle drive a per-miner ``MinerActivity`` machine (D4): ``PoolResolved``
@@ -31,21 +32,25 @@ from allways.utils.rate import quantize_rate_fixed
 from allways.validator.state_store import ValidatorStateStore
 
 # Swap-lifecycle events → MinerActivity edges. A reserved miner enters FULFILLING on
-# SwapInitiated and returns to AVAILABLE on completion/timeout (see classes.MinerActivity).
+# SwapInitiated and returns to AVAILABLE on any terminal: completion, timeout, or no-fault
+# cancel — a missing terminal edge strands the hub in FULFILLING (crownless) indefinitely.
 _FULFILL_TRANSITIONS = {
     'SwapInitiated': ActivityTransition.FULFILL_START,
     'SwapCompleted': ActivityTransition.FULFILL_END,
     'SwapTimedOut': ActivityTransition.FULFILL_END,
+    'SwapCancelled': ActivityTransition.FULFILL_END,
 }
 
 # Terminal events → per-swap outcome persisted for the seam (reserve_engine._swap_stage):
 # terminal swap PDAs close on-chain, so this index is what disambiguates a slash from a
 # completion once the account is gone. ``expired`` is a claim reaped stale before attestation
 # (close_stale_claim closes the Swap PDA) — the user never completed, so it's terminal too.
+# ``cancelled`` is the no-fault cancel_swap terminal (dest provably unpayable; no slash).
 _OUTCOME_BY_EVENT = {
     'SwapCompleted': 'completed',
     'SwapTimedOut': 'timed_out',
     'StaleClaimClosed': 'expired',
+    'SwapCancelled': 'cancelled',
 }
 
 

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -569,12 +569,13 @@ def _miner_hotkey_for(validator, miner_pk) -> Optional[str]:
 class SwapStatus:
     """Seam ``/status`` payload. ``stage`` is the offering-facing lifecycle enum:
 
-    none → reserved → claimed → active → fulfilled → { completed | timed_out }
+    none → reserved → claimed → active → fulfilled → { completed | timed_out | cancelled }
     (a claim reaped stale before attestation ends at the terminal ``expired`` instead)
 
-    ``completed``, ``timed_out``, and ``expired`` are terminal; ``timed_out`` means the miner was
-    slashed, ``expired`` means the claim went stale pre-attestation (no funds moved, the Swap PDA
-    was closed by ``close_stale_claim``). They are sourced from the live PDA status or, after the terminal PDA closes on-chain, from
+    ``completed``, ``timed_out``, ``cancelled``, and ``expired`` are terminal; ``timed_out`` means
+    the miner was slashed, ``cancelled`` the no-fault cancel verdict (dest provably unpayable — no
+    slash, the miner keeps the source), ``expired`` means the claim went stale pre-attestation (no
+    funds moved, the Swap PDA was closed by ``close_stale_claim``). They are sourced from the live PDA status or, after the terminal PDA closes on-chain, from
     the validator's ``swap_outcomes`` event index. A closed PDA whose outcome isn't recorded
     yet reports ``fulfilled`` — transient, normally resolving within ~one forward step once the
     terminal event is ingested. Consumers keep polling on ``fulfilled`` and should apply their
@@ -587,7 +588,7 @@ class SwapStatus:
     moment it goes ``active``. Without ``swap_key``, resolution walks the miner's reservation
     and only the pre-attestation stages (``none``/``reserved``/``claimed``) are reliably visible."""
 
-    stage: str  # none | reserved | claimed | active | fulfilled | completed | timed_out | expired
+    stage: str  # none | reserved | claimed | active | fulfilled | completed | timed_out | cancelled | expired
     reserved_until: int = 0
     user: str = ''
     swap_key: str = ''
@@ -676,7 +677,7 @@ def _swap_stage(validator, swap, swap_key: bytes) -> str:
     """Stage for a claimed swap. A closed PDA is terminal, but Completed and TimedOut swaps both
     close on-chain, so the on-chain account alone can't tell a completion from a slash — the
     validator's own event index (``swap_outcomes``, written on SwapCompleted/SwapTimedOut/
-    StaleClaimClosed ingest) disambiguates. On an outcome miss, fall back NON-terminal to ``fulfilled``: the miss is
+    SwapCancelled/StaleClaimClosed ingest) disambiguates. On an outcome miss, fall back NON-terminal to ``fulfilled``: the miss is
     normally ingest lag (another validator's quorum closed the PDA since our last forward-step
     ingest) and self-corrects at the next ingest, whereas a terminal guess would stop the
     consumer polling on a wrong answer — for a slash, exactly the bug this index exists to fix."""

--- a/tests/test_event_index.py
+++ b/tests/test_event_index.py
@@ -88,6 +88,44 @@ class TestIngestActivity:
         assert idx.get_activity_state_at(400) == {}  # completed → AVAILABLE
         store.close()
 
+    def test_swap_cancelled_frees_the_hub(self, tmp_path: Path):
+        """The no-fault cancel is a terminal like completion/timeout: without its FULFILL_END
+        the hub stays FULFILLING (crownless) until an unrelated swap's terminal repairs it."""
+        store = make_store(tmp_path)
+        idx = make_index(store, ttl=1000)
+        idx.ingest(
+            [
+                rec('PoolResolved', miner='pk_a', block_time=200, winner='pk_router', user='pk_user', requests=1),
+                rec('SwapInitiated', miner='pk_a', block_time=250),
+                rec('SwapCancelled', miner='pk_a', block_time=400, collateral_chain='', collateral_amount=10, reason=0),
+            ],
+            ATTR,
+        )
+        assert idx.get_activity_state_at(250) == {'hk_a': _both(MinerActivity.FULFILLING)}
+        assert idx.get_activity_state_at(400) == {}  # cancelled → AVAILABLE
+        # The synthetic RESERVE_EXPIRE at 1200 then no-ops in AVAILABLE.
+        assert idx.get_activity_state_at(1200) == {}
+        store.close()
+
+    def test_swap_cancelled_frees_only_its_hub(self, tmp_path: Path):
+        """A v3.1 cancel carries the backing hub — the sibling hub's machine must not step."""
+        store = make_store(tmp_path)
+        idx = make_index(store, ttl=1000)
+        idx.ingest(
+            [
+                rec(
+                    'PoolResolved', miner='pk_a', block_time=200, winner='pk_router', user='pk_user',
+                    requests=1, collateral_chain='tao',
+                ),
+                rec('SwapInitiated', miner='pk_a', block_time=250, collateral_chain='tao'),
+                rec('SwapCancelled', miner='pk_a', block_time=400, collateral_chain='tao', collateral_amount=10, reason=0),
+            ],
+            ATTR,
+        )
+        assert idx.get_activity_state_at(250) == {'hk_a': {'tao': MinerActivity.FULFILLING}}
+        assert idx.get_activity_state_at(400) == {}  # only the tao machine ever stepped
+        store.close()
+
     def test_pool_resolved_synthesizes_reserve_expire(self, tmp_path: Path):
         """A reservation with no swap forfeits the crown until block_time + ttl,
         then RESERVE_EXPIRE returns the miner to AVAILABLE."""
@@ -395,6 +433,18 @@ class TestIngestSwapOutcomes:
         )
         assert store.get_swap_outcome(key.hex()) == 'timed_out'
         assert store.get_swap_outcome(DEFAULT_SWAP_KEY.hex()) is None  # only the event's key lands
+        store.close()
+
+    def test_swap_cancelled_records_cancelled_outcome(self, tmp_path: Path):
+        """Post-close, the seam must distinguish a cancel from a completion — both close the PDA."""
+        store = make_store(tmp_path)
+        idx = SolanaEventIndex(store)
+        key = bytes(range(32))
+        idx.ingest(
+            [rec('SwapCancelled', miner='pk_a', block_time=400, swap_key=key, collateral_chain='sol', collateral_amount=10, reason=0)],
+            ATTR,
+        )
+        assert store.get_swap_outcome(key.hex()) == 'cancelled'
         store.close()
 
     def test_stale_claim_closed_records_expired_outcome(self, tmp_path: Path):

--- a/tests/test_event_index.py
+++ b/tests/test_event_index.py
@@ -114,11 +114,23 @@ class TestIngestActivity:
         idx.ingest(
             [
                 rec(
-                    'PoolResolved', miner='pk_a', block_time=200, winner='pk_router', user='pk_user',
-                    requests=1, collateral_chain='tao',
+                    'PoolResolved',
+                    miner='pk_a',
+                    block_time=200,
+                    winner='pk_router',
+                    user='pk_user',
+                    requests=1,
+                    collateral_chain='tao',
                 ),
                 rec('SwapInitiated', miner='pk_a', block_time=250, collateral_chain='tao'),
-                rec('SwapCancelled', miner='pk_a', block_time=400, collateral_chain='tao', collateral_amount=10, reason=0),
+                rec(
+                    'SwapCancelled',
+                    miner='pk_a',
+                    block_time=400,
+                    collateral_chain='tao',
+                    collateral_amount=10,
+                    reason=0,
+                ),
             ],
             ATTR,
         )
@@ -441,7 +453,17 @@ class TestIngestSwapOutcomes:
         idx = SolanaEventIndex(store)
         key = bytes(range(32))
         idx.ingest(
-            [rec('SwapCancelled', miner='pk_a', block_time=400, swap_key=key, collateral_chain='sol', collateral_amount=10, reason=0)],
+            [
+                rec(
+                    'SwapCancelled',
+                    miner='pk_a',
+                    block_time=400,
+                    swap_key=key,
+                    collateral_chain='sol',
+                    collateral_amount=10,
+                    reason=0,
+                )
+            ],
             ATTR,
         )
         assert store.get_swap_outcome(key.hex()) == 'cancelled'


### PR DESCRIPTION
## Problem (F-14 from the 2026-08-14 testnet wave)

The no-fault cancel terminal (#669) emits `SwapCancelled`, but the validator's crown event index had no rule for it:

- `_FULFILL_TRANSITIONS` mapped only `SwapInitiated` → FULFILL_START and `SwapCompleted`/`SwapTimedOut` → FULFILL_END, and the activity machine has no other exit from FULFILLING — so a cancel stranded the serving hub in FULFILLING (crownless) indefinitely, until an unrelated swap on the same hub completed or timed out.
- `_OUTCOME_BY_EVENT` omitted it, so a closed-by-cancel PDA was indistinguishable from a completion downstream — the seam's `/status` reported a stuck non-terminal `fulfilled` forever.

**Observed live (testnet, UID 2):** after the first e2e cancel at 19:12:01Z, the miner's entire tao hub was crown-stranded ~70 minutes (tao→eth / eth→tao dropped to none, btc→tao ceded to the runner-up) while quotes were posted and busy/settling were clear. The validator itself warned `crown replay: unexpected activity transition RESERVE_START in FULFILLING` (19:27:54) and again `... FULFILL_START in FULFILLING` (20:01:27). The hub recovered only when the next completed swap on it emitted FULFILL_END — confirming the mechanism. Net effect: the deliberately penalty-free cancel path (no slash/fee/strike) carried a large hidden emissions penalty for the miner who correctly proved the destination unpayable.

## Fix

- `SwapCancelled` → `FULFILL_END` in `_FULFILL_TRANSITIONS` (the `(FULFILLING, FULFILL_END) → AVAILABLE` edge already exists; the event already carries the hub as `collateral_chain`, which `_event_hub` reads).
- `SwapCancelled` → `'cancelled'` in `_OUTCOME_BY_EVENT`, so the seam's `_swap_stage` returns a proper terminal `cancelled` stage post-close instead of `fulfilled` forever.
- Docstrings/comments updated (stage enum, outcome sources, FULFILL_END sources).

No contract change — the event was always emitted (its own doc even says the hub "was freed"); the validator just never consumed it. Existing stuck hubs self-heal on their next terminal swap, same as before.

## Tests

- cancel after initiate returns the hub to AVAILABLE (and the synthetic RESERVE_EXPIRE stays a no-op)
- a hub-scoped (v3.1) cancel frees only its hub
- `cancelled` outcome recorded by swap key

Full suite: 1810 passed (+51 in the solo-run bitcoin-signing file).