### PR TITLE
AW-026: bound the token log scan in blocks, not seconds

### DIFF
--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -39,6 +39,11 @@ MAX_TOKEN_TRANSFER_GAS = 150_000
 # Estimator-down fallback: covers FiatToken's worst case while staying under the cap.
 DEFAULT_TOKEN_TRANSFER_GAS = 120_000
 
+# Widest address-pinned eth_getLogs span the free rungs actually serve (measured 2026-08-19:
+# arbitrum publicnode and drpc both refuse 300). SCAN_LOOKBACK_BLOCKS derives from block TIME, so a
+# 1s chain asks 12x what a 12s chain does — the scan must be bounded in blocks, independent of that.
+MAX_LOG_SPAN_BLOCKS = 100
+
 # Testnet deployments per (asset id, network). The canonical mainnet deployment is the
 # registry row's asset_locator; {ASSET_ID}_TOKEN_CONTRACT overrides either (e2e fakes,
 # emergency repoint) — each address lives exactly once. Keyed by asset, not by network
@@ -571,13 +576,15 @@ class Erc20(EvmAsset):
         start = max(self.scan_cursors.get(key, floor), floor) + 1
         if start > head:
             return None
+        # One bounded chunk per call; the cursor carries the rest into the next pass.
+        end = min(head, start + MAX_LOG_SPAN_BLOCKS - 1)
         try:
             logs = self.chain.eth_rpc(
                 'eth_getLogs',
                 [
                     {
                         'fromBlock': hex(start),
-                        'toBlock': hex(head),
+                        'toBlock': hex(end),
                         'address': self.token_contract,
                         'topics': [TRANSFER_TOPIC0, '0x' + _pad_addr(from_addr), '0x' + _pad_addr(to_addr)],
                     }
@@ -594,5 +601,5 @@ class Erc20(EvmAsset):
             if value >= int(amount) and log.get('transactionHash'):
                 self.scan_cursors.pop(key, None)
                 return log['transactionHash']
-        self._set_cursor(key, head)
+        self._set_cursor(key, end)
         return None

--- a/tests/test_arbusdc_provider.py
+++ b/tests/test_arbusdc_provider.py
@@ -13,6 +13,7 @@ import pytest
 from allways.assets.arbusdc import ArbUsdc
 from allways.assets.asset import ProviderUnreachableError
 from allways.assets.erc20 import (
+    MAX_LOG_SPAN_BLOCKS,
     SEL_BALANCE_OF,
     SEL_IS_BLACKLISTED,
     SEL_PAUSED,
@@ -476,7 +477,25 @@ class TestScanner:
         rpc_stub(provider, {'eth_blockNumber': hex(1000), 'eth_getLogs': [{'data': hex(1), 'transactionHash': TX}]})
         assert provider.find_recent_outgoing(TEST_ADDR, RECIPIENT, AMOUNT) is None
         key = (TEST_ADDR.lower(), RECIPIENT.lower(), AMOUNT)
-        assert provider.scan_cursors[key] == 1000
+        # One capped chunk per call, so the cursor lands on the chunk end, not on head.
+        assert provider.scan_cursors[key] == 1000 - provider.SCAN_LOOKBACK_BLOCKS + MAX_LOG_SPAN_BLOCKS
+
+    def test_the_span_is_capped_and_the_cursor_walks_the_rest(self, provider):
+        """arbusdc is a 1s chain, so SCAN_LOOKBACK_BLOCKS is 300 — a span both free Arbitrum rungs
+        refuse (measured 2026-08-19). Ask for at most MAX_LOG_SPAN_BLOCKS and let the cursor carry
+        the remainder into the next pass, so the bound never depends on the chain's block time."""
+        spans = []
+
+        def logs(params):
+            spans.append(int(params[0]['toBlock'], 16) - int(params[0]['fromBlock'], 16) + 1)
+            return []
+
+        rpc_stub(provider, {'eth_blockNumber': hex(1000), 'eth_getLogs': logs})
+        assert provider.SCAN_LOOKBACK_BLOCKS > MAX_LOG_SPAN_BLOCKS  # else this proves nothing
+        for _ in range(4):
+            provider.find_recent_outgoing(TEST_ADDR, RECIPIENT, AMOUNT)
+        assert max(spans) <= MAX_LOG_SPAN_BLOCKS
+        assert provider.scan_cursors[(TEST_ADDR.lower(), RECIPIENT.lower(), AMOUNT)] == 1000  # caught up
 
     def test_failed_range_parks_cursor(self, provider):
         def boom(params):


### PR DESCRIPTION
`SCAN_LOOKBACK_BLOCKS` comes from block TIME, so a 1s chain asks 12x what a 12s chain does. arbusdc requests a 300-block `eth_getLogs` both free rungs refuse, so its deposit scanner never returns. Cap the span in blocks; the cursor walks the rest. Measured: polygon drpc refuses 300, serves 100.