### PR TITLE
Activate: quorum short-circuit + 30s default dendrite timeout

### DIFF
--- a/allways/cli/dendrite_lite.py
+++ b/allways/cli/dendrite_lite.py
@@ -159,6 +159,61 @@ def broadcast_synapse(
     return responses
 
 
+def broadcast_until_quorum(
+    dendrite: bt.Dendrite,
+    axons: List[bt.AxonInfo],
+    synapse: bt.Synapse,
+    needed: int,
+    timeout: float,
+) -> list:
+    """Broadcast to all axons but stop waiting once ``needed`` of them accept.
+
+    Foreign or dead validators can't hold the caller for the full timeout when the
+    accepting responses already meet the on-chain consensus headcount. Returns only
+    the responses that completed; the on-chain state stays the authority."""
+    import asyncio
+
+    needed = max(1, needed)
+
+    async def _run() -> list:
+        tasks = [
+            asyncio.ensure_future(
+                dendrite.call(target_axon=axon, synapse=synapse.model_copy(), timeout=timeout, deserialize=False)
+            )
+            for axon in axons
+        ]
+        responses: list = []
+        accepted = 0
+        pending = set(tasks)
+        while pending:
+            done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
+            for task in done:
+                try:
+                    response = task.result()
+                except Exception:
+                    continue  # dendrite.call maps transport errors into the synapse; anything else counts as no response
+                responses.append(response)
+                accepted += bool(getattr(response, 'accepted', None))
+            if accepted >= needed:
+                for task in pending:
+                    task.cancel()
+                if pending:
+                    await asyncio.gather(*pending, return_exceptions=True)
+                break
+        return responses
+
+    # A persistent loop (not a fresh one per call): the caller may broadcast repeatedly with
+    # the same dendrite, whose aiohttp session stays bound to the loop it first ran on.
+    try:
+        loop = asyncio.get_event_loop_policy().get_event_loop()
+        if loop.is_closed():
+            raise RuntimeError('event loop is closed')
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+    return loop.run_until_complete(_run())
+
+
 def resolve_dendrite_timeout(default: float) -> float:
     """Honor ALW_DENDRITE_TIMEOUT as an override for slow chains (e.g. testnet)."""
     import os

--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -145,6 +145,13 @@ def quote_update_fee_lamports(elapsed_secs: int) -> int:
     return 0
 
 
+def votes_needed(cfg) -> int:
+    """Votes required for consensus — mirrors the program's headcount check
+    (consensus.rs: votes*100 >= threshold*total), i.e. ceil(threshold*total/100)."""
+    total = len(cfg.validators)
+    return -(-cfg.consensus_threshold_percent * total // 100)
+
+
 console = Console()
 
 

--- a/allways/cli/swap_commands/miner_commands.py
+++ b/allways/cli/swap_commands/miner_commands.py
@@ -257,9 +257,7 @@ def miner_activate(backing: str):
         synapse = MinerActivateSynapse(hotkey=hotkey, signature=signature, message=message, backing=backing)
 
         with loading(f'Broadcasting activation to {len(validator_axons)} validators...'):
-            responses = broadcast_until_quorum(
-                dendrite, validator_axons, synapse, needed=needed_votes, timeout=timeout
-            )
+            responses = broadcast_until_quorum(dendrite, validator_axons, synapse, needed=needed_votes, timeout=timeout)
 
         info = render_and_aggregate(console, responses, label='V', context={'miner_hotkey': hotkey})
         skipped = len(validator_axons) - len(responses)

--- a/allways/cli/swap_commands/miner_commands.py
+++ b/allways/cli/swap_commands/miner_commands.py
@@ -1,13 +1,12 @@
 """alw miner - Miner dashboard commands."""
 
-import asyncio
 import time
 
 import click
 from rich.table import Table
 
 from allways.chains import SUPPORTED_CHAINS
-from allways.cli.dendrite_lite import discover_validators, resolve_dendrite_timeout
+from allways.cli.dendrite_lite import broadcast_until_quorum, discover_validators, resolve_dendrite_timeout
 from allways.cli.help import StyledGroup
 from allways.cli.swap_commands.helpers import (
     activation_prerequisites,
@@ -21,6 +20,7 @@ from allways.cli.swap_commands.helpers import (
     loading,
     purse_states,
     resolve_activation_backing,
+    votes_needed,
 )
 from allways.cli.swap_commands.swap_intake import rate_display_from_fixed
 from allways.cli.validator_rejections import render_and_aggregate
@@ -226,7 +226,8 @@ def miner_activate(backing: str):
     try:
         with loading('Reading your purses...'):
             miner_state = client.get_miner_state(miner_pk)
-            states = purse_states(client, miner_pk, miner_state, client.get_config())
+            cfg = client.get_config()
+            states = purse_states(client, miner_pk, miner_state, cfg)
     except SolanaClientError as e:
         fail(f'Failed to read miner data: {e}')
     if miner_state is None:
@@ -246,7 +247,8 @@ def miner_activate(backing: str):
     # Broadcast, re-signing a fresh timestamp each attempt. On a 429 the request
     # was rejected at the edge proxy and never reached the validator — back off
     # and retry rather than surfacing a transient rate-limit as a failure.
-    timeout = resolve_dendrite_timeout(60.0)
+    timeout = resolve_dendrite_timeout(30.0)
+    needed_votes = votes_needed(cfg)
     activate_max_retries = 2
     for attempt in range(activate_max_retries + 1):
         timestamp = str(int(time.time()))
@@ -255,11 +257,14 @@ def miner_activate(backing: str):
         synapse = MinerActivateSynapse(hotkey=hotkey, signature=signature, message=message, backing=backing)
 
         with loading(f'Broadcasting activation to {len(validator_axons)} validators...'):
-            responses = asyncio.get_event_loop().run_until_complete(
-                dendrite(axons=validator_axons, synapse=synapse, deserialize=False, timeout=timeout)
+            responses = broadcast_until_quorum(
+                dendrite, validator_axons, synapse, needed=needed_votes, timeout=timeout
             )
 
         info = render_and_aggregate(console, responses, label='V', context={'miner_hotkey': hotkey})
+        skipped = len(validator_axons) - len(responses)
+        if skipped > 0:
+            console.print(f'[dim]Quorum reached — stopped waiting on {skipped} slower validator(s).[/dim]')
 
         if info.category == 'rate_limited' and attempt < activate_max_retries:
             backoff_s = 6

--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -35,6 +35,7 @@ from allways.cli.swap_commands.helpers import (
     safe_read,
     secs_str,
     set_json_output,
+    votes_needed,
 )
 from allways.cli.swap_commands.swap_intake import backing_purse, rate_display_from_fixed
 from allways.constants import FEE_DIVISOR
@@ -458,15 +459,8 @@ def _tao_or(rao: int, zero_label: str) -> str:
     return f'{from_rao(rao):.4f} τ' + (f' ({zero_label})' if rao == 0 else '')
 
 
-def _votes_needed(cfg) -> int:
-    """Votes required for consensus — mirrors the program's headcount check
-    (consensus.rs: votes*100 >= threshold*total), i.e. ceil(threshold*total/100)."""
-    total = len(cfg.validators)
-    return -(-cfg.consensus_threshold_percent * total // 100)
-
-
 def _threshold_line(cfg) -> str:
-    return f'{cfg.consensus_threshold_percent}% ({_votes_needed(cfg)} of {len(cfg.validators)} validator votes)'
+    return f'{cfg.consensus_threshold_percent}% ({votes_needed(cfg)} of {len(cfg.validators)} validator votes)'
 
 
 @view_group.command('config')
@@ -488,7 +482,7 @@ def view_config(as_json):
                 'version': cfg.version,
                 'halted': bool(cfg.halted),
                 'consensus_threshold_percent': cfg.consensus_threshold_percent,
-                'votes_needed': _votes_needed(cfg),
+                'votes_needed': votes_needed(cfg),
                 'reservation_fee_sol': from_lamports(cfg.reservation_fee_lamports),
                 'min_collateral_sol': from_lamports(cfg.min_collateral),
                 'max_collateral_sol': from_lamports(cfg.max_collateral),
@@ -549,7 +543,7 @@ def view_validators(as_json):
         print_json(
             {
                 'consensus_threshold_percent': cfg.consensus_threshold_percent,
-                'votes_needed': _votes_needed(cfg),
+                'votes_needed': votes_needed(cfg),
                 'validators': validators,
             }
         )

--- a/tests/test_activate_quorum.py
+++ b/tests/test_activate_quorum.py
@@ -1,0 +1,77 @@
+"""broadcast_until_quorum — activation must not wait out dead validators once quorum is met."""
+
+import asyncio
+import time
+
+from allways.cli.dendrite_lite import broadcast_until_quorum
+
+
+class _FakeSynapse:
+    def __init__(self, accepted=None):
+        self.accepted = accepted
+
+    def model_copy(self):
+        return _FakeSynapse(self.accepted)
+
+
+class _FakeDendrite:
+    """Scripted per-axon behavior: 'accept' / 'reject' answer instantly, 'hang' sleeps forever."""
+
+    def __init__(self, behaviors):
+        self.behaviors = behaviors
+        self.cancelled = 0
+
+    async def call(self, target_axon, synapse, timeout, deserialize):
+        behavior = self.behaviors[target_axon]
+        if behavior == 'hang':
+            try:
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                self.cancelled += 1
+                raise
+        if behavior == 'raise':
+            raise ConnectionError('boom')
+        synapse.accepted = behavior == 'accept'
+        return synapse
+
+
+def test_quorum_of_one_returns_without_waiting_for_hung_validators():
+    dendrite = _FakeDendrite({0: 'hang', 1: 'accept', 2: 'hang', 3: 'hang'})
+    start = time.monotonic()
+    responses = broadcast_until_quorum(dendrite, [0, 1, 2, 3], _FakeSynapse(), needed=1, timeout=3600)
+    assert time.monotonic() - start < 5
+    assert sum(bool(r.accepted) for r in responses) == 1
+    assert dendrite.cancelled == 3
+
+
+def test_waits_for_as_many_accepts_as_the_headcount_needs():
+    dendrite = _FakeDendrite({0: 'accept', 1: 'accept', 2: 'hang'})
+    responses = broadcast_until_quorum(dendrite, [0, 1, 2], _FakeSynapse(), needed=2, timeout=3600)
+    assert sum(bool(r.accepted) for r in responses) == 2
+    assert dendrite.cancelled == 1
+
+
+def test_no_accepts_still_collects_every_response_for_the_rejection_report():
+    dendrite = _FakeDendrite({0: 'reject', 1: 'reject', 2: 'reject'})
+    responses = broadcast_until_quorum(dendrite, [0, 1, 2], _FakeSynapse(), needed=1, timeout=3600)
+    assert len(responses) == 3
+    assert not any(r.accepted for r in responses)
+
+
+def test_a_call_that_raises_is_dropped_not_fatal():
+    dendrite = _FakeDendrite({0: 'raise', 1: 'accept'})
+    responses = broadcast_until_quorum(dendrite, [0, 1], _FakeSynapse(), needed=1, timeout=3600)
+    assert sum(bool(r.accepted) for r in responses) == 1
+
+
+def test_zero_needed_is_clamped_so_the_broadcast_still_asks_someone():
+    dendrite = _FakeDendrite({0: 'accept', 1: 'hang'})
+    responses = broadcast_until_quorum(dendrite, [0, 1], _FakeSynapse(), needed=0, timeout=3600)
+    assert sum(bool(r.accepted) for r in responses) == 1
+
+
+def test_repeated_broadcasts_reuse_a_working_loop():
+    dendrite = _FakeDendrite({0: 'accept'})
+    for _ in range(3):
+        responses = broadcast_until_quorum(dendrite, [0], _FakeSynapse(), needed=1, timeout=3600)
+        assert responses[0].accepted

--- a/tests/test_cli_view_solana.py
+++ b/tests/test_cli_view_solana.py
@@ -94,10 +94,10 @@ def test_view_config_json_carries_the_tao_hub_bounds(monkeypatch):
 def test_votes_needed_mirrors_contract_headcount_math():
     """consensus.rs: votes*100 >= threshold*total. Note 67% of 3 needs ALL 3 (2/3 = 66.7% < 67%)."""
     one = types.SimpleNamespace(key=b'', weight=1)
-    assert view._votes_needed(_config(consensus_threshold_percent=67, validators=[one])) == 1
-    assert view._votes_needed(_config(consensus_threshold_percent=67, validators=[one] * 3)) == 3
-    assert view._votes_needed(_config(consensus_threshold_percent=66, validators=[one] * 3)) == 2
-    assert view._votes_needed(_config(consensus_threshold_percent=51, validators=[one] * 4)) == 3
+    assert view.votes_needed(_config(consensus_threshold_percent=67, validators=[one])) == 1
+    assert view.votes_needed(_config(consensus_threshold_percent=67, validators=[one] * 3)) == 3
+    assert view.votes_needed(_config(consensus_threshold_percent=66, validators=[one] * 3)) == 2
+    assert view.votes_needed(_config(consensus_threshold_percent=51, validators=[one] * 4)) == 3
 
 
 def test_view_config_shows_effective_votes(monkeypatch):


### PR DESCRIPTION
Mainnet launch surfaced this: \`alw miner activate\` broadcasts to every serving permit-holder and waits the full dendrite timeout (60s) for all of them. On finney, 5 of the 6 serving axons are foreign validators that never answer, so every activation stalls ~60s per attempt on validators whose votes can never count.

Two changes:

- **Return at quorum.** New \`broadcast_until_quorum\` in \`dendrite_lite\` dispatches per-axon calls and stops waiting as soon as the accepting responses meet the on-chain consensus headcount (\`votes_needed\`, moved from \`view\` to \`helpers\` and reused). Stragglers are cancelled; the on-chain poll remains the authority on activation. The CLI notes how many slower validators it stopped waiting on.
- **Default dendrite timeout 60s → 30s** for the activate broadcast. \`ALW_DENDRITE_TIMEOUT\` still overrides for slow chains.

Measured on mainnet today: activation went from ~100s to the time of the fastest accepting validator.

Tests: new \`test_activate_quorum.py\` (early return, headcount, rejection report completeness, error tolerance, loop reuse); full suite 1961 passed.