### PR TITLE
AW-063: start when a spoke provider fails

### DIFF
--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -179,6 +179,13 @@ def reserve_on_behalf(
     providers = getattr(validator, 'axon_assets', {})
     provider = providers.get(to_chain)
     miner_quote = quote or client.get_quote(miner_pk, from_chain, to_chain, backing)
+    verified = getattr(validator, 'assets', None)
+    if verified is not None:
+        missing = next(
+            (chain for chain in (from_chain, to_chain) if chain not in verified or chain not in providers), None
+        )
+        if missing:
+            return ReserveResult(False, f'this validator cannot verify {missing} right now')
     if provider is not None:
         # Validity only: NOT a deliverability prediction. Reserve-time deliverability isn't a security
         # boundary (a dest can pass here then revert later via 7702/conditional code); the sound check is

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -28,6 +28,7 @@ from allways.chains import apply_testnet_network_defaults  # noqa: E402
 from allways.constants import (  # noqa: E402
     FEE_DIVISOR,
     FORWARD_STALL_THRESHOLD_SECONDS,
+    HUB_CHAINS,
     NETUID_FINNEY,
     SCORING_WINDOW_BLOCKS,
     SCORING_WINDOW_SECS,
@@ -92,7 +93,11 @@ class Validator(BaseValidatorNeuron):
         # providers (source-leg verification) and the solana_client below.
         solana_rpc_url = resolve_rpc_url()
         self.assets = create_assets(
-            check=True, require_send=False, subtensor=self.subtensor, solana_rpc_url=solana_rpc_url
+            check=True,
+            require_send=False,
+            required_chains=set(HUB_CHAINS),
+            subtensor=self.subtensor,
+            solana_rpc_url=solana_rpc_url,
         )
         self.fee_divisor = FEE_DIVISOR
 
@@ -184,7 +189,8 @@ class Validator(BaseValidatorNeuron):
         # handler, and running it unlocked would race the locked reads' recv (#456).
         self.axon_lock = threading.RLock()
         self.axon_subtensor = bt.Subtensor(config=self.config)
-        self.axon_assets = create_assets(subtensor=bt.Subtensor(config=self.config), solana_rpc_url=solana_rpc_url)
+        axon_assets = create_assets(subtensor=bt.Subtensor(config=self.config), solana_rpc_url=solana_rpc_url)
+        self.axon_assets = {chain: provider for chain, provider in axon_assets.items() if chain in self.assets}
         bt.logging.debug(f'Validator components: fee_divisor={self.fee_divisor}')
 
         # Attach synapse handlers to axon

--- a/tests/test_assets_optional.py
+++ b/tests/test_assets_optional.py
@@ -4,6 +4,7 @@ chains still fail hard — a tao<->sol miner must start without BTC creds, a btc
 import pytest
 
 from allways import assets as cp
+from allways.constants import HUB_CHAINS
 
 
 class _Boom:
@@ -42,6 +43,12 @@ def test_required_failure_still_raises(registry):
 def test_none_means_all_required(registry):
     with pytest.raises(RuntimeError, match='failed startup check'):
         cp.create_assets(check=True)
+
+
+def test_validator_requires_hubs_only(monkeypatch):
+    monkeypatch.setattr(cp, 'ASSET_REGISTRY', (('btc', _Boom, ()), ('sol', _Ok, ()), ('tao', _Ok, ())))
+    providers = cp.create_assets(check=True, required_chains=set(HUB_CHAINS))
+    assert set(providers) == {'sol', 'tao'}
 
 
 class _NoTestnet:

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -145,6 +145,17 @@ def test_reserve_does_not_predict_dest_deliverability():
     assert 'rejects incoming transfers' not in (result.reason or '')
 
 
+def test_missing_spoke_provider_rejects_before_bid():
+    client = FakeClient()
+    validator = _validator(client)
+    validator.axon_assets = {'sol': _gate_asset(lambda addr, amt: True)}
+    validator.assets = {'sol': object()}
+    result = reserve_on_behalf(validator, HOTKEY, 'sol', 'btc', USER_PK, str(USER_PK), 'userBTCaddr', 10**9)
+    assert not result.ok
+    assert 'cannot verify btc' in result.reason
+    assert client.calls == []
+
+
 def test_malformed_destination_address_rejects_before_any_bid():
     # F4: address FORMAT is screened first — offline, and a malformed dest can never deliver.
     client = FakeClient()


### PR DESCRIPTION
Allows validators to start when a spoke provider fails its startup check. Hub failures still stop startup. The failed spoke is removed from axon providers, and new reservations using it are refused before a bid.

Example: BTC RPC down → SOL/TAO remain available; BTC pairs are refused.

Checks: 1,953 tests; Ruff.