### PR TITLE
Red-team 08-14 fixes: fund-safety + slash-correctness pass

### DIFF
--- a/allways/__init__.py
+++ b/allways/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '3.1.2'
+__version__ = '3.2.0'
 version_split = __version__.split('.')
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))

--- a/allways/assets/btc.py
+++ b/allways/assets/btc.py
@@ -767,7 +767,7 @@ class Bitcoin(Asset, Chain):
         if override is not None:
             return max(1, override)
 
-        from allways.constants import BTC_FEE_RATE_SAFETY_MULTIPLIER, BTC_MIN_FEE_RATE
+        from allways.constants import BTC_FALLBACK_FEE_RATE, BTC_FEE_RATE_SAFETY_MULTIPLIER, BTC_MIN_FEE_RATE
 
         for attempt in range(2):
             try:
@@ -782,7 +782,10 @@ class Bitcoin(Asset, Chain):
                 bt.logging.debug(f'estimate_fee_rate: attempt {attempt + 1} failed: {e}')
             if attempt == 0:
                 time.sleep(3)
-        return BTC_MIN_FEE_RATE
+        # Estimation failed both attempts — broadcast at the survivable fallback, not the strand-prone
+        # floor (V-L5). Warn (not debug): a real send is going out at a non-estimated rate.
+        bt.logging.warning(f'estimate_fee_rate: /fee-estimates unavailable — using {BTC_FALLBACK_FEE_RATE} sat/vB fallback')
+        return BTC_FALLBACK_FEE_RATE
 
     def send_amount(
         self, to_address: str, amount: int, from_address: Optional[str] = None, dedup_key: Optional[str] = None

--- a/allways/assets/btc.py
+++ b/allways/assets/btc.py
@@ -784,7 +784,9 @@ class Bitcoin(Asset, Chain):
                 time.sleep(3)
         # Estimation failed both attempts — broadcast at the survivable fallback, not the strand-prone
         # floor (V-L5). Warn (not debug): a real send is going out at a non-estimated rate.
-        bt.logging.warning(f'estimate_fee_rate: /fee-estimates unavailable — using {BTC_FALLBACK_FEE_RATE} sat/vB fallback')
+        bt.logging.warning(
+            f'estimate_fee_rate: /fee-estimates unavailable — using {BTC_FALLBACK_FEE_RATE} sat/vB fallback'
+        )
         return BTC_FALLBACK_FEE_RATE
 
     def send_amount(

--- a/allways/assets/chain.py
+++ b/allways/assets/chain.py
@@ -55,8 +55,9 @@ class Chain(ABC):
         """Canonical comparison form for this chain's addresses (identity by default).
 
         Chains whose address encoding is case-insensitive (ETH hex / EIP-55 checksum casing)
-        override this so equality checks never fail on casing alone. Comparison only — never
-        feed the normalized form back on-chain or into display."""
+        override this so equality checks never fail on casing alone. SOURCE addresses commit
+        on-chain in this form (the source-lock PDA is byte-keyed on it — V-C2); delivery
+        addresses stay as given (EVM sends re-checksum at signing)."""
         return address
 
     @abstractmethod

--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -138,8 +138,11 @@ class Erc20(EvmAsset):
         try:
             code = self.chain.eth_rpc('eth_getCode', [self.token_contract, 'latest']) or '0x'
         except Exception as e:
-            bt.logging.warning(f'{self._log} token contract probe failed: {e}')
-            return
+            # For an ERC-20 the token contract IS the asset identity — a probe we can't complete
+            # must fail boot, not warn-and-continue (a warn boots a broken token as "ready").
+            raise ConnectionError(
+                f'{self.chain_def.id} token contract probe failed on {self.chain.network}: {e}'
+            ) from e
         if code == '0x':
             # A typo'd override or wrong network would otherwise surface as every send failing.
             raise ConnectionError(

--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -141,7 +141,9 @@ class Erc20(EvmAsset):
             # A probe we can't COMPLETE is transient (unreachable RPC / rate-limit storm) — degrade, never
             # crash the whole validator at boot over one spoke's flaky endpoint (that takes the hub down too).
             # The real config fault — a codeless/wrong contract — is a COMPLETED probe returning '0x' below.
-            bt.logging.warning(f'{self.chain_def.id} token contract probe unreachable on {self.chain.network} ({e}) — degraded')
+            bt.logging.warning(
+                f'{self.chain_def.id} token contract probe unreachable on {self.chain.network} ({e}) — degraded'
+            )
             return
         if code == '0x':
             # A typo'd override or wrong network would otherwise surface as every send failing.

--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -150,13 +150,20 @@ class Erc20(EvmAsset):
     def check_connection(self, require_send: bool = True) -> None:
         super().check_connection(require_send=require_send)
         try:
-            code = self.chain.eth_rpc('eth_getCode', [self.token_contract, 'latest']) or '0x'
+            code = self.chain.eth_rpc('eth_getCode', [self.token_contract, 'latest'])
         except Exception as e:
             # A probe we can't COMPLETE is transient (unreachable RPC / rate-limit storm) — degrade, never
             # crash the whole validator at boot over one spoke's flaky endpoint (that takes the hub down too).
             # The real config fault — a codeless/wrong contract — is a COMPLETED probe returning '0x' below.
             bt.logging.warning(
                 f'{self.chain_def.id} token contract probe unreachable on {self.chain.network} ({e}) — degraded'
+            )
+            return
+        if not code:
+            # A null answer is a broken/lagging endpoint, not a codeless contract (the spec returns the
+            # string '0x' for that) — same transient treatment as the unreachable case above.
+            bt.logging.warning(
+                f'{self.chain_def.id} token contract probe returned null on {self.chain.network} — degraded'
             )
             return
         if code == '0x':

--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -138,11 +138,11 @@ class Erc20(EvmAsset):
         try:
             code = self.chain.eth_rpc('eth_getCode', [self.token_contract, 'latest']) or '0x'
         except Exception as e:
-            # For an ERC-20 the token contract IS the asset identity — a probe we can't complete
-            # must fail boot, not warn-and-continue (a warn boots a broken token as "ready").
-            raise ConnectionError(
-                f'{self.chain_def.id} token contract probe failed on {self.chain.network}: {e}'
-            ) from e
+            # A probe we can't COMPLETE is transient (unreachable RPC / rate-limit storm) — degrade, never
+            # crash the whole validator at boot over one spoke's flaky endpoint (that takes the hub down too).
+            # The real config fault — a codeless/wrong contract — is a COMPLETED probe returning '0x' below.
+            bt.logging.warning(f'{self.chain_def.id} token contract probe unreachable on {self.chain.network} ({e}) — degraded')
+            return
         if code == '0x':
             # A typo'd override or wrong network would otherwise surface as every send failing.
             raise ConnectionError(

--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -9,7 +9,11 @@ from eth_utils import keccak, to_checksum_address
 from allways.assets.asset import ProviderUnreachableError, SendResult, TransactionInfo
 from allways.assets.evm import EVM_NETWORKS, FALLBACK_PRIORITY_FEE_WEI, EvmAsset, EvmChain
 from allways.chains import ChainDefinition
-from allways.constants import CANCEL_REASON_ERC20_BLACKLIST, CANCEL_REASON_ERC20_PAUSED
+from allways.constants import (
+    CANCEL_REASON_ERC20_BLACKLIST,
+    CANCEL_REASON_ERC20_FEE_ENABLED,
+    CANCEL_REASON_ERC20_PAUSED,
+)
 
 
 def _selector(signature: str) -> str:
@@ -114,6 +118,8 @@ class Erc20(EvmAsset):
         if chain_def.refusal_checks is None:
             raise ValueError(f'{chain_def.id} declares no refusal_checks — name the freeze surface, or ()')
         self._checks = tuple(_refusal_call(sig) for sig in chain_def.refusal_checks)
+        # A `(uint256)->uint256` fee view (PAXG's getFeeFor), None for tokens with no fee lever.
+        self._fee_selector = _selector(chain_def.fee_check) if chain_def.fee_check else None
         self._chain = EvmChain(EVM_NETWORKS[chain_def.host_chain], chain_def.env_prefix)
         EvmAsset.__init__(self)
         self.token_contract = _token_contract(chain_def, self.chain.network)
@@ -131,6 +137,14 @@ class Erc20(EvmAsset):
         Anything unparseable raises rather than reading as 0: an absent function and a `False`
         answer must never collapse, or a frozen destination reads as deliverable."""
         data = selector + (_pad_addr(address) if address else '')
+        return int(self.chain.eth_rpc('eth_call', [{'to': self.token_contract, 'data': data}, block]), 16)
+
+    def _fee_for(self, amount: int, block: str = 'latest') -> int:
+        """The issuer's transfer fee on ``amount`` via the row's declared ``fee_check`` view.
+        0 when the row declares none. Raises on RPC trouble (callers fail closed / defer)."""
+        if self._fee_selector is None:
+            return 0
+        data = self._fee_selector + f'{int(amount):064x}'
         return int(self.chain.eth_rpc('eth_call', [{'to': self.token_contract, 'data': data}, block]), 16)
 
     def check_connection(self, require_send: bool = True) -> None:
@@ -520,11 +534,18 @@ class Erc20(EvmAsset):
         selectors here would revert on every other token and silently yield no evidence — which
         slashes a miner for a destination its issuer froze. Returns CANCEL_REASON_ERC20_BLACKLIST
         for a per-address freeze, _PAUSED for a token-wide stop, else None. None on RPC trouble so
-        the caller waits rather than slashing."""
+        the caller waits rather than slashing.
+
+        _FEE_ENABLED covers a token whose issuer switched on a transfer fee (PAXG's admin lever):
+        the fee shaves every honest delivery's log below the pinned amount, so it's a hub-wide
+        no-fault condition, not a miner failure. Probed on ``amount`` (the expected delivery), so a
+        fee that floors to 0 for this size never spuriously cancels."""
         try:
             for selector, takes_address in self._checks:
                 if self._eth_call(selector, address if takes_address else ''):
                     return CANCEL_REASON_ERC20_BLACKLIST if takes_address else CANCEL_REASON_ERC20_PAUSED
+            if self._fee_for(amount) > 0:
+                return CANCEL_REASON_ERC20_FEE_ENABLED
         except Exception:
             return None
         return None

--- a/allways/assets/evm_coin.py
+++ b/allways/assets/evm_coin.py
@@ -297,7 +297,9 @@ class EvmCoin(EvmAsset):
         try:
             est = int(self.chain.eth_rpc('eth_estimateGas', [params]), 16)
         except Exception as e:
-            return None if 'revert' in str(e).lower() else TRANSFER_GAS
+            # Structured on-chain verdict, not message-substring (which misses a code-3 revert whose
+            # text omits the word "revert" → a doomed tx would broadcast). Mirrors the ERC-20 twin.
+            return None if getattr(e, 'is_execution_revert', False) else TRANSFER_GAS
         gas = est + est // 5
         return None if gas > MAX_TRANSFER_GAS else gas
 

--- a/allways/assets/evm_coin.py
+++ b/allways/assets/evm_coin.py
@@ -363,10 +363,9 @@ class EvmCoin(EvmAsset):
             return None  # under-gassed — could be manufactured; never accept as refusal
         return CANCEL_REASON_EVM_REVERT
 
-    # Plain JSON-RPC has no address→tx index (Esplora/getSignaturesForAddress have one), so the
-    # deposit scanner follows the head incrementally like the TAO provider: each call scans only
-    # blocks minted since the last call for this (from, to, amount) triple, bounded by
-    # SCAN_LOOKBACK_BLOCKS on the first call or after a gap (≈5 min of the chain's blocks).
+    # Plain JSON-RPC has no address→tx index, so the scanner walks the head incrementally: each
+    # call scans blocks minted since the last for this (from, to, amount) triple. The cold-start
+    # floor is min(SCAN_LOOKBACK_BLOCKS, MAX_WALK_BLOCKS) ≤ 32 blocks — under SCAN_LOOKBACK_SECS on fast chains.
     def find_recent_outgoing(self, from_addr: str, to_addr: str, amount: int) -> Optional[str]:
         """Tx hash of a recent settled transfer ``from_addr`` → ``to_addr`` of >= ``amount``, else
         None. A hash-finder only — the seam's confirm re-verifies everything by hash, so a miss

--- a/allways/assets/sol.py
+++ b/allways/assets/sol.py
@@ -392,20 +392,30 @@ class Sol(Asset, Chain):
     def _prior_broadcast(self, want: tuple) -> Optional[SendResult]:
         """Reusable (sig, slot) from a prior own broadcast for this (to, amount, dedup) obligation that
         provably landed — so a confirm() timeout that returned None can never cause a second pay. None
-        when no prior send can have moved funds; RAISES when a recent send is neither on-chain nor
-        expired yet (caller must wait, not re-send)."""
+        when no prior send can have moved funds; RAISES when the prior send is unresolved (not yet
+        expired, or only at ``processed`` commitment) — the caller must wait, not re-send."""
         head = self._current_slot()
         for sig, (to, amt, scope, seen) in list(self.broadcasted_txids.items()):
             if (to, amt, scope) != want:
                 continue
             st = (self.rpc.get_signature_statuses([sig]) or [None])[0]
             if st is not None:
+                if st.get('confirmationStatus') not in ('confirmed', 'finalized'):
+                    # processed-only: possibly a minority fork that never settles. Reusing it would
+                    # mark the leg delivered while the user is never paid; a failed status at
+                    # processed is equally unsettled. Either way: wait for majority commitment.
+                    raise SolanaRpcError(f'prior send {sig[:16]}... only processed — waiting for confirmed')
                 if st.get('err') is None:
-                    return (sig, int(st.get('slot') or 0))  # landed (any status) → reuse, never re-send
+                    return (sig, int(st.get('slot') or 0))  # settled at majority commitment → reuse
                 del self.broadcasted_txids[sig]  # failed on-chain → moved nothing, a fresh send is safe
                 continue
-            if head is not None and head - int(seen) > self._BROADCAST_TTL_SLOTS:
-                del self.broadcasted_txids[sig]  # blockhash long expired unlanded → safe to resend
-                continue
+            if head is not None:
+                if int(seen) <= 0:
+                    # get_slot failed at record time, so the record's age is unknown: backfill with the
+                    # current head so the TTL counts from now — "can't tell" must read recent, never expired.
+                    self.broadcasted_txids[sig] = (to, amt, scope, head)
+                elif head - int(seen) > self._BROADCAST_TTL_SLOTS:
+                    del self.broadcasted_txids[sig]  # blockhash long expired unlanded → safe to resend
+                    continue
             raise SolanaRpcError(f'prior send {sig[:16]}... not on-chain yet and not expired — waiting a pass')
         return None

--- a/allways/assets/sol.py
+++ b/allways/assets/sol.py
@@ -322,7 +322,9 @@ class Sol(Asset, Chain):
         # Never send from a key that can't satisfy the validator's sender pin: the leg would be rejected
         # and the funds wasted. Refuse before broadcasting (mirrors the EVM/BTC providers).
         if from_address is not None and str(self.keypair.pubkey()) != str(from_address):
-            bt.logging.error(f'{LOG_SOL} committed sender {from_address} != wallet {self.keypair.pubkey()} — not sending')
+            bt.logging.error(
+                f'{LOG_SOL} committed sender {from_address} != wallet {self.keypair.pubkey()} — not sending'
+            )
             return None
 
         # Reuse a prior own broadcast for THIS obligation instead of paying twice: a confirm() timeout

--- a/allways/assets/sol.py
+++ b/allways/assets/sol.py
@@ -12,7 +12,7 @@ from allways.assets.asset import Asset, ProviderUnreachableError, SendResult, Tr
 from allways.assets.chain import Chain
 from allways.chains import CHAIN_SOL, ChainDefinition
 from allways.constants import CANCEL_REASON_SOL_RESERVED
-from allways.solana.rpc import SolanaRpc, resolve_rpc_url
+from allways.solana.rpc import SolanaRpc, SolanaRpcError, resolve_rpc_url
 
 LOG_SOL = '[Solana]'
 
@@ -87,6 +87,9 @@ class Sol(Asset, Chain):
         self.rpc_url = resolve_rpc_url(solana_rpc_url)
         self.rpc = SolanaRpc(self.rpc_url, timeout=timeout)
         self.keypair = solana_keypair
+        # Own-broadcast dedup: sig -> (to, amount, dedup_scope, seen_slot). A confirm() timeout returns
+        # None even when the transfer landed; without this the next poll re-signs and double-pays.
+        self.broadcasted_txids: dict[str, tuple] = {}
 
     @property
     def chain_def(self) -> ChainDefinition:
@@ -316,6 +319,19 @@ class Sol(Asset, Chain):
         if self.keypair is None:
             bt.logging.error('SOL send_amount called on a read-only Sol (no keypair)')
             return None
+
+        # Reuse a prior own broadcast for THIS obligation instead of paying twice: a confirm() timeout
+        # returns None even when the transfer landed, and the next poll would otherwise re-send.
+        want = (str(to_address), int(amount), dedup_key or '')
+        try:
+            prior = self._prior_broadcast(want)
+        except Exception as e:
+            bt.logging.error(f'{LOG_SOL} prior send unresolved ({e}) — not re-sending, would risk a double pay')
+            return None
+        if prior is not None:
+            bt.logging.info(f'{LOG_SOL} reusing prior tx {prior[0]} to {to_address} ({amount} lamports)')
+            return prior
+
         try:
             from solders.hash import Hash
             from solders.system_program import TransferParams, transfer
@@ -336,6 +352,9 @@ class Sol(Asset, Chain):
                 blockhash = Hash.from_string(self.rpc.get_latest_blockhash())
                 tx = Transaction.new_signed_with_payer([ix], self.keypair.pubkey(), [self.keypair], blockhash)
                 sig = self.rpc.send_transaction(base64.b64encode(bytes(tx)).decode())
+                # Record BEFORE confirm: if confirm() times out on a tx that actually landed, the next
+                # poll's _prior_broadcast finds this sig and reuses it rather than re-sending.
+                self._record_broadcast(sig, want)
                 status = self.rpc.confirm(sig)
                 slot = int(status.get('slot') or 0)
                 bt.logging.info(f'{LOG_SOL} sent {amount} lamports to {to_address} (sig: {sig}, slot: {slot})')
@@ -347,4 +366,39 @@ class Sol(Asset, Chain):
                 last_err = e
                 time.sleep(0.5)
         bt.logging.error(f'{LOG_SOL} send_amount failed after blockhash retries: {last_err}')
+        return None
+
+    _BROADCAST_TTL_SLOTS = 150  # a Solana blockhash expires well within ~60s; past this an unlanded sig is dead
+
+    def _record_broadcast(self, sig: str, want: tuple) -> None:
+        head = self._current_slot()
+        self.broadcasted_txids[sig] = (*want, head if head is not None else 0)
+        if len(self.broadcasted_txids) > 256:
+            self.broadcasted_txids.pop(next(iter(self.broadcasted_txids)))
+
+    def _current_slot(self) -> Optional[int]:
+        try:
+            return int(self.rpc.get_slot())
+        except Exception:
+            return None
+
+    def _prior_broadcast(self, want: tuple) -> Optional[SendResult]:
+        """Reusable (sig, slot) from a prior own broadcast for this (to, amount, dedup) obligation that
+        provably landed — so a confirm() timeout that returned None can never cause a second pay. None
+        when no prior send can have moved funds; RAISES when a recent send is neither on-chain nor
+        expired yet (caller must wait, not re-send)."""
+        head = self._current_slot()
+        for sig, (to, amt, scope, seen) in list(self.broadcasted_txids.items()):
+            if (to, amt, scope) != want:
+                continue
+            st = (self.rpc.get_signature_statuses([sig]) or [None])[0]
+            if st is not None:
+                if st.get('err') is None:
+                    return (sig, int(st.get('slot') or 0))  # landed (any status) → reuse, never re-send
+                del self.broadcasted_txids[sig]  # failed on-chain → moved nothing, a fresh send is safe
+                continue
+            if head is not None and head - int(seen) > self._BROADCAST_TTL_SLOTS:
+                del self.broadcasted_txids[sig]  # blockhash long expired unlanded → safe to resend
+                continue
+            raise SolanaRpcError(f'prior send {sig[:16]}... not on-chain yet and not expired — waiting a pass')
         return None

--- a/allways/assets/sol.py
+++ b/allways/assets/sol.py
@@ -319,6 +319,11 @@ class Sol(Asset, Chain):
         if self.keypair is None:
             bt.logging.error('SOL send_amount called on a read-only Sol (no keypair)')
             return None
+        # Never send from a key that can't satisfy the validator's sender pin: the leg would be rejected
+        # and the funds wasted. Refuse before broadcasting (mirrors the EVM/BTC providers).
+        if from_address is not None and str(self.keypair.pubkey()) != str(from_address):
+            bt.logging.error(f'{LOG_SOL} committed sender {from_address} != wallet {self.keypair.pubkey()} — not sending')
+            return None
 
         # Reuse a prior own broadcast for THIS obligation instead of paying twice: a confirm() timeout
         # returns None even when the transfer landed, and the next poll would otherwise re-send.

--- a/allways/assets/tao.py
+++ b/allways/assets/tao.py
@@ -671,7 +671,9 @@ class Tao(Asset, Chain):
                 return (tx_hash, block_num)
         return None
 
-    def _lost_hash_prior_landed(self, from_addr: str, to_addr: str, amount: int, seen_head: int) -> Optional[SendResult]:
+    def _lost_hash_prior_landed(
+        self, from_addr: str, to_addr: str, amount: int, seen_head: int
+    ) -> Optional[SendResult]:
         """Resolve a prior send whose extrinsic hash was never learned: ``subtensor.transfer`` raised
         mid-submit (e.g. a websocket drop during wait_for_inclusion), so the extrinsic may have reached
         the chain even though the call reported nothing. ``(hash, block)`` if a settled

--- a/allways/assets/tao.py
+++ b/allways/assets/tao.py
@@ -658,6 +658,13 @@ class Tao(Asset, Chain):
         if self.wallet is None:
             bt.logging.error('TAO send_amount called on a read-only Tao (no wallet)')
             return None
+        # Never send from a key that can't satisfy the validator's sender pin: the leg would be rejected
+        # and the funds wasted. Refuse before broadcasting (mirrors the EVM/BTC providers).
+        if from_address is not None and self.wallet.coldkeypub.ss58_address != str(from_address):
+            bt.logging.error(
+                f'TAO committed sender {from_address} != wallet {self.wallet.coldkeypub.ss58_address} — not sending'
+            )
+            return None
 
         # Reuse a prior own broadcast for THIS obligation rather than re-sending: subtensor.transfer can
         # report failure on a transfer that actually included, and the next poll would otherwise double-pay.

--- a/allways/assets/tao.py
+++ b/allways/assets/tao.py
@@ -544,6 +544,10 @@ class Tao(Asset, Chain):
     # watcher tick — bounded by SCAN_LOOKBACK_BLOCKS on the first call or after a gap
     # (≈5 min of 12s blocks, mirroring the BTC scanner's window).
     SCAN_LOOKBACK_BLOCKS = 25
+    # A lost-hash send is only provably dead past the extrinsic's mortality: bittensor signs
+    # transfers with a 128-block era (DEFAULT_PERIOD), so a shorter deadline re-sends while the
+    # original can still include → double pay (the re-send takes nonce N+1 once it lands).
+    LOST_SEND_DEAD_BLOCKS = 130
     _MAX_SCAN_CURSORS = 64
 
     def find_recent_outgoing(self, from_addr: str, to_addr: str, amount: int) -> Optional[str]:
@@ -705,8 +709,8 @@ class Tao(Asset, Chain):
                 settled = self.settled_credit(block_num, ext_idx, to_addr)
                 if settled is not None and settled[1] >= int(amount):
                     return (ext_hash, block_num)
-        if head - int(seen_head) > self.SCAN_LOOKBACK_BLOCKS:
-            return None  # window elapsed and scanned clean: the lost extrinsic never landed
+        if head - int(seen_head) > self.LOST_SEND_DEAD_BLOCKS:
+            return None  # mortal era elapsed and scanned clean: the lost extrinsic can never land
         raise ProviderUnreachableError('prior TAO send (hash lost mid-submit) not yet resolvable — waiting a pass')
 
     def send_amount(

--- a/allways/assets/tao.py
+++ b/allways/assets/tao.py
@@ -33,6 +33,9 @@ class Tao(Asset, Chain):
         self.events_cache: Dict[str, list] = {}
         # Deposit-scanner head cursors, keyed per (from, to, amount) triple — see find_recent_outgoing.
         self.scan_cursors: Dict[Tuple[str, str, int], int] = {}
+        # Own-broadcast dedup: dedup_scope -> (to, amount, extrinsic_hash). subtensor.transfer can report
+        # failure on a transfer that actually included; without this the next poll re-sends and double-pays.
+        self.broadcasted_txids: Dict[str, Tuple[str, int, str]] = {}
 
     @property
     def chain_def(self) -> ChainDefinition:
@@ -625,6 +628,29 @@ class Tao(Asset, Chain):
             bt.logging.error(f'TAO verify_from_proof failed: {e}')
             return False
 
+    def _own_transfer_landed(self, tx_hash: str, from_addr: str, to_addr: str, amount: int) -> Optional[SendResult]:
+        """``(tx_hash, block_num)`` if THIS exact recorded extrinsic is on-chain as a matching transfer,
+        else None. Matches on the extrinsic hash (not first-match), so it can never reuse a different
+        swap's transfer. Reliable because ``send`` uses wait_for_inclusion: after it returns the extrinsic
+        is included-or-not, never still-pending."""
+        head = self.chain.get_current_block_height()
+        if head is None:
+            return None
+        floor = max(head - self.SCAN_LOOKBACK_BLOCKS, 0)
+        for block_num in range(floor + 1, head + 1):
+            block = self.get_block(block_num)
+            if not block or 'extrinsics' not in block:
+                continue
+            is_raw = block.get('_raw', False)
+            for ext in block['extrinsics']:
+                decoded = self.decode_transfer(ext, is_raw)
+                if decoded is None:
+                    continue
+                ext_hash, dest, amt, sender = decoded
+                if ext_hash == tx_hash and dest == to_addr and sender == from_addr and int(amt) >= int(amount):
+                    return (tx_hash, block_num)
+        return None
+
     def send_amount(
         self, to_address: str, amount: int, from_address: Optional[str] = None, dedup_key: Optional[str] = None
     ) -> SendResult:
@@ -632,6 +658,22 @@ class Tao(Asset, Chain):
         if self.wallet is None:
             bt.logging.error('TAO send_amount called on a read-only Tao (no wallet)')
             return None
+
+        # Reuse a prior own broadcast for THIS obligation rather than re-sending: subtensor.transfer can
+        # report failure on a transfer that actually included, and the next poll would otherwise double-pay.
+        from_ss58 = self.wallet.coldkeypub.ss58_address
+        scope = dedup_key or ''
+        prior = self.broadcasted_txids.get(scope)
+        if prior is not None and prior[0] == to_address and prior[1] == int(amount):
+            try:
+                landed = self._own_transfer_landed(prior[2], from_ss58, to_address, amount)
+            except Exception as e:
+                bt.logging.error(f'TAO prior send unresolved ({e}) — not re-sending, would risk a double pay')
+                return None
+            if landed is not None:
+                bt.logging.info(f'TAO reusing prior tx {landed[0]} to {to_address} ({amount} rao)')
+                return landed
+
         try:
             response = self.subtensor.transfer(
                 wallet=self.wallet,
@@ -640,6 +682,13 @@ class Tao(Asset, Chain):
                 wait_for_inclusion=True,
                 wait_for_finalization=False,
             )
+            # Record the extrinsic hash BEFORE the success gate: a transfer reported failed may still have
+            # included, and only a recorded hash lets the next poll re-probe it instead of re-sending.
+            recorded = getattr(getattr(response, 'extrinsic_receipt', None), 'extrinsic_hash', None)
+            if recorded:
+                self.broadcasted_txids[scope] = (to_address, int(amount), recorded)
+                if len(self.broadcasted_txids) > 256:
+                    self.broadcasted_txids.pop(next(iter(self.broadcasted_txids)))
             if not response.success:
                 bt.logging.error(f'TAO transfer failed: {response.message}')
                 return None

--- a/allways/assets/tao.py
+++ b/allways/assets/tao.py
@@ -629,10 +629,15 @@ class Tao(Asset, Chain):
             return False
 
     def _own_transfer_landed(self, tx_hash: str, from_addr: str, to_addr: str, amount: int) -> Optional[SendResult]:
-        """``(tx_hash, block_num)`` if THIS exact recorded extrinsic is on-chain as a matching transfer,
-        else None. Matches on the extrinsic hash (not first-match), so it can never reuse a different
-        swap's transfer. Reliable because ``send`` uses wait_for_inclusion: after it returns the extrinsic
-        is included-or-not, never still-pending."""
+        """``(tx_hash, block_num)`` if THIS exact recorded extrinsic is on-chain AND its funds provably
+        moved, else None. Matches on the extrinsic hash (not first-match), so it can never reuse a
+        different swap's transfer. Inclusion is NOT settlement: an included-but-failed transfer (e.g.
+        insufficient balance) still occupies a block and decodes to the intended dest/amount, so the
+        match is gated on ``settled_credit`` (the Balances.Transfer event) exactly as the deposit
+        scanner is — otherwise a genuinely-failed send is mistaken for paid, never retried, and rides to
+        a slash. Reliable because ``send`` uses wait_for_inclusion: after it returns the extrinsic is
+        included-or-not, never still-pending. RAISES (ProviderUnreachableError) when settlement can't be
+        read, so the caller waits rather than re-sending an unresolved transfer into a double pay."""
         head = self.chain.get_current_block_height()
         if head is None:
             return None
@@ -642,13 +647,19 @@ class Tao(Asset, Chain):
             if not block or 'extrinsics' not in block:
                 continue
             is_raw = block.get('_raw', False)
-            for ext in block['extrinsics']:
+            for position, ext in enumerate(block['extrinsics']):
                 decoded = self.decode_transfer(ext, is_raw)
                 if decoded is None:
                     continue
                 ext_hash, dest, amt, sender = decoded
-                if ext_hash == tx_hash and dest == to_addr and sender == from_addr and int(amt) >= int(amount):
-                    return (tx_hash, block_num)
+                if ext_hash != tx_hash or dest != to_addr or sender != from_addr or int(amt) < int(amount):
+                    continue
+                # Exact-hash call match is only a candidate; confirm the funds actually moved.
+                ext_idx = ext.get('extrinsic_idx', position) if is_raw else position
+                settled = self.settled_credit(block_num, ext_idx, to_addr)
+                if settled is None or settled[1] < int(amount):
+                    return None  # included but the transfer failed → moved nothing → safe to re-send
+                return (tx_hash, block_num)
         return None
 
     def send_amount(

--- a/allways/assets/tao.py
+++ b/allways/assets/tao.py
@@ -33,9 +33,11 @@ class Tao(Asset, Chain):
         self.events_cache: Dict[str, list] = {}
         # Deposit-scanner head cursors, keyed per (from, to, amount) triple — see find_recent_outgoing.
         self.scan_cursors: Dict[Tuple[str, str, int], int] = {}
-        # Own-broadcast dedup: dedup_scope -> (to, amount, extrinsic_hash). subtensor.transfer can report
-        # failure on a transfer that actually included; without this the next poll re-sends and double-pays.
-        self.broadcasted_txids: Dict[str, Tuple[str, int, str]] = {}
+        # Own-broadcast dedup: dedup_scope -> (to, amount, extrinsic_hash, seen_block). subtensor.transfer
+        # can report failure — or raise mid-submit — on a transfer that actually included; without this the
+        # next poll re-sends and double-pays. hash '' = submit raised before the hash was learned (resolved
+        # by triple scan); seen_block 0 = head unreadable at record time (backfilled on the next poll).
+        self.broadcasted_txids: Dict[str, Tuple[str, int, str, int]] = {}
 
     @property
     def chain_def(self) -> ChainDefinition:
@@ -628,7 +630,9 @@ class Tao(Asset, Chain):
             bt.logging.error(f'TAO verify_from_proof failed: {e}')
             return False
 
-    def _own_transfer_landed(self, tx_hash: str, from_addr: str, to_addr: str, amount: int) -> Optional[SendResult]:
+    def _own_transfer_landed(
+        self, tx_hash: str, from_addr: str, to_addr: str, amount: int, seen_head: Optional[int] = None
+    ) -> Optional[SendResult]:
         """``(tx_hash, block_num)`` if THIS exact recorded extrinsic is on-chain AND its funds provably
         moved, else None. Matches on the extrinsic hash (not first-match), so it can never reuse a
         different swap's transfer. Inclusion is NOT settlement: an included-but-failed transfer (e.g.
@@ -636,16 +640,21 @@ class Tao(Asset, Chain):
         match is gated on ``settled_credit`` (the Balances.Transfer event) exactly as the deposit
         scanner is — otherwise a genuinely-failed send is mistaken for paid, never retried, and rides to
         a slash. Reliable because ``send`` uses wait_for_inclusion: after it returns the extrinsic is
-        included-or-not, never still-pending. RAISES (ProviderUnreachableError) when settlement can't be
-        read, so the caller waits rather than re-sending an unresolved transfer into a double pay."""
+        included-or-not, never still-pending. RAISES (ProviderUnreachableError) when the head, any
+        in-window block, or settlement can't be read: an unreadable chain can hide a landed transfer,
+        so "couldn't check" waits rather than clearing a re-send into a double pay. ``seen_head``
+        anchors the scan window on the block the send was recorded at, so an RPC outage spanning polls
+        can't slide the landed transfer out of the lookback and read as "never landed"."""
         head = self.chain.get_current_block_height()
         if head is None:
-            return None
-        floor = max(head - self.SCAN_LOOKBACK_BLOCKS, 0)
-        for block_num in range(floor + 1, head + 1):
+            raise ProviderUnreachableError('TAO head unavailable — cannot resolve the prior send')
+        anchor = min(int(seen_head), head) if seen_head else head
+        floor = max(anchor - self.SCAN_LOOKBACK_BLOCKS, 0)
+        top = min(head, anchor + self.SCAN_LOOKBACK_BLOCKS)
+        for block_num in range(floor + 1, top + 1):
             block = self.get_block(block_num)
             if not block or 'extrinsics' not in block:
-                continue
+                raise ProviderUnreachableError(f'TAO block {block_num} unreadable — cannot rule out the prior send')
             is_raw = block.get('_raw', False)
             for position, ext in enumerate(block['extrinsics']):
                 decoded = self.decode_transfer(ext, is_raw)
@@ -661,6 +670,42 @@ class Tao(Asset, Chain):
                     return None  # included but the transfer failed → moved nothing → safe to re-send
                 return (tx_hash, block_num)
         return None
+
+    def _lost_hash_prior_landed(self, from_addr: str, to_addr: str, amount: int, seen_head: int) -> Optional[SendResult]:
+        """Resolve a prior send whose extrinsic hash was never learned: ``subtensor.transfer`` raised
+        mid-submit (e.g. a websocket drop during wait_for_inclusion), so the extrinsic may have reached
+        the chain even though the call reported nothing. ``(hash, block)`` if a settled
+        ``from → to >= amount`` transfer is found since just before the attempt; None only once the
+        inclusion window since the attempt has fully elapsed AND every block in it scanned clean, so the
+        lost extrinsic provably never landed. RAISES (ProviderUnreachableError) while the window is
+        still open or any block is unreadable — the caller must wait, not re-send."""
+        head = self.chain.get_current_block_height()
+        if head is None:
+            raise ProviderUnreachableError('TAO head unavailable — cannot resolve the prior send')
+        floor = max(min(int(seen_head), head) - self.SCAN_LOOKBACK_BLOCKS, 0)
+        for block_num in range(floor + 1, head + 1):
+            block = self.get_block(block_num)
+            if not block or 'extrinsics' not in block:
+                raise ProviderUnreachableError(f'TAO block {block_num} unreadable — cannot rule out the prior send')
+            is_raw = block.get('_raw', False)
+            for position, ext in enumerate(block['extrinsics']):
+                decoded = self.decode_transfer(ext, is_raw)
+                if decoded is None:
+                    continue
+                ext_hash, dest, amt, sender = decoded
+                if dest != to_addr or sender != from_addr or int(amt) < int(amount):
+                    continue
+                # A hash already recorded under any scope belongs to a DIFFERENT obligation this
+                # process sent — the lost extrinsic's hash was, by definition, never recorded.
+                if any(rec[2] == ext_hash for rec in self.broadcasted_txids.values()):
+                    continue
+                ext_idx = ext.get('extrinsic_idx', position) if is_raw else position
+                settled = self.settled_credit(block_num, ext_idx, to_addr)
+                if settled is not None and settled[1] >= int(amount):
+                    return (ext_hash, block_num)
+        if head - int(seen_head) > self.SCAN_LOOKBACK_BLOCKS:
+            return None  # window elapsed and scanned clean: the lost extrinsic never landed
+        raise ProviderUnreachableError('prior TAO send (hash lost mid-submit) not yet resolvable — waiting a pass')
 
     def send_amount(
         self, to_address: str, amount: int, from_address: Optional[str] = None, dedup_key: Optional[str] = None
@@ -678,20 +723,43 @@ class Tao(Asset, Chain):
             return None
 
         # Reuse a prior own broadcast for THIS obligation rather than re-sending: subtensor.transfer can
-        # report failure on a transfer that actually included, and the next poll would otherwise double-pay.
+        # report failure — or raise mid-submit — on a transfer that actually included, and the next poll
+        # would otherwise double-pay.
         from_ss58 = self.wallet.coldkeypub.ss58_address
         scope = dedup_key or ''
         prior = self.broadcasted_txids.get(scope)
         if prior is not None and prior[0] == to_address and prior[1] == int(amount):
             try:
-                landed = self._own_transfer_landed(prior[2], from_ss58, to_address, amount)
+                seen = int(prior[3]) if len(prior) > 3 else 0
+                if seen <= 0:
+                    # Head was unreadable at record time: backfill with the current head so the
+                    # resolution window counts from now — unknown age must read recent, never stale.
+                    head_now = self.chain.get_current_block_height()
+                    if head_now is None:
+                        raise ProviderUnreachableError('TAO head unavailable — cannot resolve the prior send')
+                    seen = head_now
+                    self.broadcasted_txids[scope] = (prior[0], prior[1], prior[2], seen)
+                if prior[2]:
+                    landed = self._own_transfer_landed(prior[2], from_ss58, to_address, amount, seen)
+                else:
+                    landed = self._lost_hash_prior_landed(from_ss58, to_address, amount, seen)
             except Exception as e:
                 bt.logging.error(f'TAO prior send unresolved ({e}) — not re-sending, would risk a double pay')
                 return None
             if landed is not None:
+                self.broadcasted_txids[scope] = (to_address, int(amount), landed[0], int(landed[1] or seen))
                 bt.logging.info(f'TAO reusing prior tx {landed[0]} to {to_address} ({amount} rao)')
                 return landed
+            # landed is None → the prior send provably moved nothing; fall through to a fresh send.
 
+        # Record the attempt BEFORE the send: the extrinsic hash only exists after subtensor.transfer
+        # returns, but the extrinsic can reach the chain even when the call raises (websocket drop
+        # during wait_for_inclusion). A pre-send marker means a raise leaves the next poll resolving
+        # the attempt by scan instead of blindly re-sending.
+        attempt_head = self.chain.get_current_block_height()
+        self.broadcasted_txids[scope] = (to_address, int(amount), '', attempt_head or 0)
+        if len(self.broadcasted_txids) > 256:
+            self.broadcasted_txids.pop(next(iter(self.broadcasted_txids)))
         try:
             response = self.subtensor.transfer(
                 wallet=self.wallet,
@@ -700,26 +768,30 @@ class Tao(Asset, Chain):
                 wait_for_inclusion=True,
                 wait_for_finalization=False,
             )
-            # Record the extrinsic hash BEFORE the success gate: a transfer reported failed may still have
-            # included, and only a recorded hash lets the next poll re-probe it instead of re-sending.
-            recorded = getattr(getattr(response, 'extrinsic_receipt', None), 'extrinsic_hash', None)
-            if recorded:
-                self.broadcasted_txids[scope] = (to_address, int(amount), recorded)
-                if len(self.broadcasted_txids) > 256:
-                    self.broadcasted_txids.pop(next(iter(self.broadcasted_txids)))
-            if not response.success:
-                bt.logging.error(f'TAO transfer failed: {response.message}')
-                return None
-            try:
-                receipt = response.extrinsic_receipt
-                tx_hash = receipt.extrinsic_hash
-                block_num = self.subtensor.substrate.get_block_number(receipt.block_hash)
-            except Exception:
-                bt.logging.warning('Could not parse transfer receipt, using fallback')
-                tx_hash = getattr(getattr(response, 'extrinsic_receipt', None), 'extrinsic_hash', '') or 'tao_transfer'
-                block_num = self.subtensor.get_current_block()
-            bt.logging.info(f'Sent {amount} rao to {to_address} (tx: {tx_hash}, block: {block_num})')
-            return (tx_hash, block_num)
         except Exception as e:
-            bt.logging.error(f'TAO transfer error: {e}')
+            bt.logging.error(f'TAO transfer error: {e} — send unresolved, recorded attempt blocks a blind re-send')
             return None
+        # Record the extrinsic hash BEFORE the success gate: a transfer reported failed may still have
+        # included, and only a recorded hash lets the next poll re-probe it instead of re-sending.
+        recorded = getattr(getattr(response, 'extrinsic_receipt', None), 'extrinsic_hash', None)
+        if recorded:
+            self.broadcasted_txids[scope] = (to_address, int(amount), recorded, attempt_head or 0)
+        if not response.success:
+            bt.logging.error(f'TAO transfer failed: {response.message}')
+            return None
+        try:
+            receipt = response.extrinsic_receipt
+            tx_hash = receipt.extrinsic_hash
+            block_num = self.subtensor.substrate.get_block_number(receipt.block_hash)
+        except Exception:
+            bt.logging.warning('Could not parse transfer receipt, using fallback')
+            tx_hash = recorded or 'tao_transfer'
+            try:
+                block_num = self.subtensor.get_current_block()
+            except Exception:
+                block_num = attempt_head or 0
+        if recorded and block_num:
+            # Anchor the record on the inclusion block so a later reuse scan can't miss it.
+            self.broadcasted_txids[scope] = (to_address, int(amount), recorded, int(block_num))
+        bt.logging.info(f'Sent {amount} rao to {to_address} (tx: {tx_hash}, block: {block_num})')
+        return (tx_hash, block_num)

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -434,12 +434,10 @@ CHAIN_POLUSDC = ChainDefinition(
     # 600s default fulfillment grace. Pinned against CHAIN_POL by test, so neither can drift.
     seconds_per_block=1,
     min_confirmations=100,
-    # Rate sanity floor, not an economic guarantee: 0.01 USDC covers FiatToken's measured 79k-gas
-    # transfer below ~1700 gwei — ~7x the 230-260 gwei base fee Polygon has held for weeks. Priced
-    # on the COLD recipient (79k; a warm one is 61k), since a payout goes to a user's address that
-    # usually holds no USDC yet. Far under ethusdc's 5 USDC because Polygon gas costs cents, but
-    # above bare dust because Polygon gas is not free either.
-    min_onchain_amount=10_000,
+    # 5 USDC, matching the other USDC spokes: min_onchain_amount doubles as the crown-eligibility
+    # floor in is_executable_rate, so a Polygon-cheap-gas send floor here would widen the crown band
+    # ~500x vs siblings. Polygon's low gas is priced into miner quotes, not this floor.
+    min_onchain_amount=5_000_000,
     # CHAIN_POL's clock, for the same reason its finality is: what this absorbs is hub-vs-spoke
     # skew, and two assets on one chain disagreeing about that chain's clock would be indefensible.
     replay_grace_secs=60,

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -252,7 +252,7 @@ CHAIN_ETHUSDC = ChainDefinition(
     min_confirmations=32,
     # Rate sanity floor, not an economic guarantee: 5 USDC covers FiatToken's ~65k-gas transfer
     # only below ~41 gwei — miners price real gas into their quotes, and the per-swap lever is the
-    # contract's min_swap_amount. Above arbusdc's unit floor because L1 gas is not L2 gas.
+    # contract's min_swap_amount. L1 gas dwarfs L2 gas, so the floor sits well above bare dust.
     min_onchain_amount=5_000_000,
     # Ethereum's clock, as CHAIN_ETH: what this absorbs is hub-vs-spoke skew, and two assets on
     # one chain disagreeing about that chain's clock would be indefensible.
@@ -437,8 +437,8 @@ CHAIN_POLUSDC = ChainDefinition(
     # Rate sanity floor, not an economic guarantee: 0.01 USDC covers FiatToken's measured 79k-gas
     # transfer below ~1700 gwei — ~7x the 230-260 gwei base fee Polygon has held for weeks. Priced
     # on the COLD recipient (79k; a warm one is 61k), since a payout goes to a user's address that
-    # usually holds no USDC yet. Far under ethusdc's 5 USDC because Polygon gas costs cents, far
-    # over arbusdc's unit floor because it is not free either.
+    # usually holds no USDC yet. Far under ethusdc's 5 USDC because Polygon gas costs cents, but
+    # above bare dust because Polygon gas is not free either.
     min_onchain_amount=10_000,
     # CHAIN_POL's clock, for the same reason its finality is: what this absorbs is hub-vs-spoke
     # skew, and two assets on one chain disagreeing about that chain's clock would be indefensible.

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -1,4 +1,5 @@
 import math
+import os
 from dataclasses import dataclass
 
 from allways.constants import (
@@ -502,6 +503,24 @@ SUPPORTED_CHAINS = {
     'polusdc': CHAIN_POLUSDC,
     'paxg': CHAIN_PAXG,
 }
+
+
+def apply_testnet_network_defaults() -> dict[str, str]:
+    """Default any unset spoke ``{PREFIX}_NETWORK`` to the chain's ``testnet_network``.
+
+    A testnet neuron that never set e.g. ``ETH_NETWORK`` otherwise falls through to the provider's
+    mainnet default (``evm.py``/``btc.py``) — verifying test swaps against mainnet, or broadcasting a
+    real mainnet payout for a test obligation. An explicitly-set env var always wins (set
+    ``ETH_NETWORK=mainnet`` to opt one spoke back). Returns the vars it set, for the caller to log."""
+    applied: dict[str, str] = {}
+    for chain in SUPPORTED_CHAINS.values():
+        if not chain.networks or not chain.testnet_network:
+            continue  # network isn't picked by name here, or shares another asset's prefix
+        env_var = f'{chain.env_prefix}_NETWORK'
+        if not os.environ.get(env_var):
+            os.environ[env_var] = chain.testnet_network
+            applied[env_var] = chain.testnet_network
+    return applied
 
 
 def get_chain_def(chain_id: str) -> ChainDefinition:

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -47,6 +47,10 @@ class ChainDefinition:
     # ABI signatures the issuer refuses delivery with: 'f()' stops the whole token, 'f(address)'
     # freezes one destination. Required on every token row; () claims no freeze surface at all.
     refusal_checks: tuple[str, ...] | None = None
+    # ABI signature of a `(uint256)->uint256` view returning the transfer fee an issuer would take
+    # on a given amount (PAXG's getFeeFor). Set only on tokens with an admin-settable fee; a live
+    # non-zero fee shaves every delivery below the pinned amount, so it's a no-fault cancel (V-M2).
+    fee_check: str | None = None
 
 
 # ─── Supported Chains ────────────────────────────────────
@@ -482,6 +486,10 @@ CHAIN_PAXG = ChainDefinition(
     # surface here would make every probe raise, which defers each slash only as far as
     # max_extend_at (~2.6h) and then times out anyway — slashing and striking an honest miner.
     refusal_checks=('isFrozen(address)', 'paused()'),
+    # PAXG's fee is an admin-upgradeable proxy lever, currently 0. If Paxos ever sets feeRate>0,
+    # getFeeFor(amount) turns non-zero and every honest delivery's Transfer log falls below the
+    # pinned amount — probe it so the swap cancels no-fault instead of mass-slashing (V-M2).
+    fee_check='getFeeFor(uint256)',
 )
 
 SUPPORTED_CHAINS = {

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -402,6 +402,11 @@ def swap_now_command(
     user_from_addr = str(user) if from_chain == NUMERAIRE_CHAIN else (from_address_opt or '')
     if not user_from_addr:
         fail(f'--from-address (your source-chain address) is required for a non-{NUMERAIRE_CHAIN.upper()} source.')
+    # Canonical source form before anything commits it: the finalize hash + source-lock PDA are
+    # byte-keyed on this string (V-C2), so a cased variant would mint a divergent lock on-chain.
+    _src_gate = _gate_provider(from_chain, client, config)
+    if _src_gate is not None:
+        user_from_addr = _src_gate.chain.normalize_address(user_from_addr)
 
     cfg = client.get_config()
     bounds = bounds_from_config(cfg) if cfg else {}

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -946,6 +946,7 @@ def _reserve_self_represented(
             fill.from_amount,
             fill.to_amount,
             backing,
+            from_chain=from_chain,
         )
     except Exception as e:
         reason = contract_reject_reason(e)

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -53,6 +53,9 @@ CANCEL_REASON_EVM_REVERT = 0
 CANCEL_REASON_ERC20_BLACKLIST = 1
 CANCEL_REASON_ERC20_PAUSED = 2
 CANCEL_REASON_SOL_RESERVED = 3
+# An issuer-enabled transfer fee shaves the delivered log below the pinned amount, so every
+# honest delivery on the token would false-slash — a hub-wide, no-fault condition (V-M2/PAXG).
+CANCEL_REASON_ERC20_FEE_ENABLED = 4
 CANCEL_REASON_OTHER = 255
 
 BTC_MIN_FEE_RATE = 5

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -59,6 +59,11 @@ CANCEL_REASON_ERC20_FEE_ENABLED = 4
 CANCEL_REASON_OTHER = 255
 
 BTC_MIN_FEE_RATE = 5
+# Estimation-DOWN fallback (sat/vB), distinct from the mempool floor above: used only when
+# /fee-estimates fails both attempts. A silent drop to the 5 floor has stranded a real dest tx
+# (V-L5), so a failed estimate broadcasts at a survivable rate instead of the strand-prone floor —
+# without lifting the floor itself (calm-mempool sends still pay the real low rate).
+BTC_FALLBACK_FEE_RATE = 15
 # Modest pad on estimated fee rates (not on explicit user overrides) against
 # mempool conditions drifting between estimate and broadcast. Goal is
 # 'reliably confirms within ~30 min', not 'next block at any cost'.

--- a/allways/miner/fulfillment.py
+++ b/allways/miner/fulfillment.py
@@ -280,10 +280,10 @@ class SwapFulfiller:
             dev_signal.emit('refuse', swap_key=swap.key_hex, reason='withhold_dest')
             return None
 
-        # Miner's own dest-chain sending address — cached from this miner's posted quote at startup, passed
-        # as a hint so UTXO-based providers can skip probing. Providers that identify their own sender from
-        # a wallet keypair (e.g. subtensor) ignore it, so this is uniform across chains.
-        from_address = self.my_addresses.get(swap.to_chain)
+        # Miner's committed dest sender for THIS swap — the pinned miner_to_addr the validator checks the
+        # leg against, NOT a chain-wide cache that last-write-wins across quotes (which could send from the
+        # wrong wallet → slash). Providers verify it against their signing key and refuse a mismatch.
+        from_address = swap.miner_to_addr
 
         bt.logging.info(
             f'Swap {swap.key_hex[:16]}: initiating dest send of {user_receives_amount} to {swap.user_to_addr} '

--- a/allways/miner/fulfillment.py
+++ b/allways/miner/fulfillment.py
@@ -282,8 +282,10 @@ class SwapFulfiller:
 
         # Miner's committed dest sender for THIS swap — the pinned miner_to_addr the validator checks the
         # leg against, NOT a chain-wide cache that last-write-wins across quotes (which could send from the
-        # wrong wallet → slash). Providers verify it against their signing key and refuse a mismatch.
-        from_address = swap.miner_to_addr
+        # wrong wallet → slash). Providers verify it against their signing key and refuse a mismatch. Coerce
+        # '' → None (as the validator does): an unset pin means "no sender constraint", so the provider must
+        # send from its default key, not refuse a well-formed empty pin and strand the miner into a slash.
+        from_address = swap.miner_to_addr or None
 
         bt.logging.info(
             f'Swap {swap.key_hex[:16]}: initiating dest send of {user_receives_amount} to {swap.user_to_addr} '

--- a/allways/solana/client.py
+++ b/allways/solana/client.py
@@ -647,6 +647,9 @@ class AllwaysSolanaClient:
             AccountMeta(pdas.vote_round_pda(pdas.REQ_INITIATE, swap_key, self.program_id), False, True),
             AccountMeta(pdas.swap_pda(swap_key, self.program_id), False, True),
             AccountMeta(self._attestation_meta(m, backing), False, False),
+            # The Binding PDA is always passed; the program tolerates it uninitialized (never-bound
+            # miner) and pins the bonded hotkey onto the Swap at quorum (V-M1).
+            AccountMeta(pdas.binding_pda(m, self.program_id), False, False),
             AccountMeta(SYSTEM_PROGRAM, False, False),
         ]
         args = layouts.IX_SWAP_KEY_ARGS.build({'swap_key': swap_key})

--- a/allways/solana/client.py
+++ b/allways/solana/client.py
@@ -894,12 +894,19 @@ class AllwaysSolanaClient:
         from_amount: int,
         to_amount: int,
         backing: str = 'sol',
+        *,
+        from_chain: str,
     ) -> str:
         """Fill the reservation this client's keypair won at the draw (signer must == reservation.router).
         Names the taker + amounts, running the swap-size bounds + collateral gate + the collateral bind.
-        `backing` must be the reservation's pinned `collateral_chain` — it is a PDA seed now (v3.1)."""
+        `backing` must be the reservation's pinned `collateral_chain` — it is a PDA seed now (v3.1).
+        `from_chain` + keccak(user_from_addr) seed the V-C2 source_lock, which blocks a duplicate source
+        across hubs sharing that chain — routed or self-represented alike."""
         router = self.keypair.pubkey()
         m = _as_pubkey(miner)
+        # keccak256(user_from_addr) — mirrors the contract's hashv(&[user_from_addr.as_bytes()]) source-lock
+        # seed (same construction as swap_key_from_tx_hash); verified on-chain against user_from_addr.
+        from_addr_hash = keccak.new(data=user_from_addr.encode(), digest_bits=256).digest()
         args = layouts.IX_FINALIZE_RESERVATION_ARGS.build(
             {
                 'user': bytes(_as_pubkey(user)),
@@ -908,15 +915,18 @@ class AllwaysSolanaClient:
                 'collateral_amount': collateral_amount,
                 'from_amount': from_amount,
                 'to_amount': to_amount,
+                'from_addr_hash': from_addr_hash,
             }
         )
         metas = [
-            AccountMeta(router, True, False),
+            AccountMeta(router, True, True),  # mut: payer for the source_lock init_if_needed
             AccountMeta(pdas.config_pda(self.program_id), False, False),
             AccountMeta(m, False, False),
             AccountMeta(pdas.miner_state_pda(m, self.program_id), False, True),  # mut: finalize writes busy_until
             AccountMeta(pdas.reservation_pda(m, backing, self.program_id), False, True),
             AccountMeta(self._attestation_meta(m, backing), False, False),
+            AccountMeta(pdas.source_lock_pda(m, from_chain, from_addr_hash, self.program_id), False, True),
+            AccountMeta(SYSTEM_PROGRAM, False, False),
         ]
         return self._send([self._ix('finalize_reservation', args, metas)])
 

--- a/allways/solana/client.py
+++ b/allways/solana/client.py
@@ -632,18 +632,22 @@ class AllwaysSolanaClient:
         ]
         return self._send([self._ix('submit_swap_claim', args, metas)])
 
-    def vote_initiate(self, swap_key: bytes, miner, backing: str = 'sol') -> str:
+    def vote_initiate(self, swap_key: bytes, miner, from_chain: str, from_addr: str, backing: str = 'sol') -> str:
         """Vote to attest a PendingAttestation swap; on quorum it transitions to Active.
         `backing` must be the swap's pinned `collateral_chain` — it selects the purse the obligation
-        gate reads (and hence which BondAttestation account travels with the vote)."""
+        gate reads (and hence which BondAttestation account travels with the vote). `from_chain` +
+        `from_addr` (the reservation's committed source) target the SourceLock the quorum releases
+        (V-C2); the program verifies the hash against the reservation before touching it."""
         validator = self.keypair.pubkey()
         m = _as_pubkey(miner)
+        from_addr_hash = keccak.new(data=from_addr.encode(), digest_bits=256).digest()
         metas = [
             AccountMeta(validator, True, True),
             AccountMeta(pdas.config_pda(self.program_id), False, False),
             AccountMeta(m, False, False),
             AccountMeta(pdas.miner_state_pda(m, self.program_id), False, True),
             AccountMeta(pdas.reservation_pda(m, backing, self.program_id), False, True),
+            AccountMeta(pdas.source_lock_pda(m, from_chain, from_addr_hash, self.program_id), False, True),
             AccountMeta(pdas.vote_round_pda(pdas.REQ_INITIATE, swap_key, self.program_id), False, True),
             AccountMeta(pdas.swap_pda(swap_key, self.program_id), False, True),
             AccountMeta(self._attestation_meta(m, backing), False, False),
@@ -652,7 +656,7 @@ class AllwaysSolanaClient:
             AccountMeta(pdas.binding_pda(m, self.program_id), False, False),
             AccountMeta(SYSTEM_PROGRAM, False, False),
         ]
-        args = layouts.IX_SWAP_KEY_ARGS.build({'swap_key': swap_key})
+        args = layouts.IX_VOTE_INITIATE_ARGS.build({'swap_key': swap_key, 'from_addr_hash': from_addr_hash})
         return self._send([self._ix('vote_initiate', args, metas)])
 
     def confirm_swap(self, swap_key: bytes, miner, from_chain: str, to_chain: str) -> str:

--- a/allways/solana/client.py
+++ b/allways/solana/client.py
@@ -843,18 +843,23 @@ class AllwaysSolanaClient:
         args = layouts.IX_EXTEND_TIMEOUT_ARGS.build({'swap_key': swap_key, 'target_at': target_at})
         return self._send([self._ix('extend_timeout', args, metas)])
 
-    def extend_reservation(self, miner, target_at: int, backing: str = 'sol') -> str:
-        """Single-validator slide of a reservation's reserved_until forward (no consensus)."""
+    def extend_reservation(
+        self, miner, target_at: int, backing: str = 'sol', *, from_chain: str, from_addr: str
+    ) -> str:
+        """Single-validator slide of a reservation's reserved_until forward (no consensus). Slides the
+        V-C2 source_lock in lockstep — `from_chain` + keccak(`from_addr`) seed it (verified on-chain)."""
         validator = self.keypair.pubkey()
         m = _as_pubkey(miner)
+        from_addr_hash = keccak.new(data=from_addr.encode(), digest_bits=256).digest()
         metas = [
             AccountMeta(validator, True, False),
             AccountMeta(pdas.config_pda(self.program_id), False, False),
             AccountMeta(m, False, False),
             AccountMeta(pdas.miner_state_pda(m, self.program_id), False, True),
             AccountMeta(pdas.reservation_pda(m, backing, self.program_id), False, True),
+            AccountMeta(pdas.source_lock_pda(m, from_chain, from_addr_hash, self.program_id), False, True),
         ]
-        args = layouts.IX_EXTEND_RESERVATION_ARGS.build({'target_at': target_at})
+        args = layouts.IX_EXTEND_RESERVATION_ARGS.build({'target_at': target_at, 'from_addr_hash': from_addr_hash})
         return self._send([self._ix('extend_reservation', args, metas)])
 
     # ---------- swap intake (Phase 9: reservation-lottery pool) ----------

--- a/allways/solana/layouts.py
+++ b/allways/solana/layouts.py
@@ -213,6 +213,8 @@ Swap = CStruct(
     'max_extend_at' / I64,
     'fulfilled_at' / I64,
     'bump' / U8,
+    # V-M1 — hotkey pinned from the Binding at initiate ([0]*32 = never bound); appended last.
+    'hotkey' / Hash32,
 )
 
 Pool = CStruct(
@@ -442,6 +444,9 @@ EVENT_LAYOUTS = {
         'penalty' / U64,
         'reimbursement' / U64,
         'payee' / String,
+        # V-M1 — the hotkey the swap pinned at initiate ([0]*32 = never bound): the bond the vault
+        # seizure targets, carried in the verdict so no reconciler ever consults the live binding.
+        'hotkey' / Hash32,
     ),
     'SwapCancelled': CStruct(
         'swap_key' / Hash32,

--- a/allways/solana/layouts.py
+++ b/allways/solana/layouts.py
@@ -585,7 +585,7 @@ IX_SUBMIT_CLAIM_ARGS = CStruct('swap_key' / Hash32, 'from_tx_hash' / String, 'fr
 IX_CONFIRM_SWAP_ARGS = CStruct('swap_key' / Hash32, 'from_chain' / String, 'to_chain' / String)
 IX_MARK_FULFILLED_ARGS = CStruct('swap_key' / Hash32, 'to_tx_hash' / String, 'to_tx_block' / U32)
 IX_EXTEND_TIMEOUT_ARGS = CStruct('swap_key' / Hash32, 'target_at' / I64)
-IX_EXTEND_RESERVATION_ARGS = CStruct('target_at' / I64)
+IX_EXTEND_RESERVATION_ARGS = CStruct('target_at' / I64, 'from_addr_hash' / Hash32)  # V-C2: keccak(from_addr)
 IX_ADD_VALIDATOR_ARGS = CStruct('validator' / Pubkey32, 'weight' / U64)
 
 # B4 — quote retract + admin-setter args. (`deactivate` takes no args → empty body.)

--- a/allways/solana/layouts.py
+++ b/allways/solana/layouts.py
@@ -584,7 +584,9 @@ IX_SET_QUOTE_ARGS = CStruct(
 IX_AMOUNT_ARGS = CStruct('amount' / U64)
 
 # B2 swap-lifecycle args. `swap_key` is a borsh `[u8; 32]` (fixed array → raw 32 bytes, no len prefix).
-IX_SWAP_KEY_ARGS = CStruct('swap_key' / Hash32)  # vote_initiate, timeout_swap, close_stale_claim
+IX_SWAP_KEY_ARGS = CStruct('swap_key' / Hash32)  # timeout_swap, close_stale_claim
+# V-C2: initiate quorum releases the source lock; the hash targets it (verified vs reservation.from_addr).
+IX_VOTE_INITIATE_ARGS = CStruct('swap_key' / Hash32, 'from_addr_hash' / Hash32)
 IX_CANCEL_SWAP_ARGS = CStruct('swap_key' / Hash32, 'reason' / U8)  # cancel_swap (reason is advisory)
 IX_SUBMIT_CLAIM_ARGS = CStruct('swap_key' / Hash32, 'from_tx_hash' / String, 'from_tx_block' / U32)
 IX_CONFIRM_SWAP_ARGS = CStruct('swap_key' / Hash32, 'from_chain' / String, 'to_chain' / String)

--- a/allways/solana/layouts.py
+++ b/allways/solana/layouts.py
@@ -604,6 +604,7 @@ IX_FINALIZE_RESERVATION_ARGS = CStruct(
     'collateral_amount' / U64,
     'from_amount' / U128,
     'to_amount' / U128,
+    'from_addr_hash' / Hash32,  # V-C2: keccak(user_from_addr); seeds the source_lock, verified on-chain
 )
 IX_SET_WEIGHTS_ARGS = CStruct('weights' / Vec(U64), 'round_key' / Hash32)  # vote_set_weights
 # W2 — vote_activate / vote_deactivate now name the purse they act on.

--- a/allways/solana/pdas.py
+++ b/allways/solana/pdas.py
@@ -94,9 +94,7 @@ def pool_pda(miner, backing: str = BACKING_CHAIN_SOL, program_id: Optional[Pubke
     return _derive([b'pool', _pk_bytes(miner), backing.encode()], program_id)
 
 
-def source_lock_pda(
-    miner, from_chain: str, from_addr_hash: bytes, program_id: Optional[Pubkey] = None
-) -> Pubkey:
+def source_lock_pda(miner, from_chain: str, from_addr_hash: bytes, program_id: Optional[Pubkey] = None) -> Pubkey:
     """V-C2 source lock — one live-unclaimed reservation per (miner, from_chain, from_addr). NOT keyed by
     backing, so a colliding reservation on any other hub sharing that source chain resolves the SAME PDA.
     `from_addr_hash` is keccak(from_addr), mirroring finalize_reservation's on-chain seeds."""

--- a/allways/solana/pdas.py
+++ b/allways/solana/pdas.py
@@ -94,6 +94,15 @@ def pool_pda(miner, backing: str = BACKING_CHAIN_SOL, program_id: Optional[Pubke
     return _derive([b'pool', _pk_bytes(miner), backing.encode()], program_id)
 
 
+def source_lock_pda(
+    miner, from_chain: str, from_addr_hash: bytes, program_id: Optional[Pubkey] = None
+) -> Pubkey:
+    """V-C2 source lock — one live-unclaimed reservation per (miner, from_chain, from_addr). NOT keyed by
+    backing, so a colliding reservation on any other hub sharing that source chain resolves the SAME PDA.
+    `from_addr_hash` is keccak(from_addr), mirroring finalize_reservation's on-chain seeds."""
+    return _derive([b'srclock', _pk_bytes(miner), from_chain.encode(), from_addr_hash], program_id)
+
+
 def legacy_reservation_pda(miner, program_id: Optional[Pubkey] = None) -> Pubkey:
     """The RETIRED pre-v3.1 per-miner address — only `close_legacy_reservation` resolves it now."""
     return _derive([b'resv', _pk_bytes(miner)], program_id)

--- a/allways/solana/rpc.py
+++ b/allways/solana/rpc.py
@@ -27,6 +27,67 @@ def resolve_rpc_url(explicit: Optional[str] = None) -> str:
     return url
 
 
+# A Solana cluster is identified by its immutable genesis hash, not its RPC URL: a real paid
+# mainnet endpoint (Helius/QuickNode subdomain, bare IP, ?api-key= URL) rarely contains the
+# literal string "mainnet", so a substring check misses exactly the dangerous case. These three
+# are stable network constants (`solana genesis-hash` on each cluster).
+SOLANA_GENESIS_HASHES = {
+    '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d': 'mainnet',
+    'EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG': 'devnet',
+    '4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY': 'testnet',
+}
+ALLOW_MAINNET_ON_TESTNET_ENV = 'ALLWAYS_ALLOW_MAINNET_ON_TESTNET'
+
+
+def classify_cluster(genesis_hash: str) -> str:
+    """Known public cluster name for a genesis hash, else 'unknown' (localnet / custom validator)."""
+    return SOLANA_GENESIS_HASHES.get(genesis_hash, 'unknown')
+
+
+def assert_cluster_safe(rpc: 'SolanaRpc', program_id, netuid: int, role: str = 'neuron') -> None:
+    """Fail-closed boot guard against the env misconfig that silently runs a testnet neuron on the
+    Solana MAINNET cluster (V-M3). The resolved cluster is classified *positively* by genesis hash —
+    immune to the 'mainnet'-substring blind spot — and the program is confirmed present on it.
+
+    Raises RuntimeError on (testnet neuron + mainnet cluster) or a program-id↔cluster mismatch;
+    ``ALLWAYS_ALLOW_MAINNET_ON_TESTNET=1`` overrides (the 'explicit env wins' convention). An
+    unreachable RPC only warns — a boot-time transport hiccup must not crash the process; the guard
+    is hard only against a positively identified fault, never a failed read."""
+    import bittensor as bt
+
+    from allways.constants import NETUID_FINNEY
+
+    if os.environ.get(ALLOW_MAINNET_ON_TESTNET_ENV) == '1':
+        bt.logging.warning(f'{ALLOW_MAINNET_ON_TESTNET_ENV}=1 — skipping the Solana cluster safety guard.')
+        return
+    try:
+        cluster = classify_cluster(rpc.get_genesis_hash())
+    except Exception as e:
+        bt.logging.warning(f'Solana cluster guard: genesis-hash read failed ({e}) — skipping (RPC transient).')
+        return
+    if int(netuid) != NETUID_FINNEY and cluster == 'mainnet':
+        raise RuntimeError(
+            f'testnet {role} (netuid {netuid}) is pointed at the Solana MAINNET cluster ({rpc.url}). '
+            f'This is an env misconfig — a test obligation would settle against mainnet. Fix '
+            f'SOLANA_RPC_URL, or set {ALLOW_MAINNET_ON_TESTNET_ENV}=1 to override.'
+        )
+    # Program existence, on a known public cluster only: a wrong program id (or the right id on the
+    # wrong cluster) otherwise reads every account as merely absent. Skipped on localnet/unknown —
+    # dev deploys are fluid and the program may not be up yet.
+    if cluster == 'unknown':
+        return
+    try:
+        exists = rpc.get_account_info(program_id) is not None
+    except Exception as e:
+        bt.logging.warning(f'Solana cluster guard: program probe failed ({e}) — skipping existence check.')
+        return
+    if not exists:
+        raise RuntimeError(
+            f'allways program {program_id} does not exist on the {cluster} cluster ({rpc.url}) — a '
+            f'program-id / cluster mismatch. Fix ALLWAYS_PROGRAM_ID or SOLANA_RPC_URL.'
+        )
+
+
 class SolanaRpcError(Exception):
     pass
 
@@ -144,6 +205,11 @@ class SolanaRpc:
 
     def get_slot(self, commitment: str = 'confirmed') -> int:
         return int(self._call('getSlot', [{'commitment': commitment}]))
+
+    def get_genesis_hash(self) -> str:
+        """The cluster's genesis hash — its immutable identity. Unlike the RPC URL (which can be any
+        custom/keyed endpoint), this positively identifies mainnet/devnet/testnet."""
+        return str(self._call('getGenesisHash', []))
 
     def get_balance(self, pubkey, commitment: str = 'confirmed') -> int:
         res = self._call('getBalance', [str(pubkey), {'commitment': commitment}])

--- a/allways/validator/event_index.py
+++ b/allways/validator/event_index.py
@@ -123,6 +123,14 @@ class SolanaEventIndex:
             return self._apply_reservation(hotkey, block_time, self._event_hub(rec))
         if name in ('ReservationFilled', 'ReservationExtended'):
             return self._apply_reservation_deadline(hotkey, rec)
+        if name == 'UnfilledReservationClosed':
+            # Permissionless reap of a drawn-but-unfilled reservation frees the miner on-chain; the
+            # crown index must free it too or the miner stays reserved until the synthetic
+            # RESERVE_EXPIRE. Insert a RESERVE_EXPIRE at the event's block_time on its own hub.
+            self.state_store.insert_activity_event(
+                block_time, hotkey, ActivityTransition.RESERVE_EXPIRE, hub=self._event_hub(rec)
+            )
+            return True
         if name == 'SwapFulfilled':
             # Persist the delivery hash for post-close receipts — the Swap PDA (and its
             # to_tx_hash) is gone once the swap completes, and the offering's receipt links

--- a/allways/validator/event_index.py
+++ b/allways/validator/event_index.py
@@ -127,9 +127,7 @@ class SolanaEventIndex:
             # Permissionless reap of a drawn-but-unfilled reservation frees the miner on-chain; MOVE the
             # synthetic RESERVE_EXPIRE (draw+ttl guess) to the reap block — inserting beside it leaves
             # the stale guess to fire later, freeing the miner's NEXT reservation early.
-            self.state_store.restamp_reservation_expiry(
-                hotkey, self._event_hub(rec), block_time, not_before=block_time
-            )
+            self.state_store.restamp_reservation_expiry(hotkey, self._event_hub(rec), block_time, not_before=block_time)
             return True
         if name == 'SwapFulfilled':
             # Persist the delivery hash for post-close receipts — the Swap PDA (and its
@@ -247,9 +245,7 @@ class SolanaEventIndex:
         reserved_until = int(rec.fields['reserved_until'])
         if reserved_until <= 0:
             return False
-        self.state_store.restamp_reservation_expiry(
-            hotkey, self._event_hub(rec), reserved_until, not_before=block_time
-        )
+        self.state_store.restamp_reservation_expiry(hotkey, self._event_hub(rec), reserved_until, not_before=block_time)
         return True
 
     @staticmethod

--- a/allways/validator/event_index.py
+++ b/allways/validator/event_index.py
@@ -96,6 +96,8 @@ class SolanaEventIndex:
             return True
         if name == 'PoolResolved':
             return self._apply_reservation(hotkey, block_time, self._event_hub(rec))
+        if name in ('ReservationFilled', 'ReservationExtended'):
+            return self._apply_reservation_deadline(hotkey, rec)
         if name == 'SwapFulfilled':
             # Persist the delivery hash for post-close receipts — the Swap PDA (and its
             # to_tx_hash) is gone once the swap completes, and the offering's receipt links
@@ -192,16 +194,26 @@ class SolanaEventIndex:
 
     def _apply_reservation(self, hotkey: str, block_time: int, hub: Optional[str]) -> bool:
         """PoolResolved → RESERVE_START now + a synthetic RESERVE_EXPIRE at
-        ``block_time + reservation_ttl_secs`` (``reserved_until`` isn't on the
-        event). Dropped if no TTL source is wired, so the reservation never opens
-        without its matching expiry. The expiry inherits the start's hub so the
-        pair opens and closes the same per-hub machine."""
+        ``block_time + reservation_ttl_secs`` — a guess, since ``reserved_until`` isn't on this
+        event; ReservationFilled/Extended later re-stamp it to the real deadline (drawn-unfilled
+        reservations keep the guess as their fallback expiry). Dropped if no TTL source is wired,
+        so the reservation never opens without an expiry. The expiry inherits the start's hub."""
         ttl = self._reservation_ttl()
         if ttl is None:
             bt.logging.warning('SolanaEventIndex: no reservation_ttl; dropping PoolResolved')
             return False
         self.state_store.insert_activity_event(block_time, hotkey, ActivityTransition.RESERVE_START, hub=hub)
         self.state_store.insert_activity_event(block_time + ttl, hotkey, ActivityTransition.RESERVE_EXPIRE, hub=hub)
+        return True
+
+    def _apply_reservation_deadline(self, hotkey: str, rec: EventRecord) -> bool:
+        """ReservationFilled/Extended carry the real ``reserved_until`` — re-stamp the synthetic
+        RESERVE_EXPIRE off PoolResolved's draw+ttl guess. Without this a busy miner is scored
+        AVAILABLE once SwapInitiated lands after the guess (slow BTC confs, or a claim-runway extend)."""
+        reserved_until = int(rec.fields['reserved_until'])
+        if reserved_until <= 0:
+            return False
+        self.state_store.restamp_reservation_expiry(hotkey, self._event_hub(rec), reserved_until)
         return True
 
     @staticmethod

--- a/allways/validator/event_index.py
+++ b/allways/validator/event_index.py
@@ -83,11 +83,36 @@ class SolanaEventIndex:
                 continue
             hotkey = attribution.get(miner_pk)
             if hotkey is None:
-                # Unbound (or invalid binding) miner — no UID to credit, so its events are dropped.
+                # Unbound (or invalid binding) miner — no UID to credit, so the crown-relevant
+                # effects (activity/collateral/quote/clearing) are dropped and healed by the
+                # per-round reconciles. But the swap's terminal outcome + delivery hash are keyed
+                # purely by swap_key, so still record them — else a dereg-mid-swap permanently
+                # strands /status at ``fulfilled`` (V-M5), since the cursor advances regardless.
+                if self._record_unattributed_outcome(rec, int(block_time)):
+                    written += 1
                 continue
             if self._apply(rec, hotkey, int(block_time)):
                 written += 1
         return written
+
+    def _record_unattributed_outcome(self, rec: EventRecord, block_time: int) -> bool:
+        """Persist only the swap_key-keyed terminal facts (delivery hash + terminal/stale outcome)
+        for an event whose miner pubkey is unbound at ingest. These rows credit no UID — they are
+        the seam's post-close truth read by /status — so they must land even when every
+        crown-relevant effect is dropped. Idempotent upserts, so a later re-bind + re-ingest is a
+        no-op. Returns True if a row was written."""
+        if rec.name == 'SwapFulfilled':
+            self.state_store.record_swap_fulfillment(
+                bytes(rec.fields['swap_key']).hex(), str(rec.fields['to_tx_hash']), block_time
+            )
+            return True
+        outcome = _OUTCOME_BY_EVENT.get(rec.name)
+        if outcome is not None:
+            swap_key = bytes(rec.fields['swap_key']).hex()
+            self.state_store.record_swap_outcome(swap_key, outcome, block_time)
+            dev_signal.emit('swap_outcome', swap_key=swap_key, outcome=outcome)
+            return True
+        return False
 
     def _apply(self, rec: EventRecord, hotkey: str, block_time: int) -> bool:
         name = rec.name

--- a/allways/validator/event_index.py
+++ b/allways/validator/event_index.py
@@ -68,9 +68,9 @@ class SolanaEventIndex:
 
     def ingest(self, records: List[EventRecord], attribution: Dict[str, str]) -> int:
         """Persist ``records`` (oldest-first) into the event tables, mapping each event's miner Solana
-        pubkey → bound hotkey via ``attribution`` (B3.2 ``build_attribution``). Events from an unbound
-        pubkey are dropped (no UID to credit); the per-round reconciles (``reconcile_live_state`` for
-        active/collateral, ``reconcile_live_quotes`` for rates) later heal the state they carried.
+        pubkey → bound hotkey via ``attribution`` (B3.2 ``build_attribution``). For an unbound pubkey
+        the crown-relevant effects are dropped (no UID to credit) and healed by the per-round
+        reconciles, but swap_key-keyed facts (terminal outcome, delivery hash) still record (V-M5).
         Records with no ``blockTime`` are skipped defensively — poll() already holds the cursor before
         unstamped txs, so none should reach here. Returns the count written."""
         written = 0
@@ -122,13 +122,13 @@ class SolanaEventIndex:
         if name == 'PoolResolved':
             return self._apply_reservation(hotkey, block_time, self._event_hub(rec))
         if name in ('ReservationFilled', 'ReservationExtended'):
-            return self._apply_reservation_deadline(hotkey, rec)
+            return self._apply_reservation_deadline(hotkey, rec, block_time)
         if name == 'UnfilledReservationClosed':
-            # Permissionless reap of a drawn-but-unfilled reservation frees the miner on-chain; the
-            # crown index must free it too or the miner stays reserved until the synthetic
-            # RESERVE_EXPIRE. Insert a RESERVE_EXPIRE at the event's block_time on its own hub.
-            self.state_store.insert_activity_event(
-                block_time, hotkey, ActivityTransition.RESERVE_EXPIRE, hub=self._event_hub(rec)
+            # Permissionless reap of a drawn-but-unfilled reservation frees the miner on-chain; MOVE the
+            # synthetic RESERVE_EXPIRE (draw+ttl guess) to the reap block — inserting beside it leaves
+            # the stale guess to fire later, freeing the miner's NEXT reservation early.
+            self.state_store.restamp_reservation_expiry(
+                hotkey, self._event_hub(rec), block_time, not_before=block_time
             )
             return True
         if name == 'SwapFulfilled':
@@ -239,14 +239,17 @@ class SolanaEventIndex:
         self.state_store.insert_activity_event(block_time + ttl, hotkey, ActivityTransition.RESERVE_EXPIRE, hub=hub)
         return True
 
-    def _apply_reservation_deadline(self, hotkey: str, rec: EventRecord) -> bool:
+    def _apply_reservation_deadline(self, hotkey: str, rec: EventRecord, block_time: int) -> bool:
         """ReservationFilled/Extended carry the real ``reserved_until`` — re-stamp the synthetic
         RESERVE_EXPIRE off PoolResolved's draw+ttl guess. Without this a busy miner is scored
-        AVAILABLE once SwapInitiated lands after the guess (slow BTC confs, or a claim-runway extend)."""
+        AVAILABLE once SwapInitiated lands after the guess (slow BTC confs, or a claim-runway extend).
+        The event's block_time floors the move so a fired prior-reservation row is never dragged."""
         reserved_until = int(rec.fields['reserved_until'])
         if reserved_until <= 0:
             return False
-        self.state_store.restamp_reservation_expiry(hotkey, self._event_hub(rec), reserved_until)
+        self.state_store.restamp_reservation_expiry(
+            hotkey, self._event_hub(rec), reserved_until, not_before=block_time
+        )
         return True
 
     @staticmethod

--- a/allways/validator/relay/slash.py
+++ b/allways/validator/relay/slash.py
@@ -18,18 +18,25 @@ from typing import Any, Dict
 import bittensor as bt
 
 from allways import dev_signal
+from allways.validator.binding import hotkey_ss58
 from allways.vault import codec
 
 
 def record_verdict(relay, fields: Dict[str, Any], block_time: int) -> None:
-    """Persist a ``SwapTimedOut`` verdict as an obligation. The payee comes from the snapshot the
-    swap loop took while the swap was live; failing that, from the verdict itself (W3.1), which is
-    what lets a validator relay a swap it never saw."""
+    """Persist a ``SwapTimedOut`` verdict as an obligation. The payee and hotkey come from the
+    snapshot the swap loop took while the swap was live; failing that, from the verdict itself
+    (W3.1 payee, V-M1 hotkey), which is what lets a validator relay a swap it never saw."""
     swap_key = bytes(fields['swap_key']).hex()
     miner = str(fields['miner'])
     snapshot = relay.store.get_relay_swap(swap_key)
     user_addr = _payable(snapshot['user_addr']) if snapshot else ''
     hotkey = (snapshot.get('hotkey') if snapshot else None) or None
+    if hotkey is None:
+        # V-M1: the verdict carries the hotkey the swap pinned at initiate, so a validator with no
+        # snapshot still seizes the right bond. All-zeros = pre-pin swap / never-bound miner.
+        raw = bytes(fields.get('hotkey') or b'')
+        if any(raw):
+            hotkey = hotkey_ss58(raw)
     if not user_addr:
         # No snapshot (fresh state DB, or down for the swap's whole life): the event names the payee
         # itself, so history alone is enough to discharge this. Older verdicts predate the field and
@@ -100,8 +107,8 @@ def relay_verdicts(relay, now: int) -> bool:
 def _relay_one(relay, row: Dict[str, Any], now: int) -> bool:
     swap_key = row['swap_key']
     miner = row['miner']
-    # F1: the observe-time snapshot (H1) is authoritative; a rebind after acceptance must not move
-    # the seizure. Fall back to the live lookup only when no snapshot was taken (pre-F1 rows).
+    # The recorded hotkey (observe-time snapshot, else the verdict's V-M1 pin) is authoritative.
+    # The live lookup only covers pre-upgrade rows — and is safe now the binding is set-once.
     hotkey = row.get('hotkey') or relay.hotkey_for(miner)
     if hotkey is None:
         bt.logging.warning(f'relay: {miner[:8]} has no hotkey binding — cannot slash its bond')

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -110,6 +110,12 @@ def reserve_on_behalf(
     if from_chain not in SUPPORTED_CHAINS or to_chain not in SUPPORTED_CHAINS:
         return ReserveResult(False, f'unsupported chain pair {from_chain}->{to_chain} (chain ids are lowercase)')
 
+    # Canonical source form at intake: the finalize hash + source-lock PDA are byte-keyed on this
+    # string (V-C2), so a case variant of a live source would mint a second lock over one deposit.
+    src_asset = (getattr(validator, 'axon_assets', None) or {}).get(from_chain)
+    if src_asset is not None:
+        user_from_addr = src_asset.chain.normalize_address(user_from_addr)
+
     client = validator.solana_client
     miner_pk = resolve_miner_pubkey(validator, miner_hotkey)
     if miner_pk is None:
@@ -322,7 +328,9 @@ def finalize_won_seats(validator, now: int) -> list:
             client.finalize_reservation(
                 Pubkey.from_string(miner),
                 Pubkey.from_string(req['user_pubkey']),
-                req['user_from_addr'],
+                # Normalized again at commit: rows queued before the intake normalization shipped
+                # (or by an older validator) must still land canonical, or the lock PDA diverges.
+                src.chain.normalize_address(req['user_from_addr']) if src else req['user_from_addr'],
                 req['user_to_addr'],
                 fill.collateral_amount,
                 fill.from_amount,
@@ -459,8 +467,8 @@ def confirm_deposit(validator, miner_hotkey: str, from_tx_hash: str, from_tx_blo
     # deposit's hub is not knowable up front. Verify the deposit against each slot and claim the one it
     # matches — picking the first live slot blindly would reject a TAO deposit whenever a SOL slot is
     # also live (V-1). `verify_transaction` is the authoritative matcher (pinned recipient/amount/sender).
-    reservation = backing = tx_info = None
-    unreachable = False
+    matches = []
+    unreachable = stale = False
     for resv, resv_backing in slots:
         provider = validator.axon_assets.get(resv.from_chain)
         if provider is None:
@@ -480,20 +488,27 @@ def confirm_deposit(validator, miner_hotkey: str, from_tx_hash: str, from_tx_blo
             continue  # absent or content-mismatch for this hub — try the next live slot
         # Deferred intake: accept a content-valid deposit pre-confirmation — the crank defers voting
         # until it confirms. A 0-conf mempool tx has no block_time, so its freshness is deferred too;
-        # only a mined tx is freshness-checked here. A matched-but-stale deposit is terminal for this
-        # hub (its params are pinned), so fast-fail rather than fall through to a different slot.
+        # only a mined tx is freshness-checked here. A matched-but-stale deposit is terminal for its
+        # hub (its params are pinned), so it never claims — but a fresh match on another hub still can.
         if candidate.block_time is not None:
             grace = getattr(provider.chain_def, 'replay_grace_secs', 0)
             if not is_tx_fresh(candidate, int(resv.created_at), grace):
-                return ConfirmResult(False, 'Source tx fails freshness — stale/replayed deposit')
-        reservation, backing, tx_info = resv, resv_backing, candidate
-        break
+                stale = True
+                continue
+        # Deterministic pick when one deposit matches several slots (normalize-equal senders): a
+        # canonical-form from_addr wins — honest lanes commit canonical, while a case variant is the
+        # source-lock dodge (V-C2) — then the oldest reservation (the one the variant was copied from).
+        canonical = resv.from_addr == provider.chain.normalize_address(resv.from_addr)
+        matches.append(((0 if canonical else 1, int(resv.created_at)), resv, resv_backing, candidate))
 
-    if reservation is None:
+    if not matches:
+        if stale:
+            return ConfirmResult(False, 'Source tx fails freshness — stale/replayed deposit')
         if unreachable:
             return ConfirmResult(False, 'Source-chain provider unreachable; resend shortly')
         # No live slot matched; fast-fail (no claim) so the short TTL frees the miner.
         return ConfirmResult(False, 'Source tx not visible or does not match the reservation')
+    _, reservation, backing, tx_info = min(matches, key=lambda m: m[0])
 
     # The taker's funds are already on the source chain and this deposit just verified against the
     # pinned reservation — but submit_swap_claim needs reserved_until >= now, and once it lapses there

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -274,6 +274,28 @@ def finalize_won_seats(validator, now: int) -> list:
                 store.delete_routed_requests(miner, from_chain, to_chain, backing)
             continue
         req = draw_pool_winner(queue)
+        # A source address may back only ONE live-unclaimed reservation per miner at a time. Two live
+        # reservations that share (from_chain, from_addr) on one miner are both matchable by a single
+        # deposit — matching is `>=` amount, so the amount can't disambiguate — and confirm_deposit
+        # would claim it for whichever slot is scanned first. That lets an attacker who declares a
+        # victim's from_addr on the miner's OTHER hub siphon the victim's deposit. Refuse to finalize a
+        # colliding seat. No post-claim state needed: a claimed reservation leaves the live-unclaimed
+        # set on its own, so the address frees itself.
+        providers = getattr(validator, 'axon_assets', {})
+        src = providers.get(from_chain)
+        want_addr = src.chain.normalize_address(req['user_from_addr']) if src else req['user_from_addr']
+        live_slots, _ = _live_unclaimed_slots(client, Pubkey.from_string(miner), now)
+        if any(
+            s.from_chain == from_chain
+            and (src.chain.normalize_address(s.from_addr) if src else s.from_addr) == want_addr
+            for s, _b in live_slots
+        ):
+            bt.logging.warning(
+                f'routed sweep {miner[:8]}: source address already backs a live reservation on this '
+                f'miner — refusing a duplicate-source seat, dropping queue'
+            )
+            store.delete_routed_requests(miner, from_chain, to_chain, backing)
+            continue
         if read_only:
             bt.logging.info(f'routed sweep {miner[:8]}: WOULD finalize for {req["user_pubkey"][:8]} (read-only)')
             continue

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -297,7 +297,8 @@ def finalize_won_seats(validator, now: int) -> list:
         def _collides(addr: str) -> bool:
             want = src.chain.normalize_address(addr) if src else addr
             return any(
-                s.from_chain == from_chain and (src.chain.normalize_address(s.from_addr) if src else s.from_addr) == want
+                s.from_chain == from_chain
+                and (src.chain.normalize_address(s.from_addr) if src else s.from_addr) == want
                 for s, _b in live_slots
             )
 

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -426,7 +426,9 @@ def _extend_for_claim(client, miner_pk, reservation, backing) -> None:
     if target <= reserved_until:
         return  # already at the contract ceiling — nothing left to buy
     try:
-        client.extend_reservation(miner_pk, target, backing)
+        client.extend_reservation(
+            miner_pk, target, backing, from_chain=reservation.from_chain, from_addr=reservation.from_addr
+        )
         bt.logging.info(f'claim runway: extended reserved_until {reserved_until} -> {target} (+{target - now}s)')
     except Exception as e:  # noqa: BLE001 - never block the claim on a failed extension
         bt.logging.warning(f'claim runway: extend_reservation failed ({e}); attempting the claim anyway')

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -281,29 +281,34 @@ def finalize_won_seats(validator, now: int) -> list:
                 bt.logging.info(f'routed sweep {miner[:8]}: reservation filled or window lapsed, dropping queue')
                 store.delete_routed_requests(miner, from_chain, to_chain, backing)
             continue
-        req = draw_pool_winner(queue)
-        # A source address may back only ONE live-unclaimed reservation per miner at a time. Two live
-        # reservations that share (from_chain, from_addr) on one miner are both matchable by a single
-        # deposit — matching is `>=` amount, so the amount can't disambiguate — and confirm_deposit
-        # would claim it for whichever slot is scanned first. That lets an attacker who declares a
-        # victim's from_addr on the miner's OTHER hub siphon the victim's deposit. Refuse to finalize a
-        # colliding seat. No post-claim state needed: a claimed reservation leaves the live-unclaimed
-        # set on its own, so the address frees itself.
+        # A source may back only ONE live-unclaimed reservation per miner: two reservations sharing
+        # (from_chain, from_addr) are both matchable by a single `>=`-amount deposit, so an attacker
+        # declaring a victim's from_addr on the miner's OTHER hub could siphon that deposit. Draw only from
+        # queued users whose source doesn't already back a live seat — skip a colliding entry, don't drop
+        # the whole queue (else one crafted front-of-queue request knocks out every honest queued user).
         providers = getattr(validator, 'axon_assets', {})
         src = providers.get(from_chain)
-        want_addr = src.chain.normalize_address(req['user_from_addr']) if src else req['user_from_addr']
-        live_slots, _ = _live_unclaimed_slots(client, Pubkey.from_string(miner), now)
-        if any(
-            s.from_chain == from_chain
-            and (src.chain.normalize_address(s.from_addr) if src else s.from_addr) == want_addr
-            for s, _b in live_slots
-        ):
-            bt.logging.warning(
-                f'routed sweep {miner[:8]}: source address already backs a live reservation on this '
-                f'miner — refusing a duplicate-source seat, dropping queue'
-            )
-            store.delete_routed_requests(miner, from_chain, to_chain, backing)
+        try:
+            live_slots, _ = _live_unclaimed_slots(client, Pubkey.from_string(miner), now)
+        except Exception as e:
+            bt.logging.warning(f'routed sweep {miner[:8]}: live-slot read failed, retrying next step: {e}')
             continue
+
+        def _collides(addr: str) -> bool:
+            want = src.chain.normalize_address(addr) if src else addr
+            return any(
+                s.from_chain == from_chain and (src.chain.normalize_address(s.from_addr) if src else s.from_addr) == want
+                for s, _b in live_slots
+            )
+
+        eligible = [q for q in queue if not _collides(q['user_from_addr'])]
+        if not eligible:
+            bt.logging.warning(
+                f'routed sweep {miner[:8]}: every queued source already backs a live seat — nothing to '
+                f'finalize this pass (TTL prunes stale colliders)'
+            )
+            continue
+        req = draw_pool_winner(eligible)
         if read_only:
             bt.logging.info(f'routed sweep {miner[:8]}: WOULD finalize for {req["user_pubkey"][:8]} (read-only)')
             continue

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -328,6 +328,7 @@ def finalize_won_seats(validator, now: int) -> list:
                 fill.from_amount,
                 fill.to_amount,
                 backing,
+                from_chain=from_chain,
             )
         except Exception as e:
             reason = contract_reject_reason(e) or (str(e) if isinstance(e, ValueError) else None)

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -179,6 +179,14 @@ def reserve_on_behalf(
         # the delivery-time reverted-tx proof (cancel_swap). Fat-finger UX belongs in the client app.
         if not provider.chain.is_valid_address(user_to_addr):
             return ReserveResult(False, f'destination is not a valid {to_chain} address')
+        # Reject user_to_addr == the miner's committed delivery address. The miner must deliver FROM
+        # miner_to_addr, so this makes every delivery a from==to self-transfer that the anti-wash
+        # verifier rejects → the leg never confirms → the miner is force-slashed with no cancel escape.
+        miner_to_addr = getattr(miner_quote, 'miner_to_addr', '') if miner_quote else ''
+        if miner_to_addr and provider.chain.normalize_address(user_to_addr) == provider.chain.normalize_address(
+            miner_to_addr
+        ):
+            return ReserveResult(False, 'destination must differ from the miner delivery address')
     # Same gate, source side (T18): the miner's receive address must accept the user's funds —
     # a miner quoting a malformed/rejecting/blacklisted address griefs takers into a burned fee.
     src_provider = providers.get(from_chain)

--- a/allways/validator/solana_swap_loop.py
+++ b/allways/validator/solana_swap_loop.py
@@ -142,12 +142,13 @@ class SolanaSwapLoop:
         self, chain: str, tx_hash: str, recipient: str, amount: int, block_hint: int = 0, sender: str = ''
     ) -> Tuple[str, Any]:
         """Tri-state leg status: ('ok', info) confirmed match, ('pending', info) all details match but
-        awaiting confirmations (extendable), ('no', None) absent/mismatch/no-provider (slash-eligible),
-        ('down', None) provider unreachable this round."""
+        awaiting confirmations (extendable), ('no', None) absent/mismatch (slash-eligible), ('down', None)
+        unverifiable this round — provider unreachable OR no provider for the chain (never slash on absence
+        of a verifier; an unsupported/disabled spoke reaching chain state must SKIP, not TIMEOUT)."""
         provider = self.providers.get(chain)
         if provider is None:
-            bt.logging.warning(f'no chain provider for {chain}; cannot verify')
-            return ('no', None)
+            bt.logging.warning(f'no chain provider for {chain}; cannot verify — treating as unverifiable (down)')
+            return ('down', None)
         if not tx_hash:
             return ('no', None)
         try:
@@ -418,6 +419,11 @@ class SolanaSwapLoop:
         if status == 'PendingAttestation':
             return self._decide_pending_attestation(swap, now)
         if status == 'Active':
+            # An Active swap never re-fetches the dest leg (no tx yet), so a missing dest provider would
+            # slip past the tri-state guard and TIMEOUT below on mere absence of a verifier. Same rule as
+            # _fetch_leg's None provider: unverifiable → SKIP, never slash an unsupported/disabled spoke.
+            if self.providers.get(swap.to_chain) is None:
+                return SwapAction(SwapDecision.SKIP, reason=f'no provider for dest {swap.to_chain} — cannot verify')
             # No-fault cancel for chains whose refusal is provable WITHOUT a delivery tx (Solana reserved
             # account, ERC-20 issuer freeze): an Active swap into such a dest cancels immediately — no point
             # waiting for a fulfillment that can never land. Native EVM has no tx yet, so this is None until

--- a/allways/validator/solana_swap_loop.py
+++ b/allways/validator/solana_swap_loop.py
@@ -366,6 +366,14 @@ class SolanaSwapLoop:
         if expected_to == 0 or abs(int(swap.to_amount) - expected_to) > 1:
             self._reject_logged(swap, expected_to)
             return SwapAction(SwapDecision.REJECT, reason=f'to_amount {swap.to_amount} != pinned-rate {expected_to}')
+        # V-H1 (authoritative, chain-aware): never attest a swap whose payout address equals the miner's
+        # own delivery address — normalized per-chain, so it catches the EVM checksum-variants the on-chain
+        # raw compare misses. Equal addresses force a self-transfer the anti-wash verifier slashes; the
+        # taker poisoned it, so refuse before the miner is obligated (routed + self-represented alike).
+        to_provider = self.providers.get(swap.to_chain)
+        norm = to_provider.chain.normalize_address if to_provider is not None else (lambda a: a)
+        if swap.miner_to_addr and norm(swap.user_to_addr) == norm(swap.miner_to_addr):
+            return SwapAction(SwapDecision.REJECT, reason='dest == miner delivery address (poisoned) — refusing to attest')
         # Source deposit must exist, confirm, be sent BY the reserved user, AND be fresh vs the
         # Reservation before we'd attest — sender pin matches the relay's confirm_deposit check.
         s_status, info = self._fetch_leg(
@@ -488,7 +496,13 @@ class SolanaSwapLoop:
                     return False
                 sig = self.client.cancel_swap(swap_key, swap.miner, action.reason_code or CANCEL_REASON_OTHER)
             elif decision == SwapDecision.EXTEND_RESERVATION:
-                sig = self.client.extend_reservation(swap.miner, action.target_at, str(swap.collateral_chain))
+                sig = self.client.extend_reservation(
+                    swap.miner,
+                    action.target_at,
+                    str(swap.collateral_chain),
+                    from_chain=swap.from_chain,
+                    from_addr=swap.user_from_addr,
+                )
             elif decision == SwapDecision.EXTEND_TIMEOUT:
                 sig = self.client.extend_timeout(swap_key, swap.miner, action.target_at)
             else:

--- a/allways/validator/solana_swap_loop.py
+++ b/allways/validator/solana_swap_loop.py
@@ -373,7 +373,9 @@ class SolanaSwapLoop:
         to_provider = self.providers.get(swap.to_chain)
         norm = to_provider.chain.normalize_address if to_provider is not None else (lambda a: a)
         if swap.miner_to_addr and norm(swap.user_to_addr) == norm(swap.miner_to_addr):
-            return SwapAction(SwapDecision.REJECT, reason='dest == miner delivery address (poisoned) — refusing to attest')
+            return SwapAction(
+                SwapDecision.REJECT, reason='dest == miner delivery address (poisoned) — refusing to attest'
+            )
         # Source deposit must exist, confirm, be sent BY the reserved user, AND be fresh vs the
         # Reservation before we'd attest — sender pin matches the relay's confirm_deposit check.
         s_status, info = self._fetch_leg(

--- a/allways/validator/solana_swap_loop.py
+++ b/allways/validator/solana_swap_loop.py
@@ -480,7 +480,9 @@ class SolanaSwapLoop:
                 if self.client.has_voted(pdas.REQ_INITIATE, swap_key, voter):
                     return False
                 backing = str(getattr(swap, 'collateral_chain', 'sol') or 'sol').lower()
-                sig = self.client.vote_initiate(swap_key, swap.miner, backing=backing)
+                sig = self.client.vote_initiate(
+                    swap_key, swap.miner, swap.from_chain, str(swap.user_from_addr), backing=backing
+                )
             elif decision == SwapDecision.CONFIRM:
                 if self.client.has_voted(pdas.REQ_CONFIRM, swap_key, voter):
                     return False

--- a/allways/validator/solana_swap_loop.py
+++ b/allways/validator/solana_swap_loop.py
@@ -416,14 +416,19 @@ class SolanaSwapLoop:
         chain providers + the Reservation PDA."""
         status = _status_name(swap)
         overdue = now >= int(swap.timeout_at)
+        # No dest provider here → can't verify locally. SKIP below the ceiling (a re-enabled spoke or a
+        # provider-equipped peer still resolves it); past max_extend_at TIMEOUT so a permanently unverifiable
+        # pair frees the collateral instead of freezing it forever (only network-wide gaps reach quorum).
+        if status in ('Active', 'Fulfilled') and self.providers.get(swap.to_chain) is None:
+            if now < int(swap.max_extend_at):
+                return SwapAction(SwapDecision.SKIP, reason=f'no provider for dest {swap.to_chain} — cannot verify yet')
+            return SwapAction(
+                SwapDecision.TIMEOUT,
+                reason=f'no provider for dest {swap.to_chain} past max_extend_at — terminal, else collateral freezes',
+            )
         if status == 'PendingAttestation':
             return self._decide_pending_attestation(swap, now)
         if status == 'Active':
-            # An Active swap never re-fetches the dest leg (no tx yet), so a missing dest provider would
-            # slip past the tri-state guard and TIMEOUT below on mere absence of a verifier. Same rule as
-            # _fetch_leg's None provider: unverifiable → SKIP, never slash an unsupported/disabled spoke.
-            if self.providers.get(swap.to_chain) is None:
-                return SwapAction(SwapDecision.SKIP, reason=f'no provider for dest {swap.to_chain} — cannot verify')
             # No-fault cancel for chains whose refusal is provable WITHOUT a delivery tx (Solana reserved
             # account, ERC-20 issuer freeze): an Active swap into such a dest cancels immediately — no point
             # waiting for a fulfillment that can never land. Native EVM has no tx yet, so this is None until

--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -232,6 +232,22 @@ class ValidatorStateStore:
             (block_num, hotkey, int(transition), hub),
         )
 
+    def restamp_reservation_expiry(self, hotkey: str, hub: Optional[str], new_block_num: int) -> None:
+        """Move the miner's most-recent synthetic RESERVE_EXPIRE (this hub) to the chain's real
+        ``reserved_until``. PoolResolved stamps a draw+ttl guess before the true deadline is known;
+        ReservationFilled/Extended carry it, so a busy miner isn't freed before its swap initiates."""
+        self._execute(
+            """
+            UPDATE activity_events SET block_num = ?
+            WHERE id = (
+                SELECT id FROM activity_events
+                WHERE hotkey = ? AND kind = ? AND hub IS ?
+                ORDER BY id DESC LIMIT 1
+            )
+            """,
+            (int(new_block_num), hotkey, int(ActivityTransition.RESERVE_EXPIRE), hub),
+        )
+
     def load_all_active_events(self) -> List[dict]:
         rows = self._fetchall('SELECT block_num, hotkey, active FROM active_events ORDER BY block_num ASC, id ASC')
         return [{'block_num': r['block_num'], 'hotkey': r['hotkey'], 'active': bool(r['active'])} for r in rows]

--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -232,7 +232,9 @@ class ValidatorStateStore:
             (block_num, hotkey, int(transition), hub),
         )
 
-    def restamp_reservation_expiry(self, hotkey: str, hub: Optional[str], new_block_num: int, not_before: int = 0) -> None:
+    def restamp_reservation_expiry(
+        self, hotkey: str, hub: Optional[str], new_block_num: int, not_before: int = 0
+    ) -> None:
         """Move the miner's most-recent synthetic RESERVE_EXPIRE (this hub) to the chain's real
         ``reserved_until``. PoolResolved stamps a draw+ttl guess before the true deadline is known;
         ReservationFilled/Extended carry it, so a busy miner isn't freed before its swap initiates.

--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -232,20 +232,22 @@ class ValidatorStateStore:
             (block_num, hotkey, int(transition), hub),
         )
 
-    def restamp_reservation_expiry(self, hotkey: str, hub: Optional[str], new_block_num: int) -> None:
+    def restamp_reservation_expiry(self, hotkey: str, hub: Optional[str], new_block_num: int, not_before: int = 0) -> None:
         """Move the miner's most-recent synthetic RESERVE_EXPIRE (this hub) to the chain's real
         ``reserved_until``. PoolResolved stamps a draw+ttl guess before the true deadline is known;
-        ReservationFilled/Extended carry it, so a busy miner isn't freed before its swap initiates."""
+        ReservationFilled/Extended carry it, so a busy miner isn't freed before its swap initiates.
+        ``not_before`` bounds the move: a row already fired before the triggering event belongs to a
+        PRIOR reservation (this one's PoolResolved was dropped) — clobbering it strands the hub busy."""
         self._execute(
             """
             UPDATE activity_events SET block_num = ?
             WHERE id = (
                 SELECT id FROM activity_events
-                WHERE hotkey = ? AND kind = ? AND hub IS ?
+                WHERE hotkey = ? AND kind = ? AND hub IS ? AND block_num >= ?
                 ORDER BY id DESC LIMIT 1
             )
             """,
-            (int(new_block_num), hotkey, int(ActivityTransition.RESERVE_EXPIRE), hub),
+            (int(new_block_num), hotkey, int(ActivityTransition.RESERVE_EXPIRE), hub, int(not_before)),
         )
 
     def load_all_active_events(self) -> List[dict]:

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -27,7 +27,7 @@ from allways.miner.fulfillment import SwapFulfiller  # noqa: E402
 from allways.miner.swap_poller import SwapPoller  # noqa: E402
 from allways.solana import keys  # noqa: E402
 from allways.solana.client import AllwaysSolanaClient  # noqa: E402
-from allways.solana.rpc import resolve_rpc_url  # noqa: E402
+from allways.solana.rpc import assert_cluster_safe, resolve_rpc_url  # noqa: E402
 from neurons.base.miner import BaseMinerNeuron  # noqa: E402
 
 
@@ -57,12 +57,10 @@ class Miner(BaseMinerNeuron):
 
         # Solana program client (signer = the miner's Solana keypair; separate from the bt wallet).
         solana_rpc_url = resolve_rpc_url()
-        if int(self.config.netuid) != NETUID_FINNEY and 'mainnet' in solana_rpc_url.lower():
-            bt.logging.warning(
-                f'testnet neuron (netuid {self.config.netuid}) resolved a mainnet-looking Solana RPC '
-                f'({solana_rpc_url}) — the hub/control plane may target the wrong cluster.'
-            )
         self.solana_client = AllwaysSolanaClient(solana_rpc_url, keypair=keys.load_or_create())
+        # Fail closed if a testnet neuron is pointed at mainnet, or the program id is on the wrong
+        # cluster — positively classified by genesis hash, not the mainnet-substring blind spot.
+        assert_cluster_safe(self.solana_client.rpc, self.solana_client.program_id, self.config.netuid, role='miner')
         self.solana_pubkey = self.solana_client.keypair.pubkey()
         # SOL swap-leg provider signs the dest leg with the same Solana keypair (peer-to-peer
         # user↔miner transfer; separate from the program client that never custodies swap assets).

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -21,7 +21,8 @@ import bittensor as bt  # noqa: E402
 from bittensor import Keypair as BtKeypair  # noqa: E402
 
 from allways.assets import create_assets  # noqa: E402
-from allways.constants import FORWARD_STALL_THRESHOLD_SECONDS, NUMERAIRE_CHAIN  # noqa: E402
+from allways.chains import apply_testnet_network_defaults  # noqa: E402
+from allways.constants import FORWARD_STALL_THRESHOLD_SECONDS, NETUID_FINNEY, NUMERAIRE_CHAIN  # noqa: E402
 from allways.miner.fulfillment import SwapFulfiller  # noqa: E402
 from allways.miner.swap_poller import SwapPoller  # noqa: E402
 from allways.solana import keys  # noqa: E402
@@ -41,10 +42,26 @@ class Miner(BaseMinerNeuron):
     def __init__(self, config=None):
         super().__init__(config=config)
 
+        # A testnet neuron must not silently run mainnet spokes: unset {PREFIX}_NETWORK defaults to
+        # mainnet in the providers, so a miner with real keys could broadcast a mainnet payout for a
+        # test obligation. Default unset spokes to testnet here (an explicit env var still wins).
+        if int(self.config.netuid) != NETUID_FINNEY:
+            applied = apply_testnet_network_defaults()
+            if applied:
+                bt.logging.warning(
+                    f'testnet neuron (netuid {self.config.netuid}): defaulted unset spoke networks to '
+                    f'testnet {applied} — set {{PREFIX}}_NETWORK to override.'
+                )
+
         self.unlock_coldkey()
 
         # Solana program client (signer = the miner's Solana keypair; separate from the bt wallet).
         solana_rpc_url = resolve_rpc_url()
+        if int(self.config.netuid) != NETUID_FINNEY and 'mainnet' in solana_rpc_url.lower():
+            bt.logging.warning(
+                f'testnet neuron (netuid {self.config.netuid}) resolved a mainnet-looking Solana RPC '
+                f'({solana_rpc_url}) — the hub/control plane may target the wrong cluster.'
+            )
         self.solana_client = AllwaysSolanaClient(solana_rpc_url, keypair=keys.load_or_create())
         self.solana_pubkey = self.solana_client.keypair.pubkey()
         # SOL swap-leg provider signs the dest leg with the same Solana keypair (peer-to-peer

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -35,7 +35,7 @@ from allways.constants import (  # noqa: E402
 from allways.solana import keys  # noqa: E402
 from allways.solana.client import AllwaysSolanaClient  # noqa: E402
 from allways.solana.events import SolanaEventIngest  # noqa: E402
-from allways.solana.rpc import resolve_rpc_url  # noqa: E402
+from allways.solana.rpc import assert_cluster_safe, resolve_rpc_url  # noqa: E402
 from allways.validator.axon_handlers import (  # noqa: E402
     blacklist_miner_activate,
     blacklist_swap_confirm,
@@ -91,11 +91,6 @@ class Validator(BaseValidatorNeuron):
         # One rpc-url source of truth shared by every SOL consumer: the chain
         # providers (source-leg verification) and the solana_client below.
         solana_rpc_url = resolve_rpc_url()
-        if int(self.config.netuid) != NETUID_FINNEY and 'mainnet' in solana_rpc_url.lower():
-            bt.logging.warning(
-                f'testnet neuron (netuid {self.config.netuid}) resolved a mainnet-looking Solana RPC '
-                f'({solana_rpc_url}) — the hub/control plane may target the wrong cluster.'
-            )
         self.assets = create_assets(
             check=True, require_send=False, subtensor=self.subtensor, solana_rpc_url=solana_rpc_url
         )
@@ -133,6 +128,9 @@ class Validator(BaseValidatorNeuron):
             bt.logging.warning('VALIDATOR_MODE=vote — Solana contract votes ON, set_weights OFF.')
         solana_read_only = mode == 'watch'
         self.solana_client = AllwaysSolanaClient(solana_rpc_url, keypair=keys.load_or_create())
+        # Fail closed if a testnet neuron is pointed at mainnet, or the program id is on the wrong
+        # cluster — positively classified by genesis hash, not the mainnet-substring blind spot.
+        assert_cluster_safe(self.solana_client.rpc, self.solana_client.program_id, self.config.netuid, role='validator')
         warn_if_unbound(self.solana_client)
         # `solana_config_cache` serves swap bounds + halt (and the relay's heartbeat freshness)
         # off one TTL-cached Config read, replacing the old substrate reads.

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -24,9 +24,11 @@ import wandb  # noqa: E402
 
 from allways import __version__  # noqa: E402
 from allways.assets import create_assets  # noqa: E402
+from allways.chains import apply_testnet_network_defaults  # noqa: E402
 from allways.constants import (  # noqa: E402
     FEE_DIVISOR,
     FORWARD_STALL_THRESHOLD_SECONDS,
+    NETUID_FINNEY,
     SCORING_WINDOW_BLOCKS,
     SCORING_WINDOW_SECS,
 )
@@ -75,9 +77,25 @@ class Validator(BaseValidatorNeuron):
     def __init__(self, config=None):
         super().__init__(config=config)
 
+        # A testnet neuron must not silently verify against mainnet spokes: unset {PREFIX}_NETWORK
+        # defaults to mainnet in the providers, so a test swap would be checked on mainnet. Default
+        # unset spokes to testnet here (an explicit env var still wins).
+        if int(self.config.netuid) != NETUID_FINNEY:
+            applied = apply_testnet_network_defaults()
+            if applied:
+                bt.logging.warning(
+                    f'testnet neuron (netuid {self.config.netuid}): defaulted unset spoke networks to '
+                    f'testnet {applied} — set {{PREFIX}}_NETWORK to override.'
+                )
+
         # One rpc-url source of truth shared by every SOL consumer: the chain
         # providers (source-leg verification) and the solana_client below.
         solana_rpc_url = resolve_rpc_url()
+        if int(self.config.netuid) != NETUID_FINNEY and 'mainnet' in solana_rpc_url.lower():
+            bt.logging.warning(
+                f'testnet neuron (netuid {self.config.netuid}) resolved a mainnet-looking Solana RPC '
+                f'({solana_rpc_url}) — the hub/control plane may target the wrong cluster.'
+            )
         self.assets = create_assets(
             check=True, require_send=False, subtensor=self.subtensor, solana_rpc_url=solana_rpc_url
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "allways"
-version = "3.1.2"
+version = "3.2.0"
 description = "Allways - Universal Transaction Layer: Collateral-backed cross-chain swaps on Bittensor Subnet 7"
 license = "MIT"
 requires-python = ">=3.10,<3.15"

--- a/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
@@ -26,6 +26,7 @@ pub const RESV_SEED: &[u8] = b"resv";
 /// PDA seed prefix for the V-C2 source-address lock
 /// (`seeds = [SRCLOCK_SEED, miner_pubkey, from_chain, keccak(from_addr)]`) — one live-unclaimed
 /// reservation per `(miner, from_chain, from_addr)`, enforced for routed and self-represented alike.
+#[constant]
 pub const SRCLOCK_SEED: &[u8] = b"srclock";
 
 /// PDA seed prefix for a swap (`seeds = [SWAP_SEED, swap_key]`, swap_key = keccak(from_tx_hash)).

--- a/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
@@ -23,6 +23,11 @@ pub const VOTE_SEED: &[u8] = b"vote";
 #[constant]
 pub const RESV_SEED: &[u8] = b"resv";
 
+/// PDA seed prefix for the V-C2 source-address lock
+/// (`seeds = [SRCLOCK_SEED, miner_pubkey, from_chain, keccak(from_addr)]`) — one live-unclaimed
+/// reservation per `(miner, from_chain, from_addr)`, enforced for routed and self-represented alike.
+pub const SRCLOCK_SEED: &[u8] = b"srclock";
+
 /// PDA seed prefix for a swap (`seeds = [SWAP_SEED, swap_key]`, swap_key = keccak(from_tx_hash)).
 #[constant]
 pub const SWAP_SEED: &[u8] = b"swap";

--- a/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
@@ -103,6 +103,9 @@ pub const CANCEL_REASON_EVM_REVERT: u8 = 0;
 pub const CANCEL_REASON_ERC20_BLACKLIST: u8 = 1;
 pub const CANCEL_REASON_ERC20_PAUSED: u8 = 2;
 pub const CANCEL_REASON_SOL_RESERVED: u8 = 3;
+/// An issuer-enabled ERC-20 transfer fee shaves every honest delivery's log below the pinned
+/// amount — a hub-wide no-fault condition, cancelled rather than slashed (V-M2/PAXG).
+pub const CANCEL_REASON_ERC20_FEE_ENABLED: u8 = 4;
 pub const CANCEL_REASON_OTHER: u8 = 255;
 
 /// Slots the draw's seed slot is pinned ahead of the arming crank. Three leader windows (4 slots

--- a/smart-contracts/solana/programs/allways_swap_manager/src/error.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/error.rs
@@ -135,6 +135,12 @@ pub enum ErrorCode {
     SelfSwapNotAllowed,
     #[msg("Taker pubkey must not be the default address")]
     InvalidUser,
+    #[msg("Taker payout address must differ from the miner's delivery address")]
+    DestEqualsMinerAddr,
+    #[msg("This source address already backs a live reservation on this miner")]
+    DuplicateSourceAddr,
+    #[msg("from_addr_hash does not match keccak(user_from_addr)")]
+    SourceHashMismatch,
     #[msg("round_key does not match the keccak hash of the submitted weights snapshot")]
     WeightsRoundKeyMismatch,
 

--- a/smart-contracts/solana/programs/allways_swap_manager/src/error.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/error.rs
@@ -173,4 +173,8 @@ pub enum ErrorCode {
     MigrationSwapNotDrained,
     #[msg("Attestation would lower the bond while a reservation/swap is live on this hub")]
     AttestationWouldStrandSwap,
+
+    // --- V-M1: hotkey-binding freeze ---
+    #[msg("Hotkey binding is set-once; a bound pubkey cannot change its hotkey")]
+    HotkeyChangeForbidden,
 }

--- a/smart-contracts/solana/programs/allways_swap_manager/src/events.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/events.rs
@@ -107,6 +107,10 @@ pub struct SwapTimedOut {
     /// the seizure can be relayed from this event alone. Empty when the backing settles locally —
     /// that refund already moved, to `Swap::user`.
     pub payee: String,
+    /// Bittensor hotkey the swap pinned at initiate ([0;32] = never bound) — the bond the vault
+    /// seizure targets, so a rebind can never redirect it (V-M1). Appended last; prefix decoders
+    /// keep working.
+    pub hotkey: [u8; 32],
 }
 
 /// The no-fault cancel verdict: the destination provably could not receive the payout, so the swap is

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/bind_hotkey.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/bind_hotkey.rs
@@ -10,7 +10,9 @@ use crate::state::{Binding, Config, HotkeyBinding, MinerState};
 /// costly on-chain, so the validator verifies off-chain. Signed by the miner (proves the Solana side).
 /// The set-once `hotkey_binding` marker enforces hotkey→≤1 pubkey on-chain: the first pubkey to claim a
 /// hotkey owns it forever, so a struck pubkey can't rotate + re-bind the same hotkey to dodge strikes.
-/// The same miner may re-bind in place (refresh sig / change hotkey). Not halt-gated — identity, no value.
+/// The forward binding is ALSO set-once (V-M1): a bound pubkey may refresh its signature in place but
+/// never change its hotkey — a mutable hotkey let an attacker rebind mid-swap to dodge bond seizure.
+/// Legit rotation = new pubkey + new hotkey + re-posted collateral. Not halt-gated — identity, no value.
 ///
 /// Gated to registered miners (MinerState exists + collateral >= min_collateral) and whitelisted
 /// validators (Config.validators — they bind so peers can attribute their stake for the weights
@@ -89,6 +91,13 @@ pub fn handler(ctx: Context<BindHotkey>, hotkey: [u8; 32], hotkey_sig: [u8; 64])
     }
 
     let binding = &mut ctx.accounts.binding;
+    // Hotkey is set-once (same-hotkey sig refresh still allowed). A mutable hotkey let an
+    // attacker rebind mid-swap to dodge bond seizure (V-M1). Legit rotation = new pubkey +
+    // new hotkey + re-post collateral; funds never trapped (withdraw is pubkey-keyed).
+    require!(
+        binding.miner == Pubkey::default() || binding.hotkey == hotkey,
+        ErrorCode::HotkeyChangeForbidden
+    );
     if binding.miner == Pubkey::default() {
         binding.miner = miner;
         binding.bump = binding_bump;

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/close_stale_claim.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/close_stale_claim.rs
@@ -38,6 +38,14 @@ pub fn handler(ctx: Context<CloseStaleClaim>, swap_key: [u8; 32]) -> Result<()> 
         ctx.accounts.swap.status == SwapStatus::PendingAttestation,
         ErrorCode::NotPending
     );
+    // The `reservation` PDA is seeded on its OWN `collateral_chain`, so any of the miner's reservations
+    // (e.g. the other hub of a dual-hub miner) validates here. Bind it to the swap's backing: without
+    // this, a foreign reservation trivially satisfies the `claimed_swap_key != swap_key` staleness clause
+    // below and reaps a HEALTHY swap → permanent taker fund-strand (permissionless).
+    require!(
+        ctx.accounts.reservation.collateral_chain == ctx.accounts.swap.collateral_chain,
+        ErrorCode::ChainMismatch
+    );
 
     let now = Clock::get()?.unix_timestamp;
     {

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/extend_reservation.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/extend_reservation.rs
@@ -1,16 +1,18 @@
 use anchor_lang::prelude::*;
+use solana_keccak_hasher::hashv;
 
 use crate::consensus::ensure_validator;
-use crate::constants::{CONFIG_SEED, MINER_SEED, RESV_SEED};
+use crate::constants::{CONFIG_SEED, MINER_SEED, RESV_SEED, SRCLOCK_SEED};
 use crate::error::ErrorCode;
 use crate::events::ReservationExtended;
-use crate::state::{Config, MinerState, Reservation};
+use crate::state::{Config, MinerState, Reservation, SourceLock};
 
 /// A single validator slides a reservation's `reserved_until` forward while it waits on slow source-
 /// chain confirmation. No quorum — an extension moves no funds, so worst case it only delays a slash
 /// (still quorum-gated) up to the frozen ceiling. Monotonic + ceiling are the only guards; ignores
 /// `halted` so in-flight swaps can finish.
 #[derive(Accounts)]
+#[instruction(target_at: i64, from_addr_hash: [u8; 32])]
 pub struct ExtendReservation<'info> {
     pub validator: Signer<'info>,
 
@@ -34,13 +36,27 @@ pub struct ExtendReservation<'info> {
         bump = reservation.bump,
     )]
     pub reservation: Account<'info, Reservation>,
+
+    /// V-C2: this reservation's source lock (created at finalize). Slid forward with reserved_until so an
+    /// extended, still-unclaimed reservation can't outlive its lock and re-open the cross-hub collision.
+    #[account(
+        mut,
+        seeds = [SRCLOCK_SEED, miner.key().as_ref(), reservation.from_chain.as_bytes(), from_addr_hash.as_ref()],
+        bump = source_lock.bump,
+    )]
+    pub source_lock: Account<'info, SourceLock>,
 }
 
-pub fn handler(ctx: Context<ExtendReservation>, target_at: i64) -> Result<()> {
+pub fn handler(ctx: Context<ExtendReservation>, target_at: i64, from_addr_hash: [u8; 32]) -> Result<()> {
     let validator = ctx.accounts.validator.key();
     ensure_validator(&ctx.accounts.config, &validator)?;
 
     let now = Clock::get()?.unix_timestamp;
+    // Bind from_addr_hash to the reservation's real source before it seeds the lock (swap_key idiom).
+    require!(
+        from_addr_hash == hashv(&[ctx.accounts.reservation.from_addr.as_bytes()]).to_bytes(),
+        ErrorCode::SourceHashMismatch
+    );
     let resv = &mut ctx.accounts.reservation;
 
     // Must still be live — don't resurrect an expired (overwritable) reservation.
@@ -49,6 +65,8 @@ pub fn handler(ctx: Context<ExtendReservation>, target_at: i64) -> Result<()> {
     require!(target_at <= resv.max_extend_at, ErrorCode::ExtensionExceedsCeiling);
 
     resv.reserved_until = target_at;
+    // V-C2: slide the source lock in lockstep so the extended reservation never outlives it.
+    ctx.accounts.source_lock.reserved_until = target_at;
     // Forward-only on the hub's own slot: an extension may never shorten another obligation's lock.
     let bit = crate::backing::backing_bit(&resv.collateral_chain)?;
     ctx.accounts.miner_state.extend_busy(bit, target_at);

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/finalize_reservation.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/finalize_reservation.rs
@@ -107,24 +107,17 @@ pub fn handler(
     // that half. Also reject the default pubkey: a timeout would "refund" the slash to the burn address.
     require!(user != ctx.accounts.miner.key(), ErrorCode::SelfSwapNotAllowed);
     require!(user != Pubkey::default(), ErrorCode::InvalidUser);
-    // H1 (V-H1) on-chain backstop: a taker's payout address must differ from the miner's own delivery
-    // address (pinned on the reservation at draw). Equal addresses make the miner "deliver to itself" —
-    // a self-represented taker (who skips the validator's normalized reserve-time gate) could poison it
-    // into a false non-delivery slash or a collusion volume-farm. Raw compare: fully effective on
-    // case-sensitive chains; EVM case-variants stay covered by the validator's normalized routed check.
+    // H1 (V-H1) fast-fail: reject an exact user_to_addr == miner delivery address at finalize (pinned on
+    // the reservation at draw) so a poisoned self-represented reservation dies BEFORE the taker deposits.
+    // Raw byte compare — complete on case-sensitive chains (BTC/SOL/TAO). It CANNOT normalize per-chain,
+    // so an EVM checksum-variant slips past here; the authoritative, chain-aware H1 check runs validator-
+    // side at the attest gate (_decide_pending_attestation), which BOTH lanes hit before any obligation.
     require!(
         user_to_addr != ctx.accounts.reservation.miner_to_addr,
         ErrorCode::DestEqualsMinerAddr
     );
 
     let now = Clock::get()?.unix_timestamp;
-    // V-C2: the source_lock's seeds omit the backing, so it is shared across hubs. A lock still live
-    // (reserved_until in the future) means another unclaimed reservation on this miner already holds this
-    // (from_chain, from_addr) — reject the duplicate. A stale/`< now` (or freshly-init 0) lock is ours.
-    require!(
-        ctx.accounts.source_lock.reserved_until < now,
-        ErrorCode::DuplicateSourceAddr
-    );
     let cfg = &ctx.accounts.config;
 
     // Fill exactly once, and only inside the finalize window. Both sentinels are load-bearing:
@@ -189,6 +182,15 @@ pub fn handler(
         ErrorCode::InsufficientCollateral
     );
 
+    // V-C2 (after the fundamental entry gates above so a settling/halted/undercollateralized miner reports
+    // THAT, not this): the source_lock's seeds omit the backing, so it is shared across hubs. A lock still
+    // live (reserved_until >= now) means another unclaimed reservation on this miner already holds this
+    // (from_chain, from_addr) — reject the duplicate. A stale/`< now` (or freshly-init 0) lock is ours.
+    require!(
+        ctx.accounts.source_lock.reserved_until < now,
+        ErrorCode::DuplicateSourceAddr
+    );
+
     let ttl = cfg.reservation_ttl_secs;
     let extension_budget = cfg.max_total_extension_secs;
     let miner_key = ctx.accounts.miner.key();
@@ -208,8 +210,9 @@ pub fn handler(
         (r.from_chain.clone(), r.to_chain.clone(), r.reserved_until, r.collateral_chain.clone())
     };
 
-    // V-C2: hold this (from_chain, from_addr) for the fill's live window. A colliding finalize (any hub)
-    // seeds the same lock and reverts above until this lapses.
+    // V-C2: hold this (from_chain, from_addr) for the reservation's live window. extend_reservation slides
+    // this lock forward in lockstep with reserved_until, so an extended reservation can never outlive its
+    // lock and re-open the cross-hub collision. A colliding finalize on any hub reverts until it lapses.
     ctx.accounts.source_lock.reserved_until = reserved_until;
     ctx.accounts.source_lock.bump = ctx.bumps.source_lock;
 

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/finalize_reservation.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/finalize_reservation.rs
@@ -1,20 +1,32 @@
 use anchor_lang::prelude::*;
 
 use crate::backing;
+use solana_keccak_hasher::hashv;
+
 use crate::constants::{
-    required_collateral, ATTEST_SEED, CONFIG_SEED, MAX_ADDR_LEN, MINER_SEED, RESV_SEED,
+    required_collateral, ATTEST_SEED, CONFIG_SEED, MAX_ADDR_LEN, MINER_SEED, RESV_SEED, SRCLOCK_SEED,
 };
 use crate::error::ErrorCode;
 use crate::events::ReservationFilled;
-use crate::state::{BondAttestation, Config, MinerState, Reservation};
+use crate::state::{BondAttestation, Config, MinerState, Reservation, SourceLock};
 
 /// The seat winner (`reservation.router`) fills the reservation it won at the draw: names the taker +
 /// amounts and sets `reserved_until`, making the reservation live (sendable/claimable). Only the router
 /// may call this. The swap-size bounds + collateral gate + the collateral bind run here — the amount
 /// is unknown at bid time, so these moved from `open_or_request`.
 #[derive(Accounts)]
+#[instruction(
+    user: Pubkey,
+    user_from_addr: String,
+    user_to_addr: String,
+    collateral_amount: u64,
+    from_amount: u128,
+    to_amount: u128,
+    from_addr_hash: [u8; 32],
+)]
 pub struct FinalizeReservation<'info> {
     /// The seat winner. Must equal `reservation.router` (constraint below).
+    #[account(mut)]
     pub router: Signer<'info>,
 
     #[account(seeds = [CONFIG_SEED], bump = config.bump)]
@@ -46,6 +58,21 @@ pub struct FinalizeReservation<'info> {
         bump,
     )]
     pub attestation: Option<Account<'info, BondAttestation>>,
+
+    /// V-C2 source lock, keyed by (miner, from_chain, keccak(from_addr)) — NOT by backing, so it is the
+    /// SAME PDA for a colliding reservation on ANY other hub sharing that source chain, but distinct for a
+    /// concurrent swap on a different from_chain (a deposit is chain-specific; one can't satisfy both).
+    /// `init_if_needed` reuses a stale lock; the handler rejects a still-live one and verifies the hash.
+    #[account(
+        init_if_needed,
+        payer = router,
+        space = 8 + SourceLock::INIT_SPACE,
+        seeds = [SRCLOCK_SEED, miner.key().as_ref(), reservation.from_chain.as_bytes(), from_addr_hash.as_ref()],
+        bump,
+    )]
+    pub source_lock: Account<'info, SourceLock>,
+
+    pub system_program: Program<'info, System>,
 }
 
 pub fn handler(
@@ -56,6 +83,7 @@ pub fn handler(
     collateral_amount: u64,
     from_amount: u128,
     to_amount: u128,
+    from_addr_hash: [u8; 32],
 ) -> Result<()> {
     require!(!ctx.accounts.config.halted, ErrorCode::SystemHalted);
     require!(
@@ -66,6 +94,12 @@ pub fn handler(
         user_from_addr.len() <= MAX_ADDR_LEN && user_to_addr.len() <= MAX_ADDR_LEN,
         ErrorCode::StringTooLong
     );
+    // V-C2: `from_addr_hash` seeds the source_lock PDA, so bind it to the real address (as swap_key binds
+    // to from_tx_hash) — else a caller could seed a lock for a DIFFERENT address than it declares.
+    require!(
+        from_addr_hash == hashv(&[user_from_addr.as_bytes()]).to_bytes(),
+        ErrorCode::SourceHashMismatch
+    );
 
     // Self-dealing guard: a miner may not be its own taker. Two tiny self-swaps would otherwise buy
     // permanent eligibility (successful_swaps >= 2) and pad fill volume at zero real cost. A sybil
@@ -73,8 +107,24 @@ pub fn handler(
     // that half. Also reject the default pubkey: a timeout would "refund" the slash to the burn address.
     require!(user != ctx.accounts.miner.key(), ErrorCode::SelfSwapNotAllowed);
     require!(user != Pubkey::default(), ErrorCode::InvalidUser);
+    // H1 (V-H1) on-chain backstop: a taker's payout address must differ from the miner's own delivery
+    // address (pinned on the reservation at draw). Equal addresses make the miner "deliver to itself" —
+    // a self-represented taker (who skips the validator's normalized reserve-time gate) could poison it
+    // into a false non-delivery slash or a collusion volume-farm. Raw compare: fully effective on
+    // case-sensitive chains; EVM case-variants stay covered by the validator's normalized routed check.
+    require!(
+        user_to_addr != ctx.accounts.reservation.miner_to_addr,
+        ErrorCode::DestEqualsMinerAddr
+    );
 
     let now = Clock::get()?.unix_timestamp;
+    // V-C2: the source_lock's seeds omit the backing, so it is shared across hubs. A lock still live
+    // (reserved_until in the future) means another unclaimed reservation on this miner already holds this
+    // (from_chain, from_addr) — reject the duplicate. A stale/`< now` (or freshly-init 0) lock is ours.
+    require!(
+        ctx.accounts.source_lock.reserved_until < now,
+        ErrorCode::DuplicateSourceAddr
+    );
     let cfg = &ctx.accounts.config;
 
     // Fill exactly once, and only inside the finalize window. Both sentinels are load-bearing:
@@ -157,6 +207,11 @@ pub fn handler(
         r.max_extend_at = r.reserved_until.saturating_add(extension_budget);
         (r.from_chain.clone(), r.to_chain.clone(), r.reserved_until, r.collateral_chain.clone())
     };
+
+    // V-C2: hold this (from_chain, from_addr) for the fill's live window. A colliding finalize (any hub)
+    // seeds the same lock and reverts above until this lapses.
+    ctx.accounts.source_lock.reserved_until = reserved_until;
+    ctx.accounts.source_lock.bump = ctx.bumps.source_lock;
 
     // Tighten the hub's busy lock to the filled reservation's actual life. The bid set it
     // conservatively to cover the whole finalize window; now that we've filled, `now + ttl` is exact

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/submit_swap_claim.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/submit_swap_claim.rs
@@ -119,6 +119,7 @@ pub fn handler(
     swap.max_extend_at = 0;
     swap.fulfilled_at = 0;
     swap.bump = swap_bump;
+    swap.hotkey = [0u8; 32]; // pinned from the Binding at vote_initiate (V-M1)
 
     ctx.accounts.reservation.claimed_swap_key = swap_key;
 

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/timeout_swap.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/timeout_swap.rs
@@ -88,6 +88,7 @@ pub fn handler(ctx: Context<TimeoutSwap>, swap_key: [u8; 32]) -> Result<()> {
         let miner = ctx.accounts.swap.miner;
         let min_collateral = ctx.accounts.config.min_collateral;
         let collateral_chain = ctx.accounts.swap.collateral_chain.clone();
+        let hotkey = ctx.accounts.swap.hotkey;
 
         // v2 #4: a failed swap is penalized at the over-collateralization multiplier (1.10×), and
         // the entire slash is refunded to the wronged user (made more than whole). The 1.1× initiate
@@ -159,6 +160,7 @@ pub fn handler(ctx: Context<TimeoutSwap>, swap_key: [u8; 32]) -> Result<()> {
             penalty,
             reimbursement,
             payee,
+            hotkey,
         });
     }
     Ok(())

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/vote_initiate.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/vote_initiate.rs
@@ -2,11 +2,13 @@ use anchor_lang::prelude::*;
 
 use crate::consensus::{record_vote, swap_request_hash};
 use crate::constants::{
-    ATTEST_SEED, CONFIG_SEED, MINER_SEED, REQ_INITIATE, RESV_SEED, SWAP_SEED, VOTE_SEED,
+    ATTEST_SEED, BIND_SEED, CONFIG_SEED, MINER_SEED, REQ_INITIATE, RESV_SEED, SWAP_SEED, VOTE_SEED,
 };
 use crate::error::ErrorCode;
 use crate::events::SwapInitiated;
-use crate::state::{BondAttestation, Config, MinerState, Reservation, Swap, SwapStatus, VoteRound};
+use crate::state::{
+    Binding, BondAttestation, Config, MinerState, Reservation, Swap, SwapStatus, VoteRound,
+};
 
 /// Validators attest a `PendingAttestation` claim: confirm the source-chain deposit is real and, on
 /// quorum, promote the swap to `Active` — where the miner's obligation (`timeout_at`) begins. All terms
@@ -65,6 +67,11 @@ pub struct VoteInitiate<'info> {
         bump,
     )]
     pub attestation: Option<Box<Account<'info, BondAttestation>>>,
+
+    /// CHECK: the miner's Binding PDA, seeds-checked; may be uninitialized (never-bound miner →
+    /// the swap pins a zeroed hotkey). Read at quorum so the verdict names the bonded hotkey (V-M1).
+    #[account(seeds = [BIND_SEED, miner.key().as_ref()], bump)]
+    pub binding: UncheckedAccount<'info>,
 
     pub system_program: Program<'info, System>,
 }
@@ -141,11 +148,19 @@ pub fn handler(ctx: Context<VoteInitiate>, swap_key: [u8; 32]) -> Result<()> {
         let to_amount = ctx.accounts.swap.to_amount;
         let collateral_chain = ctx.accounts.swap.collateral_chain.clone();
 
+        // V-M1: pin the bonded hotkey the moment the obligation binds. The binding is set-once, so
+        // this equals every validator's view and a later rebind can never move the seizure.
+        let pinned_hotkey = {
+            let data = ctx.accounts.binding.try_borrow_data()?;
+            Binding::try_deserialize(&mut &data[..]).map(|b| b.hotkey).unwrap_or_default()
+        };
+
         let swap = &mut ctx.accounts.swap;
         swap.status = SwapStatus::Active;
         swap.initiated_at = now;
         swap.timeout_at = timeout_at;
         swap.max_extend_at = max_extend_at;
+        swap.hotkey = pinned_hotkey;
 
         let bit = crate::backing::backing_bit(&ctx.accounts.swap.collateral_chain)?;
         ctx.accounts.miner_state.set_swap(bit, true);

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/vote_initiate.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/vote_initiate.rs
@@ -1,13 +1,14 @@
 use anchor_lang::prelude::*;
+use solana_keccak_hasher::hashv;
 
 use crate::consensus::{record_vote, swap_request_hash};
 use crate::constants::{
-    ATTEST_SEED, BIND_SEED, CONFIG_SEED, MINER_SEED, REQ_INITIATE, RESV_SEED, SWAP_SEED, VOTE_SEED,
+    ATTEST_SEED, BIND_SEED, CONFIG_SEED, MINER_SEED, REQ_INITIATE, RESV_SEED, SRCLOCK_SEED, SWAP_SEED, VOTE_SEED,
 };
 use crate::error::ErrorCode;
 use crate::events::SwapInitiated;
 use crate::state::{
-    Binding, BondAttestation, Config, MinerState, Reservation, Swap, SwapStatus, VoteRound,
+    Binding, BondAttestation, Config, MinerState, Reservation, SourceLock, Swap, SwapStatus, VoteRound,
 };
 
 /// Validators attest a `PendingAttestation` claim: confirm the source-chain deposit is real and, on
@@ -15,7 +16,7 @@ use crate::state::{
 /// are already on the claim-created Swap (copied from the immutable reservation), so the bound hash is
 /// trivial (`swap_key`) and no payout can be redirected at attestation.
 #[derive(Accounts)]
-#[instruction(swap_key: [u8; 32])]
+#[instruction(swap_key: [u8; 32], from_addr_hash: [u8; 32])]
 pub struct VoteInitiate<'info> {
     #[account(mut)]
     pub validator: Signer<'info>,
@@ -40,6 +41,16 @@ pub struct VoteInitiate<'info> {
         bump,
     )]
     pub reservation: Box<Account<'info, Reservation>>,
+
+    /// V-C2: this reservation's source lock (created at finalize). Released at initiate quorum — the
+    /// deposit is hash-bound to the swap, so a repeat swap from the same source needn't wait out the
+    /// original reserved_until. The clock stays the backstop for reservations that never initiate.
+    #[account(
+        mut,
+        seeds = [SRCLOCK_SEED, miner.key().as_ref(), reservation.from_chain.as_bytes(), from_addr_hash.as_ref()],
+        bump = source_lock.bump,
+    )]
+    pub source_lock: Account<'info, SourceLock>,
 
     /// Keyed by swap_key like the confirm/timeout rounds (v3.1): per-hub for free (a swap pins its
     /// backing), and closable at quorum since the unique seed is never reused.
@@ -76,7 +87,7 @@ pub struct VoteInitiate<'info> {
     pub system_program: Program<'info, System>,
 }
 
-pub fn handler(ctx: Context<VoteInitiate>, swap_key: [u8; 32]) -> Result<()> {
+pub fn handler(ctx: Context<VoteInitiate>, swap_key: [u8; 32], from_addr_hash: [u8; 32]) -> Result<()> {
     require!(
         ctx.accounts.swap.status == SwapStatus::PendingAttestation,
         ErrorCode::NotPending
@@ -93,6 +104,11 @@ pub fn handler(ctx: Context<VoteInitiate>, swap_key: [u8; 32]) -> Result<()> {
             ErrorCode::NoReservation
         );
         require!(resv.claimed_swap_key == swap_key, ErrorCode::NotPending);
+        // Bind from_addr_hash to the reservation's real source before it targets the lock (swap_key idiom).
+        require!(
+            from_addr_hash == hashv(&[resv.from_addr.as_bytes()]).to_bytes(),
+            ErrorCode::SourceHashMismatch
+        );
         // Never obligate a removed miner (defense-in-depth; resolve_pool also refuses an inactive miner).
         require!(ctx.accounts.miner_state.active, ErrorCode::MinerNotActive);
         // Self-dealing backstop (finalize_reservation is the primary guard; this also covers
@@ -172,6 +188,9 @@ pub fn handler(ctx: Context<VoteInitiate>, swap_key: [u8; 32]) -> Result<()> {
             .add_reserved(bit, crate::constants::required_collateral(collateral_amount))?;
         ctx.accounts.reservation.reserved_until = 0; // consume the reservation
         ctx.accounts.reservation.claimed_swap_key = [0u8; 32];
+        // V-C2: the deposit is now hash-bound to the swap — release the source lock with the
+        // reservation, so a repeat swap from this source needn't wait out the old deadline.
+        ctx.accounts.source_lock.reserved_until = 0;
         // Unique swap_key seed → the round is never reused; close it and refund rent, like the
         // confirm/timeout rounds. A straggler's late vote reverts on the NotPending status gate
         // above before it could re-create the round.

--- a/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
@@ -233,8 +233,8 @@ pub mod allways_swap_manager {
     }
     /// Validators attest a pending claim (`PendingAttestation` → `Active` on quorum); the miner's
     /// obligation deadline starts here.
-    pub fn vote_initiate(ctx: Context<VoteInitiate>, swap_key: [u8; 32]) -> Result<()> {
-        vote_initiate::handler(ctx, swap_key)
+    pub fn vote_initiate(ctx: Context<VoteInitiate>, swap_key: [u8; 32], from_addr_hash: [u8; 32]) -> Result<()> {
+        vote_initiate::handler(ctx, swap_key, from_addr_hash)
     }
     /// Permissionless: reap an orphaned `PendingAttestation` claim whose reservation expired (rent →
     /// caller; frees the reservation's claim slot).

--- a/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
@@ -272,8 +272,12 @@ pub mod allways_swap_manager {
     // --- Deadline extensions (single validator, no quorum; bounded by a frozen ceiling) ---
     /// A validator slides a reservation's deadline forward while it waits on slow source-chain
     /// confirmation. Bounded by the per-reservation ceiling frozen at creation.
-    pub fn extend_reservation(ctx: Context<ExtendReservation>, target_at: i64) -> Result<()> {
-        extend_reservation::handler(ctx, target_at)
+    pub fn extend_reservation(
+        ctx: Context<ExtendReservation>,
+        target_at: i64,
+        from_addr_hash: [u8; 32],
+    ) -> Result<()> {
+        extend_reservation::handler(ctx, target_at, from_addr_hash)
     }
     /// A validator slides a swap's fulfillment timeout forward while it waits on slow destination-chain
     /// confirmation. Bounded by the per-swap ceiling frozen at creation.

--- a/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/lib.rs
@@ -202,6 +202,7 @@ pub mod allways_swap_manager {
         collateral_amount: u64,
         from_amount: u128,
         to_amount: u128,
+        from_addr_hash: [u8; 32],
     ) -> Result<()> {
         finalize_reservation::handler(
             ctx,
@@ -211,6 +212,7 @@ pub mod allways_swap_manager {
             collateral_amount,
             from_amount,
             to_amount,
+            from_addr_hash,
         )
     }
     /// Permissionless: reap an unfilled reservation past its finalize deadline, freeing the miner.

--- a/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
@@ -352,8 +352,10 @@ pub struct Reservation {
 /// V-C2 on-chain source-address lock (`seeds = [SRCLOCK_SEED, miner, from_chain, keccak(from_addr)]`).
 /// `finalize_reservation` claims it so a live-unclaimed reservation holds a `(from_chain, from_addr)`
 /// exclusively per miner — a second reservation (any backing/hub) declaring the same source finds a live
-/// lock and reverts. `reserved_until` is the staleness marker: a lock at or past it is free to reclaim,
-/// so a lapsed reservation never permanently strands its source. Reused across rounds (never closed).
+/// lock and reverts. `reserved_until` mirrors the holding reservation's `reserved_until` and is slid
+/// forward by `extend_reservation` in lockstep, so an extended reservation can't outlive its lock; a lock
+/// at or past `now` is free to reclaim, so a lapsed reservation never permanently strands its source.
+/// Reused across rounds (never closed).
 #[account]
 #[derive(InitSpace)]
 pub struct SourceLock {

--- a/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
@@ -349,6 +349,19 @@ pub struct Reservation {
     pub bump: u8,
 }
 
+/// V-C2 on-chain source-address lock (`seeds = [SRCLOCK_SEED, miner, from_chain, keccak(from_addr)]`).
+/// `finalize_reservation` claims it so a live-unclaimed reservation holds a `(from_chain, from_addr)`
+/// exclusively per miner — a second reservation (any backing/hub) declaring the same source finds a live
+/// lock and reverts. `reserved_until` is the staleness marker: a lock at or past it is free to reclaim,
+/// so a lapsed reservation never permanently strands its source. Reused across rounds (never closed).
+#[account]
+#[derive(InitSpace)]
+pub struct SourceLock {
+    /// The holding reservation's `reserved_until`; a lock `< now` is stale and reclaimable.
+    pub reserved_until: i64,
+    pub bump: u8,
+}
+
 /// Swap lifecycle status. `PendingAttestation` = source-tx claim recorded, not yet attested (no miner
 /// obligation). Terminal states (Completed/TimedOut) aren't stored — the Swap PDA is closed on
 /// confirm/timeout. New variant appended last to keep Active/Fulfilled discriminants stable.

--- a/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
@@ -418,6 +418,9 @@ pub struct Swap {
     pub max_extend_at: i64,
     pub fulfilled_at: i64,
     pub bump: u8,
+    /// Bittensor hotkey pinned from the miner's Binding at initiate ([0;32] = never bound), so the
+    /// timeout verdict names the bonded hotkey itself (V-M1). Appended last (Config precedent).
+    pub hotkey: [u8; 32],
 }
 
 // (Removed: the permanent `TxMarker` source-replay marker — A4. Source replay is now blocked by a
@@ -495,7 +498,7 @@ pub struct MinerDirectionStats {
 /// Bittensor hotkey. `hotkey_sig` is an sr25519 signature by the hotkey over the miner's Solana pubkey;
 /// the contract only STORES it (sr25519 verify is too costly on-chain) — the validator verifies it
 /// off-chain. This PDA enforces pubkey→≤1 hotkey structurally; the reverse (hotkey→≤1 pubkey) is enforced
-/// by the `HotkeyBinding` marker below. The miner may re-bind in place (refresh sig / change hotkey).
+/// by the `HotkeyBinding` marker below. The hotkey is set-once (V-M1); only the sig may refresh in place.
 #[account]
 #[derive(InitSpace)]
 pub struct Binding {

--- a/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
@@ -354,7 +354,7 @@ pub struct Reservation {
 /// exclusively per miner — a second reservation (any backing/hub) declaring the same source finds a live
 /// lock and reverts. `reserved_until` mirrors the holding reservation's `reserved_until` and is slid
 /// forward by `extend_reservation` in lockstep, so an extended reservation can't outlive its lock; a lock
-/// at or past `now` is free to reclaim, so a lapsed reservation never permanently strands its source.
+/// whose `reserved_until < now` is free to reclaim, so a lapsed reservation never permanently strands its source.
 /// Reused across rounds (never closed).
 #[account]
 #[derive(InitSpace)]
@@ -375,8 +375,9 @@ pub enum SwapStatus {
 }
 
 /// An in-flight swap (`seeds = [SWAP_SEED, swap_key]`, swap_key = keccak(from_tx_hash)).
-/// Created by `vote_initiate` on quorum; closed by `confirm_swap` / `timeout_swap`. Chains/amounts/
-/// miner-quote copied from the immutable Reservation; user-side fields from the hash-bound initiate vote.
+/// Created by `submit_swap_claim` (PendingAttestation), activated by `vote_initiate` on quorum, closed
+/// by `confirm_swap` / `timeout_swap`. Chains/amounts/miner-quote copied from the immutable Reservation;
+/// user-side fields from the hash-bound initiate vote.
 #[account]
 #[derive(InitSpace)]
 pub struct Swap {

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
@@ -354,6 +354,7 @@ fn initiate_ix(validator: &Pubkey, miner: &Pubkey, from_tx_hash: &str) -> Instru
             vote_round: vote_pda(REQ_INITIATE, &key),
             swap: swap_pda(&key),
             attestation: None,
+            binding: bind_pda(miner),
             system_program: SYSTEM_PROGRAM,
         }
         .to_account_metas(None),

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
@@ -344,13 +344,22 @@ fn initiate_ix(validator: &Pubkey, miner: &Pubkey, from_tx_hash: &str) -> Instru
     let key = swap_key(from_tx_hash);
     Instruction::new_with_bytes(
         pid(),
-        &allways_swap_manager::instruction::VoteInitiate { swap_key: key }.data(),
+        &allways_swap_manager::instruction::VoteInitiate {
+            swap_key: key,
+            from_addr_hash: hashv(&[FROM_ADDR.as_bytes()]).to_bytes(),
+        }
+        .data(),
         allways_swap_manager::accounts::VoteInitiate {
             validator: *validator,
             config: config_pda(),
             miner: *miner,
             miner_state: miner_pda(miner),
             reservation: resv_pda(miner),
+            source_lock: Pubkey::find_program_address(
+                &[b"srclock", miner.as_ref(), FROM_CHAIN.as_bytes(), &hashv(&[FROM_ADDR.as_bytes()]).to_bytes()],
+                &pid(),
+            )
+            .0,
             vote_round: vote_pda(REQ_INITIATE, &key),
             swap: swap_pda(&key),
             attestation: None,

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
@@ -276,6 +276,7 @@ fn finalize_ix(router: &Pubkey, miner: &Pubkey, user: &Pubkey) -> Instruction {
             collateral_amount: SOL_AMOUNT,
             from_amount: 100_000,
             to_amount: SOL_AMOUNT as u128,
+            from_addr_hash: hashv(&[FROM_ADDR.as_bytes()]).to_bytes(),
         }
         .data(),
         allways_swap_manager::accounts::FinalizeReservation {
@@ -285,6 +286,12 @@ fn finalize_ix(router: &Pubkey, miner: &Pubkey, user: &Pubkey) -> Instruction {
             miner_state: miner_pda(miner),
             reservation: resv_pda(miner),
             attestation: None,
+            source_lock: Pubkey::find_program_address(
+                &[b"srclock", miner.as_ref(), FROM_CHAIN.as_bytes(), &hashv(&[FROM_ADDR.as_bytes()]).to_bytes()],
+                &pid(),
+            )
+            .0,
+            system_program: SYSTEM_PROGRAM,
         }
         .to_account_metas(None),
     )

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_attestation.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_attestation.rs
@@ -120,6 +120,9 @@ fn legacy_pool_pda(m: &Pubkey) -> Pubkey {
 fn swap_pda(key: &[u8; 32]) -> Pubkey {
     Pubkey::find_program_address(&[b"swap", key], &pid()).0
 }
+fn bind_pda(m: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&[b"bind", m.as_ref()], &pid()).0
+}
 fn swap_key(from_tx_hash: &str) -> [u8; 32] {
     hashv(&[from_tx_hash.as_bytes()]).to_bytes()
 }
@@ -441,6 +444,7 @@ fn initiate_ix_b(
             vote_round: vote_pda(REQ_INITIATE, &key),
             swap: swap_pda(&key),
             attestation,
+            binding: bind_pda(miner),
             system_program: SYSTEM_PROGRAM,
         }
         .to_account_metas(None),
@@ -2101,6 +2105,9 @@ fn test_a_forced_tao_deactivation_leaves_the_sol_cooldown_alone() {
 
 /// Bytes v3 added to each reused slot: one `collateral_chain` String at `MAX_CHAIN_LEN`.
 const LEGACY_SHRINK: usize = 4 + MAX_CHAIN_LEN;
+/// Swap grew past v10 by `collateral_chain` (v3) AND the pinned `hotkey` (V-M1) — its legacy
+/// allocation is smaller than the live one by both.
+const SWAP_LEGACY_SHRINK: usize = LEGACY_SHRINK + 32;
 
 /// The v10 `Pool` body — no `collateral_chain`, and its seeds are the SAME as the live one's, which is
 /// the whole reason a closer is needed at all.
@@ -2466,7 +2473,7 @@ fn test_close_legacy_swap_decodes_a_v10_layout_and_reaps_it() {
     // that keys on where the walk ends instead of the allocation length.
     let mut body = Vec::new();
     legacy.serialize(&mut body).unwrap();
-    plant_legacy(&mut svm, swap_pda(&key), &Swap::DISCRIMINATOR, body, 8 + Swap::INIT_SPACE - LEGACY_SHRINK);
+    plant_legacy(&mut svm, swap_pda(&key), &Swap::DISCRIMINATOR, body, 8 + Swap::INIT_SPACE - SWAP_LEGACY_SHRINK);
 
     // Put the miner into the stranded state a surviving v10 swap leaves behind: SOL hub in-flight,
     // busy, with the swap's reservation still held. Reaping must free all of it or the hub stays bricked.
@@ -2519,6 +2526,7 @@ fn test_close_legacy_swap_refuses_a_current_layout_swap() {
         max_extend_at: BASE_TS + 7_200,
         fulfilled_at: 0,
         bump: 255,
+        hotkey: [0u8; 32],
     };
     // Padded to the real current-layout allocation (longer than a v10 Swap by exactly collateral_chain),
     // so the length gate rejects it — the whole point being the closer only ever reaps a v10-length PDA.

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_attestation.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_attestation.rs
@@ -364,6 +364,7 @@ fn finalize_ix_b(
             collateral_amount,
             from_amount,
             to_amount,
+            from_addr_hash: hashv(&["userSrcAddr".as_bytes()]).to_bytes(),
         }
         .data(),
         allways_swap_manager::accounts::FinalizeReservation {
@@ -373,6 +374,17 @@ fn finalize_ix_b(
             miner_state: miner_pda(miner),
             reservation: resv_pda_b(miner, backing),
             attestation,
+            source_lock: Pubkey::find_program_address(
+                &[
+                    b"srclock",
+                    miner.as_ref(),
+                    (if backing == SOL { SPOKE_FROM } else { HUB_FROM }).as_bytes(),
+                    &hashv(&["userSrcAddr".as_bytes()]).to_bytes(),
+                ],
+                &pid(),
+            )
+            .0,
+            system_program: SYSTEM_PROGRAM,
         }
         .to_account_metas(None),
     )

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_attestation.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_attestation.rs
@@ -434,13 +434,27 @@ fn initiate_ix_b(
     let key = swap_key(from_tx_hash);
     Instruction::new_with_bytes(
         pid(),
-        &allways_swap_manager::instruction::VoteInitiate { swap_key: key }.data(),
+        &allways_swap_manager::instruction::VoteInitiate {
+            swap_key: key,
+            from_addr_hash: hashv(&["userSrcAddr".as_bytes()]).to_bytes(),
+        }
+        .data(),
         allways_swap_manager::accounts::VoteInitiate {
             validator: *validator,
             config: config_pda(),
             miner: *miner,
             miner_state: miner_pda(miner),
             reservation: resv_pda_b(miner, backing),
+            source_lock: Pubkey::find_program_address(
+                &[
+                    b"srclock",
+                    miner.as_ref(),
+                    (if backing == SOL { SPOKE_FROM } else { HUB_FROM }).as_bytes(),
+                    &hashv(&["userSrcAddr".as_bytes()]).to_bytes(),
+                ],
+                &pid(),
+            )
+            .0,
             vote_round: vote_pda(REQ_INITIATE, &key),
             swap: swap_pda(&key),
             attestation,

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_backing.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_backing.rs
@@ -92,6 +92,27 @@ fn pool_pda(m: &Pubkey) -> Pubkey {
 fn swap_pda(key: &[u8; 32]) -> Pubkey {
     Pubkey::find_program_address(&[b"swap", key], &pid()).0
 }
+fn bind_pda(m: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&[b"bind", m.as_ref()], &pid()).0
+}
+fn hkbind_pda(hotkey: &[u8; 32]) -> Pubkey {
+    Pubkey::find_program_address(&[b"hkbind", hotkey], &pid()).0
+}
+fn bind_ix(miner: &Pubkey, hotkey: [u8; 32], hotkey_sig: [u8; 64]) -> Instruction {
+    Instruction::new_with_bytes(
+        pid(),
+        &allways_swap_manager::instruction::BindHotkey { hotkey, hotkey_sig }.data(),
+        allways_swap_manager::accounts::BindHotkey {
+            miner: *miner,
+            config: config_pda(),
+            miner_state: Some(miner_pda(miner)),
+            binding: bind_pda(miner),
+            hotkey_binding: hkbind_pda(&hotkey),
+            system_program: SYSTEM_PROGRAM,
+        }
+        .to_account_metas(None),
+    )
+}
 fn swap_key(from_tx_hash: &str) -> [u8; 32] {
     hashv(&[from_tx_hash.as_bytes()]).to_bytes()
 }
@@ -336,6 +357,7 @@ fn initiate_ix(validator: &Pubkey, miner: &Pubkey, from_tx_hash: &str) -> Instru
             vote_round: vote_pda(REQ_INITIATE, &key),
             swap: swap_pda(&key),
             attestation: None,
+            binding: bind_pda(miner),
             system_program: SYSTEM_PROGRAM,
         }
         .to_account_metas(None),
@@ -675,6 +697,49 @@ fn test_the_verdict_names_the_payee_on_the_backing_chain() {
     assert_eq!(ev.collateral_chain, "tao");
     assert_eq!(ev.payee, "userDstAddr", "TAO is the destination leg, so its address is the payee");
     assert_eq!(ev.reimbursement, required_collateral(SOL_AMOUNT), "figures unchanged by W3.1");
+}
+
+#[test]
+fn test_timeout_verdict_carries_the_hotkey_pinned_at_initiate() {
+    // V-M1: the swap pins the miner's bonded hotkey at initiate quorum and the timeout verdict
+    // emits it, so the vault seizure targets that hotkey without any live binding lookup — and the
+    // set-once binding means a post-initiate change attempt reverts instead of moving the target.
+    let (mut svm, _admin, vals, miner) = setup();
+    let hotkey = [9u8; 32];
+    send(&mut svm, bind_ix(&miner.pubkey(), hotkey, [1u8; 64]), &miner.pubkey(), &miner).expect("bind");
+
+    reserve_spoke(&mut svm, &vals[0], &miner.pubkey());
+    let initiated_at = now_ts(&svm);
+    do_initiate(&mut svm, &vals, &miner.pubkey(), "srctx1");
+    let key = swap_key("srctx1");
+    assert_eq!(swap_acct(&svm, &key).hotkey, hotkey, "hotkey pinned onto the swap at initiate");
+    set_swap_backing(&mut svm, &key, "tao");
+
+    // The dodge attempt: rebinding to a fresh hotkey mid-swap must revert (set-once binding).
+    let res = send(&mut svm, bind_ix(&miner.pubkey(), [8u8; 32], [2u8; 64]), &miner.pubkey(), &miner);
+    assert!(res.is_err(), "a mid-swap hotkey change must be refused");
+    assert_eq!(swap_acct(&svm, &key).hotkey, hotkey, "the pinned target did not move");
+
+    set_clock(&mut svm, initiated_at + TIMEOUT_SECS + 1);
+    send(&mut svm, timeout_ix(&vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER, "srctx1"), &vals[0].pubkey(), &vals[0]).expect("t0");
+    let logs = send_meta(&mut svm, timeout_ix(&vals[1].pubkey(), &miner.pubkey(), &LOTTERY_USER, "srctx1"), &vals[1].pubkey(), &vals[1]).expect("t1");
+    assert_eq!(timed_out_event(&logs).hotkey, hotkey, "the verdict names the pinned hotkey");
+}
+
+#[test]
+fn test_unbound_miner_swap_pins_a_zeroed_hotkey() {
+    // No Binding PDA: the initiate-time read degrades to zeros — the swap and its timeout still
+    // work; the relay treats a zeroed hotkey as unattributable, exactly as before the pin existed.
+    let (mut svm, _admin, vals, miner) = setup();
+    reserve_spoke(&mut svm, &vals[0], &miner.pubkey());
+    let initiated_at = now_ts(&svm);
+    do_initiate(&mut svm, &vals, &miner.pubkey(), "srctx1");
+    assert_eq!(swap_acct(&svm, &swap_key("srctx1")).hotkey, [0u8; 32]);
+
+    set_clock(&mut svm, initiated_at + TIMEOUT_SECS + 1);
+    send(&mut svm, timeout_ix(&vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER, "srctx1"), &vals[0].pubkey(), &vals[0]).expect("t0");
+    let logs = send_meta(&mut svm, timeout_ix(&vals[1].pubkey(), &miner.pubkey(), &LOTTERY_USER, "srctx1"), &vals[1].pubkey(), &vals[1]).expect("t1");
+    assert_eq!(timed_out_event(&logs).hotkey, [0u8; 32]);
 }
 
 #[test]

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_backing.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_backing.rs
@@ -252,6 +252,7 @@ fn resolve_ix(caller: &Pubkey, miner: &Pubkey) -> Instruction {
     )
 }
 fn finalize_ix(
+    from_chain: &str,
     router: &Pubkey,
     miner: &Pubkey,
     user: &Pubkey,
@@ -259,10 +260,11 @@ fn finalize_ix(
     from_amount: u128,
     to_amount: u128,
 ) -> Instruction {
-    finalize_ix_b("sol", router, miner, user, collateral_amount, from_amount, to_amount)
+    finalize_ix_b("sol", from_chain, router, miner, user, collateral_amount, from_amount, to_amount)
 }
 fn finalize_ix_b(
     backing: &str,
+    from_chain: &str,
     router: &Pubkey,
     miner: &Pubkey,
     user: &Pubkey,
@@ -279,6 +281,7 @@ fn finalize_ix_b(
             collateral_amount,
             from_amount,
             to_amount,
+            from_addr_hash: hashv(&["userSrcAddr".as_bytes()]).to_bytes(),
         }
         .data(),
         allways_swap_manager::accounts::FinalizeReservation {
@@ -288,6 +291,12 @@ fn finalize_ix_b(
             miner_state: miner_pda(miner),
             reservation: resv_pda_b(miner, backing),
             attestation: None,
+            source_lock: Pubkey::find_program_address(
+                &[b"srclock", miner.as_ref(), from_chain.as_bytes(), &hashv(&["userSrcAddr".as_bytes()]).to_bytes()],
+                &pid(),
+            )
+            .0,
+            system_program: SYSTEM_PROGRAM,
         }
         .to_account_metas(None),
     )
@@ -512,7 +521,7 @@ fn reserve_spoke(svm: &mut LiteSVM, val: &Keypair, miner: &Pubkey) {
     draw(svm, val, miner, SPOKE_FROM, SPOKE_TO);
     send(
         svm,
-        finalize_ix(&val.pubkey(), miner, &LOTTERY_USER, SOL_AMOUNT, OTHER_AMOUNT, SOL_AMOUNT as u128),
+        finalize_ix(SPOKE_FROM, &val.pubkey(), miner, &LOTTERY_USER, SOL_AMOUNT, OTHER_AMOUNT, SOL_AMOUNT as u128),
         &val.pubkey(),
         val,
     )
@@ -539,7 +548,7 @@ fn test_backing_defaults_to_sol_and_is_pinned_through_the_swap() {
 
     send(
         &mut svm,
-        finalize_ix(&vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER, SOL_AMOUNT, OTHER_AMOUNT, SOL_AMOUNT as u128),
+        finalize_ix(SPOKE_FROM, &vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER, SOL_AMOUNT, OTHER_AMOUNT, SOL_AMOUNT as u128),
         &vals[0].pubkey(),
         &vals[0],
     )
@@ -649,7 +658,7 @@ fn test_the_verdict_names_the_payee_on_the_backing_chain() {
     draw(&mut svm, &vals[0], &miner.pubkey(), HUB_FROM, HUB_TO);
     send(
         &mut svm,
-        finalize_ix(&vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER, SOL_AMOUNT, SOL_AMOUNT as u128, TAO_AMOUNT),
+        finalize_ix(HUB_FROM, &vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER, SOL_AMOUNT, SOL_AMOUNT as u128, TAO_AMOUNT),
         &vals[0].pubkey(),
         &vals[0],
     )
@@ -711,7 +720,7 @@ fn test_swap_bounds_are_selected_by_backing_not_converted() {
     draw(&mut svm, &vals[0], &miner.pubkey(), HUB_FROM, HUB_TO);
     send(
         &mut svm,
-        finalize_ix(&vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER, SOL_AMOUNT, SOL_AMOUNT as u128, TAO_AMOUNT),
+        finalize_ix(HUB_FROM, &vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER, SOL_AMOUNT, SOL_AMOUNT as u128, TAO_AMOUNT),
         &vals[0].pubkey(),
         &vals[0],
     )
@@ -730,7 +739,7 @@ fn test_swap_bounds_are_selected_by_backing_not_converted() {
     set_reservation_backing(&mut svm, &miner.pubkey(), "tao");
     let err = send(
         &mut svm,
-        finalize_ix_b("tao", &vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER, TAO_AMOUNT as u64, SOL_AMOUNT as u128, TAO_AMOUNT),
+        finalize_ix_b("tao", HUB_FROM, &vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER, TAO_AMOUNT as u64, SOL_AMOUNT as u128, TAO_AMOUNT),
         &vals[0].pubkey(),
         &vals[0],
     )
@@ -751,7 +760,7 @@ fn test_swap_bounds_are_selected_by_backing_not_converted() {
     .expect("lower tao min");
     let err = send(
         &mut svm,
-        finalize_ix_b("tao", &vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER, TAO_AMOUNT as u64, SOL_AMOUNT as u128, TAO_AMOUNT),
+        finalize_ix_b("tao", HUB_FROM, &vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER, TAO_AMOUNT as u64, SOL_AMOUNT as u128, TAO_AMOUNT),
         &vals[0].pubkey(),
         &vals[0],
     )
@@ -767,7 +776,7 @@ fn test_collateral_binds_to_the_backing_leg_on_either_side_of_the_pair() {
     draw(&mut svm, &vals[0], &miner.pubkey(), HUB_FROM, HUB_TO);
     let err = send(
         &mut svm,
-        finalize_ix(&vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER, TAO_AMOUNT as u64, SOL_AMOUNT as u128, TAO_AMOUNT),
+        finalize_ix(HUB_FROM, &vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER, TAO_AMOUNT as u64, SOL_AMOUNT as u128, TAO_AMOUNT),
         &vals[0].pubkey(),
         &vals[0],
     )
@@ -781,7 +790,7 @@ fn test_collateral_binds_to_the_backing_leg_on_either_side_of_the_pair() {
     set_reservation_backing(&mut svm, &miner.pubkey(), "tao"); // btc→sol, backed by TAO
     let err = send(
         &mut svm,
-        finalize_ix_b("tao", &vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER, TAO_AMOUNT as u64, OTHER_AMOUNT, SOL_AMOUNT as u128),
+        finalize_ix_b("tao", SPOKE_FROM, &vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER, TAO_AMOUNT as u64, OTHER_AMOUNT, SOL_AMOUNT as u128),
         &vals[0].pubkey(),
         &vals[0],
     )
@@ -798,7 +807,7 @@ fn test_unsupported_backing_is_refused_at_finalize_and_at_initiate() {
     set_reservation_backing(&mut svm, &miner.pubkey(), "btc");
     let err = send(
         &mut svm,
-        finalize_ix_b("btc", &vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER, OTHER_AMOUNT as u64, OTHER_AMOUNT, SOL_AMOUNT as u128),
+        finalize_ix_b("btc", SPOKE_FROM, &vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER, OTHER_AMOUNT as u64, OTHER_AMOUNT, SOL_AMOUNT as u128),
         &vals[0].pubkey(),
         &vals[0],
     )

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_backing.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_backing.rs
@@ -343,17 +343,26 @@ fn claim_ix(caller: &Pubkey, miner: &Pubkey, from_tx_hash: &str) -> Instruction 
         .to_account_metas(None),
     )
 }
-fn initiate_ix(validator: &Pubkey, miner: &Pubkey, from_tx_hash: &str) -> Instruction {
+fn initiate_ix(validator: &Pubkey, miner: &Pubkey, from_tx_hash: &str, from_chain: &str) -> Instruction {
     let key = swap_key(from_tx_hash);
     Instruction::new_with_bytes(
         pid(),
-        &allways_swap_manager::instruction::VoteInitiate { swap_key: key }.data(),
+        &allways_swap_manager::instruction::VoteInitiate {
+            swap_key: key,
+            from_addr_hash: hashv(&["userSrcAddr".as_bytes()]).to_bytes(),
+        }
+        .data(),
         allways_swap_manager::accounts::VoteInitiate {
             validator: *validator,
             config: config_pda(),
             miner: *miner,
             miner_state: miner_pda(miner),
             reservation: resv_pda(miner),
+            source_lock: Pubkey::find_program_address(
+                &[b"srclock", miner.as_ref(), from_chain.as_bytes(), &hashv(&["userSrcAddr".as_bytes()]).to_bytes()],
+                &pid(),
+            )
+            .0,
             vote_round: vote_pda(REQ_INITIATE, &key),
             swap: swap_pda(&key),
             attestation: None,
@@ -550,10 +559,10 @@ fn reserve_spoke(svm: &mut LiteSVM, val: &Keypair, miner: &Pubkey) {
     .expect("finalize");
 }
 
-fn do_initiate(svm: &mut LiteSVM, vals: &[Keypair], miner: &Pubkey, tx: &str) {
+fn do_initiate(svm: &mut LiteSVM, vals: &[Keypair], miner: &Pubkey, tx: &str, from_chain: &str) {
     send(svm, claim_ix(&vals[0].pubkey(), miner, tx), &vals[0].pubkey(), &vals[0]).expect("claim");
-    send(svm, initiate_ix(&vals[0].pubkey(), miner, tx), &vals[0].pubkey(), &vals[0]).expect("i0");
-    send(svm, initiate_ix(&vals[1].pubkey(), miner, tx), &vals[1].pubkey(), &vals[1]).expect("i1");
+    send(svm, initiate_ix(&vals[0].pubkey(), miner, tx, from_chain), &vals[0].pubkey(), &vals[0]).expect("i0");
+    send(svm, initiate_ix(&vals[1].pubkey(), miner, tx, from_chain), &vals[1].pubkey(), &vals[1]).expect("i1");
 }
 
 #[test]
@@ -579,8 +588,8 @@ fn test_backing_defaults_to_sol_and_is_pinned_through_the_swap() {
 
     let key = swap_key("srctx1");
     assert_eq!(swap_acct(&svm, &key).collateral_chain, "sol", "copied Reservation → Swap");
-    send(&mut svm, initiate_ix(&vals[0].pubkey(), &miner.pubkey(), "srctx1"), &vals[0].pubkey(), &vals[0]).expect("i0");
-    send(&mut svm, initiate_ix(&vals[1].pubkey(), &miner.pubkey(), "srctx1"), &vals[1].pubkey(), &vals[1]).expect("i1");
+    send(&mut svm, initiate_ix(&vals[0].pubkey(), &miner.pubkey(), "srctx1", SPOKE_FROM), &vals[0].pubkey(), &vals[0]).expect("i0");
+    send(&mut svm, initiate_ix(&vals[1].pubkey(), &miner.pubkey(), "srctx1", SPOKE_FROM), &vals[1].pubkey(), &vals[1]).expect("i1");
     assert_eq!(swap_acct(&svm, &key).collateral_chain, "sol", "immutable across attestation");
 }
 
@@ -591,7 +600,7 @@ fn test_sol_backed_timeout_still_slashes_refunds_and_frees() {
     let (mut svm, _admin, vals, miner) = setup();
     reserve_spoke(&mut svm, &vals[0], &miner.pubkey());
     let initiated_at = now_ts(&svm);
-    do_initiate(&mut svm, &vals, &miner.pubkey(), "srctx1");
+    do_initiate(&mut svm, &vals, &miner.pubkey(), "srctx1", SPOKE_FROM);
 
     set_clock(&mut svm, initiated_at + TIMEOUT_SECS + 1);
     let coll_before = miner_state(&svm, &miner.pubkey()).collateral;
@@ -631,7 +640,7 @@ fn test_non_sol_backed_timeout_is_verdict_only_and_holds_the_miner() {
     let (mut svm, _admin, vals, miner) = setup();
     reserve_spoke(&mut svm, &vals[0], &miner.pubkey());
     let initiated_at = now_ts(&svm);
-    do_initiate(&mut svm, &vals, &miner.pubkey(), "srctx1");
+    do_initiate(&mut svm, &vals, &miner.pubkey(), "srctx1", SPOKE_FROM);
     set_swap_backing(&mut svm, &swap_key("srctx1"), "tao");
 
     let timeout_ts = initiated_at + TIMEOUT_SECS + 1;
@@ -686,7 +695,7 @@ fn test_the_verdict_names_the_payee_on_the_backing_chain() {
     )
     .expect("finalize the hub pair");
     let initiated_at = now_ts(&svm);
-    do_initiate(&mut svm, &vals, &miner.pubkey(), "srctx1");
+    do_initiate(&mut svm, &vals, &miner.pubkey(), "srctx1", HUB_FROM);
     set_swap_backing(&mut svm, &swap_key("srctx1"), "tao");
 
     set_clock(&mut svm, initiated_at + TIMEOUT_SECS + 1);
@@ -710,7 +719,7 @@ fn test_timeout_verdict_carries_the_hotkey_pinned_at_initiate() {
 
     reserve_spoke(&mut svm, &vals[0], &miner.pubkey());
     let initiated_at = now_ts(&svm);
-    do_initiate(&mut svm, &vals, &miner.pubkey(), "srctx1");
+    do_initiate(&mut svm, &vals, &miner.pubkey(), "srctx1", SPOKE_FROM);
     let key = swap_key("srctx1");
     assert_eq!(swap_acct(&svm, &key).hotkey, hotkey, "hotkey pinned onto the swap at initiate");
     set_swap_backing(&mut svm, &key, "tao");
@@ -733,7 +742,7 @@ fn test_unbound_miner_swap_pins_a_zeroed_hotkey() {
     let (mut svm, _admin, vals, miner) = setup();
     reserve_spoke(&mut svm, &vals[0], &miner.pubkey());
     let initiated_at = now_ts(&svm);
-    do_initiate(&mut svm, &vals, &miner.pubkey(), "srctx1");
+    do_initiate(&mut svm, &vals, &miner.pubkey(), "srctx1", SPOKE_FROM);
     assert_eq!(swap_acct(&svm, &swap_key("srctx1")).hotkey, [0u8; 32]);
 
     set_clock(&mut svm, initiated_at + TIMEOUT_SECS + 1);
@@ -884,7 +893,7 @@ fn test_unsupported_backing_is_refused_at_finalize_and_at_initiate() {
     reserve_spoke(&mut svm, &vals[0], &miner.pubkey());
     send(&mut svm, claim_ix(&vals[0].pubkey(), &miner.pubkey(), "srctx1"), &vals[0].pubkey(), &vals[0]).expect("claim");
     set_swap_backing(&mut svm, &swap_key("srctx1"), "btc");
-    let err = send(&mut svm, initiate_ix(&vals[0].pubkey(), &miner.pubkey(), "srctx1"), &vals[0].pubkey(), &vals[0])
+    let err = send(&mut svm, initiate_ix(&vals[0].pubkey(), &miner.pubkey(), "srctx1", SPOKE_FROM), &vals[0].pubkey(), &vals[0])
         .expect_err("initiate must refuse an unsupported backing");
     assert!(err.contains("BackingNotSupported"), "{err}");
 }

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_binding.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_binding.rs
@@ -2,7 +2,8 @@
 //   cargo test -p allways_swap_manager --test test_binding
 //
 // bind_hotkey is miner-signed and per-miner (one Binding PDA). It only STORES the hotkey + sr25519
-// sig (the validator verifies off-chain) and overwrites in place on re-bind. The H3 squat gate
+// sig (the validator verifies off-chain); the hotkey is set-once (V-M1) — a re-bind may only refresh
+// the sig in place, never change the hotkey. The H3 squat gate
 // admits registered miners (MinerState with collateral >= min_collateral) and whitelisted
 // validators (no MinerState — they pass None and bind so peers can attribute their stake).
 use {
@@ -206,19 +207,28 @@ fn test_bind_none_miner_state_still_gated() {
 }
 
 #[test]
-fn test_rebind_overwrites_in_place() {
+fn test_rebind_refreshes_sig_but_never_the_hotkey() {
+    // V-M1 freeze: the forward binding is set-once. A same-hotkey re-bind (sig refresh) succeeds;
+    // a re-bind to a DIFFERENT hotkey — even a fresh, unclaimed one — is rejected, so a miner can
+    // never move its identity mid-swap to dodge a bond seizure.
     let mut svm = setup();
     let miner = registered_miner(&mut svm);
-    send(&mut svm, bind_ix(&miner.pubkey(), [1u8; 32], [1u8; 64]), &miner.pubkey(), &miner).expect("bind1");
-    // re-bind with a different hotkey/sig overwrites the same PDA
-    let hotkey2 = [2u8; 32];
-    let sig2 = [4u8; 64];
-    send(&mut svm, bind_ix(&miner.pubkey(), hotkey2, sig2), &miner.pubkey(), &miner).expect("bind2");
+    let hotkey = [1u8; 32];
+    send(&mut svm, bind_ix(&miner.pubkey(), hotkey, [1u8; 64]), &miner.pubkey(), &miner).expect("bind1");
 
+    // Same hotkey, new sig: allowed.
+    send(&mut svm, bind_ix(&miner.pubkey(), hotkey, [4u8; 64]), &miner.pubkey(), &miner).expect("sig refresh");
     let b = read_binding(&svm, &miner.pubkey());
-    assert_eq!(b.hotkey, hotkey2, "hotkey overwritten");
-    assert_eq!(b.hotkey_sig, sig2, "sig overwritten");
+    assert_eq!(b.hotkey, hotkey);
+    assert_eq!(b.hotkey_sig, [4u8; 64], "sig refreshed in place");
     assert_eq!(b.miner, miner.pubkey(), "miner identity stable");
+
+    // Different hotkey: rejected, binding untouched.
+    let res = send(&mut svm, bind_ix(&miner.pubkey(), [2u8; 32], [5u8; 64]), &miner.pubkey(), &miner);
+    assert!(res.is_err(), "a bound pubkey must not change its hotkey (V-M1)");
+    let b = read_binding(&svm, &miner.pubkey());
+    assert_eq!(b.hotkey, hotkey, "binding unchanged after the rejected change");
+    assert_eq!(b.hotkey_sig, [4u8; 64]);
 }
 
 #[test]

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_extensions.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_extensions.rs
@@ -74,6 +74,9 @@ fn pool_pda(m: &Pubkey) -> Pubkey {
 fn swap_pda(key: &[u8; 32]) -> Pubkey {
     Pubkey::find_program_address(&[b"swap", key], &pid()).0
 }
+fn bind_pda(m: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&[b"bind", m.as_ref()], &pid()).0
+}
 fn swap_key(from_tx_hash: &str) -> [u8; 32] {
     hashv(&[from_tx_hash.as_bytes()]).to_bytes()
 }
@@ -295,6 +298,7 @@ fn initiate_ix(validator: &Pubkey, miner: &Pubkey, from_tx_hash: &str) -> Instru
             vote_round: vote_pda(REQ_INITIATE, &key),
             swap: swap_pda(&key),
             attestation: None,
+            binding: bind_pda(miner),
             system_program: SYSTEM_PROGRAM,
         }
         .to_account_metas(None),

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_extensions.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_extensions.rs
@@ -317,13 +317,22 @@ fn fulfill_ix(miner: &Pubkey, from_tx_hash: &str) -> Instruction {
 fn extend_reservation_ix(validator: &Pubkey, miner: &Pubkey, target_at: i64) -> Instruction {
     Instruction::new_with_bytes(
         pid(),
-        &allways_swap_manager::instruction::ExtendReservation { target_at }.data(),
+        &allways_swap_manager::instruction::ExtendReservation {
+            target_at,
+            from_addr_hash: hashv(&[FROM_ADDR.as_bytes()]).to_bytes(),
+        }
+        .data(),
         allways_swap_manager::accounts::ExtendReservation {
             validator: *validator,
             config: config_pda(),
             miner: *miner,
             miner_state: miner_pda(miner),
             reservation: resv_pda(miner),
+            source_lock: Pubkey::find_program_address(
+                &[b"srclock", miner.as_ref(), FROM_CHAIN.as_bytes(), &hashv(&[FROM_ADDR.as_bytes()]).to_bytes()],
+                &pid(),
+            )
+            .0,
         }
         .to_account_metas(None),
     )

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_extensions.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_extensions.rs
@@ -223,6 +223,7 @@ fn finalize_ix(router: &Pubkey, miner: &Pubkey, user: &Pubkey) -> Instruction {
             collateral_amount: SOL_AMOUNT,
             from_amount: 100_000,
             to_amount: SOL_AMOUNT as u128,
+            from_addr_hash: hashv(&[FROM_ADDR.as_bytes()]).to_bytes(),
         }
         .data(),
         allways_swap_manager::accounts::FinalizeReservation {
@@ -232,6 +233,12 @@ fn finalize_ix(router: &Pubkey, miner: &Pubkey, user: &Pubkey) -> Instruction {
             miner_state: miner_pda(miner),
             reservation: resv_pda(miner),
             attestation: None,
+            source_lock: Pubkey::find_program_address(
+                &[b"srclock", miner.as_ref(), FROM_CHAIN.as_bytes(), &hashv(&[FROM_ADDR.as_bytes()]).to_bytes()],
+                &pid(),
+            )
+            .0,
+            system_program: SYSTEM_PROGRAM,
         }
         .to_account_metas(None),
     )

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_extensions.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_extensions.rs
@@ -288,13 +288,22 @@ fn initiate_ix(validator: &Pubkey, miner: &Pubkey, from_tx_hash: &str) -> Instru
     let key = swap_key(from_tx_hash);
     Instruction::new_with_bytes(
         pid(),
-        &allways_swap_manager::instruction::VoteInitiate { swap_key: key }.data(),
+        &allways_swap_manager::instruction::VoteInitiate {
+            swap_key: key,
+            from_addr_hash: hashv(&[FROM_ADDR.as_bytes()]).to_bytes(),
+        }
+        .data(),
         allways_swap_manager::accounts::VoteInitiate {
             validator: *validator,
             config: config_pda(),
             miner: *miner,
             miner_state: miner_pda(miner),
             reservation: resv_pda(miner),
+            source_lock: Pubkey::find_program_address(
+                &[b"srclock", miner.as_ref(), FROM_CHAIN.as_bytes(), &hashv(&[FROM_ADDR.as_bytes()]).to_bytes()],
+                &pid(),
+            )
+            .0,
             vote_round: vote_pda(REQ_INITIATE, &key),
             swap: swap_pda(&key),
             attestation: None,

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_reservation.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_reservation.rs
@@ -225,7 +225,9 @@ fn open_ix(router: &Pubkey, miner: &Pubkey, f: &str, t: &str) -> Instruction {
 }
 /// The seat winner names the fill (taker + amounts), making the reservation live.
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 fn finalize_ix(
+    from_chain: &str,
     router: &Pubkey,
     miner: &Pubkey,
     user: &Pubkey,
@@ -244,6 +246,7 @@ fn finalize_ix(
             collateral_amount,
             from_amount,
             to_amount,
+            from_addr_hash: hashv(&[ufrom.as_bytes()]).to_bytes(),
         }
         .data(),
         allways_swap_manager::accounts::FinalizeReservation {
@@ -253,6 +256,12 @@ fn finalize_ix(
             miner_state: miner_pda(miner),
             reservation: resv_pda(miner),
             attestation: None,
+            source_lock: Pubkey::find_program_address(
+                &[b"srclock", miner.as_ref(), from_chain.as_bytes(), &hashv(&[ufrom.as_bytes()]).to_bytes()],
+                &pid(),
+            )
+            .0,
+            system_program: SYSTEM_PROGRAM,
         }
         .to_account_metas(None),
     )
@@ -269,7 +278,7 @@ fn finalize_btc_sol(
     collateral_amount: u64,
     from_amount: u128,
 ) -> Result<(), String> {
-    let ix = finalize_ix(&winner.pubkey(), miner, user, ufrom, uto, collateral_amount, from_amount, collateral_amount as u128);
+    let ix = finalize_ix("btc", &winner.pubkey(), miner, user, ufrom, uto, collateral_amount, from_amount, collateral_amount as u128);
     send(svm, ix, &winner.pubkey(), winner)
 }
 /// arm+resolve a single-bidder pool (the sole bidder is the winner) then finalize a BTC→SOL fill.
@@ -936,7 +945,7 @@ fn test_finalize_rejects_non_router_signer() {
     bid_and_draw(&mut svm, &vals, &miner.pubkey());
     let user = Keypair::new().pubkey();
     // vals[1] did not win the seat — it must not be able to fill vals[0]'s reservation.
-    let ix = finalize_ix(&vals[1].pubkey(), &miner.pubkey(), &user, "u", "uSOL", 2_000_000_000, 1, 2_000_000_000);
+    let ix = finalize_ix("btc", &vals[1].pubkey(), &miner.pubkey(), &user, "u", "uSOL", 2_000_000_000, 1, 2_000_000_000);
     let e = send(&mut svm, ix, &vals[1].pubkey(), &vals[1]);
     assert!(e.is_err(), "only reservation.router may finalize");
     assert_eq!(reservation(&svm, &miner.pubkey()).reserved_until, 0, "still unfilled");
@@ -988,10 +997,10 @@ fn test_collateral_bind_rejects_mismatch_spoke_to_sol() {
     bid_and_draw(&mut svm, &vals, &miner.pubkey());
     let user = Keypair::new().pubkey();
     // collateral_amount=2e9 but to_amount=1 (mismatch) → rejected.
-    let bad = finalize_ix(&vals[0].pubkey(), &miner.pubkey(), &user, "u", "uSOL", 2_000_000_000, 5, 1);
+    let bad = finalize_ix("btc", &vals[0].pubkey(), &miner.pubkey(), &user, "u", "uSOL", 2_000_000_000, 5, 1);
     assert!(send(&mut svm, bad, &vals[0].pubkey(), &vals[0]).is_err(), "collateral_amount must equal the SOL (to) leg");
     // matching triple succeeds.
-    let ok = finalize_ix(&vals[0].pubkey(), &miner.pubkey(), &user, "u", "uSOL", 2_000_000_000, 5, 2_000_000_000);
+    let ok = finalize_ix("btc", &vals[0].pubkey(), &miner.pubkey(), &user, "u", "uSOL", 2_000_000_000, 5, 2_000_000_000);
     send(&mut svm, ok, &vals[0].pubkey(), &vals[0]).expect("matching bind fills");
 }
 
@@ -1007,10 +1016,10 @@ fn test_collateral_bind_rejects_mismatch_sol_to_spoke() {
     arm_and_resolve(&mut svm, &vals[0], &miner.pubkey()).expect("resolve");
     let user = Keypair::new().pubkey();
     // collateral_amount=2e9 but from_amount=1 (mismatch) → rejected.
-    let bad = finalize_ix(&vals[0].pubkey(), &miner.pubkey(), &user, "uSOL", "uBTC", 2_000_000_000, 1, 9);
+    let bad = finalize_ix("sol", &vals[0].pubkey(), &miner.pubkey(), &user, "uSOL", "uBTC", 2_000_000_000, 1, 9);
     assert!(send(&mut svm, bad, &vals[0].pubkey(), &vals[0]).is_err(), "collateral_amount must equal the sol (from) leg");
     // matching triple succeeds.
-    let ok = finalize_ix(&vals[0].pubkey(), &miner.pubkey(), &user, "uSOL", "uBTC", 2_000_000_000, 2_000_000_000, 9);
+    let ok = finalize_ix("sol", &vals[0].pubkey(), &miner.pubkey(), &user, "uSOL", "uBTC", 2_000_000_000, 2_000_000_000, 9);
     send(&mut svm, ok, &vals[0].pubkey(), &vals[0]).expect("matching bind fills");
 }
 

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_swap.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_swap.rs
@@ -86,6 +86,9 @@ fn pool_pda(m: &Pubkey) -> Pubkey {
 fn swap_pda(key: &[u8; 32]) -> Pubkey {
     Pubkey::find_program_address(&[b"swap", key], &pid()).0
 }
+fn bind_pda(m: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&[b"bind", m.as_ref()], &pid()).0
+}
 fn srclock_pda(m: &Pubkey, from_chain: &str, from_addr: &str) -> Pubkey {
     Pubkey::find_program_address(
         &[b"srclock", m.as_ref(), from_chain.as_bytes(), &hashv(&[from_addr.as_bytes()]).to_bytes()],
@@ -343,6 +346,7 @@ fn initiate_ix(validator: &Pubkey, miner: &Pubkey, from_tx_hash: &str) -> Instru
             vote_round: vote_pda(REQ_INITIATE, &key),
             swap: swap_pda(&key),
             attestation: None,
+            binding: bind_pda(miner),
             system_program: SYSTEM_PROGRAM,
         }
         .to_account_metas(None),

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_swap.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_swap.rs
@@ -336,13 +336,18 @@ fn initiate_ix(validator: &Pubkey, miner: &Pubkey, from_tx_hash: &str) -> Instru
     let key = swap_key(from_tx_hash);
     Instruction::new_with_bytes(
         pid(),
-        &allways_swap_manager::instruction::VoteInitiate { swap_key: key }.data(),
+        &allways_swap_manager::instruction::VoteInitiate {
+            swap_key: key,
+            from_addr_hash: hashv(&[FROM_ADDR.as_bytes()]).to_bytes(),
+        }
+        .data(),
         allways_swap_manager::accounts::VoteInitiate {
             validator: *validator,
             config: config_pda(),
             miner: *miner,
             miner_state: miner_pda(miner),
             reservation: resv_pda(miner),
+            source_lock: srclock_pda(miner, FROM_CHAIN, FROM_ADDR),
             vote_round: vote_pda(REQ_INITIATE, &key),
             swap: swap_pda(&key),
             attestation: None,
@@ -707,31 +712,50 @@ fn test_finalize_rejects_dest_equal_to_miner_delivery_addr() {
 
 #[test]
 fn test_finalize_rejects_duplicate_live_source() {
-    // V-C2: a source (from_chain, from_addr) may back only ONE live reservation per miner within its TTL
-    // window. After a completed swap from FROM_ADDR, re-reserving and re-filling the SAME source before its
-    // source_lock lapses is refused — the on-chain half of the dup-source guard (covers the self-
-    // represented lane, which bypasses the validator's off-chain check). A second UNCLAIMED reservation
-    // matchable by one deposit is the deposit-siphon the guard closes.
+    // V-C2: a source (from_chain, from_addr) may back only ONE live reservation per miner. A completed
+    // swap RELEASES its lock at initiate quorum, so the same source refills immediately; against a LIVE
+    // lock the duplicate is refused. The live-sibling collision is cross-hub (the per-hub busy gate
+    // blocks a same-hub second seat), so the live lock is poked directly — the branch is hub-agnostic.
     let (mut svm, vals, miner, _rent) = setup();
     run_full_swap(&mut svm, &vals, &miner, "srctx1");
-    // Re-open past the consumed reservation's finalize window — but NOT past the source_lock (finalize +
-    // TTL), so the same source is still held.
+    assert_eq!(srclock_reserved_until(&svm, &miner.pubkey()), 0, "completed swap released the lock");
+
     let fb = reservation_acct(&svm, &miner.pubkey()).finalize_by;
     let now = fb + 1;
     set_clock(&mut svm, now);
     send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0]).expect("re-open");
     set_clock(&mut svm, now + POOL_WINDOW_SECS + 1);
     arm_and_resolve(&mut svm, &vals[0], &miner.pubkey());
-    let res = send(&mut svm, finalize_ix(&vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER), &vals[0].pubkey(), &vals[0]);
-    assert!(res.is_err(), "a second live reservation from the same source must be refused (V-C2)");
-    // And once the lock lapses (past the reservation's reserved_until — base TTL here, since it was never
-    // extended), the same source is free again.
-    set_clock(&mut svm, now + TTL + 1);
-    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0]).expect("re-open after lapse");
-    set_clock(&mut svm, now + TTL + POOL_WINDOW_SECS + 2);
-    arm_and_resolve(&mut svm, &vals[0], &miner.pubkey());
     send(&mut svm, finalize_ix(&vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER), &vals[0].pubkey(), &vals[0])
-        .expect("same source finalizes once its prior lock has lapsed");
+        .expect("same source refills immediately after its swap completed — no TTL wait, no burned bid");
+
+    // Simulate a still-live sibling reservation holding the source (the cross-hub case): a live lock
+    // refuses the duplicate.
+    run_full_swap(&mut svm, &vals, &miner, "srctx2");
+    set_srclock_reserved_until(&mut svm, &miner.pubkey(), now + 100 * TTL);
+    let now2 = reservation_acct(&svm, &miner.pubkey()).finalize_by + 1;
+    set_clock(&mut svm, now2);
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0]).expect("re-open 2");
+    set_clock(&mut svm, now2 + POOL_WINDOW_SECS + 1);
+    arm_and_resolve(&mut svm, &vals[0], &miner.pubkey());
+    let res = send(&mut svm, finalize_ix(&vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER), &vals[0].pubkey(), &vals[0]);
+    assert!(res.is_err(), "a live lock (sibling reservation) still refuses the duplicate source (V-C2)");
+}
+
+fn set_srclock_reserved_until(svm: &mut LiteSVM, miner: &Pubkey, until: i64) {
+    use allways_swap_manager::state::SourceLock;
+    let pda = srclock_pda(miner, FROM_CHAIN, FROM_ADDR);
+    let old = svm.get_account(&pda).unwrap();
+    let mut lock = SourceLock::try_deserialize(&mut old.data.as_slice()).unwrap();
+    lock.reserved_until = until;
+    let mut data = Vec::new();
+    lock.try_serialize(&mut data).unwrap();
+    data.resize(old.data.len(), 0);
+    svm.set_account(
+        pda,
+        Account { lamports: old.lamports, data, owner: old.owner, executable: old.executable, rent_epoch: old.rent_epoch },
+    )
+    .unwrap();
 }
 
 #[test]
@@ -1265,5 +1289,24 @@ fn test_extend_slides_the_source_lock() {
         srclock_reserved_until(&svm, &miner.pubkey()),
         target,
         "the source lock slid with it — no lapse window opens under extension"
+    );
+}
+
+#[test]
+fn test_initiate_releases_the_source_lock() {
+    // The deposit is hash-bound to the swap at initiate quorum, so the lock's job is done — release
+    // it with the reservation. Held to the old reserved_until, a repeat swap from the same source
+    // would burn a bid fee against a lock protecting nothing.
+    let (mut svm, _admin, vals, miner, _rr) = setup_full(COLLATERAL);
+    let finalize_by = reservation_acct(&svm, &miner.pubkey()).finalize_by;
+    set_clock(&mut svm, finalize_by - 5);
+    assert!(srclock_reserved_until(&svm, &miner.pubkey()) > 0, "lock live after finalize");
+
+    do_initiate(&mut svm, &vals, &miner.pubkey(), "srctx1");
+
+    assert_eq!(
+        srclock_reserved_until(&svm, &miner.pubkey()),
+        0,
+        "initiate quorum released the source lock with the reservation"
     );
 }

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_swap.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_swap.rs
@@ -3,13 +3,14 @@
 use {
     anchor_lang::{
         prelude::Pubkey, solana_program::clock::Clock, solana_program::instruction::Instruction,
-        AccountDeserialize, InstructionData, ToAccountMetas,
+        AccountDeserialize, AccountSerialize, InstructionData, Space, ToAccountMetas,
     },
     allways_swap_manager::constants::{
         FULFILL_GRACE_SOL_SECS, MAX_TOTAL_EXTENSION_SECS, POOL_WINDOW_SECS, RESERVATION_FEE_LAMPORTS,
     },
     allways_swap_manager::state::{MinerDirectionStats, MinerState, Pool, Reservation, Swap, SwapStatus, Treasury},
     litesvm::LiteSVM,
+    solana_account::Account,
     solana_hash::Hash,
     solana_keccak_hasher::hashv,
     solana_keypair::Keypair,
@@ -351,6 +352,70 @@ fn close_stale_claim_ix(caller: &Pubkey, miner: &Pubkey, from_tx_hash: &str) -> 
         .to_account_metas(None),
     )
 }
+/// Like `close_stale_claim_ix` but lets the caller aim an ARBITRARY reservation account at the swap —
+/// the whole point of the V-C1 cross-hub reap (hand in the miner's OTHER-hub reservation).
+fn close_stale_claim_ix_with_resv(
+    caller: &Pubkey,
+    miner: &Pubkey,
+    from_tx_hash: &str,
+    reservation: Pubkey,
+) -> Instruction {
+    let key = swap_key(from_tx_hash);
+    Instruction::new_with_bytes(
+        pid(),
+        &allways_swap_manager::instruction::CloseStaleClaim { swap_key: key }.data(),
+        allways_swap_manager::accounts::CloseStaleClaim {
+            caller: *caller,
+            miner: *miner,
+            reservation,
+            swap: swap_pda(&key),
+        }
+        .to_account_metas(None),
+    )
+}
+/// Plant an initialized Reservation PDA for `miner` under a non-sol `backing` (the second hub of a
+/// dual-hub miner), so a test can hand it to `close_stale_claim`. `reserved_until`/`claimed` control
+/// whether the contract's staleness clause would fire absent the backing bind.
+fn plant_reservation(
+    svm: &mut LiteSVM,
+    miner: &Pubkey,
+    backing: &str,
+    claimed: [u8; 32],
+    reserved_until: i64,
+) -> Pubkey {
+    let (pda, bump) =
+        Pubkey::find_program_address(&[b"resv", miner.as_ref(), backing.as_bytes()], &pid());
+    let r = Reservation {
+        router: *miner,
+        from_addr: String::new(),
+        user: LOTTERY_USER,
+        user_to_addr: String::new(),
+        from_chain: String::new(),
+        to_chain: String::new(),
+        collateral_chain: backing.to_string(),
+        collateral_amount: 0,
+        from_amount: 0,
+        to_amount: 0,
+        miner_from_addr: String::new(),
+        miner_to_addr: String::new(),
+        rate: 0,
+        created_at: BASE_TS,
+        reserved_until,
+        finalize_by: 0,
+        max_extend_at: 0,
+        claimed_swap_key: claimed,
+        bump,
+    };
+    let mut data = Vec::new();
+    r.try_serialize(&mut data).unwrap();
+    data.resize(8 + Reservation::INIT_SPACE, 0);
+    svm.set_account(
+        pda,
+        Account { lamports: 10_000_000, data, owner: pid(), executable: false, rent_epoch: 0 },
+    )
+    .unwrap();
+    pda
+}
 fn fulfill_ix(miner: &Pubkey, from_tx_hash: &str) -> Instruction {
     let key = swap_key(from_tx_hash);
     Instruction::new_with_bytes(
@@ -633,6 +698,33 @@ fn test_stale_claim_reap() {
     assert!(svm.get_account(&swap_pda(&key)).is_none(), "stale claim closed");
     let r = Reservation::try_deserialize(&mut svm.get_account(&resv_pda(&miner.pubkey())).unwrap().data.as_slice()).unwrap();
     assert_eq!(r.claimed_swap_key, [0u8; 32], "claim slot freed");
+}
+
+#[test]
+fn test_cross_backing_reap_rejected() {
+    // Red-team V-C1 (F1): a dual-hub miner's OTHER-hub reservation must not reap a HEALTHY swap.
+    // The `reservation` PDA is seeded on its own collateral_chain, so a foreign (tao) reservation
+    // validates in `close_stale_claim`; without the backing bind it trivially satisfies the
+    // `claimed_swap_key != swap_key` staleness clause and closes a live sol swap → permanent taker
+    // strand (permissionless). The fix rejects on ChainMismatch before the staleness test.
+    let (mut svm, vals, miner, _rent) = setup();
+    send(&mut svm, claim_ix(&vals[0].pubkey(), &miner.pubkey(), "srctx1"), &vals[0].pubkey(), &vals[0]).expect("claim");
+    let key = swap_key("srctx1");
+    // Clock stays at BASE_TS: the sol reservation is LIVE, so its own slot is non-stale (the honest
+    // guard) — the cross-hub substitution is the ONLY way to force a reap here.
+    let tao_resv = plant_reservation(&mut svm, &miner.pubkey(), "tao", [0u8; 32], BASE_TS - 1);
+
+    let res = send(
+        &mut svm,
+        close_stale_claim_ix_with_resv(&vals[0].pubkey(), &miner.pubkey(), "srctx1", tao_resv),
+        &vals[0].pubkey(),
+        &vals[0],
+    );
+    assert!(res.is_err(), "cross-backing reap of a healthy swap must be rejected (ChainMismatch)");
+    // Healthy swap survives; the sol reservation still owns the claim.
+    assert!(svm.get_account(&swap_pda(&key)).is_some(), "healthy swap must survive the rejected reap");
+    let sol = reservation_acct(&svm, &miner.pubkey());
+    assert_eq!(sol.claimed_swap_key, key, "sol claim slot must be untouched");
 }
 
 fn read_swap(svm: &LiteSVM, key: &[u8; 32]) -> Swap {

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_swap.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_swap.rs
@@ -720,7 +720,8 @@ fn test_finalize_rejects_duplicate_live_source() {
     arm_and_resolve(&mut svm, &vals[0], &miner.pubkey());
     let res = send(&mut svm, finalize_ix(&vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER), &vals[0].pubkey(), &vals[0]);
     assert!(res.is_err(), "a second live reservation from the same source must be refused (V-C2)");
-    // And once the lock lapses (past finalize + TTL), the same source is free again.
+    // And once the lock lapses (past the reservation's reserved_until — base TTL here, since it was never
+    // extended), the same source is free again.
     set_clock(&mut svm, now + TTL + 1);
     send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0]).expect("re-open after lapse");
     set_clock(&mut svm, now + TTL + POOL_WINDOW_SECS + 2);
@@ -1107,7 +1108,7 @@ fn test_contract_no_longer_blocks_reused_tx() {
     // miner freed → re-reserve, re-claim + re-attest the SAME from_tx_hash → now permitted on-chain.
     // The consumed reservation blocks a re-open until its finalize window lapses; warp past it.
     let fb = reservation_acct(&svm, &miner.pubkey()).finalize_by;
-    set_clock(&mut svm, fb + TTL + 1); // +TTL: also clears the V-C2 source-lock (held for the reservation TTL)
+    set_clock(&mut svm, fb + TTL + 1); // +TTL clears the V-C2 source lock (held for the reservation TTL)
     do_reserve(&mut svm, &vals[0], &miner.pubkey());
     do_initiate(&mut svm, &vals, &miner.pubkey(), "srctx1");
     let s = Swap::try_deserialize(&mut svm.get_account(&swap_pda(&swap_key("srctx1"))).unwrap().data.as_slice()).unwrap();
@@ -1131,7 +1132,7 @@ fn test_stats_accumulate_same_direction() {
     // miner freed → re-reserve via the lottery, run a second swap (different source tx) same direction.
     // The consumed reservation blocks a re-open until its finalize window lapses; warp past it.
     let fb = reservation_acct(&svm, &miner.pubkey()).finalize_by;
-    set_clock(&mut svm, fb + TTL + 1); // +TTL: also clears the V-C2 source-lock (held for the reservation TTL)
+    set_clock(&mut svm, fb + TTL + 1); // +TTL clears the V-C2 source lock (held for the reservation TTL)
     do_reserve(&mut svm, &vals[0], &miner.pubkey());
     run_full_swap(&mut svm, &vals, &miner, "srctx2");
 
@@ -1206,4 +1207,59 @@ fn test_finalize_refuses_a_reservation_already_consumed_by_initiate() {
 
 fn reservation_acct(svm: &LiteSVM, miner: &Pubkey) -> Reservation {
     Reservation::try_deserialize(&mut svm.get_account(&resv_pda(miner)).unwrap().data.as_slice()).unwrap()
+}
+
+// ── REVIEW PROBE (c15ae2b / V-C2 extension gap) ─────────────────────────────────────────────────
+// Demonstrates that `extend_reservation` slides a live-unclaimed reservation's `reserved_until`
+// forward but never touches its SourceLock, so the lock lapses while the reservation is still live —
+// re-opening the cross-hub collision window the C2 guard is meant to hold shut.
+fn extend_ix(validator: &Pubkey, miner: &Pubkey, target_at: i64) -> Instruction {
+    Instruction::new_with_bytes(
+        pid(),
+        &allways_swap_manager::instruction::ExtendReservation {
+            target_at,
+            from_addr_hash: hashv(&[FROM_ADDR.as_bytes()]).to_bytes(),
+        }
+        .data(),
+        allways_swap_manager::accounts::ExtendReservation {
+            validator: *validator,
+            config: config_pda(),
+            miner: *miner,
+            miner_state: miner_pda(miner),
+            reservation: resv_pda(miner),
+            source_lock: srclock_pda(miner, FROM_CHAIN, FROM_ADDR),
+        }
+        .to_account_metas(None),
+    )
+}
+
+fn srclock_reserved_until(svm: &LiteSVM, miner: &Pubkey) -> i64 {
+    use allways_swap_manager::state::SourceLock;
+    let acct = svm.get_account(&srclock_pda(miner, FROM_CHAIN, FROM_ADDR)).unwrap();
+    SourceLock::try_deserialize(&mut acct.data.as_slice()).unwrap().reserved_until
+}
+
+#[test]
+fn test_extend_slides_the_source_lock() {
+    // V-C2 under extension: extend_reservation slides the source lock forward in lockstep with
+    // reserved_until, so an extended, still-unclaimed reservation never outlives its lock and re-opens the
+    // cross-hub collision (a colliding finalize on another hub keeps finding a live lock).
+    let (mut svm, vals, miner, _rent) = setup();
+    let resv = reservation_acct(&svm, &miner.pubkey());
+    assert_eq!(
+        srclock_reserved_until(&svm, &miner.pubkey()),
+        resv.reserved_until,
+        "lock is aligned to the reservation at finalize"
+    );
+
+    let target = resv.reserved_until + 5_000; // still-unclaimed reservation extended (slow source deposit)
+    send(&mut svm, extend_ix(&vals[0].pubkey(), &miner.pubkey(), target), &vals[0].pubkey(), &vals[0])
+        .expect("extend");
+
+    assert_eq!(reservation_acct(&svm, &miner.pubkey()).reserved_until, target, "reservation slid forward");
+    assert_eq!(
+        srclock_reserved_until(&svm, &miner.pubkey()),
+        target,
+        "the source lock slid with it — no lapse window opens under extension"
+    );
 }

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_swap.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_swap.rs
@@ -86,6 +86,13 @@ fn pool_pda(m: &Pubkey) -> Pubkey {
 fn swap_pda(key: &[u8; 32]) -> Pubkey {
     Pubkey::find_program_address(&[b"swap", key], &pid()).0
 }
+fn srclock_pda(m: &Pubkey, from_chain: &str, from_addr: &str) -> Pubkey {
+    Pubkey::find_program_address(
+        &[b"srclock", m.as_ref(), from_chain.as_bytes(), &hashv(&[from_addr.as_bytes()]).to_bytes()],
+        &pid(),
+    )
+    .0
+}
 fn swap_key(from_tx_hash: &str) -> [u8; 32] {
     hashv(&[from_tx_hash.as_bytes()]).to_bytes()
 }
@@ -268,6 +275,7 @@ fn finalize_ix(router: &Pubkey, miner: &Pubkey, user: &Pubkey) -> Instruction {
             collateral_amount: SOL_AMOUNT,
             from_amount: FROM_AMOUNT,
             to_amount: TO_AMOUNT,
+            from_addr_hash: hashv(&[FROM_ADDR.as_bytes()]).to_bytes(),
         }
         .data(),
         allways_swap_manager::accounts::FinalizeReservation {
@@ -277,6 +285,8 @@ fn finalize_ix(router: &Pubkey, miner: &Pubkey, user: &Pubkey) -> Instruction {
             miner_state: miner_pda(miner),
             reservation: resv_pda(miner),
             attestation: None,
+            source_lock: srclock_pda(miner, FROM_CHAIN, FROM_ADDR),
+            system_program: SYSTEM_PROGRAM,
         }
         .to_account_metas(None),
     )
@@ -631,6 +641,92 @@ fn test_finalize_rejected_below_overcollateralization() {
     // ...but the fill is rejected: 2 SOL × 1.10 = 2.2 SOL > 2.1 SOL held.
     let res = send(&mut svm, finalize_ix(&vals[0].pubkey(), &miner.pubkey(), &user), &vals[0].pubkey(), &vals[0]);
     assert!(res.is_err(), "finalize must reject collateral below 1.1× the swap size");
+}
+
+#[test]
+fn test_finalize_rejects_dest_equal_to_miner_delivery_addr() {
+    // V-H1 on-chain backstop: user_to_addr == the miner's own delivery address (pinned on the reservation
+    // at draw) makes the miner "deliver to itself" — a self-represented taker (bypassing the validator's
+    // reserve-time gate) could poison it into a false non-delivery slash. Reject at finalize.
+    let mut svm = LiteSVM::new();
+    svm.add_program(pid(), include_bytes!("../../../target/deploy/allways_swap_manager.so")).unwrap();
+    set_clock(&mut svm, BASE_TS);
+    let admin = Keypair::new();
+    svm.airdrop(&admin.pubkey(), 100_000_000_000).unwrap();
+    send(&mut svm, init_ix(&admin.pubkey()), &admin.pubkey(), &admin).expect("init");
+    let mut vals = Vec::new();
+    for _ in 0..3 {
+        let v = Keypair::new();
+        svm.airdrop(&v.pubkey(), 100_000_000_000).unwrap();
+        send(&mut svm, add_validator_ix(&admin.pubkey(), v.pubkey()), &admin.pubkey(), &admin).expect("add val");
+        vals.push(v);
+    }
+    let miner = Keypair::new();
+    svm.airdrop(&miner.pubkey(), 100_000_000_000).unwrap();
+    send(&mut svm, post_ix(&miner.pubkey(), 10 * SOL_AMOUNT), &miner.pubkey(), &miner).expect("post");
+    send(&mut svm, vote_activate_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0]).expect("a0");
+    send(&mut svm, vote_activate_ix(&vals[1].pubkey(), &miner.pubkey()), &vals[1].pubkey(), &vals[1]).expect("a1");
+    send(&mut svm, set_quote_ix(&miner.pubkey()), &miner.pubkey(), &miner).expect("quote");
+    let user = Keypair::new().pubkey();
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0]).expect("bid");
+    set_clock(&mut svm, BASE_TS + POOL_WINDOW_SECS + 1);
+    arm_and_resolve(&mut svm, &vals[0], &miner.pubkey());
+    let poisoned = Instruction::new_with_bytes(
+        pid(),
+        &allways_swap_manager::instruction::FinalizeReservation {
+            user,
+            user_from_addr: FROM_ADDR.to_string(),
+            user_to_addr: MINER_TO.to_string(), // == the pinned miner delivery address
+            collateral_amount: SOL_AMOUNT,
+            from_amount: FROM_AMOUNT,
+            to_amount: TO_AMOUNT,
+            from_addr_hash: hashv(&[FROM_ADDR.as_bytes()]).to_bytes(),
+        }
+        .data(),
+        allways_swap_manager::accounts::FinalizeReservation {
+            router: vals[0].pubkey(),
+            config: config_pda(),
+            miner: miner.pubkey(),
+            miner_state: miner_pda(&miner.pubkey()),
+            reservation: resv_pda(&miner.pubkey()),
+            attestation: None,
+            source_lock: srclock_pda(&miner.pubkey(), FROM_CHAIN, FROM_ADDR),
+            system_program: SYSTEM_PROGRAM,
+        }
+        .to_account_metas(None),
+    );
+    assert!(
+        send(&mut svm, poisoned, &vals[0].pubkey(), &vals[0]).is_err(),
+        "finalize must reject user_to_addr == miner delivery address"
+    );
+}
+
+#[test]
+fn test_finalize_rejects_duplicate_live_source() {
+    // V-C2: a source (from_chain, from_addr) may back only ONE live reservation per miner within its TTL
+    // window. After a completed swap from FROM_ADDR, re-reserving and re-filling the SAME source before its
+    // source_lock lapses is refused — the on-chain half of the dup-source guard (covers the self-
+    // represented lane, which bypasses the validator's off-chain check). A second UNCLAIMED reservation
+    // matchable by one deposit is the deposit-siphon the guard closes.
+    let (mut svm, vals, miner, _rent) = setup();
+    run_full_swap(&mut svm, &vals, &miner, "srctx1");
+    // Re-open past the consumed reservation's finalize window — but NOT past the source_lock (finalize +
+    // TTL), so the same source is still held.
+    let fb = reservation_acct(&svm, &miner.pubkey()).finalize_by;
+    let now = fb + 1;
+    set_clock(&mut svm, now);
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0]).expect("re-open");
+    set_clock(&mut svm, now + POOL_WINDOW_SECS + 1);
+    arm_and_resolve(&mut svm, &vals[0], &miner.pubkey());
+    let res = send(&mut svm, finalize_ix(&vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER), &vals[0].pubkey(), &vals[0]);
+    assert!(res.is_err(), "a second live reservation from the same source must be refused (V-C2)");
+    // And once the lock lapses (past finalize + TTL), the same source is free again.
+    set_clock(&mut svm, now + TTL + 1);
+    send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0]).expect("re-open after lapse");
+    set_clock(&mut svm, now + TTL + POOL_WINDOW_SECS + 2);
+    arm_and_resolve(&mut svm, &vals[0], &miner.pubkey());
+    send(&mut svm, finalize_ix(&vals[0].pubkey(), &miner.pubkey(), &LOTTERY_USER), &vals[0].pubkey(), &vals[0])
+        .expect("same source finalizes once its prior lock has lapsed");
 }
 
 #[test]
@@ -1011,7 +1107,7 @@ fn test_contract_no_longer_blocks_reused_tx() {
     // miner freed → re-reserve, re-claim + re-attest the SAME from_tx_hash → now permitted on-chain.
     // The consumed reservation blocks a re-open until its finalize window lapses; warp past it.
     let fb = reservation_acct(&svm, &miner.pubkey()).finalize_by;
-    set_clock(&mut svm, fb + 1);
+    set_clock(&mut svm, fb + TTL + 1); // +TTL: also clears the V-C2 source-lock (held for the reservation TTL)
     do_reserve(&mut svm, &vals[0], &miner.pubkey());
     do_initiate(&mut svm, &vals, &miner.pubkey(), "srctx1");
     let s = Swap::try_deserialize(&mut svm.get_account(&swap_pda(&swap_key("srctx1"))).unwrap().data.as_slice()).unwrap();
@@ -1035,7 +1131,7 @@ fn test_stats_accumulate_same_direction() {
     // miner freed → re-reserve via the lottery, run a second swap (different source tx) same direction.
     // The consumed reservation blocks a re-open until its finalize window lapses; warp past it.
     let fb = reservation_acct(&svm, &miner.pubkey()).finalize_by;
-    set_clock(&mut svm, fb + 1);
+    set_clock(&mut svm, fb + TTL + 1); // +TTL: also clears the V-C2 source-lock (held for the reservation TTL)
     do_reserve(&mut svm, &vals[0], &miner.pubkey());
     run_full_swap(&mut svm, &vals, &miner, "srctx2");
 

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_treasury.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_treasury.rs
@@ -169,8 +169,8 @@ fn setup_with_fee() -> (LiteSVM, Keypair, u64) {
 
     // sole bidder (vals[0]) won the seat → it finalizes the fill (BTC→SOL: to_amount == collateral).
     send(&mut svm, Instruction::new_with_bytes(pid(),
-        &allways_swap_manager::instruction::FinalizeReservation { user: pool_user, user_from_addr: "userBTC".to_string(), user_to_addr: "userSOL".to_string(), collateral_amount: SOL_AMOUNT, from_amount: 1, to_amount: SOL_AMOUNT as u128 }.data(),
-        allways_swap_manager::accounts::FinalizeReservation { router: vals[0].pubkey(), config: cfg(), miner: miner.pubkey(), miner_state: miner_pda(&miner.pubkey()), reservation: resv_pda(&miner.pubkey()), attestation: None }.to_account_metas(None),
+        &allways_swap_manager::instruction::FinalizeReservation { user: pool_user, user_from_addr: "userBTC".to_string(), user_to_addr: "userSOL".to_string(), collateral_amount: SOL_AMOUNT, from_amount: 1, to_amount: SOL_AMOUNT as u128, from_addr_hash: hashv(&["userBTC".as_bytes()]).to_bytes() }.data(),
+        allways_swap_manager::accounts::FinalizeReservation { router: vals[0].pubkey(), config: cfg(), miner: miner.pubkey(), miner_state: miner_pda(&miner.pubkey()), reservation: resv_pda(&miner.pubkey()), attestation: None, source_lock: Pubkey::find_program_address(&[b"srclock", miner.pubkey().as_ref(), b"btc", &hashv(&["userBTC".as_bytes()]).to_bytes()], &pid()).0, system_program: SYS }.to_account_metas(None),
     ), &vals[0].pubkey(), &vals[0]).expect("finalize");
 
     let key = skey("tx1");

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_treasury.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_treasury.rs
@@ -184,8 +184,8 @@ fn setup_with_fee() -> (LiteSVM, Keypair, u64) {
     ), &vals[0].pubkey(), &vals[0]).expect("claim");
     let initiate = |svm: &mut LiteSVM, v: &Keypair| {
         send(svm, Instruction::new_with_bytes(pid(),
-            &allways_swap_manager::instruction::VoteInitiate { swap_key: key }.data(),
-            allways_swap_manager::accounts::VoteInitiate { validator: v.pubkey(), config: cfg(), miner: miner.pubkey(), miner_state: miner_pda(&miner.pubkey()), reservation: resv_pda(&miner.pubkey()), vote_round: vote_pda(2, &key), swap: swap_pda(&key), attestation: None, binding: bind_pda(&miner.pubkey()), system_program: SYS }.to_account_metas(None),
+            &allways_swap_manager::instruction::VoteInitiate { swap_key: key, from_addr_hash: hashv(&["userBTC".as_bytes()]).to_bytes() }.data(),
+            allways_swap_manager::accounts::VoteInitiate { validator: v.pubkey(), config: cfg(), miner: miner.pubkey(), miner_state: miner_pda(&miner.pubkey()), reservation: resv_pda(&miner.pubkey()), source_lock: Pubkey::find_program_address(&[b"srclock", miner.pubkey().as_ref(), b"btc", &hashv(&["userBTC".as_bytes()]).to_bytes()], &pid()).0, vote_round: vote_pda(2, &key), swap: swap_pda(&key), attestation: None, binding: bind_pda(&miner.pubkey()), system_program: SYS }.to_account_metas(None),
         ), &v.pubkey(), v).expect("initiate");
     };
     initiate(&mut svm, &vals[0]);

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_treasury.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_treasury.rs
@@ -61,6 +61,9 @@ fn pool_pda(m: &Pubkey) -> Pubkey {
 fn swap_pda(k: &[u8; 32]) -> Pubkey {
     Pubkey::find_program_address(&[b"swap", k], &pid()).0
 }
+fn bind_pda(m: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&[b"bind", m.as_ref()], &pid()).0
+}
 fn skey(tx: &str) -> [u8; 32] {
     hashv(&[tx.as_bytes()]).to_bytes()
 }
@@ -182,7 +185,7 @@ fn setup_with_fee() -> (LiteSVM, Keypair, u64) {
     let initiate = |svm: &mut LiteSVM, v: &Keypair| {
         send(svm, Instruction::new_with_bytes(pid(),
             &allways_swap_manager::instruction::VoteInitiate { swap_key: key }.data(),
-            allways_swap_manager::accounts::VoteInitiate { validator: v.pubkey(), config: cfg(), miner: miner.pubkey(), miner_state: miner_pda(&miner.pubkey()), reservation: resv_pda(&miner.pubkey()), vote_round: vote_pda(2, &key), swap: swap_pda(&key), attestation: None, system_program: SYS }.to_account_metas(None),
+            allways_swap_manager::accounts::VoteInitiate { validator: v.pubkey(), config: cfg(), miner: miner.pubkey(), miner_state: miner_pda(&miner.pubkey()), reservation: resv_pda(&miner.pubkey()), vote_round: vote_pda(2, &key), swap: swap_pda(&key), attestation: None, binding: bind_pda(&miner.pubkey()), system_program: SYS }.to_account_metas(None),
         ), &v.pubkey(), v).expect("initiate");
     };
     initiate(&mut svm, &vals[0]);

--- a/tests/test_axon_solana_handlers.py
+++ b/tests/test_axon_solana_handlers.py
@@ -96,6 +96,10 @@ class FakeProvider:
     def chain_def(self):
         return SimpleNamespace(replay_grace_secs=self.grace)
 
+    @property
+    def chain(self):
+        return SimpleNamespace(normalize_address=lambda a: a)
+
     def verify_transaction(self, **kw):
         return self.tx_info
 

--- a/tests/test_block_time.py
+++ b/tests/test_block_time.py
@@ -149,6 +149,15 @@ def _raw_transfer_block(txid, dest, amount, sender, settled=True):
     }
 
 
+def test_tao_send_refuses_when_from_address_mismatches_wallet():
+    # H3: never broadcast from a wallet the validator's sender-pin would reject (wasted funds).
+    p = Tao.__new__(Tao)
+    p.wallet = MagicMock()
+    p.wallet.coldkeypub.ss58_address = 'minerTAO'
+    p.broadcasted_txids = {}
+    assert p.send_amount('userTAO', 1000, from_address='someoneElse') is None
+
+
 def test_tao_own_transfer_landed_matches_exact_hash():
     # H2: reuse a prior payout only when THAT exact extrinsic is on-chain, so a confirm-timeout retry
     # can't double-pay. (payout block: sender=miner, dest=user)

--- a/tests/test_block_time.py
+++ b/tests/test_block_time.py
@@ -250,7 +250,7 @@ def test_tao_lost_hash_skips_a_transfer_owned_by_another_obligation():
     # A hash recorded under any scope belongs to a DIFFERENT swap this process sent — adopting it
     # would report the same tx for two swaps. With the window elapsed, the lost send is dead.
     blocks = {100: _raw_transfer_block('0xother', 'userTAO', 5000, 'minerTAO')}
-    p = _scan_provider(head=150, blocks=blocks, readable_default=True)
+    p = _scan_provider(head=99 + Tao.LOST_SEND_DEAD_BLOCKS + 1, blocks=blocks, readable_default=True)
     p.broadcasted_txids['swapA'] = ('userTAO', 5000, '0xother', 100)
     assert p._lost_hash_prior_landed('minerTAO', 'userTAO', 5000, seen_head=99) is None
 
@@ -263,15 +263,23 @@ def test_tao_lost_hash_waits_while_the_inclusion_window_is_open():
 
 
 def test_tao_lost_hash_dead_after_window_scanned_clean():
-    # The full window since the attempt elapsed and every block read clean → provably never landed.
-    p = _scan_provider(head=100 + Tao.SCAN_LOOKBACK_BLOCKS + 1, blocks={}, readable_default=True)
+    # The full mortality window since the attempt elapsed and every block read clean → provably never landed.
+    p = _scan_provider(head=100 + Tao.LOST_SEND_DEAD_BLOCKS + 1, blocks={}, readable_default=True)
     assert p._lost_hash_prior_landed('minerTAO', 'userTAO', 5000, seen_head=100) is None
+
+
+def test_tao_lost_hash_waits_out_the_full_mortal_era():
+    # Past the scan window but inside the 128-block mortal era the extrinsic can STILL include —
+    # declaring it dead here re-sends into a double pay. Wait, don't clear.
+    p = _scan_provider(head=100 + Tao.SCAN_LOOKBACK_BLOCKS + 26, blocks={}, readable_default=True)
+    with pytest.raises(ProviderUnreachableError):
+        p._lost_hash_prior_landed('minerTAO', 'userTAO', 5000, seen_head=100)
 
 
 def test_tao_lost_hash_raises_when_a_block_is_unreadable():
     # Even past the window, an unreadable block could hide the landed transfer → keep waiting.
     blocks = {110: None}
-    p = _scan_provider(head=100 + Tao.SCAN_LOOKBACK_BLOCKS + 1, blocks=blocks, readable_default=True)
+    p = _scan_provider(head=100 + Tao.LOST_SEND_DEAD_BLOCKS + 1, blocks=blocks, readable_default=True)
     with pytest.raises(ProviderUnreachableError):
         p._lost_hash_prior_landed('minerTAO', 'userTAO', 5000, seen_head=100)
 

--- a/tests/test_block_time.py
+++ b/tests/test_block_time.py
@@ -149,6 +149,27 @@ def _raw_transfer_block(txid, dest, amount, sender, settled=True):
     }
 
 
+def test_tao_own_transfer_landed_matches_exact_hash():
+    # H2: reuse a prior payout only when THAT exact extrinsic is on-chain, so a confirm-timeout retry
+    # can't double-pay. (payout block: sender=miner, dest=user)
+    blocks = {100: _raw_transfer_block('0xpay', 'userTAO', 5000, 'minerTAO')}
+    p = _scan_provider(head=100, blocks=blocks)
+    assert p._own_transfer_landed('0xpay', 'minerTAO', 'userTAO', 5000) == ('0xpay', 100)
+
+
+def test_tao_own_transfer_landed_ignores_a_different_extrinsic():
+    # A matching (to, amount) transfer from a DIFFERENT extrinsic must NOT be reused — no mis-attribution.
+    blocks = {100: _raw_transfer_block('0xpay', 'userTAO', 5000, 'minerTAO')}
+    p = _scan_provider(head=100, blocks=blocks)
+    assert p._own_transfer_landed('0xNOTMINE', 'minerTAO', 'userTAO', 5000) is None
+
+
+def test_tao_own_transfer_landed_absent_returns_none():
+    # Genuine failure (nothing on chain) → None → the caller re-sends, which is correct.
+    p = _scan_provider(head=100, blocks={})
+    assert p._own_transfer_landed('0xpay', 'minerTAO', 'userTAO', 5000) is None
+
+
 def test_tao_scanner_finds_matching_transfer_in_new_blocks():
     blocks = {100: _raw_transfer_block('0xdep', 'minerTAO', 5000, 'userTAO')}
     p = _scan_provider(head=100, blocks=blocks)

--- a/tests/test_block_time.py
+++ b/tests/test_block_time.py
@@ -92,7 +92,13 @@ def test_subtensor_get_block_time_none_on_error():
 # Substrate has no address index, so the scanner follows the head incrementally.
 
 
-def _scan_provider(head, blocks):
+def _empty_block():
+    """A readable block holding no transfers — what a real get_block returns for a quiet block.
+    (None from get_block means UNREADABLE, which the dedup resolvers must treat as 'wait'.)"""
+    return {'_raw': True, 'extrinsics': [], '_events': []}
+
+
+def _scan_provider(head, blocks, readable_default=False):
     p = Tao.__new__(Tao)  # skip __init__ (no real subtensor needed)
     p.subtensor = MagicMock()
     p.subtensor.get_current_block.return_value = head
@@ -100,7 +106,11 @@ def _scan_provider(head, blocks):
     p.block_hash_cache = {}
     p.events_cache = {}
     p.scan_cursors = {}
-    p.get_block = lambda n: blocks.get(n)
+    p.broadcasted_txids = {}
+    if readable_default:
+        p.get_block = lambda n: blocks.get(n, _empty_block())
+    else:
+        p.get_block = lambda n: blocks.get(n)
     p.get_block_hash = lambda n: f'0xblock{n}'
     p.get_block_events = lambda h: (blocks.get(int(h.removeprefix('0xblock'))) or {}).get('_events', [])
     return p
@@ -162,21 +172,46 @@ def test_tao_own_transfer_landed_matches_exact_hash():
     # H2: reuse a prior payout only when THAT exact extrinsic is on-chain, so a confirm-timeout retry
     # can't double-pay. (payout block: sender=miner, dest=user)
     blocks = {100: _raw_transfer_block('0xpay', 'userTAO', 5000, 'minerTAO')}
-    p = _scan_provider(head=100, blocks=blocks)
+    p = _scan_provider(head=100, blocks=blocks, readable_default=True)
     assert p._own_transfer_landed('0xpay', 'minerTAO', 'userTAO', 5000) == ('0xpay', 100)
 
 
 def test_tao_own_transfer_landed_ignores_a_different_extrinsic():
     # A matching (to, amount) transfer from a DIFFERENT extrinsic must NOT be reused — no mis-attribution.
     blocks = {100: _raw_transfer_block('0xpay', 'userTAO', 5000, 'minerTAO')}
-    p = _scan_provider(head=100, blocks=blocks)
+    p = _scan_provider(head=100, blocks=blocks, readable_default=True)
     assert p._own_transfer_landed('0xNOTMINE', 'minerTAO', 'userTAO', 5000) is None
 
 
 def test_tao_own_transfer_landed_absent_returns_none():
-    # Genuine failure (nothing on chain) → None → the caller re-sends, which is correct.
-    p = _scan_provider(head=100, blocks={})
+    # Genuine failure (a fully readable window with nothing in it) → None → the caller re-sends.
+    p = _scan_provider(head=100, blocks={}, readable_default=True)
     assert p._own_transfer_landed('0xpay', 'minerTAO', 'userTAO', 5000) is None
+
+
+def test_tao_own_transfer_landed_raises_when_head_unreadable():
+    # Q4a: "couldn't read the head" is not "didn't land" — returning None here would green-light a
+    # re-send of a transfer that may be sitting on-chain → double pay. Must raise so the caller waits.
+    p = _scan_provider(head=100, blocks={}, readable_default=True)
+    p.subtensor.get_current_block.side_effect = RuntimeError('rpc down')
+    with pytest.raises(ProviderUnreachableError):
+        p._own_transfer_landed('0xpay', 'minerTAO', 'userTAO', 5000)
+
+
+def test_tao_own_transfer_landed_raises_when_a_block_in_the_window_is_unreadable():
+    # Q4a: skipping an unreadable block can skip the very block holding the landed transfer.
+    blocks = {90: None}  # one unreadable block mid-window; the rest are readable and empty
+    p = _scan_provider(head=100, blocks=blocks, readable_default=True)
+    with pytest.raises(ProviderUnreachableError):
+        p._own_transfer_landed('0xpay', 'minerTAO', 'userTAO', 5000)
+
+
+def test_tao_own_transfer_landed_anchors_the_scan_on_the_recorded_block():
+    # An RPC outage between polls must not slide the landed transfer out of the lookback window:
+    # the scan anchors on the block recorded at send time, not on today's head.
+    blocks = {100: _raw_transfer_block('0xpay', 'userTAO', 5000, 'minerTAO')}
+    p = _scan_provider(head=1000, blocks=blocks, readable_default=True)
+    assert p._own_transfer_landed('0xpay', 'minerTAO', 'userTAO', 5000, seen_head=100) == ('0xpay', 100)
 
 
 def test_tao_own_transfer_landed_rejects_an_included_but_failed_extrinsic():
@@ -184,7 +219,7 @@ def test_tao_own_transfer_landed_rejects_an_included_but_failed_extrinsic():
     # but it dispatched with an error (fee taken, no Balances.Transfer). Reusing it would mark a swap paid
     # that moved no funds → the miner never retries and rides to a slash. Must return None (safe re-send).
     blocks = {100: _raw_transfer_block('0xpay', 'userTAO', 5000, 'minerTAO', settled=False)}
-    p = _scan_provider(head=100, blocks=blocks)
+    p = _scan_provider(head=100, blocks=blocks, readable_default=True)
     assert p._own_transfer_landed('0xpay', 'minerTAO', 'userTAO', 5000) is None
 
 
@@ -196,9 +231,96 @@ def test_tao_own_transfer_landed_raises_when_settlement_unreadable():
         'extrinsics': [{'extrinsic_hash': '0xpay', 'dest': 'userTAO', 'amount': 5000, 'sender': 'minerTAO'}],
         '_events': [],  # settled_credit treats no-events-on-a-block-with-extrinsics as unreachable
     }
-    p = _scan_provider(head=100, blocks={100: block})
+    p = _scan_provider(head=100, blocks={100: block}, readable_default=True)
     with pytest.raises(ProviderUnreachableError):
         p._own_transfer_landed('0xpay', 'minerTAO', 'userTAO', 5000)
+
+
+# ─── Q4b: a send whose extrinsic hash was lost mid-submit (transfer raised after submission) ─────
+
+
+def test_tao_lost_hash_prior_found_by_triple_scan():
+    # The hash is unknown, but a settled from→to transfer of the amount since the attempt IS the send.
+    blocks = {100: _raw_transfer_block('0xlost', 'userTAO', 5000, 'minerTAO')}
+    p = _scan_provider(head=105, blocks=blocks, readable_default=True)
+    assert p._lost_hash_prior_landed('minerTAO', 'userTAO', 5000, seen_head=99) == ('0xlost', 100)
+
+
+def test_tao_lost_hash_skips_a_transfer_owned_by_another_obligation():
+    # A hash recorded under any scope belongs to a DIFFERENT swap this process sent — adopting it
+    # would report the same tx for two swaps. With the window elapsed, the lost send is dead.
+    blocks = {100: _raw_transfer_block('0xother', 'userTAO', 5000, 'minerTAO')}
+    p = _scan_provider(head=150, blocks=blocks, readable_default=True)
+    p.broadcasted_txids['swapA'] = ('userTAO', 5000, '0xother', 100)
+    assert p._lost_hash_prior_landed('minerTAO', 'userTAO', 5000, seen_head=99) is None
+
+
+def test_tao_lost_hash_waits_while_the_inclusion_window_is_open():
+    # Nothing found yet, but the extrinsic could still include: raise-and-wait, never re-send.
+    p = _scan_provider(head=105, blocks={}, readable_default=True)
+    with pytest.raises(ProviderUnreachableError):
+        p._lost_hash_prior_landed('minerTAO', 'userTAO', 5000, seen_head=100)
+
+
+def test_tao_lost_hash_dead_after_window_scanned_clean():
+    # The full window since the attempt elapsed and every block read clean → provably never landed.
+    p = _scan_provider(head=100 + Tao.SCAN_LOOKBACK_BLOCKS + 1, blocks={}, readable_default=True)
+    assert p._lost_hash_prior_landed('minerTAO', 'userTAO', 5000, seen_head=100) is None
+
+
+def test_tao_lost_hash_raises_when_a_block_is_unreadable():
+    # Even past the window, an unreadable block could hide the landed transfer → keep waiting.
+    blocks = {110: None}
+    p = _scan_provider(head=100 + Tao.SCAN_LOOKBACK_BLOCKS + 1, blocks=blocks, readable_default=True)
+    with pytest.raises(ProviderUnreachableError):
+        p._lost_hash_prior_landed('minerTAO', 'userTAO', 5000, seen_head=100)
+
+
+def _send_provider(head, blocks):
+    p = _scan_provider(head=head, blocks=blocks, readable_default=True)
+    p.wallet = MagicMock()
+    p.wallet.coldkeypub.ss58_address = 'minerTAO'
+    return p
+
+
+def test_tao_send_records_attempt_before_transfer_can_raise():
+    # Q4b: subtensor.transfer raising post-submission (websocket drop during wait_for_inclusion) must
+    # leave a marker, or the next poll re-sends an extrinsic that may have included → double pay.
+    p = _send_provider(head=500, blocks={})
+    p.subtensor.transfer = MagicMock(side_effect=ConnectionError('ws dropped'))
+    assert p.send_amount('userTAO', 5000, dedup_key='swap1') is None
+    assert p.broadcasted_txids['swap1'] == ('userTAO', 5000, '', 500)
+
+
+def test_tao_send_resolves_a_lost_hash_marker_instead_of_resending():
+    # Next poll after the raise: the transfer DID land. It must be adopted and reused — no second send.
+    blocks = {501: _raw_transfer_block('0xlost', 'userTAO', 5000, 'minerTAO')}
+    p = _send_provider(head=505, blocks=blocks)
+    p.broadcasted_txids['swap1'] = ('userTAO', 5000, '', 500)
+    p.subtensor.transfer = MagicMock()
+    assert p.send_amount('userTAO', 5000, dedup_key='swap1') == ('0xlost', 501)
+    p.subtensor.transfer.assert_not_called()
+    assert p.broadcasted_txids['swap1'] == ('userTAO', 5000, '0xlost', 501)
+
+
+def test_tao_send_waits_on_an_unresolved_lost_hash_marker():
+    # Window still open and nothing found: send_amount returns None WITHOUT re-sending.
+    p = _send_provider(head=505, blocks={})
+    p.broadcasted_txids['swap1'] = ('userTAO', 5000, '', 500)
+    p.subtensor.transfer = MagicMock()
+    assert p.send_amount('userTAO', 5000, dedup_key='swap1') is None
+    p.subtensor.transfer.assert_not_called()
+
+
+def test_tao_send_backfills_an_unknown_attempt_head():
+    # Q2's TAO sibling: head was unreadable when the marker was recorded (seen 0). Backfill from the
+    # current head and wait — never treat "age unknown" as "expired, safe to re-send".
+    p = _send_provider(head=505, blocks={})
+    p.broadcasted_txids['swap1'] = ('userTAO', 5000, '', 0)
+    p.subtensor.transfer = MagicMock()
+    assert p.send_amount('userTAO', 5000, dedup_key='swap1') is None
+    p.subtensor.transfer.assert_not_called()
+    assert p.broadcasted_txids['swap1'] == ('userTAO', 5000, '', 505)
 
 
 def test_tao_scanner_finds_matching_transfer_in_new_blocks():

--- a/tests/test_block_time.py
+++ b/tests/test_block_time.py
@@ -179,6 +179,28 @@ def test_tao_own_transfer_landed_absent_returns_none():
     assert p._own_transfer_landed('0xpay', 'minerTAO', 'userTAO', 5000) is None
 
 
+def test_tao_own_transfer_landed_rejects_an_included_but_failed_extrinsic():
+    # Inclusion is NOT settlement: the extrinsic is in the block and decodes to the intended dest/amount,
+    # but it dispatched with an error (fee taken, no Balances.Transfer). Reusing it would mark a swap paid
+    # that moved no funds → the miner never retries and rides to a slash. Must return None (safe re-send).
+    blocks = {100: _raw_transfer_block('0xpay', 'userTAO', 5000, 'minerTAO', settled=False)}
+    p = _scan_provider(head=100, blocks=blocks)
+    assert p._own_transfer_landed('0xpay', 'minerTAO', 'userTAO', 5000) is None
+
+
+def test_tao_own_transfer_landed_raises_when_settlement_unreadable():
+    # The exact extrinsic is on-chain but its settlement events can't be read: RAISE so the caller waits
+    # rather than re-sending an unresolved transfer into a double pay (the send_amount except-branch).
+    block = {
+        '_raw': True,
+        'extrinsics': [{'extrinsic_hash': '0xpay', 'dest': 'userTAO', 'amount': 5000, 'sender': 'minerTAO'}],
+        '_events': [],  # settled_credit treats no-events-on-a-block-with-extrinsics as unreachable
+    }
+    p = _scan_provider(head=100, blocks={100: block})
+    with pytest.raises(ProviderUnreachableError):
+        p._own_transfer_landed('0xpay', 'minerTAO', 'userTAO', 5000)
+
+
 def test_tao_scanner_finds_matching_transfer_in_new_blocks():
     blocks = {100: _raw_transfer_block('0xdep', 'minerTAO', 5000, 'userTAO')}
     p = _scan_provider(head=100, blocks=blocks)

--- a/tests/test_bnb_provider.py
+++ b/tests/test_bnb_provider.py
@@ -13,6 +13,7 @@ from eth_account import Account
 from allways.assets import evm_coin
 from allways.assets.asset import ProviderUnreachableError
 from allways.assets.bnb import Bnb
+from allways.assets.evm import EvmRpcError
 from allways.assets.evm import BSC, EvmChain
 from allways.assets.evm_coin import MAX_WALK_BLOCKS
 from allways.chains import CHAIN_BNB, get_chain_def
@@ -242,7 +243,7 @@ class TestDeliveryGates:
         assert provider.can_deliver_to(RECIPIENT, 10**16) is True
 
         def refuse(params):
-            raise RuntimeError('rpc error execution reverted')
+            raise EvmRpcError('execution reverted', {'code': 3, 'message': 'execution reverted'})
 
         rpc_stub(provider, {'eth_getCode': '0x60806040', 'eth_estimateGas': refuse})
         assert provider.can_deliver_to(RECIPIENT, 10**16) is False
@@ -255,7 +256,7 @@ class TestDeliveryGates:
 
         def gas(params):
             if params[0]['from'] == miner:
-                raise RuntimeError('rpc error execution reverted')
+                raise EvmRpcError('execution reverted', {'code': 3, 'message': 'execution reverted'})
             return hex(90_000)  # 90k raw → 108k with headroom → over the 100k cap
 
         rpc_stub(provider, {'eth_getCode': '0x60806040', 'eth_estimateGas': gas})

--- a/tests/test_bnb_provider.py
+++ b/tests/test_bnb_provider.py
@@ -13,8 +13,7 @@ from eth_account import Account
 from allways.assets import evm_coin
 from allways.assets.asset import ProviderUnreachableError
 from allways.assets.bnb import Bnb
-from allways.assets.evm import EvmRpcError
-from allways.assets.evm import BSC, EvmChain
+from allways.assets.evm import BSC, EvmChain, EvmRpcError
 from allways.assets.evm_coin import MAX_WALK_BLOCKS
 from allways.chains import CHAIN_BNB, get_chain_def
 from allways.constants import LAUNCH_SPOKES

--- a/tests/test_bond_relay.py
+++ b/tests/test_bond_relay.py
@@ -180,21 +180,24 @@ def _relay(vault=None, solana=None, store=None, attribution=None, **cfg):
     return relay
 
 
-def _timeout_event(swap_key=SWAP, miner=MINER, penalty=22 * RAO, reimbursement=22 * RAO, chain='tao', payee=''):
-    return SimpleNamespace(
-        name='SwapTimedOut',
-        block_time=NOW,
-        fields={
-            'swap_key': bytes.fromhex(swap_key),
-            'miner': miner,
-            'collateral_amount': 20 * RAO,
-            'slash': 0,
-            'collateral_chain': chain,
-            'penalty': penalty,
-            'reimbursement': reimbursement,
-            'payee': payee,
-        },
-    )
+def _timeout_event(
+    swap_key=SWAP, miner=MINER, penalty=22 * RAO, reimbursement=22 * RAO, chain='tao', payee='', hotkey=None
+):
+    fields = {
+        'swap_key': bytes.fromhex(swap_key),
+        'miner': miner,
+        'collateral_amount': 20 * RAO,
+        'slash': 0,
+        'collateral_chain': chain,
+        'penalty': penalty,
+        'reimbursement': reimbursement,
+        'payee': payee,
+    }
+    # V-M1: the verdict carries the initiate-pinned hotkey (raw bytes). None = a pre-upgrade event
+    # without the field, which the relay must keep tolerating.
+    if hotkey is not None:
+        fields['hotkey'] = hotkey
+    return SimpleNamespace(name='SwapTimedOut', block_time=NOW, fields=fields)
 
 
 def _completed_event(swap_key=SWAP2, miner=MINER, fee=2 * RAO, chain='tao'):
@@ -466,6 +469,26 @@ def test_a_pre_f1_snapshot_without_a_hotkey_falls_back_to_the_live_binding():
     relay.step(NOW)
     slash = next(c for c in relay.vault.calls if c[0] == 'vote_slash')
     assert slash[1] == HOTKEY
+
+
+def test_a_snapshotless_validator_reads_the_hotkey_from_the_verdict_itself():
+    # V-M1: no observe-time snapshot (down for the swap's whole life) — the verdict's pinned hotkey
+    # is the seizure target, taking precedence over the live binding lookup.
+    relay = _relay(attribution={MINER: HOTKEY2})  # live binding disagrees; the pin must win
+    relay.ingest_events([_timeout_event(payee=USER_TAO, hotkey=bytes([1] * 32))])
+    relay.step(NOW)
+    slash = next(c for c in relay.vault.calls if c[0] == 'vote_slash')
+    assert slash[1] == HOTKEY, 'the seizure targets the hotkey pinned on-chain at initiate'
+
+
+def test_a_zeroed_verdict_hotkey_is_treated_as_unbound_not_a_target():
+    # A pre-pin swap / never-bound miner emits [0]*32 — that must not become a vault AccountId; the
+    # relay falls back to the live lookup exactly as before the field existed.
+    relay = _relay()
+    relay.ingest_events([_timeout_event(payee=USER_TAO, hotkey=bytes(32))])
+    relay.step(NOW)
+    slash = next(c for c in relay.vault.calls if c[0] == 'vote_slash')
+    assert slash[1] == HOTKEY, 'zeros defer to the live binding'
 
 
 def test_the_hotkey_snapshot_round_trips_through_swap_and_slash():

--- a/tests/test_btc_fee_estimate.py
+++ b/tests/test_btc_fee_estimate.py
@@ -6,8 +6,6 @@ higher `BTC_FALLBACK_FEE_RATE`, while a successful estimate still floors at `BTC
 (calm-mempool sends keep paying the real low rate). Backend mocked — no network, no real sleep.
 """
 
-import pytest
-
 from allways.constants import BTC_FALLBACK_FEE_RATE, BTC_MIN_FEE_RATE
 
 

--- a/tests/test_btc_fee_estimate.py
+++ b/tests/test_btc_fee_estimate.py
@@ -1,0 +1,69 @@
+"""BTC fee-rate estimation fallback (V-L5).
+
+A silent drop to the 5 sat/vB mempool floor when /fee-estimates is down stranded a real dest tx.
+The floor and the estimation-DOWN fallback are now distinct: a failed estimate broadcasts at the
+higher `BTC_FALLBACK_FEE_RATE`, while a successful estimate still floors at `BTC_MIN_FEE_RATE`
+(calm-mempool sends keep paying the real low rate). Backend mocked — no network, no real sleep.
+"""
+
+import pytest
+
+from allways.constants import BTC_FALLBACK_FEE_RATE, BTC_MIN_FEE_RATE
+
+
+class _Resp:
+    def __init__(self, *, status_code=200, body=None):
+        self.status_code = status_code
+        self._body = body if body is not None else {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(str(self.status_code))
+
+    def json(self):
+        return self._body
+
+
+def _provider(monkeypatch):
+    monkeypatch.setenv('BTC_MODE', 'lightweight')
+    import allways.assets.btc as btc_mod
+    from allways.assets.btc import Bitcoin
+
+    monkeypatch.setattr(btc_mod.time, 'sleep', lambda _s: None)  # no real 3s retry wait
+    return Bitcoin()
+
+
+def test_estimate_success_pads_and_floors(monkeypatch):
+    p = _provider(monkeypatch)
+    # 20 sat/vB * 1.25 pad = 25, above the floor → returned as-is.
+    monkeypatch.setattr(p, 'btc_api_get', lambda path, timeout=10: _Resp(body={'2': 20.0}))
+    assert p.estimate_fee_rate() == 25
+
+
+def test_calm_mempool_still_floors_low_not_fallback(monkeypatch):
+    p = _provider(monkeypatch)
+    # 1 sat/vB * 1.25 = 1 < floor → floor binds. The fallback must NOT leak into the success path.
+    monkeypatch.setattr(p, 'btc_api_get', lambda path, timeout=10: _Resp(body={'2': 1.0}))
+    assert p.estimate_fee_rate() == BTC_MIN_FEE_RATE
+
+
+def test_estimation_down_uses_fallback_not_floor(monkeypatch):
+    p = _provider(monkeypatch)
+
+    def down(path, timeout=10):
+        raise ConnectionError('fee-estimates unavailable')
+
+    monkeypatch.setattr(p, 'btc_api_get', down)
+    rate = p.estimate_fee_rate()
+    assert rate == BTC_FALLBACK_FEE_RATE
+    assert rate > BTC_MIN_FEE_RATE  # the whole point: not the strand-prone floor
+
+
+def test_override_bypasses_estimation(monkeypatch):
+    p = _provider(monkeypatch)
+
+    def forbidden(*_a, **_kw):
+        raise AssertionError('an explicit override must not hit the estimator')
+
+    monkeypatch.setattr(p, 'btc_api_get', forbidden)
+    assert p.estimate_fee_rate(override=7) == 7

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -289,3 +289,44 @@ class TestReplayGrace:
         grace = CHAIN_ETH.replay_grace_secs
         assert is_tx_fresh(SimpleNamespace(block_time=floor - grace), floor, grace)
         assert not is_tx_fresh(SimpleNamespace(block_time=floor - grace - 1), floor, grace)
+
+
+class TestApplyTestnetNetworkDefaults:
+    """A testnet neuron must never fall through to a provider's mainnet default for an unset
+    {PREFIX}_NETWORK — that verifies test swaps against mainnet or spends real mainnet funds."""
+
+    def test_unset_spokes_default_to_testnet(self, monkeypatch):
+        from allways.chains import apply_testnet_network_defaults
+
+        for chain in SUPPORTED_CHAINS.values():
+            if chain.networks:
+                monkeypatch.delenv(f'{chain.env_prefix}_NETWORK', raising=False)
+        applied = apply_testnet_network_defaults()
+        # BTC's testnet is testnet4; ETH's is sepolia — a representative name-selected pair.
+        assert applied['BTC_NETWORK'] == CHAIN_BTC.testnet_network == 'testnet4'
+        assert applied['ETH_NETWORK'] == CHAIN_ETH.testnet_network == 'sepolia'
+        import os
+
+        assert os.environ['BTC_NETWORK'] == 'testnet4'
+
+    def test_explicit_env_var_wins(self, monkeypatch):
+        from allways.chains import apply_testnet_network_defaults
+
+        monkeypatch.setenv('ETH_NETWORK', 'mainnet')  # operator opts one spoke back to mainnet
+        applied = apply_testnet_network_defaults()
+        assert 'ETH_NETWORK' not in applied
+        import os
+
+        assert os.environ['ETH_NETWORK'] == 'mainnet'
+
+    def test_skips_chains_without_a_named_testnet(self, monkeypatch):
+        # sol/tao pick their network by RPC/bittensor, not {PREFIX}_NETWORK; a shared-prefix
+        # secondary (polusdc under POL) carries no networks of its own. Neither is touched.
+        from allways.chains import apply_testnet_network_defaults
+
+        monkeypatch.delenv('POL_NETWORK', raising=False)
+        applied = apply_testnet_network_defaults()
+        assert CHAIN_TAO.env_prefix + '_NETWORK' not in applied
+        assert CHAIN_POLUSDC.env_prefix + '_NETWORK' in applied  # POL (its own row) IS named
+        # polusdc itself contributes no separate var — POL owns the prefix.
+        assert CHAIN_POLUSDC.networks == ()

--- a/tests/test_cro_provider.py
+++ b/tests/test_cro_provider.py
@@ -14,6 +14,7 @@ from eth_account import Account
 from allways.assets import evm_coin
 from allways.assets.asset import ProviderUnreachableError
 from allways.assets.cro import Cro
+from allways.assets.evm import EvmRpcError
 from allways.assets.evm import CRONOS, EvmChain
 from allways.assets.evm_coin import MAX_WALK_BLOCKS
 from allways.chains import CHAIN_CRO, get_chain_def
@@ -252,7 +253,7 @@ class TestDeliveryGates:
         assert provider.can_deliver_to(RECIPIENT, 10**16) is True
 
         def refuse(params):
-            raise RuntimeError('rpc error execution reverted')
+            raise EvmRpcError('execution reverted', {'code': 3, 'message': 'execution reverted'})
 
         rpc_stub(provider, {'eth_getCode': '0x60806040', 'eth_estimateGas': refuse})
         assert provider.can_deliver_to(RECIPIENT, 10**16) is False

--- a/tests/test_cro_provider.py
+++ b/tests/test_cro_provider.py
@@ -14,8 +14,7 @@ from eth_account import Account
 from allways.assets import evm_coin
 from allways.assets.asset import ProviderUnreachableError
 from allways.assets.cro import Cro
-from allways.assets.evm import EvmRpcError
-from allways.assets.evm import CRONOS, EvmChain
+from allways.assets.evm import CRONOS, EvmChain, EvmRpcError
 from allways.assets.evm_coin import MAX_WALK_BLOCKS
 from allways.chains import CHAIN_CRO, get_chain_def
 from allways.constants import LAUNCH_SPOKES

--- a/tests/test_erc20_refusal_checks.py
+++ b/tests/test_erc20_refusal_checks.py
@@ -55,9 +55,9 @@ def test_an_undeclared_row_fails_at_construction():
         Erc20(replace(DECLARED, refusal_checks=None))
 
 
-def test_check_connection_raises_when_token_probe_errors():
-    # An ERC-20's token contract is its asset identity — a getCode probe we can't complete must fail
-    # boot, not warn-and-continue (a warn boots a broken/misconfigured token as "ready").
+def test_check_connection_degrades_when_token_probe_unreachable():
+    # A probe we can't COMPLETE is transient (flaky RPC / rate-limit storm). It must NOT crash the whole
+    # validator at boot over one spoke — that takes the hub down too. Degrade (return), don't raise.
     def rpc(method, params, **kw):
         if method == 'eth_getCode':
             raise EvmRpcError('token RPC unreachable')
@@ -65,7 +65,20 @@ def test_check_connection_raises_when_token_probe_errors():
 
     provider = build(DECLARED, rpc)
     provider.chain.connect_network = lambda: (1, 100)  # host chain reachable; isolate the token probe
-    with pytest.raises(ConnectionError):
+    provider.check_connection(require_send=False)  # no raise
+
+
+def test_check_connection_raises_on_codeless_contract():
+    # The genuine config fault is a COMPLETED probe returning '0x' (typo'd / wrong-network contract) —
+    # that stays fatal, or every later send fails against a non-contract.
+    def rpc(method, params, **kw):
+        if method == 'eth_getCode':
+            return '0x'
+        return hex(1000)
+
+    provider = build(DECLARED, rpc)
+    provider.chain.connect_network = lambda: (1, 100)
+    with pytest.raises(ConnectionError, match='no code'):
         provider.check_connection(require_send=False)
 
 

--- a/tests/test_erc20_refusal_checks.py
+++ b/tests/test_erc20_refusal_checks.py
@@ -72,6 +72,19 @@ def test_check_connection_degrades_when_token_probe_unreachable():
     provider.check_connection(require_send=False)  # no raise
 
 
+def test_check_connection_degrades_on_a_null_code_answer():
+    # `result: null` from a broken/lagging endpoint is not a codeless contract (the spec returns the
+    # string '0x' for that) — it must take the transient/degrade path, not the fatal config raise.
+    def rpc(method, params, **kw):
+        if method == 'eth_getCode':
+            return None
+        return hex(1000)
+
+    provider = build(DECLARED, rpc)
+    provider.chain.connect_network = lambda: (1, 100)
+    provider.check_connection(require_send=False)  # no raise
+
+
 def test_check_connection_raises_on_codeless_contract():
     # The genuine config fault is a COMPLETED probe returning '0x' (typo'd / wrong-network contract) —
     # that stays fatal, or every later send fails against a non-contract.

--- a/tests/test_erc20_refusal_checks.py
+++ b/tests/test_erc20_refusal_checks.py
@@ -14,10 +14,14 @@ from dataclasses import replace
 
 import pytest
 
-from allways.assets.erc20 import SEL_IS_BLACKLISTED, Erc20, _refusal_call
+from allways.assets.erc20 import SEL_IS_BLACKLISTED, Erc20, _refusal_call, _selector
 from allways.assets.evm import EvmRpcError
-from allways.chains import CHAIN_ETHUSDC
-from allways.constants import CANCEL_REASON_ERC20_BLACKLIST, CANCEL_REASON_ERC20_PAUSED
+from allways.chains import CHAIN_ETHUSDC, CHAIN_PAXG
+from allways.constants import (
+    CANCEL_REASON_ERC20_BLACKLIST,
+    CANCEL_REASON_ERC20_FEE_ENABLED,
+    CANCEL_REASON_ERC20_PAUSED,
+)
 
 RECIPIENT = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
 DECLARED = CHAIN_ETHUSDC  # ('isBlacklisted(address)', 'paused()')
@@ -174,3 +178,37 @@ class TestCancelEvidenceReadsTheDeclaredSurface:
             raise ConnectionError('every endpoint is down')
 
         assert build(self.PAXOS, down).cancel_evidence(RECIPIENT, amount=1) is None
+
+
+class TestFeeEnabledYieldsCancelEvidence:
+    """V-M2: an issuer that switches on a transfer fee (PAXG's admin lever) shaves every honest
+    delivery's Transfer log below the pinned amount — a hub-wide, no-fault condition. The row's
+    ``fee_check`` (getFeeFor) turns it into a cancel instead of mass-slashing honest miners."""
+
+    FEE_SEL = _selector('getFeeFor(uint256)')  # CHAIN_PAXG's declared fee_check
+
+    def _rpc(self, fee):
+        # Refusal probes (isFrozen/paused) answer clean; only the fee view carries a value.
+        def rpc(method, params, **kw):
+            if params[0]['data'].startswith(self.FEE_SEL):
+                return f'0x{fee:064x}'
+            return f'0x{0:064x}'
+
+        return rpc
+
+    def test_a_live_fee_becomes_a_no_fault_cancel(self):
+        provider = build(CHAIN_PAXG, self._rpc(fee=7))
+        assert provider.cancel_evidence(RECIPIENT, amount=2_000_000_000_000_000) == CANCEL_REASON_ERC20_FEE_ENABLED
+
+    def test_a_zero_fee_yields_no_evidence(self):
+        # The live state today: Paxos feeRate==0, so getFeeFor floors to 0 and deliveries flow.
+        provider = build(CHAIN_PAXG, self._rpc(fee=0))
+        assert provider.cancel_evidence(RECIPIENT, amount=2_000_000_000_000_000) is None
+
+    def test_a_row_without_a_fee_lever_never_probes(self):
+        # A token declaring no fee_check must answer WITHOUT sending the fee selector.
+        def rpc(method, params, **kw):
+            assert not params[0]['data'].startswith(self.FEE_SEL), 'probed a fee on a fee-less row'
+            return f'0x{0:064x}'
+
+        assert build(CHAIN_ETHUSDC, rpc).cancel_evidence(RECIPIENT, amount=1) is None

--- a/tests/test_erc20_refusal_checks.py
+++ b/tests/test_erc20_refusal_checks.py
@@ -55,6 +55,20 @@ def test_an_undeclared_row_fails_at_construction():
         Erc20(replace(DECLARED, refusal_checks=None))
 
 
+def test_check_connection_raises_when_token_probe_errors():
+    # An ERC-20's token contract is its asset identity — a getCode probe we can't complete must fail
+    # boot, not warn-and-continue (a warn boots a broken/misconfigured token as "ready").
+    def rpc(method, params, **kw):
+        if method == 'eth_getCode':
+            raise EvmRpcError('token RPC unreachable')
+        return hex(1000)
+
+    provider = build(DECLARED, rpc)
+    provider.chain.connect_network = lambda: (1, 100)  # host chain reachable; isolate the token probe
+    with pytest.raises(ConnectionError):
+        provider.check_connection(require_send=False)
+
+
 class TestNoChecksNeverTouchTheRpc:
     """Recorded on a transcript, never by raising inside the stub — ``can_deliver_to`` swallows
     every exception into its fail-open ``True``, so a raising stub would be satisfied by the

--- a/tests/test_ethereum_provider.py
+++ b/tests/test_ethereum_provider.py
@@ -706,7 +706,7 @@ class TestDeliveryGates:
     must be ungameable (slash gate)."""
 
     def _revert(self, params):
-        raise RuntimeError('rpc error execution reverted')
+        raise EvmRpcError('execution reverted', {'code': 3, 'message': 'execution reverted'})
 
     def test_can_deliver_to_eoa_true_without_simulation(self, provider):
         calls = counting_rpc_stub(provider, {'eth_getCode': '0x'})
@@ -733,7 +733,7 @@ class TestDeliveryGates:
         # `receive()` gated on msg.sender) — the reserve gate must run the send's simulation.
         def gas(params):
             if params[0]['from'] == TEST_ADDR:
-                raise RuntimeError('rpc error execution reverted')
+                raise EvmRpcError('execution reverted', {'code': 3, 'message': 'execution reverted'})
             return '0xb000'
 
         rpc_stub(provider, {'eth_getCode': '0x6080', 'eth_estimateGas': gas})
@@ -789,7 +789,7 @@ class TestTransferGas:
         # P0: a reverting dest no longer bails silently — the miner broadcasts a floor-gas attempt so the
         # on-chain reverted tx becomes no-fault-cancel evidence (a REFUSE, not a false timeout slash).
         def revert(params):
-            raise RuntimeError('rpc error execution reverted')
+            raise EvmRpcError('execution reverted', {'code': 3, 'message': 'execution reverted'})
 
         assert self._send(provider, revert) is not None
 

--- a/tests/test_event_index.py
+++ b/tests/test_event_index.py
@@ -225,10 +225,24 @@ class TestIngestActivity:
         idx = make_index(store, ttl=30)
         idx.ingest(
             [
-                rec('PoolResolved', miner='pk_a', block_time=200, winner='pk_router',
-                    user='pk_user', requests=1, collateral_chain='sol'),
-                rec('PoolResolved', miner='pk_a', block_time=200, winner='pk_router',
-                    user='pk_user', requests=1, collateral_chain='tao'),
+                rec(
+                    'PoolResolved',
+                    miner='pk_a',
+                    block_time=200,
+                    winner='pk_router',
+                    user='pk_user',
+                    requests=1,
+                    collateral_chain='sol',
+                ),
+                rec(
+                    'PoolResolved',
+                    miner='pk_a',
+                    block_time=200,
+                    winner='pk_router',
+                    user='pk_user',
+                    requests=1,
+                    collateral_chain='tao',
+                ),
                 rec('ReservationFilled', miner='pk_a', block_time=210, reserved_until=600, collateral_chain='tao'),
             ],
             ATTR,

--- a/tests/test_event_index.py
+++ b/tests/test_event_index.py
@@ -577,6 +577,35 @@ class TestIngestSwapOutcomes:
         assert store.get_swap_outcome(key.hex()) == 'expired'
         store.close()
 
+    def test_unbound_miner_still_records_terminal_outcome(self, tmp_path: Path):
+        """V-M5: a miner that deregs mid-swap is unbound at ingest, but the terminal outcome +
+        delivery hash are keyed purely by swap_key — record them so /status can resolve, while
+        the UID-crediting clearing volume stays empty."""
+        store = make_store(tmp_path)
+        idx = SolanaEventIndex(store)
+        key = bytes(range(32))
+        n = idx.ingest(
+            [
+                rec('SwapFulfilled', miner='pk_c', block_time=390, swap_key=key, to_tx_hash='0xdead'),
+                rec(
+                    'SwapCompleted',
+                    miner='pk_c',  # unbound
+                    block_time=400,
+                    swap_key=key,
+                    from_chain='btc',
+                    to_chain='tao',
+                    from_amount=100,
+                    to_amount=200,
+                ),
+            ],
+            ATTR,
+        )
+        assert n == 2
+        assert store.get_swap_outcome(key.hex()) == 'completed'
+        assert store.get_swap_fulfillment(key.hex()) == '0xdead'
+        assert store.get_clearing_volumes(0, 1000) == {}  # no UID → no volume credited
+        store.close()
+
     def test_reingest_of_same_event_is_a_noop_upsert(self, tmp_path: Path):
         """A cursor reset can replay history — the outcome row upserts instead of erroring."""
         store = make_store(tmp_path)

--- a/tests/test_event_index.py
+++ b/tests/test_event_index.py
@@ -104,6 +104,41 @@ class TestIngestActivity:
         assert idx.get_activity_state_at(400) == {}  # reap → AVAILABLE, well before the synthetic 1200 expiry
         store.close()
 
+    def test_reap_moves_the_guess_so_the_next_reservation_is_not_freed_early(self, tmp_path: Path):
+        """The reap must MOVE the draw+ttl guess, not insert a second expiry beside it: the leftover
+        guess fires later, inside the next reservation's pre-initiate window, freeing it early."""
+        store = make_store(tmp_path)
+        idx = make_index(store, ttl=1000)
+        idx.ingest(
+            [
+                rec('PoolResolved', miner='pk_a', block_time=200, winner='pk_router', user='pk_user', requests=1),
+                rec('UnfilledReservationClosed', miner='pk_a', block_time=400, router='pk_router'),
+                rec('PoolResolved', miner='pk_a', block_time=1100, winner='pk_router', user='pk_user', requests=1),
+            ],
+            ATTR,
+        )
+        assert idx.get_activity_state_at(1150) == {'hk_a': _both(MinerActivity.RESERVED)}
+        # The first reservation's stale guess (draw 200 + ttl 1000 = 1200) must not fire mid-reservation.
+        assert idx.get_activity_state_at(1300) == {'hk_a': _both(MinerActivity.RESERVED)}
+        store.close()
+
+    def test_restamp_never_drags_a_prior_reservations_fired_expiry(self, tmp_path: Path):
+        """A ReservationFilled whose own PoolResolved was dropped (fresh DB, no-TTL gap) must not move
+        the PREVIOUS reservation's already-fired expiry forward — that reads the miner busy across
+        the gap between the two reservations."""
+        store = make_store(tmp_path)
+        idx = make_index(store, ttl=100)
+        idx.ingest(
+            [
+                rec('PoolResolved', miner='pk_a', block_time=200, winner='pk_router', user='pk_user', requests=1),
+                rec('ReservationFilled', miner='pk_a', block_time=500, reserved_until=900),
+            ],
+            ATTR,
+        )
+        # The first reservation expired at 300; the orphaned Filled (its PoolResolved unseen) is a no-op.
+        assert idx.get_activity_state_at(600) == {}
+        store.close()
+
     def test_swap_cancelled_frees_the_hub(self, tmp_path: Path):
         """The no-fault cancel is a terminal like completion/timeout: without its FULFILL_END
         the hub stays FULFILLING (crownless) until an unrelated swap's terminal repairs it."""

--- a/tests/test_event_index.py
+++ b/tests/test_event_index.py
@@ -88,6 +88,22 @@ class TestIngestActivity:
         assert idx.get_activity_state_at(400) == {}  # completed → AVAILABLE
         store.close()
 
+    def test_unfilled_reservation_closed_frees_the_miner(self, tmp_path: Path):
+        """V-L8: the permissionless reap frees the miner on-chain; the crown index must free it too,
+        not leave it RESERVED until the synthetic RESERVE_EXPIRE fires."""
+        store = make_store(tmp_path)
+        idx = make_index(store, ttl=1000)  # synthetic expiry would land at 1200
+        idx.ingest(
+            [
+                rec('PoolResolved', miner='pk_a', block_time=200, winner='pk_router', user='pk_user', requests=1),
+                rec('UnfilledReservationClosed', miner='pk_a', block_time=400, router='pk_router'),
+            ],
+            ATTR,
+        )
+        assert idx.get_activity_state_at(300) == {'hk_a': _both(MinerActivity.RESERVED)}  # reserved before the reap
+        assert idx.get_activity_state_at(400) == {}  # reap → AVAILABLE, well before the synthetic 1200 expiry
+        store.close()
+
     def test_swap_cancelled_frees_the_hub(self, tmp_path: Path):
         """The no-fault cancel is a terminal like completion/timeout: without its FULFILL_END
         the hub stays FULFILLING (crownless) until an unrelated swap's terminal repairs it."""

--- a/tests/test_event_index.py
+++ b/tests/test_event_index.py
@@ -154,6 +154,92 @@ class TestIngestActivity:
         assert kinds == [1, 3]  # RESERVE_START then synthetic RESERVE_EXPIRE
         store.close()
 
+    def test_reservation_filled_restamps_expiry_so_late_initiate_stays_busy(self, tmp_path: Path):
+        """V-H5: PoolResolved's draw+ttl expiry is a guess. When SwapInitiated lands after it
+        (slow BTC confs), the miner must still be FULFILLING — not scored AVAILABLE and earning the
+        crown while busy. ReservationFilled carries the real reserved_until; we re-stamp the guess."""
+        store = make_store(tmp_path)
+        idx = make_index(store, ttl=30)  # tiny ttl → synthetic expiry at 230, before SwapInitiated
+        idx.ingest(
+            [
+                rec('PoolResolved', miner='pk_a', block_time=200, winner='pk_router', user='pk_user', requests=1),
+                rec('ReservationFilled', miner='pk_a', block_time=210, reserved_until=600),
+                rec('SwapInitiated', miner='pk_a', block_time=250),
+                rec(
+                    'SwapCompleted',
+                    miner='pk_a',
+                    block_time=400,
+                    from_chain='btc',
+                    to_chain='tao',
+                    from_amount=100_000,
+                    to_amount=500_000_000,
+                ),
+            ],
+            ATTR,
+        )
+        # Re-stamped to 600, so the miner is NOT freed at the old 230 guess.
+        assert idx.get_activity_state_at(230) == {'hk_a': _both(MinerActivity.RESERVED)}
+        # The bug regression: without the re-stamp this would be {} (AVAILABLE) — FULFILL_START
+        # would have hit AVAILABLE (no edge) and held there through the whole swap.
+        assert idx.get_activity_state_at(250) == {'hk_a': _both(MinerActivity.FULFILLING)}
+        assert idx.get_activity_state_at(399) == {'hk_a': _both(MinerActivity.FULFILLING)}
+        assert idx.get_activity_state_at(400) == {}  # completed → AVAILABLE
+        # The single RESERVE_EXPIRE row was moved (not duplicated) from 230 to 600.
+        expiries = [e['block'] for e in idx.get_activity_events_in_range(0, 2000) if e['kind'] == 3]
+        assert expiries == [600]
+        store.close()
+
+    def test_reservation_extended_pushes_expiry(self, tmp_path: Path):
+        """A claim-runway extend (validator slides reserved_until for slow source confs) emits
+        ReservationExtended — the expiry must follow it, else the miner is freed mid-fulfillment."""
+        store = make_store(tmp_path)
+        idx = make_index(store, ttl=30)
+        idx.ingest(
+            [
+                rec('PoolResolved', miner='pk_a', block_time=200, winner='pk_router', user='pk_user', requests=1),
+                rec('ReservationFilled', miner='pk_a', block_time=210, reserved_until=300),
+                rec('ReservationExtended', miner='pk_a', block_time=280, reserved_until=900, validator='pk_router'),
+                rec('SwapInitiated', miner='pk_a', block_time=350),  # past the pre-extend 300 deadline
+                rec(
+                    'SwapCompleted',
+                    miner='pk_a',
+                    block_time=600,
+                    from_chain='btc',
+                    to_chain='tao',
+                    from_amount=100_000,
+                    to_amount=500_000_000,
+                ),
+            ],
+            ATTR,
+        )
+        assert idx.get_activity_state_at(250) == {'hk_a': _both(MinerActivity.RESERVED)}
+        assert idx.get_activity_state_at(350) == {'hk_a': _both(MinerActivity.FULFILLING)}
+        assert idx.get_activity_state_at(600) == {}  # completed → AVAILABLE
+        expiries = [e['block'] for e in idx.get_activity_events_in_range(0, 2000) if e['kind'] == 3]
+        assert expiries == [900]  # one row, pushed guess(230)→fill(300)→extend(900)
+        store.close()
+
+    def test_restamp_targets_only_its_own_hub(self, tmp_path: Path):
+        """The re-stamp matches on hub, so a fill on one purse must not move the sibling's expiry."""
+        store = make_store(tmp_path)
+        idx = make_index(store, ttl=30)
+        idx.ingest(
+            [
+                rec('PoolResolved', miner='pk_a', block_time=200, winner='pk_router',
+                    user='pk_user', requests=1, collateral_chain='sol'),
+                rec('PoolResolved', miner='pk_a', block_time=200, winner='pk_router',
+                    user='pk_user', requests=1, collateral_chain='tao'),
+                rec('ReservationFilled', miner='pk_a', block_time=210, reserved_until=600, collateral_chain='tao'),
+            ],
+            ATTR,
+        )
+        # tao expiry moved to 600; sol expiry untouched at the 230 guess.
+        rows = idx.get_activity_events_in_range(0, 2000)
+        expiries = sorted((e['hub'], e['block']) for e in rows if e['kind'] == 3)
+        assert expiries == [('sol', 230), ('tao', 600)]
+        assert idx.get_activity_state_at(400) == {'hk_a': {'tao': MinerActivity.RESERVED}}  # sol freed, tao held
+        store.close()
+
     def test_busy_miner_is_the_reserved_miner_not_the_router(self, tmp_path: Path):
         """PoolResolved.miner (not .winner, the router) is busy-gated."""
         store = make_store(tmp_path)

--- a/tests/test_finalize_sweep.py
+++ b/tests/test_finalize_sweep.py
@@ -35,8 +35,17 @@ class SweepClient:
         return self._reservation
 
     def finalize_reservation(
-        self, miner, user, user_from_addr, user_to_addr, collateral_amount, from_amount, to_amount, backing='sol',
-        *, from_chain=None
+        self,
+        miner,
+        user,
+        user_from_addr,
+        user_to_addr,
+        collateral_amount,
+        from_amount,
+        to_amount,
+        backing='sol',
+        *,
+        from_chain=None,
     ):
         self.finalized.append(
             (str(miner), str(user), user_from_addr, user_to_addr, collateral_amount, from_amount, to_amount)

--- a/tests/test_finalize_sweep.py
+++ b/tests/test_finalize_sweep.py
@@ -35,7 +35,8 @@ class SweepClient:
         return self._reservation
 
     def finalize_reservation(
-        self, miner, user, user_from_addr, user_to_addr, collateral_amount, from_amount, to_amount, backing='sol'
+        self, miner, user, user_from_addr, user_to_addr, collateral_amount, from_amount, to_amount, backing='sol',
+        *, from_chain=None
     ):
         self.finalized.append(
             (str(miner), str(user), user_from_addr, user_to_addr, collateral_amount, from_amount, to_amount)

--- a/tests/test_finalize_sweep.py
+++ b/tests/test_finalize_sweep.py
@@ -26,9 +26,12 @@ class SweepClient:
     def __init__(self, reservation):
         self.keypair = SolKeypair()
         self._reservation = reservation
+        self.siblings = {}  # backing -> reservation, for the duplicate-source guard's sibling read
         self.finalized = []
 
     def get_reservation(self, miner, backing='sol'):
+        if backing in self.siblings:
+            return self.siblings[backing]
         return self._reservation
 
     def finalize_reservation(
@@ -80,6 +83,43 @@ def test_won_seat_finalizes_fifo_user_at_pinned_rate(tmp_path):
     assert to_amount == 210_000
     # Whole queue dropped: winner served, losers re-request via their clients.
     assert v.state_store.distinct_routed_pools() == []
+    v.state_store.close()
+
+
+def _live_sibling(*, from_chain='sol', from_addr='', reserved_until=NOW + 300):
+    """A live-unclaimed reservation on the miner's OTHER hub, for the duplicate-source guard."""
+    return SimpleNamespace(
+        from_chain=from_chain,
+        from_addr=from_addr,
+        reserved_until=reserved_until,
+        claimed_swap_key=b'\x00' * 32,  # unclaimed → in the matchable set
+    )
+
+
+def test_duplicate_source_addr_on_other_hub_is_refused(tmp_path):
+    # V-C2: a source address may back only one live-unclaimed reservation per miner. The winner's
+    # from_addr already backs a LIVE reservation on the miner's tao hub (same from_chain), so a single
+    # deposit could satisfy both — refuse to finalize the duplicate rather than let it be siphoned.
+    client = SweepClient(None)
+    client._reservation = _drawn_seat(client)  # the sol seat we're about to finalize
+    client.siblings['tao'] = _live_sibling(from_chain='sol', from_addr=f'{USER_A[:6]}src')
+    v = _validator(tmp_path, client)
+    _queue(v.state_store, USER_A)  # user_from_addr == f'{USER_A[:6]}src' → collides
+    assert finalize_won_seats(v, NOW) == []
+    assert not client.finalized, 'colliding-source seat must not be finalized'
+    assert v.state_store.distinct_routed_pools() == [], 'colliding queue dropped'
+    v.state_store.close()
+
+
+def test_different_source_addr_on_other_hub_finalizes(tmp_path):
+    # A DIFFERENT source address on the other hub is a normal simultaneous swap — must still finalize.
+    client = SweepClient(None)
+    client._reservation = _drawn_seat(client)
+    client.siblings['tao'] = _live_sibling(from_chain='sol', from_addr='someone-elses-src')
+    v = _validator(tmp_path, client)
+    _queue(v.state_store, USER_A)  # user_from_addr == f'{USER_A[:6]}src' → no collision
+    assert finalize_won_seats(v, NOW) == [MINER]
+    assert len(client.finalized) == 1
     v.state_store.close()
 
 

--- a/tests/test_finalize_sweep.py
+++ b/tests/test_finalize_sweep.py
@@ -107,7 +107,24 @@ def test_duplicate_source_addr_on_other_hub_is_refused(tmp_path):
     _queue(v.state_store, USER_A)  # user_from_addr == f'{USER_A[:6]}src' → collides
     assert finalize_won_seats(v, NOW) == []
     assert not client.finalized, 'colliding-source seat must not be finalized'
-    assert v.state_store.distinct_routed_pools() == [], 'colliding queue dropped'
+    # Queue is NOT dropped: the only user collides, so nothing finalizes this pass, but the entry persists
+    # (its sibling may clear, or the TTL prunes it) — dropping it would be a griefing lever (see below).
+    assert v.state_store.distinct_routed_pools() != [], 'colliding queue must persist, not be dropped'
+    v.state_store.close()
+
+
+def test_colliding_front_user_does_not_block_an_honest_user(tmp_path):
+    # V-C2 griefing guard: from_addrs are public, so an attacker can queue a front (oldest) request whose
+    # source collides with a live seat. That must NOT knock out the honest queued users behind it — the
+    # sweep skips the colliding entry and finalizes the next eligible user.
+    client = SweepClient(None)
+    client._reservation = _drawn_seat(client)
+    client.siblings['tao'] = _live_sibling(from_chain='sol', from_addr=f'{USER_A[:6]}src')  # USER_A collides
+    v = _validator(tmp_path, client)
+    _queue(v.state_store, USER_A, created_at=NOW - 50)  # oldest, colliding — the griefer
+    _queue(v.state_store, USER_B, created_at=NOW - 5)  # honest, non-colliding
+    assert finalize_won_seats(v, NOW) == [MINER]
+    assert len(client.finalized) == 1 and client.finalized[0][1] == USER_B, 'honest user must still be served'
     v.state_store.close()
 
 

--- a/tests/test_finalize_sweep.py
+++ b/tests/test_finalize_sweep.py
@@ -96,6 +96,19 @@ def test_won_seat_finalizes_fifo_user_at_pinned_rate(tmp_path):
     v.state_store.close()
 
 
+def test_finalize_commits_the_canonical_source_form(tmp_path):
+    # V-C2: the finalize hash + source-lock PDA are byte-keyed on this string, so a cased variant
+    # (queued pre-normalization or by an older validator) must land canonical at commit time.
+    client = SweepClient(None)
+    client._reservation = _drawn_seat(client)
+    v = _validator(tmp_path, client)
+    v.axon_assets = {'sol': SimpleNamespace(chain=SimpleNamespace(normalize_address=lambda a: a.lower()))}
+    v.state_store.upsert_routed_request(MINER, 'sol', 'btc', 'sol', USER_A, '0xAbCsrc', 'dst', 1_000_000_000, NOW - 10)
+    assert finalize_won_seats(v, NOW) == [MINER]
+    assert client.finalized[0][2] == '0xabcsrc'
+    v.state_store.close()
+
+
 def _live_sibling(*, from_chain='sol', from_addr='', reserved_until=NOW + 300):
     """A live-unclaimed reservation on the miner's OTHER hub, for the duplicate-source guard."""
     return SimpleNamespace(

--- a/tests/test_fulfillment.py
+++ b/tests/test_fulfillment.py
@@ -248,5 +248,17 @@ class TestTotalObligationGate:
         f.providers['tao'].get_balance.assert_not_called()
 
 
+class TestSendDestUsesPinnedSender:
+    def test_send_dest_funds_passes_pinned_miner_to_addr_not_stale_cache(self):
+        # H4: the dest send must use the swap's pinned miner_to_addr, not a chain-wide cache that
+        # last-write-wins across quotes (sending from the wrong wallet → slash).
+        provider = MagicMock()
+        provider.send_amount.return_value = ('tx', 1)
+        f = make_fulfiller(my_addresses={'tao': 'STALE-cache-addr'})  # != swap.miner_to_addr ('5miner')
+        f.providers = {'tao': provider}
+        f.send_dest_funds(make_swap(), 396_000_000)
+        assert provider.send_amount.call_args.kwargs['from_address'] == '5miner'
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])

--- a/tests/test_pol_provider.py
+++ b/tests/test_pol_provider.py
@@ -283,7 +283,7 @@ class TestDeliveryGates:
         assert provider.can_deliver_to(RECIPIENT, 10**16) is True
 
         def refuse(params):
-            raise RuntimeError('rpc error execution reverted')
+            raise EvmRpcError('execution reverted', {'code': 3, 'message': 'execution reverted'})
 
         rpc_stub(provider, {'eth_getCode': '0x60806040', 'eth_estimateGas': refuse})
         assert provider.can_deliver_to(RECIPIENT, 10**16) is False

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -515,7 +515,7 @@ class _ConfirmClient(FakeClient):
         self.claims.append((swap_key, from_tx_hash, from_tx_block, backing))
         return 'claimsig'
 
-    def extend_reservation(self, miner, target_at, backing='sol'):
+    def extend_reservation(self, miner, target_at, backing='sol', *, from_chain=None, from_addr=None):
         if self.extend_raises:
             raise RuntimeError('rpc down')
         self.extensions.append(target_at)

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -113,6 +113,19 @@ def test_open_happy_path_persists_routed_request():
     store.close()
 
 
+def test_open_normalizes_the_source_address_at_intake():
+    # V-C2: the queued source address is the string later hashed into the source-lock PDA —
+    # canonicalize at intake so a checksummed EVM-style entry can't mint a divergent lock.
+    client = FakeClient()
+    validator = _validator(client)
+    validator.axon_assets = {'sol': SimpleNamespace(chain=SimpleNamespace(normalize_address=lambda a: a.lower()))}
+    r = reserve_on_behalf(validator, HOTKEY, 'sol', 'btc', USER_PK, 'MiXeDcAsE', 'userBTCaddr', 1_000_000_000)
+    assert r.ok
+    queued = validator.state_store.pending_routed_requests(str(MINER_PK), 'sol', 'btc')
+    assert queued[0]['user_from_addr'] == 'mixedcase'
+    validator.state_store.close()
+
+
 def _gate_asset(can_deliver, valid=lambda addr: True):
     """Duck-typed asset for the reserve deliverability gates (can_deliver_to + chain format check)."""
     return SimpleNamespace(
@@ -524,10 +537,11 @@ class _ConfirmClient(FakeClient):
 
 
 class _FakeProvider:
-    def __init__(self, tx_info, *, unreachable=False, grace=0):
+    def __init__(self, tx_info, *, unreachable=False, grace=0, normalize=None):
         self._tx = tx_info
         self._unreachable = unreachable
         self._grace = grace
+        self._normalize = normalize or (lambda a: a)
 
     def verify_transaction(self, **kw):
         if self._unreachable:
@@ -537,6 +551,10 @@ class _FakeProvider:
     @property
     def chain_def(self):
         return SimpleNamespace(replay_grace_secs=self._grace)
+
+    @property
+    def chain(self):
+        return SimpleNamespace(normalize_address=self._normalize)
 
 
 def _confirm_reservation(**over):
@@ -623,6 +641,46 @@ def test_confirm_rejects_when_reservation_already_claimed():
 def test_confirm_provider_unreachable_resends_without_claim():
     r, client = _confirm(_confirm_reservation(), None, unreachable=True)
     assert not r.ok and not client.claims and 'unreachable' in r.reason.lower()
+
+
+def test_confirm_prefers_canonical_form_slot_over_case_variant():
+    # V-C2 residual: a case variant of a live source dodges the byte-keyed source lock. When one
+    # deposit content-matches two slots, the canonical-form (honest-lane) reservation wins the claim
+    # even when the variant slot is older — the variant can only come from bypassing our tooling.
+    variant = _confirm_reservation(from_addr='0xABC', created_at=500)
+    canonical = _confirm_reservation(from_addr='0xabc', created_at=900)
+    client = _ConfirmClient({'sol': variant, 'tao': canonical})
+    provider = _FakeProvider(_tx(confirmed=True, block_time=CONFIRM_CREATED_AT + 5, confirmations=6), normalize=str.lower)
+    validator = SimpleNamespace(solana_client=client, axon_assets={'btc': provider}, axon_lock=threading.RLock())
+    r = confirm_deposit(validator, HOTKEY, 'srctxhash')
+    assert r.ok and len(client.claims) == 1
+    assert client.claims[0][3] == 'tao'  # the canonical slot's backing claimed, not the variant's
+
+
+def test_confirm_prefers_the_oldest_slot_on_a_form_tie():
+    # Dual-backing (V-I1): the same source legitimately backs two hubs. Deterministic pick = oldest.
+    younger = _confirm_reservation(created_at=900)
+    older = _confirm_reservation(created_at=500)
+    client = _ConfirmClient({'sol': younger, 'tao': older})
+    provider = _FakeProvider(_tx(confirmed=True, block_time=CONFIRM_CREATED_AT + 5, confirmations=6))
+    validator = SimpleNamespace(solana_client=client, axon_assets={'btc': provider}, axon_lock=threading.RLock())
+    r = confirm_deposit(validator, HOTKEY, 'srctxhash')
+    assert r.ok and client.claims[0][3] == 'tao'
+
+
+def test_confirm_fresh_match_on_one_hub_survives_stale_match_on_another():
+    # A stale match is terminal for ITS hub only: a fresh match on the miner's other hub still claims
+    # (the old first-match-wins scan could fail the whole confirm on slot-scan order).
+    stale_hub = _confirm_reservation(created_at=CONFIRM_CREATED_AT)
+    fresh_hub = _confirm_reservation(from_chain='sol', created_at=CONFIRM_CREATED_AT)
+    client = _ConfirmClient({'sol': stale_hub, 'tao': fresh_hub})
+    providers = {
+        'btc': _FakeProvider(_tx(confirmed=True, block_time=CONFIRM_CREATED_AT - 1, confirmations=6)),
+        'sol': _FakeProvider(_tx(confirmed=True, block_time=CONFIRM_CREATED_AT + 5, confirmations=6)),
+    }
+    validator = SimpleNamespace(solana_client=client, axon_assets=providers, axon_lock=threading.RLock())
+    r = confirm_deposit(validator, HOTKEY, 'srctxhash')
+    assert r.ok and client.claims[0][3] == 'tao'
 
 
 # ── claim runway: a verified deposit must not lose its window mid-relay ──────
@@ -734,6 +792,10 @@ class _MatchingProvider:
     @property
     def chain_def(self):
         return SimpleNamespace(replay_grace_secs=0)
+
+    @property
+    def chain(self):
+        return SimpleNamespace(normalize_address=lambda a: a)
 
 
 def test_confirm_matches_the_right_hub_when_both_slots_are_live_unclaimed():

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -117,7 +117,7 @@ def _gate_asset(can_deliver, valid=lambda addr: True):
     """Duck-typed asset for the reserve deliverability gates (can_deliver_to + chain format check)."""
     return SimpleNamespace(
         can_deliver_to=lambda addr, amt, from_address=None: can_deliver(addr, amt),
-        chain=SimpleNamespace(is_valid_address=valid),
+        chain=SimpleNamespace(is_valid_address=valid, normalize_address=lambda addr: addr),
     )
 
 
@@ -152,6 +152,30 @@ def test_malformed_miner_receive_address_rejects():
     assert not result.ok
     assert 'miner receive address' in result.reason
     assert client.calls == []
+
+
+def test_user_to_addr_equal_miner_delivery_address_rejects():
+    # V-H1: user_to_addr == miner_to_addr makes every delivery a from==to self-transfer the anti-wash
+    # verifier rejects → the miner never confirms the leg and is force-slashed with no cancel escape.
+    # Bounce it at reserve before any bid.
+    client = FakeClient()
+    client.quote.miner_to_addr = 'minerBTCdeliver'
+    validator = _validator(client)
+    validator.axon_assets = {'btc': _gate_asset(lambda addr, amt: True)}
+    result = reserve_on_behalf(validator, HOTKEY, 'sol', 'btc', USER_PK, str(USER_PK), 'minerBTCdeliver', 10**9)
+    assert not result.ok
+    assert 'differ from the miner delivery address' in result.reason
+    assert client.calls == []
+
+
+def test_distinct_dest_addr_with_miner_to_addr_set_reserves():
+    # The guard must not over-reject: a normal dest address different from the miner's still reserves.
+    client = FakeClient()
+    client.quote.miner_to_addr = 'minerBTCdeliver'
+    validator = _validator(client)
+    validator.axon_assets = {'btc': _gate_asset(lambda addr, amt: True)}
+    result = reserve_on_behalf(validator, HOTKEY, 'sol', 'btc', USER_PK, str(USER_PK), 'userBTCaddr', 10**9)
+    assert result.ok
 
 
 def test_cased_chain_id_rejects_at_intake():

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -650,7 +650,9 @@ def test_confirm_prefers_canonical_form_slot_over_case_variant():
     variant = _confirm_reservation(from_addr='0xABC', created_at=500)
     canonical = _confirm_reservation(from_addr='0xabc', created_at=900)
     client = _ConfirmClient({'sol': variant, 'tao': canonical})
-    provider = _FakeProvider(_tx(confirmed=True, block_time=CONFIRM_CREATED_AT + 5, confirmations=6), normalize=str.lower)
+    provider = _FakeProvider(
+        _tx(confirmed=True, block_time=CONFIRM_CREATED_AT + 5, confirmations=6), normalize=str.lower
+    )
     validator = SimpleNamespace(solana_client=client, axon_assets={'btc': provider}, axon_lock=threading.RLock())
     r = confirm_deposit(validator, HOTKEY, 'srctxhash')
     assert r.ok and len(client.claims) == 1

--- a/tests/test_solana_client.py
+++ b/tests/test_solana_client.py
@@ -103,9 +103,11 @@ def test_swap_roundtrip_enum_status():
         'max_extend_at': 0,
         'fulfilled_at': 0,
         'bump': 1,
+        'hotkey': bytes(range(32)),
     }
     p = _roundtrip(layouts.Swap, v)
     assert p.from_tx_hash == 'deadbeef' and type(p.status).__name__ == 'PendingAttestation'
+    assert bytes(p.hotkey) == bytes(range(32))  # V-M1 pin stays raw bytes
 
 
 def test_pool_roundtrip_vec_of_request():

--- a/tests/test_solana_cluster_guard.py
+++ b/tests/test_solana_cluster_guard.py
@@ -1,0 +1,84 @@
+"""V-M3: a testnet neuron with an explicit mainnet SOLANA_RPC_URL silently ran the hub on mainnet.
+
+The old guard was a log-only ``'mainnet' in url`` check — blind to real paid endpoints (Helius /
+QuickNode subdomains, bare IPs, ``?api-key=`` URLs), which is exactly what a mainnet RPC looks like.
+The boot guard now classifies the cluster *positively* by genesis hash and fails closed.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from allways.constants import NETUID_FINNEY
+from allways.solana.rpc import ALLOW_MAINNET_ON_TESTNET_ENV, assert_cluster_safe, classify_cluster
+
+MAINNET = '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d'
+TESTNET = '4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY'
+PROGRAM = '6JVBEj5w27J2SVjERmv2c7wXgFee9nSSBKUJevHehyBD'
+TESTNET_NEURON = NETUID_FINNEY + 100  # any netuid != finney
+
+
+def fake_rpc(genesis, program_exists=True, url='https://rpc.helius.example/?api-key=secret'):
+    """An RPC stub with only what the guard touches. genesis/exists may be an Exception to raise."""
+
+    def get_genesis_hash():
+        if isinstance(genesis, Exception):
+            raise genesis
+        return genesis
+
+    def get_account_info(_pubkey):
+        if isinstance(program_exists, Exception):
+            raise program_exists
+        return b'\x00' if program_exists else None
+
+    return SimpleNamespace(url=url, get_genesis_hash=get_genesis_hash, get_account_info=get_account_info)
+
+
+@pytest.fixture(autouse=True)
+def _clear_override(monkeypatch):
+    monkeypatch.delenv(ALLOW_MAINNET_ON_TESTNET_ENV, raising=False)
+
+
+def test_classify_cluster_reads_genesis_not_url():
+    assert classify_cluster(MAINNET) == 'mainnet'
+    assert classify_cluster(TESTNET) == 'testnet'
+    assert classify_cluster('deadbeef') == 'unknown'  # localnet / custom validator
+
+
+def test_testnet_neuron_on_mainnet_fails_closed():
+    # The finding: a keyed mainnet URL with no literal 'mainnet' substring still gets caught.
+    with pytest.raises(RuntimeError, match='MAINNET'):
+        assert_cluster_safe(fake_rpc(MAINNET), PROGRAM, TESTNET_NEURON)
+
+
+def test_override_env_bypasses_the_guard(monkeypatch):
+    monkeypatch.setenv(ALLOW_MAINNET_ON_TESTNET_ENV, '1')
+    assert_cluster_safe(fake_rpc(MAINNET), PROGRAM, TESTNET_NEURON)  # no raise
+
+
+def test_mainnet_neuron_on_mainnet_is_fine():
+    assert_cluster_safe(fake_rpc(MAINNET, program_exists=True), PROGRAM, NETUID_FINNEY)
+
+
+def test_program_absent_on_known_cluster_is_a_mismatch():
+    with pytest.raises(RuntimeError, match='does not exist'):
+        assert_cluster_safe(fake_rpc(TESTNET, program_exists=False), PROGRAM, TESTNET_NEURON)
+
+
+def test_program_present_on_matching_cluster_passes():
+    assert_cluster_safe(fake_rpc(TESTNET, program_exists=True), PROGRAM, TESTNET_NEURON)
+
+
+def test_unknown_cluster_skips_program_check():
+    # Localnet dev: the program may not be deployed yet — never crash boot over it.
+    assert_cluster_safe(fake_rpc('localnet-hash', program_exists=False), PROGRAM, TESTNET_NEURON)
+
+
+def test_unreachable_rpc_only_warns():
+    # A boot-time transport hiccup must not crash the process — the guard is best-effort against
+    # transient faults, hard only against a positively identified mainnet.
+    assert_cluster_safe(fake_rpc(ConnectionError('every endpoint down')), PROGRAM, TESTNET_NEURON)
+
+
+def test_program_probe_failure_does_not_crash():
+    assert_cluster_safe(fake_rpc(TESTNET, program_exists=ConnectionError('probe timeout')), PROGRAM, TESTNET_NEURON)

--- a/tests/test_solana_events.py
+++ b/tests/test_solana_events.py
@@ -125,6 +125,7 @@ def test_decode_swap_timed_out_roundtrip():
             'penalty': 3_300_000_000,
             'reimbursement': 3_300_000_000,
             'payee': '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
+            'hotkey': bytes(range(32)),
         },
     )
     name, f = decode_event(raw)
@@ -133,6 +134,7 @@ def test_decode_swap_timed_out_roundtrip():
     assert f.collateral_chain == 'tao' and f.slash == 0
     assert f.penalty == 3_300_000_000 and f.reimbursement == 3_300_000_000
     assert f.payee == '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty'
+    assert bytes(f.hotkey) == bytes(range(32))  # V-M1 pin — raw bytes, like swap_key
 
 
 def test_decode_swap_timed_out_carries_no_payee_when_it_settled_locally():
@@ -149,10 +151,12 @@ def test_decode_swap_timed_out_carries_no_payee_when_it_settled_locally():
             'penalty': 2_200_000_000,
             'reimbursement': 2_200_000_000,
             'payee': '',
+            'hotkey': bytes(32),
         },
     )
     _, f = decode_event(raw)
     assert f.payee == '' and f.slash == 2_200_000_000
+    assert bytes(f.hotkey) == bytes(32)  # never-bound miner ⇒ zeroed pin decodes as a value
 
 
 def test_decode_miner_activated_and_collateral():

--- a/tests/test_solana_provider.py
+++ b/tests/test_solana_provider.py
@@ -109,6 +109,13 @@ class TestSendDedup:
         assert p._prior_broadcast(('RECIP', 5_000_000, 'swapB')) is None  # different dedup scope
 
 
+class TestSendGuard:
+    def test_send_refuses_when_from_address_mismatches_key(self):
+        # H3: never broadcast from a wallet the validator's sender-pin would reject (wasted funds).
+        p = provider_with(FakeRpc(), keypair=Keypair())
+        assert p.send_amount('RECIPIENT', 1000, from_address='someOtherWallet') is None
+
+
 class TestFetchAndVerify:
     def test_match_returns_info(self):
         p = provider_with(FakeRpc(tx=make_tx('RECIP', 2_000_000, slot=100), slot=131))

--- a/tests/test_solana_provider.py
+++ b/tests/test_solana_provider.py
@@ -12,6 +12,7 @@ from solders.keypair import Keypair
 from allways.assets.asset import ProviderUnreachableError
 from allways.assets.sol import RESERVED_ACCOUNTS, Sol
 from allways.chains import CHAIN_SOL
+from allways.solana.rpc import SolanaRpcError
 
 
 def make_tx(recipient, credit, sender='SENDER', slot=100, block_time=5000, err=None, extra_keys=None):
@@ -54,6 +55,58 @@ def provider_with(rpc, keypair=None):
     p = Sol(solana_rpc_url='fake://rpc', solana_keypair=keypair)
     p.rpc = rpc
     return p
+
+
+class DedupRpc:
+    """Programmable getSignatureStatuses[0] + getSlot for the own-broadcast dedup guard."""
+
+    def __init__(self, status, slot=1000):
+        self._status = status
+        self._slot = slot
+
+    def get_slot(self, commitment='confirmed'):
+        return self._slot
+
+    def get_signature_statuses(self, sigs):
+        return [self._status]
+
+
+class TestSendDedup:
+    """H2: a landed prior broadcast must be reused, never re-sent, so a confirm() timeout can't double-pay."""
+
+    WANT = ('RECIP', 5_000_000, 'swap1')
+
+    def _p(self, status, slot=1000):
+        p = provider_with(DedupRpc(status, slot))
+        p.broadcasted_txids['SIG'] = (*self.WANT, 1000)
+        return p
+
+    def test_reuses_landed_prior(self):
+        p = self._p({'err': None, 'slot': 123, 'confirmationStatus': 'confirmed'})
+        assert p._prior_broadcast(self.WANT) == ('SIG', 123)
+
+    def test_reuses_processed_prior_that_already_moved_funds(self):
+        p = self._p({'err': None, 'slot': 50, 'confirmationStatus': 'processed'})
+        assert p._prior_broadcast(self.WANT) == ('SIG', 50)
+
+    def test_failed_prior_dropped_allows_fresh_send(self):
+        p = self._p({'err': 'InstructionError', 'slot': 10})
+        assert p._prior_broadcast(self.WANT) is None
+        assert 'SIG' not in p.broadcasted_txids
+
+    def test_pending_recent_prior_waits(self):
+        p = self._p(None, slot=1010)  # head 1010, seen 1000 → within TTL, not on chain → must wait
+        with pytest.raises(SolanaRpcError):
+            p._prior_broadcast(self.WANT)
+
+    def test_expired_unlanded_prior_allows_fresh_send(self):
+        p = self._p(None, slot=2000)  # head-seen = 1000 > 150 TTL → blockhash expired, never landed
+        assert p._prior_broadcast(self.WANT) is None
+        assert 'SIG' not in p.broadcasted_txids
+
+    def test_different_obligation_is_ignored(self):
+        p = self._p({'err': None, 'slot': 5})
+        assert p._prior_broadcast(('RECIP', 5_000_000, 'swapB')) is None  # different dedup scope
 
 
 class TestFetchAndVerify:

--- a/tests/test_solana_provider.py
+++ b/tests/test_solana_provider.py
@@ -60,11 +60,14 @@ def provider_with(rpc, keypair=None):
 class DedupRpc:
     """Programmable getSignatureStatuses[0] + getSlot for the own-broadcast dedup guard."""
 
-    def __init__(self, status, slot=1000):
+    def __init__(self, status, slot=1000, slot_fails=False):
         self._status = status
         self._slot = slot
+        self._slot_fails = slot_fails
 
     def get_slot(self, commitment='confirmed'):
+        if self._slot_fails:
+            raise SolanaRpcError('getSlot down')
         return self._slot
 
     def get_signature_statuses(self, sigs):
@@ -72,25 +75,41 @@ class DedupRpc:
 
 
 class TestSendDedup:
-    """H2: a landed prior broadcast must be reused, never re-sent, so a confirm() timeout can't double-pay."""
+    """H2: a landed prior broadcast must be reused, never re-sent, so a confirm() timeout can't double-pay.
+    Q2/Q3: every branch where the RPC couldn't resolve the prior send must WAIT (raise), never re-send."""
 
     WANT = ('RECIP', 5_000_000, 'swap1')
 
-    def _p(self, status, slot=1000):
-        p = provider_with(DedupRpc(status, slot))
-        p.broadcasted_txids['SIG'] = (*self.WANT, 1000)
+    def _p(self, status, slot=1000, seen=1000, slot_fails=False):
+        p = provider_with(DedupRpc(status, slot, slot_fails))
+        p.broadcasted_txids['SIG'] = (*self.WANT, seen)
         return p
 
     def test_reuses_landed_prior(self):
         p = self._p({'err': None, 'slot': 123, 'confirmationStatus': 'confirmed'})
         assert p._prior_broadcast(self.WANT) == ('SIG', 123)
 
-    def test_reuses_processed_prior_that_already_moved_funds(self):
+    def test_reuses_finalized_prior(self):
+        p = self._p({'err': None, 'slot': 123, 'confirmationStatus': 'finalized'})
+        assert p._prior_broadcast(self.WANT) == ('SIG', 123)
+
+    def test_processed_only_prior_waits(self):
+        # Q3: `processed` can sit on a minority fork that never settles. Reusing it would mark the
+        # leg delivered while the user is never paid → slash. Wait for confirmed/finalized.
         p = self._p({'err': None, 'slot': 50, 'confirmationStatus': 'processed'})
-        assert p._prior_broadcast(self.WANT) == ('SIG', 50)
+        with pytest.raises(SolanaRpcError):
+            p._prior_broadcast(self.WANT)
+        assert 'SIG' in p.broadcasted_txids  # kept: re-probed next pass
+
+    def test_failed_at_processed_only_waits(self):
+        # A failure seen only at `processed` is as unsettled as a success there — don't evict yet.
+        p = self._p({'err': 'InstructionError', 'slot': 10, 'confirmationStatus': 'processed'})
+        with pytest.raises(SolanaRpcError):
+            p._prior_broadcast(self.WANT)
+        assert 'SIG' in p.broadcasted_txids
 
     def test_failed_prior_dropped_allows_fresh_send(self):
-        p = self._p({'err': 'InstructionError', 'slot': 10})
+        p = self._p({'err': 'InstructionError', 'slot': 10, 'confirmationStatus': 'finalized'})
         assert p._prior_broadcast(self.WANT) is None
         assert 'SIG' not in p.broadcasted_txids
 
@@ -103,6 +122,30 @@ class TestSendDedup:
         p = self._p(None, slot=2000)  # head-seen = 1000 > 150 TTL → blockhash expired, never landed
         assert p._prior_broadcast(self.WANT) is None
         assert 'SIG' not in p.broadcasted_txids
+
+    def test_unknown_record_slot_waits_and_backfills(self):
+        # Q2: get_slot failed at record time (seen=0). head - 0 >> TTL must NOT read as "expired" —
+        # the tx may still be propagating. Backfill seen with the current head and wait.
+        p = self._p(None, slot=2000, seen=0)
+        with pytest.raises(SolanaRpcError):
+            p._prior_broadcast(self.WANT)
+        assert p.broadcasted_txids['SIG'] == (*self.WANT, 2000)
+
+    def test_backfilled_record_expires_after_a_real_ttl(self):
+        # After the backfill the TTL counts from the backfill head, so eviction still happens.
+        p = self._p(None, slot=2000, seen=0)
+        with pytest.raises(SolanaRpcError):
+            p._prior_broadcast(self.WANT)
+        p.rpc._slot = 2000 + p._BROADCAST_TTL_SLOTS + 1
+        assert p._prior_broadcast(self.WANT) is None
+        assert 'SIG' not in p.broadcasted_txids
+
+    def test_head_unreadable_pending_prior_waits(self):
+        # Q2: no status AND no head → nothing is resolvable; never evict, never re-send.
+        p = self._p(None, seen=0, slot_fails=True)
+        with pytest.raises(SolanaRpcError):
+            p._prior_broadcast(self.WANT)
+        assert p.broadcasted_txids['SIG'] == (*self.WANT, 0)  # no head to backfill from
 
     def test_different_obligation_is_ignored(self):
         p = self._p({'err': None, 'slot': 5})

--- a/tests/test_solana_swap_loop.py
+++ b/tests/test_solana_swap_loop.py
@@ -822,3 +822,35 @@ def test_the_flattened_swap_view_carries_the_backing_it_draws_against():
         collateral_chain='tao',
     )
     assert swap_from_solana(acct).collateral_chain == 'tao'
+
+
+class TestMissingProviderNeverSlashes:
+    """A spoke with no provider on this validator (unsupported/disabled net, e.g. #678) is
+    UNVERIFIABLE, not payment-absent. A swap on that spoke reaching chain state must SKIP — never
+    slash on the absence of a verifier. _fetch_leg maps a None provider to 'down', same as an
+    unreachable RPC, and the Active branch (which never fetches) guards the dest the same way."""
+
+    def test_fetch_leg_missing_provider_is_down(self):
+        loop, providers = loop_with(result=True)
+        del providers['btc']  # loop.providers is the same dict
+        assert loop._fetch_leg('btc', 'srctx', 'r', 1) == ('down', None)
+
+    def test_fulfilled_missing_dest_provider_skips_not_timeout(self):
+        # Same swap that TIMEOUTs when the dest tx is merely absent (test_fulfilled_overdue…) must
+        # instead SKIP when the dest PROVIDER is gone — absence of a verifier, not of a payment.
+        loop, providers = loop_with(result=None)
+        del providers['sol']
+        assert loop.decide(make_swap(status='Fulfilled', timeout_at=1000), now=1500).decision == SwapDecision.SKIP
+
+    def test_pending_attestation_missing_source_provider_skips(self):
+        loop, providers = loop_with(result=True)
+        del providers['btc']
+        assert loop.decide(make_swap(status='PendingAttestation'), now=1500).decision == SwapDecision.SKIP
+
+    def test_active_overdue_missing_dest_provider_skips_not_timeout(self):
+        # The Active branch never calls _fetch_leg, so absent the guard a missing dest provider would
+        # fall straight through to the overdue TIMEOUT (slash). It must SKIP.
+        loop, providers = loop_with(result=True)
+        del providers['sol']
+        swap = make_swap(status='Active', timeout_at=1000, max_extend_at=1200)  # overdue, past ceiling
+        assert loop.decide(swap, now=5000).decision == SwapDecision.SKIP

--- a/tests/test_solana_swap_loop.py
+++ b/tests/test_solana_swap_loop.py
@@ -826,18 +826,18 @@ def test_the_flattened_swap_view_carries_the_backing_it_draws_against():
 
 class TestMissingProviderNeverSlashes:
     """A spoke with no provider on this validator (unsupported/disabled net, e.g. #678) is
-    UNVERIFIABLE, not payment-absent. A swap on that spoke reaching chain state must SKIP — never
-    slash on the absence of a verifier. _fetch_leg maps a None provider to 'down', same as an
-    unreachable RPC, and the Active branch (which never fetches) guards the dest the same way."""
+    UNVERIFIABLE, not payment-absent. Below the extension ceiling a swap on that spoke SKIPs (never slash
+    on the absence of a verifier); PAST max_extend_at it TIMEOUTs so the collateral can't freeze forever.
+    _fetch_leg maps a None provider to 'down' (like an unreachable RPC); decide() applies the ceiling."""
 
     def test_fetch_leg_missing_provider_is_down(self):
         loop, providers = loop_with(result=True)
         del providers['btc']  # loop.providers is the same dict
         assert loop._fetch_leg('btc', 'srctx', 'r', 1) == ('down', None)
 
-    def test_fulfilled_missing_dest_provider_skips_not_timeout(self):
-        # Same swap that TIMEOUTs when the dest tx is merely absent (test_fulfilled_overdue…) must
-        # instead SKIP when the dest PROVIDER is gone — absence of a verifier, not of a payment.
+    def test_fulfilled_missing_dest_provider_skips_below_ceiling(self):
+        # Dest tx merely absent → TIMEOUT; dest PROVIDER gone (before the ceiling) → SKIP: absence of a
+        # verifier, not of a payment. max_extend_at default (10_000) is well past now.
         loop, providers = loop_with(result=None)
         del providers['sol']
         assert loop.decide(make_swap(status='Fulfilled', timeout_at=1000), now=1500).decision == SwapDecision.SKIP
@@ -847,10 +847,24 @@ class TestMissingProviderNeverSlashes:
         del providers['btc']
         assert loop.decide(make_swap(status='PendingAttestation'), now=1500).decision == SwapDecision.SKIP
 
-    def test_active_overdue_missing_dest_provider_skips_not_timeout(self):
-        # The Active branch never calls _fetch_leg, so absent the guard a missing dest provider would
-        # fall straight through to the overdue TIMEOUT (slash). It must SKIP.
+    def test_active_missing_dest_provider_skips_below_ceiling(self):
+        # The Active branch never calls _fetch_leg; below the ceiling a missing dest provider must SKIP,
+        # not fall through to the overdue TIMEOUT.
         loop, providers = loop_with(result=True)
         del providers['sol']
-        swap = make_swap(status='Active', timeout_at=1000, max_extend_at=1200)  # overdue, past ceiling
+        swap = make_swap(status='Active', timeout_at=1000, max_extend_at=10_000)  # overdue, before ceiling
         assert loop.decide(swap, now=5000).decision == SwapDecision.SKIP
+
+    def test_active_missing_dest_provider_times_out_past_ceiling(self):
+        # A permanently-missing provider must not SKIP forever (freezing the taker deposit + miner
+        # collateral). Past max_extend_at it TIMEOUTs to free the collateral.
+        loop, providers = loop_with(result=True)
+        del providers['sol']
+        swap = make_swap(status='Active', timeout_at=1000, max_extend_at=1200)
+        assert loop.decide(swap, now=5000).decision == SwapDecision.TIMEOUT
+
+    def test_fulfilled_missing_dest_provider_times_out_past_ceiling(self):
+        loop, providers = loop_with(result=None)
+        del providers['sol']
+        swap = make_swap(status='Fulfilled', timeout_at=1000, max_extend_at=1200)
+        assert loop.decide(swap, now=5000).decision == SwapDecision.TIMEOUT

--- a/tests/test_solana_swap_loop.py
+++ b/tests/test_solana_swap_loop.py
@@ -90,6 +90,9 @@ class RecordingProvider:
     def is_valid_address(self, address):
         return self.valid_addr
 
+    def normalize_address(self, address):
+        return address.lower() if isinstance(address, str) else address  # mirror the EVM provider
+
     @property
     def chain_def(self):
         return SimpleNamespace(replay_grace_secs=self.grace)
@@ -289,6 +292,16 @@ def test_fulfilled_pending_dest_at_ceiling_overdue_times_out():
 def test_pending_attestation_source_ok_attests():
     loop, _ = loop_with(result=True)
     assert loop.decide(make_swap(status='PendingAttestation'), now=1500).decision == SwapDecision.ATTEST
+
+
+def test_pending_attestation_rejects_dest_equal_to_miner_delivery():
+    # V-H1 (chain-aware attest gate): user_to_addr NORMALIZE-equal to the miner's delivery address → never
+    # attest. Catches the EVM checksum-variant a self-represented taker uses to slip the on-chain raw
+    # compare (provider normalize lowercases). Poisoned dest → the miner must never be obligated.
+    loop, _ = loop_with(result=True)
+    swap = make_swap(status='PendingAttestation')
+    swap.user_to_addr = swap.miner_to_addr.upper()  # case-variant of the pinned miner delivery address
+    assert loop.decide(swap, now=1500).decision == SwapDecision.REJECT
 
 
 def test_pending_attestation_source_missing_waits():
@@ -516,7 +529,7 @@ class ExtendRecordingClient:
         self.calls = []
         self.keypair = SimpleNamespace(pubkey=lambda: 'VALIDATOR')
 
-    def extend_reservation(self, miner, target_at, backing='sol'):
+    def extend_reservation(self, miner, target_at, backing='sol', *, from_chain=None, from_addr=None):
         self.calls.append(('extend_reservation', miner, target_at))
         if self.reservation_exc:
             raise self.reservation_exc

--- a/tests/test_solana_swap_loop.py
+++ b/tests/test_solana_swap_loop.py
@@ -619,7 +619,7 @@ class VoteRecordingClient:
     def has_voted(self, req_type, target, voter):
         return self.already_voted
 
-    def vote_initiate(self, swap_key, miner, backing='sol'):
+    def vote_initiate(self, swap_key, miner, from_chain, from_addr, backing='sol'):
         self.calls.append(('vote_initiate', swap_key, miner, backing))
 
     def confirm_swap(self, swap_key, miner, from_chain, to_chain):

--- a/tests/test_solana_vote_builders.py
+++ b/tests/test_solana_vote_builders.py
@@ -104,6 +104,7 @@ def test_vote_initiate_ix(client):
         (pdas.vote_round_pda(pdas.REQ_INITIATE, SK, PID), False, True),
         (pdas.swap_pda(SK, PID), False, True),
         (PID, False, False),  # absent optional BondAttestation — a "sol"-backed swap has no bond
+        (pdas.binding_pda(miner, PID), False, False),  # V-M1: hotkey pinned onto the swap at quorum
         (SYSTEM_PROGRAM, False, False),
     ]
 

--- a/tests/test_solana_vote_builders.py
+++ b/tests/test_solana_vote_builders.py
@@ -267,14 +267,20 @@ def test_extend_timeout_ix(client):
 
 def test_extend_reservation_ix(client):
     miner = Keypair().pubkey()
-    client.extend_reservation(miner, 1_700_009_999)
+    client.extend_reservation(miner, 1_700_009_999, from_chain='btc', from_addr='userBTCaddr')
     ix = _ix(client)
+    from Crypto.Hash import keccak
+
+    expected_hash = keccak.new(data=b'userBTCaddr', digest_bits=256).digest()
     assert ix.data[:8] == layouts.IX_DISCRIMINATORS['extend_reservation']
-    assert ix.data[8:] == layouts.IX_EXTEND_RESERVATION_ARGS.build({'target_at': 1_700_009_999})
+    assert ix.data[8:] == layouts.IX_EXTEND_RESERVATION_ARGS.build(
+        {'target_at': 1_700_009_999, 'from_addr_hash': expected_hash}
+    )
     assert _metas(ix) == [
         (client.keypair.pubkey(), True, False),
         (pdas.config_pda(PID), False, False),
         (miner, False, False),
         (pdas.miner_state_pda(miner, PID), False, True),
         (pdas.reservation_pda(miner, 'sol', PID), False, True),
+        (pdas.source_lock_pda(miner, 'btc', expected_hash, PID), False, True),
     ]

--- a/tests/test_solana_vote_builders.py
+++ b/tests/test_solana_vote_builders.py
@@ -91,16 +91,18 @@ def test_submit_swap_claim_ix(client):
 
 def test_vote_initiate_ix(client):
     miner = Keypair().pubkey()
-    client.vote_initiate(SK, miner)
+    client.vote_initiate(SK, miner, 'btc', 'userBTCaddr')
     ix = _ix(client)
+    from_addr_hash = keccak_lib.new(data=b'userBTCaddr', digest_bits=256).digest()
     assert ix.data[:8] == layouts.IX_DISCRIMINATORS['vote_initiate']
-    assert ix.data[8:] == SK
+    assert ix.data[8:] == SK + from_addr_hash
     assert _metas(ix) == [
         (client.keypair.pubkey(), True, True),
         (pdas.config_pda(PID), False, False),
         (miner, False, False),
         (pdas.miner_state_pda(miner, PID), False, True),
         (pdas.reservation_pda(miner, 'sol', PID), False, True),
+        (pdas.source_lock_pda(miner, 'btc', from_addr_hash, PID), False, True),
         (pdas.vote_round_pda(pdas.REQ_INITIATE, SK, PID), False, True),
         (pdas.swap_pda(SK, PID), False, True),
         (PID, False, False),  # absent optional BondAttestation — a "sol"-backed swap has no bond

--- a/tests/test_swap_now_reservation.py
+++ b/tests/test_swap_now_reservation.py
@@ -483,7 +483,9 @@ class _Gate:
     def __init__(self, reject=(), malformed=()):
         self.reject = set(reject)
         self.checked = []
-        self.chain = types.SimpleNamespace(is_valid_address=lambda addr: addr not in set(malformed))
+        self.chain = types.SimpleNamespace(
+            is_valid_address=lambda addr: addr not in set(malformed), normalize_address=lambda addr: addr
+        )
 
     def can_deliver_to(self, addr, amount, from_address=None):
         self.checked.append(addr)

--- a/uv.lock
+++ b/uv.lock
@@ -3,8 +3,8 @@ revision = 3
 requires-python = ">=3.10, <3.15"
 resolution-markers = [
     "python_full_version >= '3.11' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and sys_platform == 'linux'",
     "python_full_version >= '3.11' and sys_platform != 'linux'",
+    "python_full_version < '3.11' and sys_platform == 'linux'",
     "python_full_version < '3.11' and sys_platform != 'linux'",
 ]
 
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "allways"
-version = "3.1.2"
+version = "3.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "base58" },
@@ -1152,7 +1152,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
Verify-then-fix pass over the two 08-14 red-team audits (Claude + Codex), merged and worked one finding at a time. Every fix was traced in code before it was written, and each lands with tests. Threat model: honest, always-on validators ("code is law").

## Fixed (most → least severe)

**Critical**
- **C1 — cross-hub stale-claim reap** (`8514e84`): `close_stale_claim` was seeded on the reservation's own `collateral_chain` with no binding to the swap's backing, so a dual-hub miner's other-hub reservation could reap a healthy swap → permanent taker fund-strand, permissionless. Now `require!`s reservation backing == swap backing. (contract + LiteSVM test)
- **C2 — duplicate-source reservation theft** (`36f17a9`): a miner could back two live seats with one deposit across hubs. Reservation-phase, amount-agnostic `(from_chain, from_addr)` guard (deposit matching is `>=`, so the key must ignore amount).

**High**
- **H1 — dest == miner delivery addr** (`e8399d5`): reservation rejected when the user's `to_addr` equals the miner's delivery address.
- **H2 — SOL/TAO double-pay** (`5905be2`): own-broadcast dedup so a confirm timeout can't re-send a delivery.
- **H3+H4 — wrong-wallet delivery** (`dfaef89`): deliver from the swap's pinned `miner_to_addr` (not a last-write-wins cache) and refuse a send whose signing key ≠ pinned sender.
- **H6 — testnet neuron → mainnet spokes** (`538c2fa`): unset `{PREFIX}_NETWORK` fell through to the provider's mainnet default, so a testnet validator verified against mainnet / a miner could broadcast a real mainnet payout for a test obligation. Neurons now default unset spoke networks to the registry's `testnet_network` when `netuid != finney`; an explicit env var still wins.
- **H7 — slash on missing provider** (`d85daba`): a missing/disabled-spoke provider was treated as "tx absent" (slash-eligible) instead of "unverifiable". Now maps to SKIP, same as an unreachable RPC; the Active-overdue branch (which never fetches a leg) is guarded too.

**Medium / Low / rot**
- **M3 (partial, `538c2fa`)**: loud startup warning when a testnet neuron resolves a mainnet-looking Solana RPC. Hard program-id guard deferred.
- **M4 (`af8bf6f`)**: ERC-20 `check_connection` raises (not warns) on a token-contract probe failure.
- **L1 (`70216ba`)**: `polusdc` `min_onchain_amount` → 5 USDC, matching sibling USDC spokes.
- **L2 (`af8bf6f`)**: EVM gas-estimate revert detection via the structured `is_execution_revert` verdict, not a message substring.
- **R1 (`af8bf6f`)**: stale `arbusdc` unit-floor comments removed.

## Regression caught in-branch
`af8bf6f` (L2) correctly switched revert detection to the structured verdict but left six EVM delivery-gate test stubs raising a bare `RuntimeError`, which the new check doesn't recognize — the gates silently stopped bouncing reverting dests *in the tests* (production was always correct). Fixed in `d483fc4` by raising the real `EvmRpcError(code 3)` the node actually returns.

## Deliberately NOT in this PR
- **H5 (crown busy-forfeit leak)** — verified real; *not* a contract change (the chain already emits `reserved_until`), but the sound fix needs real crown-scoring machinery (append-only `activity_events` re-stamp + full replay re-test). Its own focused PR.
- **M1 (TAO bond-hotkey seizure)** — the one large on-chain fix; its own PR.
- **M2 / M5 / the L-tier / the hard half of M3** — Medium/Low follow-up batch.
- **ML3 (BTC `vin[0]` sender)** — pending a severity ruling (Codex High vs Claude Low).

## Tests
Full suite green: **1885 passed**. New coverage: cross-backing reap rejection (LiteSVM), duplicate-source refusal, dest==delivery rejection, SOL/TAO send dedup, pinned-sender delivery + wrong-wallet refusal, `apply_testnet_network_defaults`, and missing-provider-never-slashes across all swap statuses.