### PR TITLE
Revert unsafe slash-history expansion

### DIFF
--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -518,7 +518,9 @@ class Erc20(EvmAsset):
         if self._refused_at(address):
             return True
         tip = int(self.chain.eth_rpc('eth_blockNumber', []), 16)
-        span = self.chain_def.blocks_for_seconds(int(time.time()) - int(since_unix))
+        # Span is in blocks; seconds_per_block floors to 1 on sub-second chains, so this reaches
+        # ~4× fewer wall-seconds than it reads. Fine here — the latest probe above is load-bearing.
+        span = min(60, max(0, int(time.time()) - int(since_unix)) // self.chain_def.seconds_per_block)
         for probe in dict.fromkeys(hex(max(0, tip - span // d)) for d in (1, 2)):
             try:
                 if self._refused_at(address, probe):

--- a/allways/assets/evm_coin.py
+++ b/allways/assets/evm_coin.py
@@ -322,7 +322,8 @@ class EvmCoin(EvmAsset):
         getCode is dest-only (miner can't influence it) where a simulation is gameable by
         either side. Raises when the chain view is unavailable (caller defers)."""
         tip = int(self.chain.eth_rpc('eth_blockNumber', []), 16)
-        span = self.chain_def.blocks_for_seconds(int(time.time()) - int(since_unix))
+        # Probe depth clamped to what non-archive public nodes serve (~128 blocks).
+        span = min(120, max(0, int(time.time()) - int(since_unix)) // self.chain_def.seconds_per_block)
         probes = ['latest'] + [hex(max(0, tip - span // d)) for d in (1, 2)]
         return any((self.chain.eth_rpc('eth_getCode', [address, b]) or '0x') != '0x' for b in probes)
 

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -29,9 +29,6 @@ class ChainDefinition:
     # supported one, so the choice must survive reordering the list.
     testnet_network: str = ''
     seconds_per_block: int = 12  # Average block time on this chain
-    # Exact rate for wall-time history. Fast chains keep ``seconds_per_block`` rounded for
-    # integer deadline math, but evidence scans must not shorten their time window.
-    observed_seconds_per_block: float | None = None
     min_confirmations: int = 1  # Minimum confirmations before accepting a transaction
     # Smallest amount that can actually exist/move on-chain, in native units
     # (BTC dust floor, TAO existential deposit). 1 = no floor.
@@ -54,9 +51,6 @@ class ChainDefinition:
     # on a given amount (PAXG's getFeeFor). Set only on tokens with an admin-settable fee; a live
     # non-zero fee shaves every delivery below the pinned amount, so it's a no-fault cancel (V-M2).
     fee_check: str | None = None
-
-    def blocks_for_seconds(self, seconds: int) -> int:
-        return math.ceil(max(0, seconds) / (self.observed_seconds_per_block or self.seconds_per_block))
 
 
 # ─── Supported Chains ────────────────────────────────────
@@ -182,7 +176,6 @@ CHAIN_BNB = ChainDefinition(
     # Fermi (Jan 2026) cut blocks to 0.45s — measured 0.4502s over the last 100k mainnet blocks.
     # 1 is the integer floor, so every derived bound is conservative in wall time, never short.
     seconds_per_block=1,
-    observed_seconds_per_block=0.45,
     # BEP-126 finalizes a block once it and its direct child carry >2/3 attestations (~2 blocks).
     # Below that quorum — e.g. across an epoch's validator-set rotation — BSC falls back to its
     # longest-chain rule, where what bounds one dishonest proposer is turn_length: the run of
@@ -313,7 +306,6 @@ CHAIN_ASTER = ChainDefinition(
     # duplicate CLI row writing the same var.
     networks=(),
     seconds_per_block=1,
-    observed_seconds_per_block=0.45,
     # CHAIN_BNB's finality, deliberately identical — two assets on one chain must not disagree
     # about its reorg depth. See CHAIN_BNB for the derivation (BEP-126 quorum, BEP-341
     # turn_length 8). 15 × 1s, inside the program's 600s default fulfillment grace.

--- a/tests/test_bnb_provider.py
+++ b/tests/test_bnb_provider.py
@@ -272,28 +272,18 @@ class TestDeliveryGates:
 
         def code_at(params):
             probed.append(params[1])
-            return DELEGATION if params[1] == hex(9_933) else '0x'
+            return DELEGATION if params[1] == hex(9_970) else '0x'
 
         rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getCode': code_at})
         assert provider.delivery_refused(RECIPIENT, frozen_now - 60) is True
-        # The 60-second wall-time window is 134 blocks at BSC's 0.45-second rate.
-        assert probed == ['latest', hex(9_866), hex(9_933)]
+        # now, then the window's far edge and its midpoint. The 60s window is 60 blocks at the
+        # stored 1s; note the gate's 120-block span cap is only ~54s of real BSC history (0.45s
+        # blocks), so "the window since since_unix" stops being true beyond that.
+        assert probed == ['latest', hex(9_940), hex(9_970)]
 
     def test_slash_gate_does_not_exempt_a_dest_that_never_had_code(self, provider, frozen_now):
         rpc_stub(provider, {'eth_blockNumber': hex(10_000), 'eth_getCode': '0x'})
         assert provider.delivery_refused(RECIPIENT, frozen_now - 60) is False
-
-    def test_slash_gate_keeps_the_full_ten_minute_window(self, provider, frozen_now):
-        probed = []
-        rpc_stub(
-            provider,
-            {
-                'eth_blockNumber': hex(10_000),
-                'eth_getCode': lambda params: probed.append(params[1]) or '0x',
-            },
-        )
-        assert provider.delivery_refused(RECIPIENT, frozen_now - 600) is False
-        assert probed == ['latest', hex(8_666), hex(9_333)]
 
 
 class TestDepositScanner:


### PR DESCRIPTION
Reverts #685. Both default BSC RPCs reject the 1,334-block historical state read, which can defer a slash forever. Restores the bounded checks until archive RPC or stored evidence is available.\n\nTest: 72 focused tests pass.