### PR TITLE
Stake-scaled reservation-fee discount (v16)

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -175,7 +175,10 @@ RECONCILE_QUIET_SECS = 600
 # Posting is block-aligned: every validator fires just after the same block boundary, so all
 # read the metagraph at ~the same stake snapshot and the quorum's hash-bound vectors converge.
 SECONDS_PER_BLOCK = 12
-WEIGHTS_STAKE_BUCKET_ALPHA = 50_000  # alpha per draw-weight unit; floor rounding
+# Alpha per draw-weight unit (floor rounding). 35k (from 50k) buys finer share resolution now that
+# weight also sets the stake-discounted reservation fee, at the cost of slightly more frequent
+# vector-change votes.
+WEIGHTS_STAKE_BUCKET_ALPHA = 35_000
 WEIGHTS_VOTE_INTERVAL_BLOCKS = 3_600  # ~12h — posting boundary cadence
 # Contract vote-round lifetime — mirrors constants.rs. A non-empty round older than this is
 # stale: record_vote clears and reopens it, and prior voters may legally vote again.

--- a/allways/solana/layouts.py
+++ b/allways/solana/layouts.py
@@ -14,7 +14,7 @@ from construct import Bytes as _Raw
 
 # `Config.version` the deployed program writes (constants.rs CONFIG_VERSION). Mirrored here so a schema
 # bump is one edit on each side rather than a literal buried in a test.
-CONFIG_VERSION = 15
+CONFIG_VERSION = 16
 
 # Width of MinerState's per-hub transient arrays (constants.rs MAX_BACKING_SLOTS) — one slot per
 # `active_backings` bit, indexed by bit position.
@@ -364,6 +364,7 @@ EVENT_LAYOUTS = {
         'collateral_chain' / String,
         'closes_at' / I64,
         'seed_slot' / U64,
+        'fee_paid' / U64,
     ),
     'PoolDrawArmed': CStruct('miner' / Pubkey32, 'seed_slot' / U64, 'collateral_chain' / String),
     'PoolResolved': CStruct('miner' / Pubkey32, 'winner' / Pubkey32, 'requests' / U8, 'collateral_chain' / String),
@@ -399,7 +400,7 @@ EVENT_LAYOUTS = {
         'reserved_until' / I64,
         'collateral_chain' / String,
     ),
-    'ReservationRequested': CStruct('miner' / Pubkey32, 'router' / Pubkey32, 'requests' / U8),
+    'ReservationRequested': CStruct('miner' / Pubkey32, 'router' / Pubkey32, 'requests' / U8, 'fee_paid' / U64),
     'StaleClaimClosed': CStruct('swap_key' / Hash32, 'miner' / Pubkey32),
     'UnfilledReservationClosed': CStruct('miner' / Pubkey32, 'router' / Pubkey32, 'collateral_chain' / String),
     'SwapClaimed': CStruct(

--- a/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
@@ -70,10 +70,12 @@ pub const TREASURY_SEED: &[u8] = b"treasury";
 #[constant]
 pub const ATTEST_SEED: &[u8] = b"attest";
 
-/// On-chain schema/version for upgrade tracking, bumped as phases land. v14: v3.1 per-hub swap
-/// concurrency — per-hub transient state on MinerState, per-hub Pool/Reservation seeds. v13 = W2b
-/// quote-level backing; v12 = W2 bond attestation; v11 = W1 seam; v10 = A4 freshness replay.
-pub const CONFIG_VERSION: u32 = 15;
+/// On-chain schema/version for upgrade tracking, bumped as phases land. v16: stake-scaled
+/// reservation-fee discount (fee semantics + entry-event `fee_paid`; layout unchanged from v15).
+/// v15 appends `vault_generation`; v14: v3.1 per-hub swap concurrency — per-hub transient state on
+/// MinerState, per-hub Pool/Reservation seeds. v13 = W2b quote-level backing; v12 = W2 bond
+/// attestation; v11 = W1 seam; v10 = A4 freshness replay.
+pub const CONFIG_VERSION: u32 = 16;
 
 /// Max validators in the whitelist (bounds the Config `validators` Vec and a round's voters).
 pub const MAX_VALIDATORS: usize = 16;
@@ -261,6 +263,46 @@ const _: () = assert!(
     "seed reservation fee must satisfy its own floor"
 );
 
+// Stake-scaled reservation-fee discount: `fee = max(floor, base × (1 − min(cap, slope·share)))`,
+// where share is the router's fraction of the Config.validators draw weight — the same vector the
+// lottery reads, so routing weight and routing cost move together. COMPILE-TIME policy like
+// COLLATERAL_REQUIREMENT_BPS — deliberately NOT Config knobs: reshaping the discount is a program
+// upgrade, and the admin key can never crank it.
+
+/// Discount slope: bps of discount per bps of weight share (20_000 = k=2, so discount grows at
+/// twice the share). Weight-0 routers — plain users, unbound validators — pay full base.
+pub const FEE_DISCOUNT_SLOPE_BPS: u64 = 20_000;
+
+/// Discount ceiling (9_500 = 95%): with k=2, ≥47.5% share pays base×5%, clamped up to the lamport
+/// floor — so a pool-open is never free at ANY share and the anti-grief brake survives.
+pub const FEE_DISCOUNT_CAP_BPS: u64 = 9_500;
+
+/// Sanity lid on the slope (k=10): a future re-tune can steepen the curve, not ship a de-facto cliff.
+pub const FEE_DISCOUNT_SLOPE_BPS_MAX: u64 = 100_000;
+
+const _: () = assert!(
+    FEE_DISCOUNT_CAP_BPS <= BPS_DENOMINATOR && FEE_DISCOUNT_SLOPE_BPS <= FEE_DISCOUNT_SLOPE_BPS_MAX,
+    "fee-discount shape out of bounds (cap <= 100%, slope <= 10x)"
+);
+
+/// Effective reservation fee for a router holding `weight` of `total_weight` draw weight:
+/// `share_bps = 10_000·w/Σw` (floored — truncation only shrinks the discount), `discount_bps =
+/// min(cap, slope·share/10_000)`, `fee = max(RESERVATION_FEE_LAMPORTS_MIN, ceil(base·(10_000−
+/// discount)/10_000))`. Zero weight or an empty set ⇒ full base. Pure u128 integer math — no wrap
+/// even at u64::MAX weights.
+pub fn discounted_reservation_fee(base: u64, weight: u64, total_weight: u128) -> u64 {
+    if weight == 0 || total_weight == 0 {
+        return base;
+    }
+    let bps = BPS_DENOMINATOR as u128;
+    let share_bps = (weight as u128).saturating_mul(bps) / total_weight;
+    let discount_bps = (share_bps.saturating_mul(FEE_DISCOUNT_SLOPE_BPS as u128) / bps)
+        .min(FEE_DISCOUNT_CAP_BPS as u128);
+    // ceil-div: rounding can only push the fee UP, never below what the shape owes.
+    let fee = ((base as u128).saturating_mul(bps - discount_bps).saturating_add(bps - 1)) / bps;
+    fee.max(RESERVATION_FEE_LAMPORTS_MIN as u128).min(u64::MAX as u128) as u64
+}
+
 /// Initial reservation-lottery pooling window (seconds). Seeds `Config.pool_window_secs` — how long
 /// a pool gathers contending requests before the stake-weighted draw. Must stay well below the
 /// reservation TTL. Runtime-adjustable via `set_pool_window` (dev seeds 5s for fast swaps).
@@ -394,6 +436,40 @@ mod tests {
         assert_eq!(quote_update_fee(86_400), 0);
         // Clock skew (negative elapsed) → most-expensive tier, never free.
         assert_eq!(quote_update_fee(-100), QUOTE_UPDATE_FEE_TIER1_LAMPORTS);
+    }
+
+    #[test]
+    fn discounted_fee_shape_matches_the_decided_curve() {
+        let base = RESERVATION_FEE_LAMPORTS; // 0.02 SOL
+        // Weight-0 routers (plain users, unbound validators) and a weightless set pay full base.
+        assert_eq!(discounted_reservation_fee(base, 0, 100), base);
+        assert_eq!(discounted_reservation_fee(base, 0, 0), base);
+        assert_eq!(discounted_reservation_fee(base, 5, 0), base);
+        // 20% share → 40% discount at k=2 → 0.012 SOL (the doc's mid-curve example).
+        assert_eq!(discounted_reservation_fee(base, 20, 100), 12_000_000);
+        // 47.5% share hits the 95% cap exactly → base×5% = the 0.001 SOL floor.
+        assert_eq!(discounted_reservation_fee(base, 475, 1_000), RESERVATION_FEE_LAMPORTS_MIN);
+        // Past the cap nothing more is shaved — even a sole 100%-share router pays the floor, never 0.
+        assert_eq!(discounted_reservation_fee(base, 999, 1_000), RESERVATION_FEE_LAMPORTS_MIN);
+        assert_eq!(discounted_reservation_fee(base, 1, 1), RESERVATION_FEE_LAMPORTS_MIN);
+        // Equal thirds (the LiteSVM harness shape): share_bps floors to 3333 → keep 3334.
+        assert_eq!(discounted_reservation_fee(base, 1, 3), 6_668_000);
+    }
+
+    #[test]
+    fn discounted_fee_rounds_up_and_never_wraps() {
+        // Ceil-div: an inexact division rounds toward the treasury.
+        assert_eq!(discounted_reservation_fee(20_000_001, 1, 3), 6_668_001);
+        // A base already at the floor never goes below it, whatever the share.
+        assert_eq!(
+            discounted_reservation_fee(RESERVATION_FEE_LAMPORTS_MIN, 1, 2),
+            RESERVATION_FEE_LAMPORTS_MIN
+        );
+        // Extreme inputs clamp instead of wrapping: 100% share → ceil of base×5%.
+        assert_eq!(
+            discounted_reservation_fee(u64::MAX, u64::MAX, u64::MAX as u128),
+            u64::MAX / 20 + 1
+        );
     }
 
     #[test]

--- a/smart-contracts/solana/programs/allways_swap_manager/src/events.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/events.rs
@@ -270,6 +270,9 @@ pub struct PoolOpened {
     pub collateral_chain: String,
     pub closes_at: i64,
     pub seed_slot: u64,
+    /// Effective (stake-discounted) reservation fee the opener paid, lamports — so treasury income
+    /// attribution can tell discounted from full fees. Appended last; prefix decoders keep working.
+    pub fee_paid: u64,
 }
 
 #[event]
@@ -278,6 +281,9 @@ pub struct ReservationRequested {
     pub router: Pubkey,
     /// Number of bids in the pool after this one.
     pub requests: u8,
+    /// Effective (stake-discounted) fee this entry paid, lamports. 0 = a same-router in-window bid
+    /// update, which is free. Appended last; prefix decoders keep working.
+    pub fee_paid: u64,
 }
 
 /// The seat winner filled its reservation: taker + amounts named, `reserved_until` set. Carries the

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/migrate.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/migrate.rs
@@ -1,7 +1,9 @@
 //! Upgrade cranks. A legacy account is shorter AND laid out differently, so the live types can't
 //! parse it: each crank reads it through a frozen mirror of the OLD layout, rebuilds it in the new one,
 //! and grows the allocation. Safe to re-run — gated on a marker the crank itself moves, moving no funds.
-//! v15 accepts THREE from-versions: v10 (mainnet, never took v3), v13 (testnet, v3 deployed) and v14.
+//! v16 accepts FOUR from-versions: v10 (mainnet, never took v3), v13 (testnet, v3 deployed), v14, and
+//! v15 — whose crank is a pure version stamp (the fee-discount shape is compile-time constants, so
+//! v15 and v16 share a layout).
 
 use anchor_lang::prelude::*;
 use anchor_lang::Discriminator;
@@ -21,6 +23,9 @@ const MIGRATE_FROM_V10: u32 = 10;
 const MIGRATE_FROM_V13: u32 = 13;
 /// v14 is the per-hub schema; v15 appends `vault_generation`.
 const MIGRATE_FROM_V14: u32 = 14;
+/// v15's layout IS the live layout (v16 changed fee semantics, not fields), so its crank only
+/// stamps the version.
+const MIGRATE_FROM_V15: u32 = 15;
 /// Byte offset of `Config.version` (discriminator + `admin`). Stable in every version, which is what
 /// lets the crank read the marker before committing to a layout.
 const CONFIG_VERSION_OFFSET: usize = 8 + 32;
@@ -129,6 +134,8 @@ enum LegacyConfig {
     V10(ConfigV10),
     /// v13 and v14 share a layout, so one frozen mirror parses both.
     V14(ConfigV14),
+    /// v15 shares the LIVE layout — parsed with the live type, only the version stamp moves.
+    V15(Config),
 }
 
 pub fn migrate_config(ctx: Context<MigrateConfig>) -> Result<()> {
@@ -154,7 +161,9 @@ pub fn migrate_config(ctx: Context<MigrateConfig>) -> Result<()> {
             msg!("config already at v{}", CONFIG_VERSION);
             return Ok(());
         }
-        if version == MIGRATE_FROM_V13 || version == MIGRATE_FROM_V14 {
+        if version == MIGRATE_FROM_V15 {
+            LegacyConfig::V15(Config::deserialize(&mut &data[8..])?)
+        } else if version == MIGRATE_FROM_V13 || version == MIGRATE_FROM_V14 {
             LegacyConfig::V14(ConfigV14::deserialize(&mut &data[8..])?)
         } else {
             require!(
@@ -171,8 +180,17 @@ pub fn migrate_config(ctx: Context<MigrateConfig>) -> Result<()> {
     let from_version = match &legacy {
         LegacyConfig::V10(_) => MIGRATE_FROM_V10,
         LegacyConfig::V14(cfg) => cfg.version,
+        LegacyConfig::V15(_) => MIGRATE_FROM_V15,
     };
     let legacy = match legacy {
+        // v15 -> v16 changed fee SEMANTICS only (compile-time discount shape + event fields), so
+        // the account neither grows nor rebuilds — the stamp just records which rules are live.
+        LegacyConfig::V15(mut cfg) => {
+            cfg.version = CONFIG_VERSION;
+            write_account(&info, &cfg)?;
+            msg!("config migrated v{} -> v{}", from_version, CONFIG_VERSION);
+            return Ok(());
+        }
         // v13/v14 -> v15 appends `vault_generation`, so the account grows by 8 bytes. Generation 0
         // is correct: the epochs already attested came from the vault in service when they landed.
         LegacyConfig::V14(cfg) => {

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/open_or_request.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/open_or_request.rs
@@ -3,8 +3,8 @@ use anchor_lang::system_program::{transfer, Transfer};
 
 use crate::backing;
 use crate::constants::{
-    ATTEST_SEED, CONFIG_SEED, MAX_CHAIN_LEN, MAX_VALIDATORS, MINER_SEED, POOL_SEED, QUOTE_SEED,
-    RESV_SEED, TREASURY_SEED,
+    discounted_reservation_fee, ATTEST_SEED, CONFIG_SEED, MAX_CHAIN_LEN, MAX_VALIDATORS,
+    MINER_SEED, POOL_SEED, QUOTE_SEED, RESV_SEED, TREASURY_SEED,
 };
 use crate::error::ErrorCode;
 use crate::events::{PoolOpened, ReservationRequested};
@@ -15,9 +15,10 @@ use crate::state::{
 /// Any account (validator OR plain user — entry is permissionless) opens or joins a per-miner
 /// reservation-lottery pool for one of the miner's quotes. First caller opens and pins that quote
 /// (pair, rate AND backing); later in-window callers add one request each against the same pinned
-/// offer. Every fresh entry pays a flat, non-refundable reservation fee (router -> treasury) — the
-/// anti-spam gate. A non-validator router gets lottery weight 0 (loses to validators / uniform among
-/// users) and, if it wins, flags down a validator to claim + attest (those are validator-gated).
+/// offer. Every fresh entry pays a non-refundable, stake-discounted reservation fee (router ->
+/// treasury) — the anti-spam gate; weight-0 routers pay the full base. A non-validator router gets
+/// lottery weight 0 (loses to validators / uniform among users) and, if it wins, flags down a
+/// validator to claim + attest (those are validator-gated).
 #[derive(Accounts)]
 #[instruction(from_chain: String, to_chain: String, collateral_chain: String)]
 pub struct OpenOrRequest<'info> {
@@ -154,18 +155,35 @@ pub fn handler(
     let pending_finalize = resv.reserved_until == 0 && resv.finalize_by != 0 && now <= resv.finalize_by;
     require!(!active_reservation && !pending_finalize, ErrorCode::MinerReserved);
 
-    // Flat, non-refundable anti-spam fee: router → treasury (subnet revenue). Charged only on a
-    // fresh entry (open or first join) — a same-router in-window bid UPDATE is free, so refining a
-    // bid against the pinned rate isn't taxed.
+    // Non-refundable anti-spam fee: router → treasury (subnet revenue), stake-discounted — the
+    // router's Config.validators draw weight (the same vector the lottery reads) earns a
+    // linear-to-cap discount off the base fee, floored so a pool-open is never free (see
+    // constants::discounted_reservation_fee). Charged only on a fresh entry (open or first join) —
+    // a same-router in-window bid UPDATE is free, so refining a bid against the pinned rate isn't
+    // taxed.
+    let router_key = ctx.accounts.router.key();
     let is_update = ctx.accounts.pool.opened_at != 0
         && ctx
             .accounts
             .pool
             .requests
             .iter()
-            .any(|r| r.router == ctx.accounts.router.key());
-    if !is_update {
-        let fee = ctx.accounts.config.reservation_fee_lamports;
+            .any(|r| r.router == router_key);
+    let fee_paid = if is_update {
+        0
+    } else {
+        let validators = &ctx.accounts.config.validators;
+        let total_weight: u128 = validators.iter().map(|v| v.weight as u128).sum();
+        let weight = validators
+            .iter()
+            .find(|v| v.key == router_key)
+            .map(|v| v.weight)
+            .unwrap_or(0);
+        let fee = discounted_reservation_fee(
+            ctx.accounts.config.reservation_fee_lamports,
+            weight,
+            total_weight,
+        );
         transfer(
             CpiContext::new(
                 ctx.accounts.system_program.key(),
@@ -182,10 +200,10 @@ pub fn handler(
             .total
             .checked_add(fee)
             .ok_or(ErrorCode::Overflow)?;
-    }
+        fee
+    };
 
     let miner_key = ctx.accounts.miner.key();
-    let router_key = ctx.accounts.router.key();
     let req = Request { router: router_key };
 
     let pool_bump = ctx.bumps.pool;
@@ -233,6 +251,7 @@ pub fn handler(
             collateral_chain,
             closes_at,
             seed_slot: 0, // armed later by resolve_pool; kept in the event for schema stability
+            fee_paid,
         });
     } else {
         // JOIN or UPDATE — must be within the window and match the pinned pair.
@@ -259,6 +278,7 @@ pub fn handler(
             miner: miner_key,
             router: router_key,
             requests: pool.requests.len() as u8,
+            fee_paid,
         });
     }
     Ok(())

--- a/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/state.rs
@@ -2,8 +2,9 @@ use anchor_lang::prelude::*;
 
 use crate::constants::{MAX_ADDR_LEN, MAX_BACKING_SLOTS, MAX_CHAIN_LEN, MAX_TX_LEN, MAX_VALIDATORS};
 
-/// A whitelisted validator and its draw weight. `weight` (default 1, admin-set) is the
-/// stake-weight seam consumed ONLY by the reservation-lottery draw; consensus stays count-based.
+/// A whitelisted validator and its draw weight. `weight` (default 1, admin-set) is the stake-weight
+/// seam consumed by the reservation-lottery draw and the entry-fee discount
+/// (`discounted_reservation_fee`); consensus stays count-based.
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
 pub struct ValidatorInfo {
     pub key: Pubkey,

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/integration_onchain.rs
@@ -696,11 +696,25 @@ fn onchain_reservation_fee_to_treasury() {
     let before = read_treasury(&rpc).total;
     send(&rpc, open_ix(&vals[0].pubkey(), &miner.pubkey()), &vals[0].pubkey(), &vals[0])
         .expect("open pool");
-    let fee = allways_swap_manager::constants::RESERVATION_FEE_LAMPORTS;
+    // The opener's fee is stake-discounted off its share of the LIVE validator set's draw weight —
+    // computed from the on-chain Config, so the assertion holds however the shared set is seeded.
+    let cfg = read_config(&rpc);
+    let total_weight: u128 = cfg.validators.iter().map(|v| v.weight as u128).sum();
+    let weight = cfg
+        .validators
+        .iter()
+        .find(|v| v.key == vals[0].pubkey())
+        .map(|v| v.weight)
+        .unwrap_or(0);
+    let fee = allways_swap_manager::constants::discounted_reservation_fee(
+        cfg.reservation_fee_lamports,
+        weight,
+        total_weight,
+    );
     assert_eq!(
         read_treasury(&rpc).total,
         before + fee,
-        "flat reservation fee accrued to treasury"
+        "stake-discounted reservation fee accrued to treasury"
     );
 }
 

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_attestation.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_attestation.rs
@@ -1740,6 +1740,28 @@ fn test_migrate_config_stamps_a_v13_config_to_v14_in_place() {
 }
 
 #[test]
+fn test_migrate_config_stamps_a_v15_config_to_v16_in_place() {
+    let (mut svm, admin, _vals, _miner) = setup();
+    // v15 and v16 share a layout (the fee-discount shape is compile-time constants), so the crank
+    // is a pure version stamp. Unlike the v13/v14 arm it must NOT re-seed `vault_generation` —
+    // a retired vault's epoch namespace stays retired across the upgrade.
+    let mut cfg = config_acct(&svm);
+    cfg.version = 15;
+    cfg.vault_generation = 5; // sentinel: the stamp path must carry it verbatim
+    let mut buf = Vec::new();
+    cfg.try_serialize(&mut buf).unwrap();
+    overwrite(&mut svm, config_pda(), buf);
+
+    send(&mut svm, migrate_config_ix(&admin.pubkey()), &admin.pubkey(), &admin).expect("migrate");
+    let cfg = config_acct(&svm);
+    assert_eq!(cfg.version, CONFIG_VERSION);
+    assert_eq!(cfg.vault_generation, 5, "v15 path stamps the version and touches nothing else");
+
+    send(&mut svm, migrate_config_ix(&admin.pubkey()), &admin.pubkey(), &admin).expect("again");
+    assert_eq!(config_acct(&svm).vault_generation, 5, "idempotent re-run");
+}
+
+#[test]
 fn test_migrate_miner_state_seeds_an_inactive_miner_with_no_bits() {
     let (mut svm, admin, _vals, miner) = setup();
     let m = miner.pubkey();

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_reservation.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_reservation.rs
@@ -13,7 +13,10 @@ use {
         prelude::Pubkey, solana_program::clock::Clock, solana_program::instruction::Instruction,
         AccountDeserialize, InstructionData, ToAccountMetas,
     },
-    allways_swap_manager::constants::{FINALIZE_WINDOW_SECS, POOL_WINDOW_SECS, RESERVATION_FEE_LAMPORTS},
+    allways_swap_manager::constants::{
+        discounted_reservation_fee, FINALIZE_WINDOW_SECS, POOL_WINDOW_SECS,
+        RESERVATION_FEE_LAMPORTS, RESERVATION_FEE_LAMPORTS_MIN,
+    },
     allways_swap_manager::state::{MinerQuote, MinerState, Pool, Reservation, Treasury},
     litesvm::LiteSVM,
     solana_hash::Hash,
@@ -342,6 +345,12 @@ fn is_active(svm: &LiteSVM, miner: &Pubkey) -> bool {
     MinerState::try_deserialize(&mut a.data.as_slice()).unwrap().active
 }
 
+/// The fee a `setup()` validator pays on a fresh entry: each holds 1 of 3 total draw weight, so
+/// the stake discount lands at the 1/3-share point of the curve.
+fn setup_val_fee() -> u64 {
+    discounted_reservation_fee(RESERVATION_FEE_LAMPORTS, 1, 3)
+}
+
 /// init + 3 validators (weight 1) + a funded, active miner with a BTC→SOL quote posted. Clock at
 /// BASE_TS. Returns (svm, admin, validators, miner).
 fn setup(min_swap: u64, max_swap: u64) -> (LiteSVM, Keypair, Vec<Keypair>, Keypair) {
@@ -389,7 +398,7 @@ fn test_open_pins_quote_and_charges_fee() {
     assert_eq!(p.closes_at, BASE_TS + POOL_WINDOW_SECS);
     assert_eq!(p.requests.len(), 1);
     assert_eq!(p.requests[0].router, vals[0].pubkey());
-    assert_eq!(treasury(&svm), t0 + RESERVATION_FEE_LAMPORTS, "flat fee accrued to treasury");
+    assert_eq!(treasury(&svm), t0 + setup_val_fee(), "stake-discounted fee accrued to treasury");
 }
 
 #[test]
@@ -399,8 +408,34 @@ fn test_each_request_charges_fee() {
     let t0 = treasury(&svm);
     send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[0].pubkey(), &vals[0]).expect("open");
     send(&mut svm, open_ix(&vals[1].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[1].pubkey(), &vals[1]).expect("join");
-    assert_eq!(treasury(&svm), t0 + 2 * RESERVATION_FEE_LAMPORTS, "both opener and joiner pay");
+    assert_eq!(treasury(&svm), t0 + 2 * setup_val_fee(), "both opener and joiner pay");
     assert_eq!(pool(&svm, &miner.pubkey()).requests.len(), 2);
+}
+
+#[test]
+fn test_weight0_router_pays_the_full_base_fee() {
+    // Entry is permissionless, but a router with no draw weight (a plain user) earns no discount —
+    // the anti-grief brake stays at full strength exactly where griefing is cheapest to mount.
+    let (mut svm, _admin, _vals, miner) = setup(0, 0);
+    let user = Keypair::new();
+    svm.airdrop(&user.pubkey(), 10_000_000_000).unwrap();
+    let t0 = treasury(&svm);
+    send(&mut svm, open_ix(&user.pubkey(), &miner.pubkey(), "btc", "sol"), &user.pubkey(), &user).expect("open");
+    assert_eq!(treasury(&svm), t0 + RESERVATION_FEE_LAMPORTS, "weight-0 router pays full base");
+}
+
+#[test]
+fn test_majority_share_pays_the_floor_never_zero() {
+    // A validator holding 57 of 60 weight (95% share) is past the 47.5% cap point → pays exactly
+    // the lamport floor. The floor is the final clamp: no share makes a pool-open free.
+    let (mut svm, admin, _vals, miner) = setup(0, 0);
+    let whale = Keypair::new();
+    svm.airdrop(&whale.pubkey(), 10_000_000_000).unwrap();
+    send(&mut svm, add_validator_ix(&admin.pubkey(), whale.pubkey(), 57), &admin.pubkey(), &admin).expect("add whale");
+    let t0 = treasury(&svm);
+    send(&mut svm, open_ix(&whale.pubkey(), &miner.pubkey(), "btc", "sol"), &whale.pubkey(), &whale).expect("open");
+    assert_eq!(treasury(&svm), t0 + RESERVATION_FEE_LAMPORTS_MIN, "capped discount lands on the floor");
+    assert!(RESERVATION_FEE_LAMPORTS_MIN > 0, "a pool-open is never free");
 }
 
 #[test]
@@ -765,9 +800,9 @@ fn test_repeat_bid_is_free() {
     let (mut svm, _admin, vals, miner) = setup(0, 0);
     let t0 = treasury(&svm);
     send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[0].pubkey(), &vals[0]).expect("open");
-    assert_eq!(treasury(&svm), t0 + RESERVATION_FEE_LAMPORTS, "first entry pays the fee");
+    assert_eq!(treasury(&svm), t0 + setup_val_fee(), "first entry pays the fee");
     send(&mut svm, open_ix(&vals[0].pubkey(), &miner.pubkey(), "btc", "sol"), &vals[0].pubkey(), &vals[0]).expect("repeat");
-    assert_eq!(treasury(&svm), t0 + RESERVATION_FEE_LAMPORTS, "in-window repeat bid is free (no extra fee)");
+    assert_eq!(treasury(&svm), t0 + setup_val_fee(), "in-window repeat bid is free (no extra fee)");
 }
 
 #[test]

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_swap.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_swap.rs
@@ -6,7 +6,8 @@ use {
         AccountDeserialize, AccountSerialize, InstructionData, Space, ToAccountMetas,
     },
     allways_swap_manager::constants::{
-        FULFILL_GRACE_SOL_SECS, MAX_TOTAL_EXTENSION_SECS, POOL_WINDOW_SECS, RESERVATION_FEE_LAMPORTS,
+        discounted_reservation_fee, FULFILL_GRACE_SOL_SECS, MAX_TOTAL_EXTENSION_SECS,
+        POOL_WINDOW_SECS, RESERVATION_FEE_LAMPORTS,
     },
     allways_swap_manager::state::{MinerDirectionStats, MinerState, Pool, Reservation, Swap, SwapStatus, Treasury},
     litesvm::LiteSVM,
@@ -932,10 +933,11 @@ fn test_fulfill_confirm_fee_and_invariant() {
 
     let fee = SOL_AMOUNT / 100;
     assert_eq!(miner_state(&svm, &miner.pubkey()).collateral, coll_before - fee, "1% fee taken");
-    // Quote creation is free; treasury holds the setup's reservation fee plus this swap's 1% confirm fee.
+    // Quote creation is free; treasury holds the setup's stake-discounted reservation fee (the
+    // opener is one of 3 weight-1 validators) plus this swap's 1% confirm fee.
     assert_eq!(
         treasury_total(&svm),
-        RESERVATION_FEE_LAMPORTS + fee,
+        discounted_reservation_fee(RESERVATION_FEE_LAMPORTS, 1, 3) + fee,
         "fees accrued to treasury"
     );
     assert!(!miner_state(&svm, &miner.pubkey()).has_active_swap);

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_treasury.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_treasury.rs
@@ -6,7 +6,9 @@ use {
         prelude::Pubkey, solana_program::clock::Clock, solana_program::instruction::Instruction,
         AccountDeserialize, InstructionData, ToAccountMetas,
     },
-    allways_swap_manager::constants::{POOL_WINDOW_SECS, RESERVATION_FEE_LAMPORTS},
+    allways_swap_manager::constants::{
+        discounted_reservation_fee, POOL_WINDOW_SECS, RESERVATION_FEE_LAMPORTS,
+    },
     allways_swap_manager::state::{Pool, Treasury},
     litesvm::LiteSVM,
     solana_hash::Hash,
@@ -206,7 +208,8 @@ fn setup_with_fee() -> (LiteSVM, Keypair, u64) {
     confirm(&mut svm, &vals[1]);
 
     // treasury = reservation fee + the 1% confirm fee (quote creation is free).
-    (svm, admin, SOL_AMOUNT / 100 + RESERVATION_FEE_LAMPORTS)
+    // The opener is one of 3 weight-1 validators, so its reservation fee is stake-discounted.
+    (svm, admin, SOL_AMOUNT / 100 + discounted_reservation_fee(RESERVATION_FEE_LAMPORTS, 1, 3))
 }
 
 #[test]

--- a/tests/test_solana_events.py
+++ b/tests/test_solana_events.py
@@ -55,6 +55,37 @@ def test_decode_quote_set_roundtrip():
     assert f.rate == 345 * 10**18 and f.updated_at == 1_700_000_000
 
 
+def test_decode_pool_entry_events_carry_the_effective_fee():
+    # v16: both pool-entry events append `fee_paid` (the stake-discounted fee actually charged),
+    # so treasury attribution can tell discounted from full fees without re-deriving weights.
+    miner, router = Keypair().pubkey(), Keypair().pubkey()
+    raw = _encode(
+        'PoolOpened',
+        {
+            'miner': bytes(miner),
+            'opener': bytes(router),
+            'from_chain': 'btc',
+            'to_chain': 'sol',
+            'collateral_chain': 'sol',
+            'closes_at': 1_700_000_030,
+            'seed_slot': 0,
+            'fee_paid': 6_668_000,
+        },
+    )
+    name, f = decode_event(raw)
+    assert name == 'PoolOpened'
+    assert f.opener == router and f.fee_paid == 6_668_000
+
+    raw = _encode(
+        'ReservationRequested',
+        {'miner': bytes(miner), 'router': bytes(router), 'requests': 2, 'fee_paid': 0},
+    )
+    name, f = decode_event(raw)
+    assert name == 'ReservationRequested'
+    assert f.requests == 2
+    assert f.fee_paid == 0, 'a same-router in-window bid update is free'
+
+
 def test_decode_bond_attested_roundtrip():
     miner = Keypair().pubkey()
     raw = _encode(

--- a/tests/test_weights_vote.py
+++ b/tests/test_weights_vote.py
@@ -73,10 +73,10 @@ def test_derive_buckets_floor_and_alignment():
     keys = [Keypair().pubkey() for _ in range(4)]
     validators = [_vali(k) for k in keys]
     attribution = {str(keys[0]): 'hkA', str(keys[1]): 'hkB', str(keys[2]): 'hkC'}  # keys[3] unbound
-    mg = _metagraph(['hkA', 'hkB', 'hkC'], [178_000.0, 49_999.0, 50_000.0])
+    mg = _metagraph(['hkA', 'hkB', 'hkC'], [178_000.0, 34_999.0, 35_000.0])
     # Sub-bucket but bound (hkB) floors to 1, not 0 — an all-zero vector makes the contract's
     # draw uniform and native bidders beat routed takers (QA finding P1). Unbound stays 0.
-    assert derive_weight_vector(validators, attribution, mg) == [3, 1, 1, 0]
+    assert derive_weight_vector(validators, attribution, mg) == [5, 1, 1, 0]
 
 
 def test_derive_hotkey_off_metagraph_is_zero():
@@ -101,7 +101,7 @@ def _whitelisted_setup(patch_attribution, stake=178_000.0, onchain_weight=1, las
 def test_bootstrap_votes_immediately(patch_attribution):
     client, vali = _whitelisted_setup(patch_attribution)
     maybe_vote_weights(vali, NOW)
-    assert client.voted == [[3]]
+    assert client.voted == [[5]]
     assert vali.weights_epoch_done is None  # done only once the quorum lands on-chain
 
 
@@ -129,7 +129,7 @@ def test_landed_this_epoch_marks_done(patch_attribution):
 def test_stale_update_before_boundary_is_due(patch_attribution):
     client, vali = _whitelisted_setup(patch_attribution, last_update=NOW - 500)  # before the boundary
     maybe_vote_weights(vali, NOW)
-    assert client.voted == [[3]]
+    assert client.voted == [[5]]
 
 
 def test_not_whitelisted_skips_epoch(patch_attribution):
@@ -142,7 +142,7 @@ def test_not_whitelisted_skips_epoch(patch_attribution):
 
 
 def test_unchanged_vector_skips(patch_attribution):
-    client, vali = _whitelisted_setup(patch_attribution, onchain_weight=3)  # derived == on-chain
+    client, vali = _whitelisted_setup(patch_attribution, onchain_weight=5)  # derived == on-chain
     maybe_vote_weights(vali, NOW)
     assert client.voted == []
     assert vali.weights_epoch_done == BLOCK // WEIGHTS_VOTE_INTERVAL_BLOCKS


### PR DESCRIPTION
Stacked on #680 (base = `redteam-08-14-fixes`; retargets `test` when it merges) so the test program takes ONE deploy cycle for both.

## What

Validator routing margin was being eaten by the flat 0.02 SOL reservation fee — with stake-weighted draws, every losing entry burns the full fee. This makes the fee stake-scaled:

```
share    = w / Σw                        (Config.validators — the vector the lottery draw already reads)
fee      = max(floor, base × (1 − min(cap, k·share)))
```

with **k = 2, cap = 95%** ⇒ 20% share pays 0.012 SOL, ≥47.5% share pays the 0.001 SOL floor ("effectively free for whales" — alpha utility = cheap miner reservations). Weight-0 routers — plain users, unbound validators — pay full base automatically, so the anti-grief brake stays at full strength exactly where griefing is cheapest to mount.

The full-waiver-at-≥20% proposal was rejected in ideation: the fee is the only cost on a pool-open (which busies a miner for window + finalize + TTL), a cliff invites threshold gaming, and free opens are a centralization flywheel. Linear-to-cap with the floor as the final clamp keeps the no-free-pool-opens invariant at any share.

## Design choices

- **Slope/cap are compile-time constants, not Config knobs** (`FEE_DISCOUNT_SLOPE_BPS` / `FEE_DISCOUNT_CAP_BPS`, const-assert bounded like `COLLATERAL_REQUIREMENT_BPS`). Reshaping the discount is a program upgrade, deliberately — the admin key can never crank it. The base fee (`set_reservation_fee`, floor-validated) stays the runtime lever.
- **No layout change.** `CONFIG_VERSION` 15→16 is a pure semantics stamp (v13→v14 precedent): `migrate_config` gains a same-layout v15 arm that stamps the version and touches nothing else (verified: `vault_generation` survives, unlike the v14 arm which seeds it). The v10 arm — mainnet is still v10 — now lands at 16 directly.
- **Effective fee is emitted**: `fee_paid` appended (last, prefix-decoder-safe) to `PoolOpened` and `ReservationRequested`, so treasury income attribution can tell discounted from full fees without re-deriving historical weights. A same-router in-window bid update emits 0 (still free).
- **Consensus stays count-based everywhere** — weight prices the draw and now the fee, never a vote (stake-weighting the weights vote is self-referential capture).

## Riding along (off-chain)

- `layouts.py`: version mirror + the two event layouts.
- `WEIGHTS_STAKE_BUCKET_ALPHA` 50k → 35k: weight now prices the fee as well as the draw, so finer share resolution is worth slightly more frequent vector votes. The `max(1, ·)` sub-bucket floor is unchanged.

## Tests

- Rust: full suite green — 48 unit + 177 LiteSVM. New coverage: the fee curve (mid-curve 0.012, cap→floor at 47.5%, ceil-rounding, no wrap at u64::MAX weights), weight-0 router pays full base, majority share pays exactly the floor (never 0), repeat-bid stays free, v15→v16 stamp idempotency + `vault_generation` carry.
- Python: full suite green — 1942 passed. New: entry-event `fee_paid` decode round-trips; weights-vote bucket tests re-anchored to 35k.

## Not in this PR

- **Weights diff-alarm watcher** — required before the prod migration now that the weight vector carries money; fast-follow PR.
- **das-allways indexer** needs the two updated event layouts (pre-upgrade entry events decode fine there until it upgrades; post-upgrade events need the new field) — cross-repo follow-up.
- Prod v10→v16 runbook execution (chained cranks, drained-swaps gate, devnet rehearsal first).
