### PR TITLE
AW-022: pin swap amounts with Decimal, not float

### DIFF
--- a/allways/cli/swap_commands/swap_intake.py
+++ b/allways/cli/swap_commands/swap_intake.py
@@ -11,6 +11,7 @@ the same reads.
 """
 
 from dataclasses import dataclass
+from decimal import Decimal
 from typing import Dict, List, Optional, Tuple
 
 from allways.chains import canonical_pair, get_chain_def
@@ -55,8 +56,10 @@ class MinerCandidate:
 
 
 def to_smallest_units(amount: float, chain: str) -> int:
-    """Display amount (e.g. 0.1 BTC) → smallest units (sat/lamport/rao)."""
-    return int(round(amount * 10 ** get_chain_def(chain).decimals))
+    """Display amount (e.g. 0.1 BTC) → smallest units (sat/lamport/wei). Decimal, not float: an
+    18-decimal chain needs more digits than a float carries, so 1.1 pins 1100000000000000128 wei —
+    over what the taker sends, and the leg never verifies. Truncating keeps the pin at or below."""
+    return int(Decimal(str(amount)) * 10 ** get_chain_def(chain).decimals)
 
 
 def rate_display_from_fixed(rate_fixed: int) -> str:

--- a/tests/test_swap_intake.py
+++ b/tests/test_swap_intake.py
@@ -36,6 +36,9 @@ def test_to_smallest_units():
     assert to_smallest_units(1.0, 'sol') == SOL
     assert to_smallest_units(0.5, 'btc') == 50_000_000  # 8 dec
     assert to_smallest_units(2.0, 'tao') == 2_000_000_000  # 9 dec
+    # 18 dec: float would pin 1100000000000000128 (over — leg never verifies) and ...9999999744.
+    assert to_smallest_units(1.1, 'eth') == 1_100_000_000_000_000_000
+    assert to_smallest_units(2.3, 'eth') == 2_300_000_000_000_000_000
 
 
 def test_sol_to_btc_amounts():


### PR DESCRIPTION
A float carries too few digits for an 18-decimal chain, so `--amount 1.1` pinned 1100000000000000128 wei — 128 over what the taker sends. The leg never verified: no claim, no Swap, no refund. Hits 10 of 17 chains. `Decimal(str(x))` is exact; low-decimal chains are unchanged.