### PR TITLE
Check the pinned funding wallet

### DIFF
--- a/allways/miner/fulfillment.py
+++ b/allways/miner/fulfillment.py
@@ -167,7 +167,7 @@ class SwapFulfiller:
         Returns the refusal reason, or None when funded (or when no balance view exists — the send
         path still fails loudly on a genuine shortfall)."""
         provider = self.providers.get(swap.to_chain)
-        from_address = self.my_addresses.get(swap.to_chain)
+        from_address = swap.miner_to_addr or None
         if provider is None or not from_address:
             return None
         pending = 0

--- a/tests/test_fulfillment.py
+++ b/tests/test_fulfillment.py
@@ -235,6 +235,12 @@ class TestTotalObligationGate:
         f, _earlier, later, payout = self._dual(balance=900_000_000)
         assert f.unfunded_obligation_reason(later, payout) is None
 
+    def test_balance_check_uses_the_pinned_sender(self):
+        f, _earlier, later, payout = self._dual(balance=900_000_000)
+        f.my_addresses['tao'] = 'STALE-cache-addr'
+        assert f.unfunded_obligation_reason(later, payout) is None
+        f.providers['tao'].get_balance.assert_called_once_with('5miner')
+
     def test_already_sent_obligations_do_not_double_count(self):
         f, earlier, later, payout = self._dual(balance=500_000_000)
         f.sent[earlier.key_hex] = SentSwap('tx', 1, marked_fulfilled=False, timeout_at=5000)


### PR DESCRIPTION
Makes the miner's obligation check read the swap's pinned sender wallet. The check and payout now use the same address, so a stale quote-address cache cannot approve or defer against the wrong balance.\n\nTest: 19 focused tests pass.