### PR TITLE
Parse swap amounts as Decimal

### DIFF
--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -4,6 +4,7 @@ import os
 import sys
 import time
 from dataclasses import dataclass, field
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Callable, List, Optional, Tuple
 
@@ -183,6 +184,24 @@ class FiniteFloatType(click.ParamType):
 
 
 FINITE_FLOAT = FiniteFloatType()
+
+
+class FiniteDecimalType(click.ParamType):
+    """A finite decimal for asset amounts that must retain every entered digit."""
+
+    name = 'decimal'
+
+    def convert(self, value, param, ctx):
+        try:
+            number = Decimal(str(value))
+        except (InvalidOperation, ValueError):
+            self.fail(f'{value!r} is not a decimal number', param, ctx)
+        if not number.is_finite():
+            self.fail(f'{value!r} must be a finite number (not nan/inf)', param, ctx)
+        return number
+
+
+FINITE_DECIMAL = FiniteDecimalType()
 
 
 def fail(message: str, code: int = 1) -> None:

--- a/allways/cli/swap_commands/quote.py
+++ b/allways/cli/swap_commands/quote.py
@@ -5,6 +5,7 @@ origination path uses (`swap_intake`), and shows every viable miner and what you
 protocol fee — without committing to a swap."""
 
 import sys
+from decimal import Decimal
 
 import click
 from rich.table import Table
@@ -12,7 +13,7 @@ from rich.text import Text
 
 from allways.chains import SUPPORTED_CHAINS, get_chain_def
 from allways.cli.swap_commands.helpers import (
-    FINITE_FLOAT,
+    FINITE_DECIMAL,
     backing_label,
     console,
     fail,
@@ -55,9 +56,9 @@ def _prompt_or_fail(value, prompt_text, opt, cast=str):
 @click.command('quote')
 @click.option('--from', 'from_chain', default=None, type=str, help='Source chain (e.g. sol, btc, tao)')
 @click.option('--to', 'to_chain', default=None, type=str, help='Destination chain (e.g. sol, btc, tao)')
-@click.option('--amount', default=None, type=FINITE_FLOAT, help='Amount to send in source chain units')
+@click.option('--amount', default=None, type=FINITE_DECIMAL, help='Amount to send in source chain units')
 @click.option('--json', 'as_json', is_flag=True, help='Emit machine-readable JSON instead of a table.')
-def quote_command(from_chain: str, to_chain: str, amount: float, as_json: bool):
+def quote_command(from_chain: str, to_chain: str, amount: Decimal, as_json: bool):
     """Preview rates and estimated receive amounts for a swap.
 
     \b
@@ -74,7 +75,7 @@ def quote_command(from_chain: str, to_chain: str, amount: float, as_json: bool):
     chains = ', '.join(SUPPORTED_CHAINS)
     from_chain = _prompt_or_fail(from_chain, f'Source chain ({chains})', '--from')
     to_chain = _prompt_or_fail(to_chain, f'Destination chain ({chains})', '--to')
-    amount = _prompt_or_fail(amount, 'Amount (source units)', '--amount', cast=float)
+    amount = _prompt_or_fail(amount, 'Amount (source units)', '--amount', cast=Decimal)
 
     from_chain = from_chain.lower()
     to_chain = to_chain.lower()

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -11,6 +11,7 @@ Either way the tail is the same: send source funds + `swap post-tx`."""
 import json
 import sys
 import time
+from decimal import Decimal
 from typing import List, NamedTuple, Optional
 
 import click
@@ -26,7 +27,7 @@ from allways.cli.dendrite_lite import (
 )
 from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
-    FINITE_FLOAT,
+    FINITE_DECIMAL,
     PENDING_SWAP_FILE,
     backing_label,
     console,
@@ -315,7 +316,7 @@ def _poll_routed_reservation(client, miner, user, timeout_secs: int):
 @swap_group.command('now', show_disclaimer=True)
 @click.option('--from', 'from_chain_opt', default=None, help='Source chain (e.g. btc, tao)')
 @click.option('--to', 'to_chain_opt', default=None, help='Destination chain (e.g. btc, tao)')
-@click.option('--amount', 'amount_opt', default=None, type=FINITE_FLOAT, help='Amount to send in source chain units')
+@click.option('--amount', 'amount_opt', default=None, type=FINITE_DECIMAL, help='Amount to send in source chain units')
 @click.option('--receive-address', 'receive_address_opt', default=None, help='Receive address on destination chain')
 @click.option('--from-address', 'from_address_opt', default=None, help='Source address on source chain')
 @click.option('--from-tx-hash', 'from_tx_hash_opt', default=None, help='Source tx hash (skip fund sending)')
@@ -352,7 +353,7 @@ def _poll_routed_reservation(client, miner, user, timeout_secs: int):
 def swap_now_command(
     from_chain_opt: Optional[str],
     to_chain_opt: Optional[str],
-    amount_opt: Optional[float],
+    amount_opt: Optional[Decimal],
     receive_address_opt: Optional[str],
     from_address_opt: Optional[str],
     from_tx_hash_opt: Optional[str],
@@ -382,7 +383,7 @@ def swap_now_command(
     if from_chain == to_chain or hub_leg(from_chain, to_chain) is None:
         fail('A swap must have a hub leg (SOL or TAO) and two distinct chains — spoke<->spoke has no market.')
     if amount_opt is None:
-        amount_opt = _prompt_missing(None, 'Amount (source units)', '--amount', cast=float)
+        amount_opt = _prompt_missing(None, 'Amount (source units)', '--amount', cast=Decimal)
     if amount_opt is None or amount_opt <= 0:
         fail('--amount (source-chain units) must be positive.')
     if not receive_address_opt:

--- a/tests/test_swap_intake.py
+++ b/tests/test_swap_intake.py
@@ -6,6 +6,7 @@ the miner + validator. Concrete rates chosen so the arithmetic is hand-checkable
 
 import pytest
 
+from allways.cli.swap_commands.helpers import FINITE_DECIMAL
 from allways.cli.swap_commands.swap_intake import (
     MinerCandidate,
     compute_intake_amounts,
@@ -39,6 +40,8 @@ def test_to_smallest_units():
     # 18 dec: float would pin 1100000000000000128 (over — leg never verifies) and ...9999999744.
     assert to_smallest_units(1.1, 'eth') == 1_100_000_000_000_000_000
     assert to_smallest_units(2.3, 'eth') == 2_300_000_000_000_000_000
+    exact = FINITE_DECIMAL.convert('0.123456789123456789', None, None)
+    assert to_smallest_units(exact, 'eth') == 123_456_789_123_456_789
 
 
 def test_sol_to_btc_amounts():


### PR DESCRIPTION
Parses swap and quote amounts directly as Decimal instead of converting through float first. This preserves all entered digits for 18-decimal assets and keeps pinned amounts exact. Other CLI numeric options are unchanged.\n\nTest: 83 focused tests pass.