### PR TITLE
Show the amount that lands and both legs in alw view swap

### DIFF
--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -37,8 +37,9 @@ from allways.cli.swap_commands.helpers import (
     set_json_output,
 )
 from allways.cli.swap_commands.swap_intake import backing_purse, rate_display_from_fixed
+from allways.constants import FEE_DIVISOR
 from allways.solana.client import swap_from_solana
-from allways.utils.rate import directional_rate
+from allways.utils.rate import apply_fee_deduction, directional_rate
 
 MINER_SORT_FIELDS = ['uid', 'rate', 'capacity', 'status']
 MINER_STATUS_CHOICES = ['available', 'offline', 'in-swap', 'reserved', 'cooldown']
@@ -381,9 +382,12 @@ def _render_swap_detail(s):
     console.print(f'  Miner:       {s.miner}')
     console.print(f'  User:        {s.user}')
     console.print(f'  Send:        {s.from_amount / 10**from_dec:g} {s.from_chain.upper()}')
-    console.print(f'  Receive:     {s.to_amount / 10**to_dec:g} {s.to_chain.upper()} (pinned payout)')
-    console.print(f'  User from:   {s.user_from_addr}')
-    console.print(f'  Miner to:    {s.miner_to_addr}')
+    # `to_amount` is the gross pinned payout; the miner sends — and the validator verifies — the
+    # fee-deducted amount, so show what actually lands.
+    receives = apply_fee_deduction(s.to_amount, FEE_DIVISOR)
+    console.print(f'  Receive:     {receives / 10**to_dec:g} {s.to_chain.upper()} (after {100 / FEE_DIVISOR:g}% fee)')
+    console.print(f'  Source leg:  {s.user_from_addr} → {s.miner_from_addr}')
+    console.print(f'  Dest leg:    {s.miner_to_addr} → {s.user_to_addr}')
     console.print(f'  Source tx:   {s.from_tx_hash or "[dim](none)[/dim]"}')
     console.print(f'  Dest tx:     {s.to_tx_hash or "[dim](none)[/dim]"}')
     console.print(f'  Initiated:   {s.initiated_at}')
@@ -434,13 +438,11 @@ def view_swap(swap_key_hex: str, watch: bool, as_json: bool):
         _render_swap_detail(s)
         return
 
-    terminal = {'PendingAttestation'}
+    # No live status is terminal — Active/Fulfilled/PendingAttestation are all mid-flight. The
+    # account closing is the only end, and it is handled below.
     while True:
         console.clear()
         _render_swap_detail(s)
-        if s.status in terminal:
-            console.print('[dim]Swap reached a terminal on-chain status.[/dim]')
-            return
         time.sleep(5)
         s = _load()
         if s is None:

--- a/tests/test_cli_view_solana.py
+++ b/tests/test_cli_view_solana.py
@@ -256,3 +256,57 @@ def test_view_rates_shows_the_quotes_backing_purse(monkeypatch):
     payload = json.loads(CliRunner().invoke(view.view_group, ['rates', '--json']).output)[0]
     assert payload['collateral_tao'] == 1.0
     assert 'collateral_sol' not in payload
+
+
+def _swap(**over):
+    fields = dict(
+        key_hex='cd' * 32,
+        status='Fulfilled',
+        from_chain='sol',
+        to_chain='pol',
+        miner=Keypair().pubkey(),
+        user=Keypair().pubkey(),
+        from_amount=100_000_000,
+        to_amount=50 * 10**18,
+        user_from_addr='USERSOL',
+        user_to_addr='0xUSERPOL',
+        miner_from_addr='MINERSOL',
+        miner_to_addr='0xMINERPOL',
+        from_tx_hash='srctx',
+        to_tx_hash='dsttx',
+        initiated_at=1,
+        timeout_at=2,
+        fulfilled_at=3,
+    )
+    fields.update(over)
+    return types.SimpleNamespace(**fields)
+
+
+def test_view_swap_shows_the_amount_that_actually_lands(monkeypatch):
+    """`to_amount` is the gross pinned payout; the miner sends and the validator verifies it net of
+    the 1% fee. Rendering the gross told the user they receive 1% more than they ever can."""
+    client = MagicMock()
+    client.get_swap.return_value = object()
+    _patch_client(monkeypatch, client)
+    monkeypatch.setattr(view, 'swap_from_solana', lambda acct, key: _swap())
+
+    result = CliRunner().invoke(view.view_group, ['swap', 'cd' * 32])
+
+    assert result.exit_code == 0, result.output
+    assert '49.5 POL' in result.output
+    assert '50 POL' not in result.output
+
+
+def test_view_swap_names_both_legs_end_to_end(monkeypatch):
+    """The payout address (`user_to_addr`) is the one address a taker must check. It used to be
+    absent, while `miner_to_addr` — a sender — was labelled "Miner to"."""
+    client = MagicMock()
+    client.get_swap.return_value = object()
+    _patch_client(monkeypatch, client)
+    monkeypatch.setattr(view, 'swap_from_solana', lambda acct, key: _swap())
+
+    result = CliRunner().invoke(view.view_group, ['swap', 'cd' * 32])
+
+    assert result.exit_code == 0, result.output
+    assert 'USERSOL → MINERSOL' in result.output
+    assert '0xMINERPOL → 0xUSERPOL' in result.output


### PR DESCRIPTION
`alw view swap` made three false statements about a live swap. All three were observed on SN19 testnet during the POL happy-path round (swap `a781f937d14d5af8…`).

**1. It reported a payout the user cannot receive.** The detail view printed `to_amount` as the "pinned payout". `to_amount` is the gross; the miner sends — and the validator verifies — `apply_fee_deduction(to_amount, FEE_DIVISOR)`. The view now uses that same shared helper. Observed: the view said `50 POL`, the user's wallet received `49.5 POL`, and `alw swap quote` had already said `49.5`. Two CLI screens disagreed by 1% about one swap.

**2. It hid the payout address and mislabelled a sender.** It showed `user_from_addr` and `miner_to_addr` — both senders — and called the second one "Miner to". `user_to_addr`, the address the miner actually pays (`fulfillment.py:296`), was absent. Now both legs read sender → recipient.

**3. `--watch` quit at the start of the lifecycle.** `terminal = {'PendingAttestation'}` treated the first post-claim state as an end state, so watching a fresh swap printed "Swap reached a terminal on-chain status" and exited while the swap was still mid-flight. No live status is terminal — `Active`/`Fulfilled`/`PendingAttestation` are all in-flight, and the account closing is the real end, which the loop already handles.

Before / after on the same swap:

```
- Receive:     50 POL (pinned payout)         Receive:     49.5 POL (after 1% fee)
- User from:   oVbhiDNQ…                      Source leg:  oVbhiDNQ… → BKHKu16h…
- Miner to:    0xB3C869…                      Dest leg:    0xB3C869… → 0x463c88…
```

`--json` is unchanged: its keys mirror the raw on-chain field names, so `to_amount` staying gross there is correct.

Two tests added, one per user-visible claim.