### PR TITLE
Reject unreadable receipt status

### DIFF
--- a/allways/assets/evm_coin.py
+++ b/allways/assets/evm_coin.py
@@ -351,8 +351,12 @@ class EvmCoin(EvmAsset):
         if not tx or not receipt:
             return None
         norm = self.chain.normalize_address
-        if int(receipt.get('status') or '0x0', 16) != 0:
-            return None  # succeeded (or unreadable status) — a delivered tx is not a refusal
+        try:
+            status = int(receipt['status'], 16)
+        except (KeyError, TypeError, ValueError):
+            return None
+        if status != 0:
+            return None  # a delivered tx is not a refusal
         if from_address and norm(tx.get('from') or '') != norm(from_address):
             return None  # not the committed miner's own attempt — could be a throwaway-sender ruse
         if norm(tx.get('to') or '') != norm(address):

--- a/tests/test_cancel_swap_nofault.py
+++ b/tests/test_cancel_swap_nofault.py
@@ -10,6 +10,8 @@ strong enough that a wrong verdict can't hand a defaulting miner a free pass:
   - passive chains (BTC/TAO) and the base default: never — they can't refuse a payout.
 """
 
+import pytest
+
 from allways.assets.eth import Ether
 from allways.assets.ethusdc import EthUsdc
 from allways.assets.sol import RESERVED_ACCOUNTS, Sol
@@ -83,6 +85,11 @@ class TestEvmCancelEvidence:
 
     def test_missing_receipt_is_none(self, monkeypatch):
         p = _stub(_evm(monkeypatch), _tx(), None)
+        assert p.cancel_evidence(DEST, AMOUNT, TX) is None
+
+    @pytest.mark.parametrize('receipt', [{}, {'status': None}, {'status': 'unknown'}])
+    def test_unreadable_status_is_none(self, monkeypatch, receipt):
+        p = _stub(_evm(monkeypatch), _tx(), receipt)
         assert p.cancel_evidence(DEST, AMOUNT, TX) is None
 
 


### PR DESCRIPTION
Treats missing, null, or malformed receipt status as unreadable. Only an explicit status 0 can prove a native EVM refusal, so incomplete RPC data cannot grant no-fault cancellation.\n\nTest: 19 focused tests pass.