### PR TITLE
AW-025: lead the Arbitrum mainnet ladder with a rung that answers

### DIFF
--- a/allways/assets/evm.py
+++ b/allways/assets/evm.py
@@ -85,7 +85,8 @@ ARBITRUM = EvmNetwork(
     label='Arbitrum',
     chain_ids={'mainnet': 42_161, 'sepolia': 421_614},
     rpc_urls={
-        'mainnet': ('https://arbitrum-one-rpc.publicnode.com', 'https://arbitrum.drpc.org'),
+        # Keyless rungs: only arb1 serves eth_getLogs.
+        'mainnet': ('https://arb1.arbitrum.io/rpc', 'https://arbitrum-one-rpc.publicnode.com'),
         'sepolia': ('https://arbitrum-sepolia-rpc.publicnode.com', 'https://arbitrum-sepolia.drpc.org'),
     },
 )


### PR DESCRIPTION
Both keyless Arbitrum mainnet rungs answer `eth_chainId` then refuse `eth_getLogs` — publicnode 403s, drpc 500s. A validator without `ARB_RPC_URLS` boots green and never finds an arbusdc deposit. Lead with arb1, which serves it. Keyed `ARB_RPC_URLS` still wins.