### PR TITLE
Add solusdc: USDC on Solana as a spoke

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,13 +17,16 @@ LOG_LEVEL=info
 # OPTIONAL dev override; must match the deployed program (mismatch = accounts read absent)
 # ALLWAYS_PROGRAM_ID=
 
-# ─── Chain: Solana (all roles) ─────────────────────────────
+# ─── Chain: Solana (all roles; SOL + solusdc legs) ──────────
 # keyed/paid recommended; unset = http://127.0.0.1:8899
 SOLANA_RPC_URL=
 # OPTIONAL keyed-provider key, composed onto the URL (api-key param)
 # SOLANA_RPC_API_KEY=
 # OPTIONAL miner/admin signer; unset = `alw config` value, then ~/.solana/id.json
 # SOLANA_KEYPAIR_PATH=
+# OPTIONAL USDC mint override (localnet/e2e fakes) — unset = Circle's mint for the cluster the RPC
+# serves (mainnet-beta or devnet, by genesis hash); solusdc is unavailable on any other cluster
+# SOLUSDC_TOKEN_MINT=
 
 # ─── Chain: Bitcoin (BTC pairs) ────────────────────────────
 BTC_NETWORK=mainnet                 # mainnet | testnet | testnet4
@@ -34,12 +37,8 @@ BTC_NETWORK=mainnet                 # mainnet | testnet | testnet4
 # WIF — required for miners; optional local signing for `alw swap`
 BTC_PRIVATE_KEY=
 
-# ─── Network: Ethereum (ETH + ethusdc + uni pairs) ─────────
-# Vars are per NETWORK, shared by every asset on it — ethusdc and uni add none of their own.
-# ─── Network: Ethereum (ETH + ethusdc + qnt pairs) ─────────
+# ─── Network: Ethereum (ETH + ethusdc + uni + qnt + paxg pairs) ─────
 # Vars are per NETWORK, shared by every asset on it — the tokens add no network vars of their own.
-# ─── Network: Ethereum (ETH + ethusdc + paxg pairs) ───────────────
-# Vars are per NETWORK, shared by every asset on it — ethusdc adds no network vars of its own.
 ETH_NETWORK=mainnet                 # mainnet | sepolia
 # OPTIONAL ordered JSON-RPC endpoints (keyed providers embed the key in the URL);
 # unset = public (publicnode, drpc)
@@ -50,11 +49,6 @@ ETH_PRIVATE_KEY=
 # OPTIONAL token contract overrides (dev/e2e fakes) — per ASSET, unset = the canonical deployment
 # ETHUSDC_TOKEN_CONTRACT=
 # UNI_TOKEN_CONTRACT=
-# 32-byte hex key — required for miners (fund ETH for the ETH legs, USDC/QNT + ETH-for-gas for
-# the token legs); optional local signing for `alw swap`
-ETH_PRIVATE_KEY=
-# OPTIONAL token contract overrides (dev/e2e fakes) — per ASSET, unset = the canonical deployment
-# ETHUSDC_TOKEN_CONTRACT=
 # QNT_TOKEN_CONTRACT=
 # PAX Gold rides the same ETH_* config. REQUIRED on testnet — Paxos publishes no Sepolia PAXG.
 # PAXG_TOKEN_CONTRACT=

--- a/README.md
+++ b/README.md
@@ -10,13 +10,7 @@ Native transactions across independent assets — no wrapped tokens, no bridges,
 
 Allways creates a verification layer above independent systems. Assets move natively. Miners complete transactions, validators independently verify the results, and a smart contract enforces outcomes through collateral and slashing.
 
-Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, SOL ↔ USDC-on-Base, SOL ↔ USDC-on-Ethereum, and SOL ↔ CRO (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
-Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, SOL ↔ USDC-on-Base, SOL ↔ USDC-on-Ethereum, and SOL ↔ ASTER (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
-Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, SOL ↔ USDC-on-Base, SOL ↔ USDC-on-Ethereum, and SOL ↔ UNI (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
-Currently live with SOL and TAO as hubs, each paired against BTC, ETH, USDC-on-Arbitrum, HYPE, BNB, AVAX, USDC-on-Base, USDC-on-Ethereum, and QNT — plus SOL ↔ TAO itself (hub-and-spoke: every pair has a SOL or TAO leg). Designed to scale to any verifiable asset.
-Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, SOL ↔ USDC-on-Base, SOL ↔ USDC-on-Ethereum, and SOL ↔ POL (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
-Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, SOL ↔ USDC-on-Base, SOL ↔ USDC-on-Ethereum, SOL ↔ POL, and SOL ↔ USDC-on-Polygon (hub-and-spoke: every pair has a SOL leg). Designed to scale to any verifiable asset.
-Currently live with SOL ↔ BTC, SOL ↔ TAO, SOL ↔ ETH, SOL ↔ USDC-on-Arbitrum, SOL ↔ HYPE, SOL ↔ BNB, SOL ↔ AVAX, SOL ↔ USDC-on-Base, SOL ↔ USDC-on-Ethereum, and SOL ↔ PAXG (hub-and-spoke: every pair has a SOL or TAO leg). Designed to scale to any verifiable asset.
+Currently live with SOL and TAO as hubs, each paired against BTC, ETH, USDC-on-Arbitrum, HYPE, BNB, AVAX, USDC-on-Base, USDC-on-Ethereum, CRO, ASTER, UNI, QNT, POL, USDC-on-Polygon, PAXG, and USDC-on-Solana — plus SOL ↔ TAO itself (hub-and-spoke: every pair has a SOL or TAO leg). Designed to scale to any verifiable asset.
 
 ## Miner Risk Disclaimer
 

--- a/allways/assets/__init__.py
+++ b/allways/assets/__init__.py
@@ -3,7 +3,7 @@ from typing import Dict, NamedTuple, Optional, Set, Tuple, Type
 import bittensor as bt
 
 from allways.assets.arbusdc import ArbUsdc
-from allways.assets.asset import Asset, SendResult, TransactionInfo
+from allways.assets.asset import Asset, MissingTestnetDeployment, SendResult, TransactionInfo
 from allways.assets.aster import Aster
 from allways.assets.avax import Avax
 from allways.assets.baseusdc import BaseUsdc
@@ -11,7 +11,7 @@ from allways.assets.bnb import Bnb
 from allways.assets.btc import Bitcoin
 from allways.assets.chain import Chain
 from allways.assets.cro import Cro
-from allways.assets.erc20 import Erc20, MissingTestnetDeployment
+from allways.assets.erc20 import Erc20
 from allways.assets.eth import Ether
 from allways.assets.ethusdc import EthUsdc
 from allways.assets.evm_coin import EvmCoin
@@ -20,7 +20,9 @@ from allways.assets.paxg import Paxg
 from allways.assets.pol import Pol
 from allways.assets.polusdc import PolUsdc
 from allways.assets.qnt import Qnt
-from allways.assets.sol import Sol
+from allways.assets.sol import Sol, SolanaChain
+from allways.assets.solusdc import SolUsdc
+from allways.assets.spl_token import SplToken
 from allways.assets.tao import Tao
 from allways.assets.uni import Uni
 
@@ -49,6 +51,9 @@ __all__ = [
     'Qnt',
     'PolUsdc',
     'Paxg',
+    'SolanaChain',
+    'SplToken',
+    'SolUsdc',
     'create_assets',
 ]
 
@@ -80,6 +85,7 @@ ASSET_REGISTRY: Tuple[AssetSpec, ...] = (
     AssetSpec('pol', Pol, ()),
     AssetSpec('polusdc', PolUsdc, ()),
     AssetSpec('paxg', Paxg, ()),
+    AssetSpec('solusdc', SolUsdc, ('solana_rpc_url', 'solana_keypair')),
 )
 
 

--- a/allways/assets/asset.py
+++ b/allways/assets/asset.py
@@ -8,6 +8,12 @@ from allways.assets.chain import Chain
 from allways.chains import ChainDefinition
 
 
+class MissingTestnetDeployment(ValueError):
+    """A hosted asset has no pinned deployment on the configured test network (issuer-deployed
+    tokens often exist on mainnet only). Distinct so create_assets can disable the spoke on
+    testnet instead of failing the whole neuron's boot."""
+
+
 class ProviderUnreachableError(Exception):
     """Raised when a chain provider cannot reach its backend during verification."""
 

--- a/allways/assets/erc20.py
+++ b/allways/assets/erc20.py
@@ -6,7 +6,7 @@ import bittensor as bt
 from eth_account import Account
 from eth_utils import keccak, to_checksum_address
 
-from allways.assets.asset import ProviderUnreachableError, SendResult, TransactionInfo
+from allways.assets.asset import MissingTestnetDeployment, ProviderUnreachableError, SendResult, TransactionInfo
 from allways.assets.evm import EVM_NETWORKS, FALLBACK_PRIORITY_FEE_WEI, EvmAsset, EvmChain
 from allways.chains import ChainDefinition
 from allways.constants import (
@@ -60,12 +60,6 @@ TESTNET_TOKEN_CONTRACTS = {
     # Circle-verified native USDC on Polygon Amoy (developers.circle.com, 2026-08-12).
     'polusdc': {'amoy': '0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582'},
 }
-
-
-class MissingTestnetDeployment(ValueError):
-    """The token has no pinned deployment on the configured test network (issuer-deployed
-    assets like QNT/PAXG often exist on mainnet only). Distinct so create_assets can disable
-    the spoke on testnet instead of failing the whole neuron's boot."""
 
 
 def _token_contract(chain_def: ChainDefinition, network: str) -> str:

--- a/allways/assets/sol.py
+++ b/allways/assets/sol.py
@@ -3,7 +3,6 @@ import time
 from typing import Any, List, Optional
 
 import bittensor as bt
-import requests
 from solders.keypair import Keypair
 from solders.pubkey import Pubkey
 from solders.signature import Signature
@@ -12,7 +11,7 @@ from allways.assets.asset import Asset, ProviderUnreachableError, SendResult, Tr
 from allways.assets.chain import Chain
 from allways.chains import CHAIN_SOL, ChainDefinition
 from allways.constants import CANCEL_REASON_SOL_RESERVED
-from allways.solana.rpc import SolanaRpc, SolanaRpcError, resolve_rpc_url
+from allways.solana.rpc import SolanaRpc, SolanaRpcError, TransientRpcError, resolve_rpc_url
 
 LOG_SOL = '[Solana]'
 
@@ -321,7 +320,10 @@ class Sol(Asset):
             return None
         try:
             tx = self.rpc.get_transaction(tx_hash)
-        except (requests.ConnectionError, requests.Timeout) as e:
+        except TransientRpcError as e:
+            # SolanaRpc._call never lets requests errors escape — it re-raises them as TransientRpcError
+            # (incl. SolanaRpcUnreachable). Catching the wrong type here fell through to `return None`,
+            # i.e. an RPC outage read as "no such payment" — slash-eligible.
             raise ProviderUnreachableError(f'Solana RPC unreachable: {e}') from e
         except Exception as e:
             bt.logging.error(f'{LOG_SOL} getTransaction failed for {tx_hash[:16]}...: {e}')

--- a/allways/assets/sol.py
+++ b/allways/assets/sol.py
@@ -64,22 +64,14 @@ RESERVED_ACCOUNTS = frozenset(
 )
 
 
-class Sol(Asset, Chain):
-    """Solana swap-leg provider for native SOL transfers.
+class SolanaChain(Chain):
+    """The Solana network: RPC transport, slot tip, ed25519 address/proof crypto and the own-broadcast
+    dedup guard — everything an asset ON Solana (native SOL, an SPL token) shares. Assets compose one
+    of these (``self._chain``) exactly as EVM assets compose ``EvmChain``; chain members call each
+    other on plain ``self``."""
 
-    The SOL leg of a launch pair (sol↔btc, sol↔tao) is a peer-to-peer user↔miner
-    transfer — the swap-manager program never custodies it. It's verified like a BTC
-    deposit: look the signature up by hash via getTransaction and confirm a >= lamport
-    credit to the expected address (balance-delta on pre/postBalances, robust to how the
-    transfer was issued).
-
-    Reuses ``allways/solana/rpc.py``. The native-SOL path is isolated in
-    ``_match_native_credit`` and ``send_amount`` so an SPL-token leg (sol↔usdc later) drops
-    in as a sibling branch — diffing meta.pre/postTokenBalances and building a token
-    transfer — without touching this interface.
-
-    Read path needs only an RPC URL; ``send_amount`` (the miner's dest leg) needs a keypair.
-    """
+    # A Solana blockhash expires well within ~60s; past this an unlanded sig is dead.
+    BROADCAST_TTL_SLOTS = 150
 
     def __init__(
         self, solana_rpc_url: Optional[str] = None, solana_keypair: Optional[Keypair] = None, timeout: int = 30
@@ -91,24 +83,225 @@ class Sol(Asset, Chain):
         # None even when the transfer landed; without this the next poll re-signs and double-pays.
         self.broadcasted_txids: dict[str, tuple] = {}
 
-    @property
-    def chain_def(self) -> ChainDefinition:
-        return CHAIN_SOL
-
     def describe(self) -> str:
         return f'Solana RPC {self.rpc_url}'
 
     def can_send_from(self, address: str) -> bool:
         return self.keypair is not None and str(self.keypair.pubkey()) == address
 
+    def check_rpc(self) -> int:
+        """The current slot, or ConnectionError — the shared half of every asset's check_connection."""
+        try:
+            return int(self.rpc.get_slot())
+        except Exception as e:
+            raise ConnectionError(f'Cannot reach Solana RPC at {self.rpc_url}: {e}') from e
+
+    @staticmethod
+    def account_keys(tx: dict, meta: dict) -> List[str]:
+        """Full account list: the message's static keys plus any address-lookup-table
+        loaded addresses (writable then readonly), to index pre/postBalances correctly."""
+        msg = (tx.get('transaction') or {}).get('message') or {}
+        raw = msg.get('accountKeys') or []
+        keys = [k if isinstance(k, str) else (k or {}).get('pubkey') for k in raw]
+        loaded = meta.get('loadedAddresses') or {}
+        keys += list(loaded.get('writable') or [])
+        keys += list(loaded.get('readonly') or [])
+        return keys
+
+    def confirmations(self, slot: Optional[int]) -> int:
+        """Confirmations = slots since the tx's slot (the tx slot counts as 1). 0 if unknown.
+
+        Reads the pass-cached tip so N legs in one forward pass share a single ``getSlot`` instead
+        of one each — the getSlot count drops from per-leg to per-pass."""
+        if slot is None:
+            return 0
+        tip = self.cached_block_height()
+        if tip is None:
+            return 0
+        return max(0, tip - int(slot) + 1)
+
+    def get_current_block_height(self) -> Optional[int]:
+        """Current confirmed slot. None on transient backend failure."""
+        try:
+            return int(self.rpc.get_slot())
+        except Exception as e:
+            bt.logging.debug(f'SOL get_current_block_height failed: {e}')
+            return None
+
+    def is_valid_address(self, address: str) -> bool:
+        """Validate a base58 ed25519 pubkey (32 bytes) without RPC."""
+        if not address or not isinstance(address, str):
+            return False
+        try:
+            Pubkey.from_string(address)
+            return True
+        except Exception:
+            return False
+
+    def sign_from_proof(self, address: str, message: str, key: Optional[Any] = None) -> str:
+        """Sign a proof message with an ed25519 Solana keypair. Returns hex signature.
+
+        ``key`` may be a solders Keypair; falls back to the chain's own keypair."""
+        kp = key if isinstance(key, Keypair) else self.keypair
+        if kp is None:
+            bt.logging.error('No Solana keypair available for signing')
+            return ''
+        try:
+            return bytes(kp.sign_message(message.encode())).hex()
+        except Exception as e:
+            bt.logging.error(f'{LOG_SOL} sign_from_proof failed: {e}')
+            return ''
+
+    def verify_from_proof(self, address: str, message: str, signature: str) -> bool:
+        """Verify an ed25519 signature over ``message`` from the given base58 pubkey."""
+        try:
+            pubkey = Pubkey.from_string(address)
+            sig_hex = signature[2:] if signature.startswith('0x') else signature
+            sig = Signature.from_bytes(bytes.fromhex(sig_hex))
+            return sig.verify(pubkey, message.encode())
+        except Exception as e:
+            bt.logging.error(f'{LOG_SOL} verify_from_proof failed: {e}')
+            return False
+
+    # --- own-broadcast dedup + send loop (shared by every asset that signs with this keypair) ---
+
+    def broadcast(self, instructions: list, want: tuple, what: str) -> SendResult:
+        """Sign ``instructions`` with the chain keypair and send, retrying a stale blockhash. ``want``
+        is the (to, amount, dedup) obligation recorded BEFORE confirm so a confirm() timeout on a tx
+        that landed is reused by ``prior_broadcast`` next pass instead of paid twice."""
+        from solders.hash import Hash
+        from solders.transaction import Transaction
+
+        last_err: Optional[Exception] = None
+        for _ in range(5):
+            try:
+                blockhash = Hash.from_string(self.rpc.get_latest_blockhash())
+                tx = Transaction.new_signed_with_payer(instructions, self.keypair.pubkey(), [self.keypair], blockhash)
+                sig = self.rpc.send_transaction(base64.b64encode(bytes(tx)).decode())
+                self.record_broadcast(sig, want)
+                status = self.rpc.confirm(sig)
+                slot = int(status.get('slot') or 0)
+                bt.logging.info(f'{LOG_SOL} sent {what} (sig: {sig}, slot: {slot})')
+                return (sig, slot)
+            except Exception as e:  # transient stale-blockhash on a fresh/lagging RPC → re-fetch + resend
+                if 'blockhash' not in str(e).lower():
+                    bt.logging.error(f'{LOG_SOL} send failed: {e}')
+                    return None
+                last_err = e
+                time.sleep(0.5)
+        bt.logging.error(f'{LOG_SOL} send failed after blockhash retries: {last_err}')
+        return None
+
+    def record_broadcast(self, sig: str, want: tuple) -> None:
+        head = self.current_slot()
+        self.broadcasted_txids[sig] = (*want, head if head is not None else 0)
+        if len(self.broadcasted_txids) > 256:
+            self.broadcasted_txids.pop(next(iter(self.broadcasted_txids)))
+
+    def current_slot(self) -> Optional[int]:
+        try:
+            return int(self.rpc.get_slot())
+        except Exception:
+            return None
+
+    def prior_broadcast(self, want: tuple) -> Optional[SendResult]:
+        """Reusable (sig, slot) from a prior own broadcast for this (to, amount, dedup) obligation that
+        provably landed — so a confirm() timeout that returned None can never cause a second pay. None
+        when no prior send can have moved funds; RAISES when the prior send is unresolved (not yet
+        expired, or only at ``processed`` commitment) — the caller must wait, not re-send."""
+        head = self.current_slot()
+        for sig, (to, amt, scope, seen) in list(self.broadcasted_txids.items()):
+            if (to, amt, scope) != want:
+                continue
+            st = (self.rpc.get_signature_statuses([sig]) or [None])[0]
+            if st is not None:
+                if st.get('confirmationStatus') not in ('confirmed', 'finalized'):
+                    # processed-only: possibly a minority fork that never settles. Reusing it would
+                    # mark the leg delivered while the user is never paid; a failed status at
+                    # processed is equally unsettled. Either way: wait for majority commitment.
+                    raise SolanaRpcError(f'prior send {sig[:16]}... only processed — waiting for confirmed')
+                if st.get('err') is None:
+                    return (sig, int(st.get('slot') or 0))  # settled at majority commitment → reuse
+                del self.broadcasted_txids[sig]  # failed on-chain → moved nothing, a fresh send is safe
+                continue
+            if head is not None:
+                if int(seen) <= 0:
+                    # get_slot failed at record time, so the record's age is unknown: backfill with the
+                    # current head so the TTL counts from now — "can't tell" must read recent, never expired.
+                    self.broadcasted_txids[sig] = (to, amt, scope, head)
+                elif head - int(seen) > self.BROADCAST_TTL_SLOTS:
+                    del self.broadcasted_txids[sig]  # blockhash long expired unlanded → safe to resend
+                    continue
+            raise SolanaRpcError(f'prior send {sig[:16]}... not on-chain yet and not expired — waiting a pass')
+        return None
+
+    def resolve_prior_send(self, want: tuple, what: str) -> tuple[bool, SendResult]:
+        """``(decided, result)``: decided=True means the caller must return ``result`` as-is — a reused
+        prior tx, or None because a prior send is still unresolved (re-sending would risk a double pay)."""
+        try:
+            prior = self.prior_broadcast(want)
+        except Exception as e:
+            bt.logging.error(f'{LOG_SOL} prior send unresolved ({e}) — not re-sending, would risk a double pay')
+            return True, None
+        if prior is not None:
+            bt.logging.info(f'{LOG_SOL} reusing prior tx {prior[0]} for {what}')
+            return True, prior
+        return False, None
+
+
+class Sol(Asset):
+    """Solana swap-leg provider for native SOL transfers.
+
+    The SOL leg of a launch pair (sol↔btc, sol↔tao) is a peer-to-peer user↔miner
+    transfer — the swap-manager program never custodies it. It's verified like a BTC
+    deposit: look the signature up by hash via getTransaction and confirm a >= lamport
+    credit to the expected address (balance-delta on pre/postBalances, robust to how the
+    transfer was issued).
+
+    Composes ``SolanaChain`` (transport, tip, crypto, broadcast dedup); this class is only
+    the native-lamport semantics — ``_match_native_credit`` and the SystemProgram transfer.
+    An SPL-token asset is its sibling on the same chain object, not a branch in here.
+
+    Read path needs only an RPC URL; ``send_amount`` (the miner's dest leg) needs a keypair.
+    """
+
+    def __init__(
+        self, solana_rpc_url: Optional[str] = None, solana_keypair: Optional[Keypair] = None, timeout: int = 30
+    ):
+        self._chain = SolanaChain(solana_rpc_url, solana_keypair, timeout=timeout)
+
+    # Transport + signer live on the chain; exposed here because callers and tests address the asset.
+    @property
+    def rpc(self) -> SolanaRpc:
+        return self.chain.rpc
+
+    @rpc.setter
+    def rpc(self, value) -> None:
+        self.chain.rpc = value
+
+    @property
+    def rpc_url(self) -> str:
+        return self.chain.rpc_url
+
+    @property
+    def keypair(self) -> Optional[Keypair]:
+        return self.chain.keypair
+
+    @property
+    def chain_def(self) -> ChainDefinition:
+        return CHAIN_SOL
+
+    def describe(self) -> str:
+        return self.chain.describe()
+
+    def can_send_from(self, address: str) -> bool:
+        return self.chain.can_send_from(address)
+
     def check_connection(self, require_send: bool = True, **kwargs) -> None:
         if require_send and self.keypair is None:
             raise ConnectionError('SOL send requires a Solana keypair (pass solana_keypair)')
-        try:
-            slot = self.rpc.get_slot()
-            bt.logging.success(f'{LOG_SOL} connected: slot={slot}')
-        except Exception as e:
-            raise ConnectionError(f'Cannot reach Solana RPC at {self.rpc_url}: {e}') from e
+        slot = self.chain.check_rpc()
+        bt.logging.success(f'{LOG_SOL} connected: slot={slot}')
 
     def fetch_matching_tx(
         self,
@@ -146,7 +339,7 @@ class Sol(Asset, Chain):
             bt.logging.debug(f'{LOG_SOL} tx {tx_hash[:16]}... failed on-chain (err={meta.get("err")})')
             return None
 
-        keys = self._account_keys(tx, meta)
+        keys = self.chain.account_keys(tx, meta)
         credit = self._match_native_credit(keys, meta, expected_recipient)
         if credit is None or credit < expected_amount:
             bt.logging.warning(
@@ -157,7 +350,7 @@ class Sol(Asset, Chain):
 
         slot = tx.get('slot')
         block_time = tx.get('blockTime')  # unix seconds, the replay-freshness floor (B2)
-        confirmations = self._confirmations(slot)
+        confirmations = self.chain.confirmations(slot)
         sender = keys[0] if keys else ''  # fee payer / first signer == the transfer source
         return TransactionInfo(
             tx_hash=tx_hash,
@@ -171,23 +364,10 @@ class Sol(Asset, Chain):
         )
 
     @staticmethod
-    def _account_keys(tx: dict, meta: dict) -> List[str]:
-        """Full account list: the message's static keys plus any address-lookup-table
-        loaded addresses (writable then readonly), to index pre/postBalances correctly."""
-        msg = (tx.get('transaction') or {}).get('message') or {}
-        raw = msg.get('accountKeys') or []
-        keys = [k if isinstance(k, str) else (k or {}).get('pubkey') for k in raw]
-        loaded = meta.get('loadedAddresses') or {}
-        keys += list(loaded.get('writable') or [])
-        keys += list(loaded.get('readonly') or [])
-        return keys
-
-    @staticmethod
     def _match_native_credit(keys: List[str], meta: dict, recipient: str) -> Optional[int]:
         """Net lamports credited to ``recipient`` in this tx (postBalance − preBalance),
         or None if the address isn't in the tx. Balance-delta is robust to how the transfer
-        was issued (plain transfer, CPI, batched). The SPL-token leg will instead diff
-        meta.pre/postTokenBalances for the recipient's token account."""
+        was issued (plain transfer, CPI, batched)."""
         pre = meta.get('preBalances') or []
         post = meta.get('postBalances') or []
         if recipient not in keys:
@@ -219,33 +399,13 @@ class Sol(Asset, Chain):
             meta = tx.get('meta') or {}
             if meta.get('err') is not None:
                 continue
-            keys = self._account_keys(tx, meta)
+            keys = self.chain.account_keys(tx, meta)
             if not keys or keys[0] != from_addr:
                 continue
             credit = self._match_native_credit(keys, meta, to_addr)
             if credit is not None and credit >= amount:
                 return sig
         return None
-
-    def _confirmations(self, slot: Optional[int]) -> int:
-        """Confirmations = slots since the tx's slot (the tx slot counts as 1). 0 if unknown.
-
-        Reads the pass-cached tip so N legs in one forward pass share a single ``getSlot`` instead
-        of one each — the getSlot count drops from per-leg to per-pass."""
-        if slot is None:
-            return 0
-        tip = self.chain.cached_block_height()
-        if tip is None:
-            return 0
-        return max(0, tip - int(slot) + 1)
-
-    def get_current_block_height(self) -> Optional[int]:
-        """Current confirmed slot. None on transient backend failure."""
-        try:
-            return int(self.rpc.get_slot())
-        except Exception as e:
-            bt.logging.debug(f'SOL get_current_block_height failed: {e}')
-            return None
 
     def get_balance(self, address: str) -> int:
         """Account balance in lamports (0 for a never-funded address)."""
@@ -274,48 +434,13 @@ class Sol(Asset, Chain):
         no slash. Returns CANCEL_REASON_SOL_RESERVED, else None."""
         return CANCEL_REASON_SOL_RESERVED if address in RESERVED_ACCOUNTS else None
 
-    def is_valid_address(self, address: str) -> bool:
-        """Validate a base58 ed25519 pubkey (32 bytes) without RPC."""
-        if not address or not isinstance(address, str):
-            return False
-        try:
-            Pubkey.from_string(address)
-            return True
-        except Exception:
-            return False
-
-    def sign_from_proof(self, address: str, message: str, key: Optional[Any] = None) -> str:
-        """Sign a proof message with an ed25519 Solana keypair. Returns hex signature.
-
-        ``key`` may be a solders Keypair; falls back to the provider's own keypair."""
-        kp = key if isinstance(key, Keypair) else self.keypair
-        if kp is None:
-            bt.logging.error('No Solana keypair available for signing')
-            return ''
-        try:
-            return bytes(kp.sign_message(message.encode())).hex()
-        except Exception as e:
-            bt.logging.error(f'{LOG_SOL} sign_from_proof failed: {e}')
-            return ''
-
-    def verify_from_proof(self, address: str, message: str, signature: str) -> bool:
-        """Verify an ed25519 signature over ``message`` from the given base58 pubkey."""
-        try:
-            pubkey = Pubkey.from_string(address)
-            sig_hex = signature[2:] if signature.startswith('0x') else signature
-            sig = Signature.from_bytes(bytes.fromhex(sig_hex))
-            return sig.verify(pubkey, message.encode())
-        except Exception as e:
-            bt.logging.error(f'{LOG_SOL} verify_from_proof failed: {e}')
-            return False
-
     def send_amount(
         self, to_address: str, amount: int, from_address: Optional[str] = None, dedup_key: Optional[str] = None
     ) -> SendResult:
         """Send ``amount`` lamports to ``to_address`` via SystemProgram transfer.
 
-        Signs with the provider's own keypair (callers pass no key material). Returns
-        (signature, slot) or None. Retries on stale-blockhash like the program client."""
+        Signs with the chain's keypair (callers pass no key material). Returns (signature, slot)
+        or None. The broadcast loop and double-send guard are the chain's."""
         if self.keypair is None:
             bt.logging.error('SOL send_amount called on a read-only Sol (no keypair)')
             return None
@@ -327,22 +452,14 @@ class Sol(Asset, Chain):
             )
             return None
 
-        # Reuse a prior own broadcast for THIS obligation instead of paying twice: a confirm() timeout
-        # returns None even when the transfer landed, and the next poll would otherwise re-send.
         want = (str(to_address), int(amount), dedup_key or '')
-        try:
-            prior = self._prior_broadcast(want)
-        except Exception as e:
-            bt.logging.error(f'{LOG_SOL} prior send unresolved ({e}) — not re-sending, would risk a double pay')
-            return None
-        if prior is not None:
-            bt.logging.info(f'{LOG_SOL} reusing prior tx {prior[0]} to {to_address} ({amount} lamports)')
-            return prior
+        what = f'{amount} lamports to {to_address}'
+        decided, result = self.chain.resolve_prior_send(want, what)
+        if decided:
+            return result
 
         try:
-            from solders.hash import Hash
             from solders.system_program import TransferParams, transfer
-            from solders.transaction import Transaction
 
             ix = transfer(
                 TransferParams(
@@ -352,70 +469,4 @@ class Sol(Asset, Chain):
         except Exception as e:
             bt.logging.error(f'{LOG_SOL} send_amount build failed: {e}')
             return None
-
-        last_err: Optional[Exception] = None
-        for _ in range(5):
-            try:
-                blockhash = Hash.from_string(self.rpc.get_latest_blockhash())
-                tx = Transaction.new_signed_with_payer([ix], self.keypair.pubkey(), [self.keypair], blockhash)
-                sig = self.rpc.send_transaction(base64.b64encode(bytes(tx)).decode())
-                # Record BEFORE confirm: if confirm() times out on a tx that actually landed, the next
-                # poll's _prior_broadcast finds this sig and reuses it rather than re-sending.
-                self._record_broadcast(sig, want)
-                status = self.rpc.confirm(sig)
-                slot = int(status.get('slot') or 0)
-                bt.logging.info(f'{LOG_SOL} sent {amount} lamports to {to_address} (sig: {sig}, slot: {slot})')
-                return (sig, slot)
-            except Exception as e:  # transient stale-blockhash on a fresh/lagging RPC → re-fetch + resend
-                if 'blockhash' not in str(e).lower():
-                    bt.logging.error(f'{LOG_SOL} send_amount failed: {e}')
-                    return None
-                last_err = e
-                time.sleep(0.5)
-        bt.logging.error(f'{LOG_SOL} send_amount failed after blockhash retries: {last_err}')
-        return None
-
-    _BROADCAST_TTL_SLOTS = 150  # a Solana blockhash expires well within ~60s; past this an unlanded sig is dead
-
-    def _record_broadcast(self, sig: str, want: tuple) -> None:
-        head = self._current_slot()
-        self.broadcasted_txids[sig] = (*want, head if head is not None else 0)
-        if len(self.broadcasted_txids) > 256:
-            self.broadcasted_txids.pop(next(iter(self.broadcasted_txids)))
-
-    def _current_slot(self) -> Optional[int]:
-        try:
-            return int(self.rpc.get_slot())
-        except Exception:
-            return None
-
-    def _prior_broadcast(self, want: tuple) -> Optional[SendResult]:
-        """Reusable (sig, slot) from a prior own broadcast for this (to, amount, dedup) obligation that
-        provably landed — so a confirm() timeout that returned None can never cause a second pay. None
-        when no prior send can have moved funds; RAISES when the prior send is unresolved (not yet
-        expired, or only at ``processed`` commitment) — the caller must wait, not re-send."""
-        head = self._current_slot()
-        for sig, (to, amt, scope, seen) in list(self.broadcasted_txids.items()):
-            if (to, amt, scope) != want:
-                continue
-            st = (self.rpc.get_signature_statuses([sig]) or [None])[0]
-            if st is not None:
-                if st.get('confirmationStatus') not in ('confirmed', 'finalized'):
-                    # processed-only: possibly a minority fork that never settles. Reusing it would
-                    # mark the leg delivered while the user is never paid; a failed status at
-                    # processed is equally unsettled. Either way: wait for majority commitment.
-                    raise SolanaRpcError(f'prior send {sig[:16]}... only processed — waiting for confirmed')
-                if st.get('err') is None:
-                    return (sig, int(st.get('slot') or 0))  # settled at majority commitment → reuse
-                del self.broadcasted_txids[sig]  # failed on-chain → moved nothing, a fresh send is safe
-                continue
-            if head is not None:
-                if int(seen) <= 0:
-                    # get_slot failed at record time, so the record's age is unknown: backfill with the
-                    # current head so the TTL counts from now — "can't tell" must read recent, never expired.
-                    self.broadcasted_txids[sig] = (to, amt, scope, head)
-                elif head - int(seen) > self._BROADCAST_TTL_SLOTS:
-                    del self.broadcasted_txids[sig]  # blockhash long expired unlanded → safe to resend
-                    continue
-            raise SolanaRpcError(f'prior send {sig[:16]}... not on-chain yet and not expired — waiting a pass')
-        return None
+        return self.chain.broadcast([ix], want, what)

--- a/allways/assets/solusdc.py
+++ b/allways/assets/solusdc.py
@@ -1,0 +1,11 @@
+from allways.assets.spl_token import SplToken
+from allways.chains import CHAIN_SOLUSDC
+
+
+class SolUsdc(SplToken):
+    """Circle USDC on Solana — a config-row binding of the generic SplToken (see chains.CHAIN_SOLUSDC).
+    Rides the Solana env identity (SOLANA_RPC_URL, the Solana keypair) beside native SOL, adding only
+    its own SOLUSDC_TOKEN_MINT override."""
+
+    def __init__(self, solana_rpc_url=None, solana_keypair=None):
+        super().__init__(CHAIN_SOLUSDC, solana_rpc_url=solana_rpc_url, solana_keypair=solana_keypair)

--- a/allways/assets/spl_token.py
+++ b/allways/assets/spl_token.py
@@ -2,7 +2,6 @@ import os
 from typing import List, Optional
 
 import bittensor as bt
-import requests
 from solders.instruction import AccountMeta, Instruction
 from solders.keypair import Keypair
 from solders.pubkey import Pubkey
@@ -17,7 +16,7 @@ from allways.assets.asset import (
 from allways.assets.sol import LOG_SOL, RESERVED_ACCOUNTS, SolanaChain
 from allways.chains import ChainDefinition
 from allways.constants import CANCEL_REASON_SOL_RESERVED, CANCEL_REASON_SPL_FROZEN
-from allways.solana.rpc import SolanaRpc, classify_cluster
+from allways.solana.rpc import SolanaRpc, TransientRpcError, classify_cluster
 
 # Legacy SPL Token — Circle's USDC mint lives here, not under Token-2022. Pinned rather than read
 # from the mint so a Token-2022 look-alike mint can never satisfy a USDC leg.
@@ -215,7 +214,10 @@ class SplToken(Asset):
             return None
         try:
             tx = self.rpc.get_transaction(tx_hash)
-        except (requests.ConnectionError, requests.Timeout) as e:
+        except TransientRpcError as e:
+            # SolanaRpc._call never lets requests errors escape — it re-raises them as TransientRpcError
+            # (incl. SolanaRpcUnreachable). Catching the wrong type here fell through to `return None`,
+            # i.e. an RPC outage read as "no such payment" — slash-eligible.
             raise ProviderUnreachableError(f'Solana RPC unreachable: {e}') from e
         except Exception as e:
             bt.logging.error(f'{LOG_SOL} getTransaction failed for {tx_hash[:16]}...: {e}')

--- a/allways/assets/spl_token.py
+++ b/allways/assets/spl_token.py
@@ -180,7 +180,11 @@ class SplToken(Asset):
         try:
             account = self.rpc.get_parsed_account(mint)
         except Exception as e:
-            raise ConnectionError(f'Cannot read {self.chain_def.id} mint {mint}: {e}') from e
+            # A probe we can't COMPLETE is transient (rate-limit, flaky endpoint) — degrade, as Erc20 does; a
+            # raise here drops the spoke for the process lifetime and it then votes TIMEOUT past max_extend_at.
+            # Unlike eth_getCode, a null account for a years-old mint IS a real fault, so only this path degrades.
+            bt.logging.warning(f'{self.chain_def.id} mint probe unreachable ({e}) — degraded')
+            return
         if account is None:
             raise ConnectionError(f'{self.chain_def.id} mint {mint} does not exist on {self.chain.rpc_url}')
         if account.get('owner') != str(TOKEN_PROGRAM_ID):

--- a/allways/assets/spl_token.py
+++ b/allways/assets/spl_token.py
@@ -1,0 +1,424 @@
+import os
+from typing import List, Optional
+
+import bittensor as bt
+import requests
+from solders.instruction import AccountMeta, Instruction
+from solders.keypair import Keypair
+from solders.pubkey import Pubkey
+
+from allways.assets.asset import (
+    Asset,
+    MissingTestnetDeployment,
+    ProviderUnreachableError,
+    SendResult,
+    TransactionInfo,
+)
+from allways.assets.sol import LOG_SOL, RESERVED_ACCOUNTS, SolanaChain
+from allways.chains import ChainDefinition
+from allways.constants import CANCEL_REASON_SOL_RESERVED, CANCEL_REASON_SPL_FROZEN
+from allways.solana.rpc import SolanaRpc, classify_cluster
+
+# Legacy SPL Token — Circle's USDC mint lives here, not under Token-2022. Pinned rather than read
+# from the mint so a Token-2022 look-alike mint can never satisfy a USDC leg.
+TOKEN_PROGRAM_ID = Pubkey.from_string('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA')
+ASSOCIATED_TOKEN_PROGRAM_ID = Pubkey.from_string('ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL')
+SYSTEM_PROGRAM_ID = Pubkey.from_string('11111111111111111111111111111111')
+# SPL Token instruction tags (spl_token::instruction::TokenInstruction discriminants).
+IX_TRANSFER_CHECKED = 12
+# Associated-token-program: CreateIdempotent — a no-op when the ATA already exists, so a send
+# can always prepend it instead of probing first.
+IX_CREATE_ATA_IDEMPOTENT = 1
+# Rent-exempt minimum for a 165-byte token account plus one signature's fee: what the miner must
+# hold in SOL beside the token balance to deliver to a wallet with no ATA yet.
+ATA_RENT_LAMPORTS = 2_039_280
+TX_FEE_LAMPORTS = 5_000
+
+# Issuer deployments per (asset id, cluster) beside the mainnet mint in the registry row. Keyed by
+# the genesis-hash cluster name — Solana has no {PREFIX}_NETWORK; the cluster is whatever the RPC
+# serves. {ASSET_ID}_TOKEN_MINT overrides either (e2e fakes on localnet, emergency repoint).
+CLUSTER_MINTS = {
+    # Circle-verified USDC on devnet (developers.circle.com). No Circle USDC exists on testnet.
+    'solusdc': {'devnet': '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU'},
+}
+
+
+def associated_token_address(owner: str, mint: Pubkey) -> Pubkey:
+    """The canonical token account for (owner, mint) — where a plain wallet receives the token."""
+    ata, _ = Pubkey.find_program_address(
+        [bytes(Pubkey.from_string(owner)), bytes(TOKEN_PROGRAM_ID), bytes(mint)], ASSOCIATED_TOKEN_PROGRAM_ID
+    )
+    return ata
+
+
+def create_ata_idempotent_ix(payer: Pubkey, owner: Pubkey, mint: Pubkey) -> Instruction:
+    return Instruction(
+        ASSOCIATED_TOKEN_PROGRAM_ID,
+        bytes([IX_CREATE_ATA_IDEMPOTENT]),
+        [
+            AccountMeta(payer, is_signer=True, is_writable=True),
+            AccountMeta(associated_token_address(str(owner), mint), is_signer=False, is_writable=True),
+            AccountMeta(owner, is_signer=False, is_writable=False),
+            AccountMeta(mint, is_signer=False, is_writable=False),
+            AccountMeta(SYSTEM_PROGRAM_ID, is_signer=False, is_writable=False),
+            AccountMeta(TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
+        ],
+    )
+
+
+def transfer_checked_ix(
+    src: Pubkey, mint: Pubkey, dst: Pubkey, owner: Pubkey, amount: int, decimals: int
+) -> Instruction:
+    """TransferChecked binds the mint and decimals into the instruction, so a wrong-mint or
+    wrong-precision send fails on-chain instead of moving the wrong asset."""
+    data = bytes([IX_TRANSFER_CHECKED]) + int(amount).to_bytes(8, 'little') + bytes([decimals])
+    return Instruction(
+        TOKEN_PROGRAM_ID,
+        data,
+        [
+            AccountMeta(src, is_signer=False, is_writable=True),
+            AccountMeta(mint, is_signer=False, is_writable=False),
+            AccountMeta(dst, is_signer=False, is_writable=True),
+            AccountMeta(owner, is_signer=True, is_writable=False),
+        ],
+    )
+
+
+def _parsed_info(account: Optional[dict]) -> Optional[dict]:
+    """``data.parsed.info`` of a jsonParsed account, or None when absent/unparsed."""
+    if not account:
+        return None
+    data = account.get('data')
+    if not isinstance(data, dict):
+        return None
+    return (data.get('parsed') or {}).get('info')
+
+
+class SplToken(Asset):
+    """Swap-leg provider for an SPL token on Solana, bound by a registry row (``host_chain='solana'``,
+    ``asset_locator`` = the mainnet mint). The Solana sibling of ``Erc20``.
+
+    Addresses are OWNER wallets, never token accounts: the leg lands in the owner's associated
+    token account, derived here, so the user-facing address is the same pubkey as for native SOL.
+    Verification diffs ``meta.pre/postTokenBalances`` at that ATA for the pinned mint; the sender is
+    the owner of the debited token account (the fee payer may be someone else entirely).
+
+    Refusal surface: the issuer can freeze a token account (USDC's mint carries a freeze authority).
+    A frozen destination ATA cannot be credited through no fault of the miner — it bounces the
+    reservation and, at slash time, is no-fault-cancel evidence (``CANCEL_REASON_SPL_FROZEN``).
+    """
+
+    def __init__(
+        self,
+        chain_def: ChainDefinition,
+        solana_rpc_url: Optional[str] = None,
+        solana_keypair: Optional[Keypair] = None,
+        timeout: int = 30,
+    ):
+        self._chain_def = chain_def
+        self._chain = SolanaChain(solana_rpc_url, solana_keypair, timeout=timeout)
+        # Resolved lazily: the cluster is only knowable from the RPC's genesis hash, and construction
+        # must stay offline (create_assets builds every provider before any check).
+        self._mint: Optional[Pubkey] = None
+
+    @property
+    def chain_def(self) -> ChainDefinition:
+        return self._chain_def
+
+    @property
+    def rpc(self) -> SolanaRpc:
+        return self.chain.rpc
+
+    @rpc.setter
+    def rpc(self, value) -> None:
+        self.chain.rpc = value
+
+    @property
+    def keypair(self) -> Optional[Keypair]:
+        return self.chain.keypair
+
+    def describe(self) -> str:
+        mint = str(self._mint) if self._mint is not None else '(mint unresolved)'
+        return f'{self.chain_def.name} {mint} via {self.chain.describe()}'
+
+    def can_send_from(self, address: str) -> bool:
+        return self.chain.can_send_from(address)
+
+    # --- mint resolution ---
+
+    @property
+    def mint(self) -> Pubkey:
+        """The token mint for the cluster this RPC serves: env override, else the cluster's pinned
+        deployment (mainnet = the registry row's asset_locator). An unknown cluster (localnet) with no
+        override raises MissingTestnetDeployment — there is no USDC there to swap."""
+        if self._mint is None:
+            self._mint = Pubkey.from_string(self._resolve_mint())
+        return self._mint
+
+    def _resolve_mint(self) -> str:
+        var = f'{self.chain_def.id.upper()}_TOKEN_MINT'
+        override = os.environ.get(var)
+        if override:
+            return override
+        cluster = classify_cluster(self.rpc.get_genesis_hash())
+        if cluster == 'mainnet':
+            return self.chain_def.asset_locator
+        mint = CLUSTER_MINTS.get(self.chain_def.id, {}).get(cluster)
+        if not mint:
+            raise MissingTestnetDeployment(f'No {self.chain_def.id} mint on the {cluster} cluster — set {var}')
+        return mint
+
+    def ata(self, owner: str) -> Pubkey:
+        return associated_token_address(owner, self.mint)
+
+    # --- connection ---
+
+    def check_connection(self, require_send: bool = True, **kwargs) -> None:
+        if require_send and self.keypair is None:
+            raise ConnectionError(f'{self.chain_def.id} send requires a Solana keypair (pass solana_keypair)')
+        slot = self.chain.check_rpc()
+        mint = self.mint
+        try:
+            account = self.rpc.get_parsed_account(mint)
+        except Exception as e:
+            raise ConnectionError(f'Cannot read {self.chain_def.id} mint {mint}: {e}') from e
+        if account is None:
+            raise ConnectionError(f'{self.chain_def.id} mint {mint} does not exist on {self.chain.rpc_url}')
+        if account.get('owner') != str(TOKEN_PROGRAM_ID):
+            raise ConnectionError(
+                f'{self.chain_def.id} mint {mint} is not a legacy SPL Token mint (owner {account.get("owner")})'
+            )
+        decimals = (_parsed_info(account) or {}).get('decimals')
+        if decimals != self.chain_def.decimals:
+            raise ConnectionError(
+                f'{self.chain_def.id} mint {mint} has {decimals} decimals, registry says {self.chain_def.decimals}'
+            )
+        if require_send:
+            me = str(self.keypair.pubkey())
+            if self.get_balance(me) == 0:
+                bt.logging.warning(
+                    f'{LOG_SOL} {self.chain_def.id}: signer {me} holds no {self.chain_def.name} — dest legs cannot be paid'
+                )
+        bt.logging.success(f'{LOG_SOL} {self.chain_def.id} connected: slot={slot} mint={mint}')
+
+    # --- verification ---
+
+    def fetch_matching_tx(
+        self,
+        tx_hash: str,
+        expected_recipient: str,
+        expected_amount: int,
+        block_hint: int = 0,  # unused — Solana indexes by signature
+        max_scan_blocks: int = 150,  # unused
+    ) -> Optional[TransactionInfo]:
+        if not tx_hash:
+            return None
+        try:
+            tx = self.rpc.get_transaction(tx_hash)
+        except (requests.ConnectionError, requests.Timeout) as e:
+            raise ProviderUnreachableError(f'Solana RPC unreachable: {e}') from e
+        except Exception as e:
+            bt.logging.error(f'{LOG_SOL} getTransaction failed for {tx_hash[:16]}...: {e}')
+            return None
+        if not tx:
+            bt.logging.debug(f'{LOG_SOL} tx {tx_hash[:16]}... not found')
+            return None
+        return self._build_tx_info(tx_hash, tx, expected_recipient, expected_amount)
+
+    def _build_tx_info(
+        self, tx_hash: str, tx: dict, expected_recipient: str, expected_amount: int
+    ) -> Optional[TransactionInfo]:
+        meta = tx.get('meta') or {}
+        if meta.get('err') is not None:
+            bt.logging.debug(f'{LOG_SOL} tx {tx_hash[:16]}... failed on-chain (err={meta.get("err")})')
+            return None
+        keys = self.chain.account_keys(tx, meta)
+        credit, sender = self._token_movement(keys, meta, expected_recipient)
+        if credit is None or credit < expected_amount:
+            bt.logging.warning(
+                f'{LOG_SOL} tx {tx_hash[:16]}... credits {expected_recipient} {credit} {self.chain_def.native_unit} '
+                f'(< {expected_amount} required)'
+            )
+            return None
+        slot = tx.get('slot')
+        confirmations = self.chain.confirmations(slot)
+        return TransactionInfo(
+            tx_hash=tx_hash,
+            confirmed=confirmations >= self.chain_def.min_confirmations,
+            sender=sender,
+            recipient=expected_recipient,
+            amount=credit,
+            block_number=slot,
+            confirmations=confirmations,
+            block_time=tx.get('blockTime'),  # unix seconds, the replay-freshness floor (B2)
+        )
+
+    def _token_movement(self, keys: List[str], meta: dict, recipient: str) -> tuple[Optional[int], str]:
+        """(net credit to recipient's ATA in the pinned mint, owner of the debited token account).
+        Credit is None when the ATA isn't in the tx. A mined tx whose token-balance arrays are missing
+        is 'unknown', never 'no such payment' — that verdict would slash a paying miner."""
+        pre = meta.get('preTokenBalances')
+        post = meta.get('postTokenBalances')
+        if pre is None or post is None:
+            raise ProviderUnreachableError('transaction meta lacks token balances — cannot judge the leg')
+        mint = str(self.mint)
+        ata = str(self.ata(recipient))
+        if ata not in keys:
+            return None, ''
+        idx = keys.index(ata)
+
+        def amounts(entries: list) -> dict[int, tuple[int, str]]:
+            out: dict[int, tuple[int, str]] = {}
+            for e in entries or []:
+                if e.get('mint') != mint:
+                    continue
+                amt = int(((e.get('uiTokenAmount') or {}).get('amount')) or 0)
+                out[int(e.get('accountIndex'))] = (amt, e.get('owner') or '')
+            return out
+
+        pre_by, post_by = amounts(pre), amounts(post)
+        credit = post_by.get(idx, (0, ''))[0] - pre_by.get(idx, (0, ''))[0]
+        # The sender is whoever's token account went down. Ambiguous (none, or several owners) fails
+        # closed as '' — the validator's sender pin then rejects rather than guesses.
+        debited = {
+            (pre_by[i][1] or post_by.get(i, (0, ''))[1])
+            for i in set(pre_by) | set(post_by)
+            if post_by.get(i, (0, ''))[0] < pre_by.get(i, (0, ''))[0]
+        }
+        debited.discard('')
+        sender = next(iter(debited)) if len(debited) == 1 else ''
+        return credit, sender
+
+    def find_recent_outgoing(self, from_addr: str, to_addr: str, amount: int) -> Optional[str]:
+        """Signature of a recent tx from ``from_addr`` crediting ``to_addr``'s ATA >= ``amount``, else
+        None. A hash-finder for deposit detection; ``verify_transaction`` stays the sole verifier."""
+        try:
+            sigs = self.rpc.get_signatures_for_address(str(self.ata(to_addr)), limit=20)
+        except Exception as e:
+            bt.logging.debug(f'{LOG_SOL} find_recent_outgoing signature scan failed: {e}')
+            return None
+        for entry in sigs or []:
+            sig = entry.get('signature')
+            if not sig or entry.get('err') is not None:
+                continue
+            try:
+                tx = self.rpc.get_transaction(sig)
+            except Exception:
+                continue
+            if not tx:
+                continue
+            meta = tx.get('meta') or {}
+            if meta.get('err') is not None:
+                continue
+            try:
+                credit, sender = self._token_movement(self.chain.account_keys(tx, meta), meta, to_addr)
+            except ProviderUnreachableError:
+                continue
+            if sender == from_addr and credit is not None and credit >= amount:
+                return sig
+        return None
+
+    # --- balances + delivery gates ---
+
+    def _token_account(self, owner: str) -> Optional[dict]:
+        """Parsed info of the owner's ATA, or None when it doesn't exist. Raises on RPC trouble."""
+        return _parsed_info(self.rpc.get_parsed_account(self.ata(owner)))
+
+    def get_balance(self, address: str) -> int:
+        """Token balance of ``address``'s ATA in the smallest unit (0 when the ATA doesn't exist)."""
+        try:
+            info = self._token_account(address)
+        except Exception as e:
+            bt.logging.error(f'{LOG_SOL} {self.chain_def.id} get_balance failed for {address}: {e}')
+            return 0
+        if not info:
+            return 0
+        return int(((info.get('tokenAmount') or {}).get('amount')) or 0)
+
+    def _frozen(self, address: str) -> bool:
+        info = self._token_account(address)
+        return bool(info) and info.get('state') == 'frozen'
+
+    def _is_token_account(self, address: str) -> bool:
+        """A token account pasted where an OWNER wallet belongs: deliverable in principle, but to a
+        different ATA than the one derived from it — the leg would never verify."""
+        account = self.rpc.get_parsed_account(address)
+        return bool(account) and account.get('owner') == str(TOKEN_PROGRAM_ID)
+
+    def can_deliver_to(self, address: str, amount: int, from_address: Optional[str] = None) -> bool:
+        """Reserve-time gate: a reserved key can't own an ATA, a frozen ATA can't be credited, and a
+        token account is not an owner. Fails open on RPC trouble (mirrors Erc20)."""
+        if address in RESERVED_ACCOUNTS:
+            return False
+        try:
+            return not (self._frozen(address) or self._is_token_account(address))
+        except Exception:
+            return True
+
+    def delivery_refused(self, address: str, since_unix: int) -> bool:
+        """Slash gate: a frozen destination ATA is issuer refusal — positive evidence, never slash over
+        it. An RPC failure raises so the caller defers: a flaky RPC postpones a slash, never falsifies
+        one. Freezes persist until the issuer thaws, so the live probe is the load-bearing signal."""
+        if address in RESERVED_ACCOUNTS:
+            return True
+        return self._frozen(address)
+
+    def cancel_evidence(
+        self, address: str, amount: int, tx_hash: Optional[str] = None, from_address: Optional[str] = None
+    ) -> Optional[int]:
+        if address in RESERVED_ACCOUNTS:
+            return CANCEL_REASON_SOL_RESERVED
+        try:
+            return CANCEL_REASON_SPL_FROZEN if self._frozen(address) else None
+        except Exception as e:
+            bt.logging.warning(f'{LOG_SOL} {self.chain_def.id} cancel_evidence probe failed for {address}: {e}')
+            return None
+
+    # --- send ---
+
+    def send_amount(
+        self, to_address: str, amount: int, from_address: Optional[str] = None, dedup_key: Optional[str] = None
+    ) -> SendResult:
+        """Deliver ``amount`` (smallest unit) to ``to_address``'s ATA, creating it if missing (miner pays
+        the rent). TransferChecked pins mint + decimals on-chain; the broadcast loop and double-send
+        guard are the chain's."""
+        if self.keypair is None:
+            bt.logging.error(f'{self.chain_def.id} send_amount called on a read-only provider (no keypair)')
+            return None
+        me = self.keypair.pubkey()
+        if from_address is not None and str(me) != str(from_address):
+            bt.logging.error(f'{LOG_SOL} committed sender {from_address} != wallet {me} — not sending')
+            return None
+
+        want = (str(to_address), int(amount), dedup_key or '')
+        what = f'{amount} {self.chain_def.native_unit} to {to_address}'
+        decided, result = self.chain.resolve_prior_send(want, what)
+        if decided:
+            return result
+
+        # Solvency before broadcast: the token leg AND the SOL that carries it (fee, plus rent for a
+        # destination with no ATA yet) — a token-rich, SOL-poor signer must refuse, not fail on-chain.
+        try:
+            mint = self.mint
+            held = self.get_balance(str(me))
+            if held < int(amount):
+                bt.logging.error(f'{LOG_SOL} {self.chain_def.id} balance {held} < {amount} — not sending')
+                return None
+            lamports_needed = TX_FEE_LAMPORTS + (0 if self._token_account(to_address) else ATA_RENT_LAMPORTS)
+            sol = int(self.rpc.get_balance(str(me)))
+            if sol < lamports_needed:
+                bt.logging.error(
+                    f'{LOG_SOL} signer holds {sol} lamports < {lamports_needed} needed for fee+rent — not sending'
+                )
+                return None
+            dst_owner = Pubkey.from_string(to_address)
+            ixs = [
+                create_ata_idempotent_ix(me, dst_owner, mint),
+                transfer_checked_ix(
+                    self.ata(str(me)), mint, self.ata(to_address), me, int(amount), self.chain_def.decimals
+                ),
+            ]
+        except Exception as e:
+            bt.logging.error(f'{LOG_SOL} {self.chain_def.id} send_amount build failed: {e}')
+            return None
+        return self.chain.broadcast(ixs, want, what)

--- a/allways/chains.py
+++ b/allways/chains.py
@@ -37,12 +37,12 @@ class ChainDefinition:
     # Default 0 (at-or-after the floor; only a tx that predates it is a replay). Absorbs honest miner
     # clock skew; MUST stay well under reservation_ttl_secs — the replay window is exactly this wide (B2).
     replay_grace_secs: int = 0
-    # The network whose txs carry this asset (assets/evm.py EVM_NETWORKS key). Every EVM row
-    # sets it — native coin and token alike — so both resolve their chain the same way.
-    # None only for assets that ARE their own network (btc/tao/sol).
+    # The network whose txs carry this asset: an assets/evm.py EVM_NETWORKS key, or 'solana'.
+    # Every EVM row sets it — native coin and token alike — so both resolve their chain the same
+    # way. None only for assets that ARE their own network (btc/tao/sol).
     host_chain: str | None = None
-    # Canonical MAINNET contract of a hosted asset. Testnet deployments + env overrides
-    # resolve in the provider (assets/erc20.py) — each address lives exactly once.
+    # Canonical MAINNET contract (or SPL mint) of a hosted asset. Testnet deployments + env
+    # overrides resolve in the provider (assets/erc20.py, spl_token.py) — each address lives once.
     asset_locator: str | None = None
     # ABI signatures the issuer refuses delivery with: 'f()' stops the whole token, 'f(address)'
     # freezes one destination. Required on every token row; () claims no freeze surface at all.
@@ -95,6 +95,28 @@ CHAIN_SOL = ChainDefinition(
     # Rent-exempt minimum for a 0-data System account — the SOL analog of TAO's
     # existential deposit (a credit below this can't keep a fresh account alive).
     min_onchain_amount=890880,
+)
+
+CHAIN_SOLUSDC = ChainDefinition(
+    id='solusdc',
+    name='USDC (Solana)',
+    native_unit='µUSDC',
+    decimals=6,
+    # Solana's env identity, shared with native SOL: the cluster is picked by the RPC's genesis hash,
+    # never by name, so no `networks` — a declared tuple would spawn a dead `sol-network` CLI key.
+    env_prefix='SOL',
+    seconds_per_block=1,
+    # Two assets on one chain must not disagree about its finality depth (pinned == CHAIN_SOL by test).
+    min_confirmations=32,
+    # 5 USDC — the crown-eligibility floor, sized like every USDC row (see CHAIN_ARBUSDC); Solana's
+    # cheap fees are not the input, the crown band is.
+    min_onchain_amount=5_000_000,
+    # Hub and spoke share ONE clock here — the leg's blockTime and the reservation floor are stamped by
+    # the same ledger — so 0 is justified on skew grounds, unlike the cross-chain spokes' 60s.
+    replay_grace_secs=0,
+    host_chain='solana',
+    # Circle's USDC mint on mainnet-beta; devnet lives in assets/spl_token.py CLUSTER_MINTS.
+    asset_locator='EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
 )
 
 CHAIN_ETH = ChainDefinition(
@@ -510,6 +532,7 @@ SUPPORTED_CHAINS = {
     'pol': CHAIN_POL,
     'polusdc': CHAIN_POLUSDC,
     'paxg': CHAIN_PAXG,
+    'solusdc': CHAIN_SOLUSDC,
 }
 
 
@@ -529,6 +552,12 @@ def apply_testnet_network_defaults() -> dict[str, str]:
             os.environ[env_var] = chain.testnet_network
             applied[env_var] = chain.testnet_network
     return applied
+
+
+def uses_solana_wallet(chain_id: str) -> bool:
+    """True for every asset whose address is a Solana wallet pubkey — native SOL and any SPL token
+    hosted on it — so the CLI can default that leg to the signer instead of asking for it."""
+    return chain_id == 'sol' or get_chain_def(chain_id).host_chain == 'solana'
 
 
 def get_chain_def(chain_id: str) -> ChainDefinition:

--- a/allways/cli/swap_commands/numeraire.py
+++ b/allways/cli/swap_commands/numeraire.py
@@ -17,6 +17,7 @@ from typing import Dict, List, Tuple
 
 import click
 
+from allways.chains import uses_solana_wallet
 from allways.cli.help import StyledCommand
 from allways.cli.swap_commands.helpers import (
     FINITE_FLOAT,
@@ -140,6 +141,8 @@ def quotes_command(spread_bps, hub, backing, dry_run, yes, **spoke_opts):
             continue
         if not price or price <= 0:
             continue
+        if not addr and uses_solana_wallet(spoke):
+            addr = spoke_opts.get(_addr_kw(NUMERAIRE_CHAIN))  # same wallet as the SOL leg
         if not addr:
             fail(f'--{spoke}-address required with --{spoke}-price')
         chain_specs[spoke] = (price, addr)

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -16,7 +16,7 @@ from typing import List, NamedTuple, Optional
 
 import click
 
-from allways.chains import SUPPORTED_CHAINS, get_chain_def
+from allways.chains import SUPPORTED_CHAINS, get_chain_def, uses_solana_wallet
 from allways.cli.dendrite_lite import (
     broadcast_synapse,
     discover_validators,
@@ -396,11 +396,12 @@ def swap_now_command(
     user = client.keypair.pubkey()
     router_hotkey = (router_opt or config.get('router') or '').strip()
     routed = bool(router_hotkey) and not no_router
-    if from_chain != NUMERAIRE_CHAIN and not from_address_opt:
+    # A Solana-wallet source (SOL, or an SPL token beside it) is sent from the signer itself.
+    if not uses_solana_wallet(from_chain) and not from_address_opt:
         from_address_opt = _prompt_missing(
             None, f'Source address (your {from_chain.upper()} address you send from)', '--from-address'
         )
-    user_from_addr = str(user) if from_chain == NUMERAIRE_CHAIN else (from_address_opt or '')
+    user_from_addr = str(user) if uses_solana_wallet(from_chain) else (from_address_opt or '')
     if not user_from_addr:
         fail(f'--from-address (your source-chain address) is required for a non-{NUMERAIRE_CHAIN.upper()} source.')
     # Canonical source form before anything commits it: the finalize hash + source-lock PDA are
@@ -745,10 +746,9 @@ def _auto_send_wizard(client, config, resv, miner_pk, from_chain, to_chain, from
     amount_disp = int(resv.from_amount) / 10 ** get_chain_def(from_chain).decimals
     to_addr = resv.miner_from_addr
     wallet_label = {
-        'sol': 'Solana keypair',
         'tao': f'Bittensor coldkey ({config.get("wallet", "?")})',
         'btc': 'Bitcoin WIF wallet',
-    }.get(from_chain, f'{from_chain.upper()} wallet')
+    }.get(from_chain, 'Solana keypair' if uses_solana_wallet(from_chain) else f'{from_chain.upper()} wallet')
     console.print(f'  [dim]Source: your configured {wallet_label}[/dim]  [cyan]{resv.from_addr}[/cyan]')
     if not skip_confirm and not click.confirm(
         f'  Send {amount_disp:g} {from_chain.upper()} to the miner now?',

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -56,6 +56,9 @@ CANCEL_REASON_SOL_RESERVED = 3
 # An issuer-enabled transfer fee shaves the delivered log below the pinned amount, so every
 # honest delivery on the token would false-slash — a hub-wide, no-fault condition (V-M2/PAXG).
 CANCEL_REASON_ERC20_FEE_ENABLED = 4
+# The issuer froze the destination's SPL token account (USDC's mint carries a freeze authority):
+# undeliverable through no fault of the miner. Python-side first; mirror into constants.rs next release.
+CANCEL_REASON_SPL_FROZEN = 5
 CANCEL_REASON_OTHER = 255
 
 BTC_MIN_FEE_RATE = 5
@@ -126,6 +129,7 @@ LAUNCH_SPOKES = (
     'pol',
     'polusdc',
     'paxg',
+    'solusdc',
 )
 # Every launch pair as (hub, spoke): each hub pairs against every spoke except itself. sol↔tao
 # lands exactly once (under SOL, its anchor) because sol never appears in LAUNCH_SPOKES.

--- a/allways/solana/rpc.py
+++ b/allways/solana/rpc.py
@@ -180,6 +180,12 @@ class SolanaRpc:
             return None
         return base64.b64decode(val['data'][0])
 
+    def get_parsed_account(self, pubkey, commitment: str = 'confirmed') -> Optional[dict]:
+        """The account's ``value`` under jsonParsed encoding (owner, lamports, data.parsed for SPL
+        mints/token accounts), or None when the account does not exist."""
+        res = self._call('getAccountInfo', [str(pubkey), {'encoding': 'jsonParsed', 'commitment': commitment}])
+        return res.get('value')
+
     def get_account_lamports(self, pubkey, commitment: str = 'confirmed') -> Optional[int]:
         res = self._call('getAccountInfo', [str(pubkey), {'encoding': 'base64', 'commitment': commitment}])
         val = res.get('value')

--- a/allways/validator/solana_swap_loop.py
+++ b/allways/validator/solana_swap_loop.py
@@ -286,7 +286,14 @@ class SolanaSwapLoop:
             sender=swap.miner_to_addr,
         )
         if d_status == 'down':
-            return SwapAction(SwapDecision.SKIP, reason=f'dest provider unreachable (src={s_status})')
+            # Same ceiling as the no-provider branch in decide(): a leg that never becomes judgeable (RPC
+            # down, meta missing its token-balance arrays) must not defer forever or the collateral freezes.
+            if now < int(swap.max_extend_at):
+                return SwapAction(SwapDecision.SKIP, reason=f'dest provider unreachable (src={s_status})')
+            return SwapAction(
+                SwapDecision.TIMEOUT,
+                reason=f'dest provider unreachable past max_extend_at (src={s_status}) — terminal, else collateral freezes',
+            )
         if d_status == 'pending':
             # Valid-but-unconfirmed payout near timeout → extend; if extension is exhausted/not yet due,
             # fall through to the same overdue rule (at the ceiling + overdue still slashes).

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -21,6 +21,8 @@ from allways.chains import (
     CHAIN_POL,
     CHAIN_POLUSDC,
     CHAIN_QNT,
+    CHAIN_SOL,
+    CHAIN_SOLUSDC,
     CHAIN_TAO,
     CHAIN_UNI,
     EXTENSION_BUCKET_SECONDS,
@@ -77,6 +79,9 @@ class TestGetChain:
     def test_polusdc(self):
         assert get_chain_def('polusdc') is CHAIN_POLUSDC
 
+    def test_solusdc(self):
+        assert get_chain_def('solusdc') is CHAIN_SOLUSDC
+
     def test_unsupported_raises(self):
         with pytest.raises(KeyError):
             get_chain_def('doge')
@@ -110,6 +115,11 @@ class TestGetChain:
         for host, found in prefixes.items():
             assert len(found) == 1, f'{host} assets disagree on env_prefix: {sorted(found)}'
         for host, ids in declared.items():
+            if host not in EVM_NETWORKS:
+                # Solana's cluster is genesis-hash-guarded, never picked by name: no row declares
+                # `networks`, and none may (it would render a dead CLI key beside `solana-network`).
+                assert ids == [], f'{host} is not name-selected; {ids} must not declare networks'
+                continue
             assert len(ids) == 1, f'{host} needs exactly one networks-declaring row, found {ids}'
         for prefix, ids in owners.items():
             assert len(ids) == 1, f'{prefix}_NETWORK is declared by more than one row: {ids}'
@@ -122,40 +132,40 @@ class TestGetChain:
             assert declared is issubclass(spec.cls, Erc20), spec.chain_id
 
     def test_only_self_hosted_assets_lack_a_host_chain(self):
-        for chain_id in ('btc', 'tao', 'sol'):
-            assert get_chain_def(chain_id).host_chain is None
-        for chain_id in ('eth', 'hype', 'bnb', 'avax', 'cro', 'arbusdc'):
-            assert get_chain_def(chain_id).host_chain in EVM_NETWORKS
-        # asset_locator is the token-only field: a native coin has no contract to pin.
-        assert CHAIN_ARBUSDC.asset_locator.startswith('0x')
-        assert all(
-            get_chain_def(c).asset_locator is None for c in ('btc', 'tao', 'sol', 'eth', 'hype', 'bnb', 'avax', 'cro')
-        )
-        for chain_id in ('eth', 'hype', 'arbusdc', 'baseusdc'):
-            assert get_chain_def(chain_id).host_chain in EVM_NETWORKS
-        # asset_locator is the token-only field: a native coin has no contract to pin.
-        assert CHAIN_ARBUSDC.asset_locator.startswith('0x')
-        assert CHAIN_BASEUSDC.asset_locator.startswith('0x')
-        for chain_id in ('eth', 'hype', 'arbusdc', 'ethusdc'):
-            assert get_chain_def(chain_id).host_chain in EVM_NETWORKS
-        # asset_locator is the token-only field: a native coin has no contract to pin.
-        assert CHAIN_ARBUSDC.asset_locator.startswith('0x') and CHAIN_ETHUSDC.asset_locator.startswith('0x')
-        assert all(get_chain_def(c).asset_locator is None for c in ('btc', 'tao', 'sol', 'eth', 'hype'))
-        # ethusdc rides CHAIN_ETH's network row — same host, same prefix, no networks of its own.
-        assert (CHAIN_ETHUSDC.host_chain, CHAIN_ETHUSDC.env_prefix) == (CHAIN_ETH.host_chain, CHAIN_ETH.env_prefix)
-        """btc/tao/sol ARE their own network; every EVM row names the network it rides. Only the
-        self-hosted list is enumerated — a new EVM asset needs no edit here."""
+        """btc/tao/sol ARE their own network; every hosted row names the network it rides — an
+        EVM_NETWORKS key, or 'solana' for an SPL token beside native SOL. Only the self-hosted list
+        is enumerated — a new hosted asset needs no edit here."""
         for chain_id, chain in SUPPORTED_CHAINS.items():
             if chain_id in ('btc', 'tao', 'sol'):
                 assert chain.host_chain is None, chain_id
             else:
-                assert chain.host_chain in EVM_NETWORKS, chain_id
+                assert chain.host_chain in EVM_NETWORKS or chain.host_chain == 'solana', chain_id
+        # asset_locator is the token-only field: a native coin has no contract/mint to pin.
+        assert CHAIN_ARBUSDC.asset_locator.startswith('0x')
+        assert all(
+            get_chain_def(c).asset_locator is None for c in ('btc', 'tao', 'sol', 'eth', 'hype', 'bnb', 'avax', 'cro')
+        )
         # Ethereum hosts several assets (eth, ethusdc, uni). Every rider takes CHAIN_ETH's network
         # row — same prefix, no networks of its own — so one ETH_NETWORK moves all of them.
         riders = [c for c in SUPPORTED_CHAINS.values() if c.host_chain == CHAIN_ETH.host_chain and c is not CHAIN_ETH]
         assert CHAIN_ETHUSDC in riders and CHAIN_UNI in riders
         for chain in riders:
             assert (chain.env_prefix, chain.networks) == (CHAIN_ETH.env_prefix, ()), chain.id
+
+    def test_spl_token_rows_ride_solana(self):
+        """An SPL token is hosted on 'solana', pins a base58 mint, shares SOL's env identity and
+        finality depth, and declares no `networks` (the cluster is genesis-hash-guarded, not named)."""
+        from solders.pubkey import Pubkey
+
+        from allways.assets.spl_token import SplToken
+
+        rows = [get_chain_def(spec.chain_id) for spec in ASSET_REGISTRY if issubclass(spec.cls, SplToken)]
+        assert CHAIN_SOLUSDC in rows
+        for chain in rows:
+            assert chain.host_chain == 'solana', chain.id
+            Pubkey.from_string(chain.asset_locator)  # a mint, not an 0x contract
+            assert chain.env_prefix == CHAIN_SOL.env_prefix and chain.networks == (), chain.id
+            assert chain.min_confirmations == CHAIN_SOL.min_confirmations, chain.id
 
 
 class TestCanonicalPair:
@@ -261,6 +271,11 @@ class TestComputeExtensionTargetSecs:
             'pol', 0, self.NOW, self.CEILING
         )
 
+    def test_solusdc_matches_the_chain_it_shares(self):
+        assert compute_extension_target_secs('solusdc', 0, self.NOW, self.CEILING) == compute_extension_target_secs(
+            'sol', 0, self.NOW, self.CEILING
+        )
+
     def test_unsupported_chain_raises(self):
         with pytest.raises(KeyError):
             compute_extension_target_secs('doge', 0, self.NOW, self.CEILING)
@@ -275,8 +290,11 @@ class TestReplayGrace:
         # Ethereum's monotonic slot timestamps once justified 0 here; the floor is hub-stamped,
         # so ETH (and ethusdc with it) need the same allowance as every other EVM row.
         for chain in SUPPORTED_CHAINS.values():
-            if chain.host_chain is not None:
+            if chain.host_chain in EVM_NETWORKS:
                 assert chain.replay_grace_secs == 60, chain.id
+        # An SPL token shares the hub's ledger AND clock: its leg's blockTime and the reservation
+        # floor are stamped by the same chain, so there is no hub-vs-spoke skew to absorb.
+        assert CHAIN_SOLUSDC.replay_grace_secs == 0
 
     def test_freshness_consumer_absorbs_the_eth_grace(self):
         # The validator reads grace off chain_def (solana_swap_loop._is_fresh) — a deposit

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -462,6 +462,13 @@ class TestIsExecutableRate:
         assert is_executable_rate(150.0, 'arbusdc', 'sol', self.MIN, self.MAX) is True
         assert is_executable_rate(150.0, 'sol', 'arbusdc', self.MIN, self.MAX) is True
 
+    def test_solusdc_routes_at_its_five_dollar_floor(self):
+        """solusdc sizes its floor like every USDC row (crown band), not off Solana's cheap fees —
+        and the same-ledger pair must route both ways like any other spoke."""
+        assert get_chain_def('solusdc').min_onchain_amount == 5_000_000
+        assert is_executable_rate(150.0, 'solusdc', 'sol', self.MIN, self.MAX) is True
+        assert is_executable_rate(150.0, 'sol', 'solusdc', self.MIN, self.MAX) is True
+
     def test_ethusdc_routes_at_its_five_dollar_floor(self):
         """ethusdc's floor is a rate-sanity input, not a per-swap minimum (that is the
         contract's min_swap_amount): non-binding here, since 0.1 SOL needs ~15 USDC at 150/SOL."""

--- a/tests/test_solana_provider.py
+++ b/tests/test_solana_provider.py
@@ -82,74 +82,74 @@ class TestSendDedup:
 
     def _p(self, status, slot=1000, seen=1000, slot_fails=False):
         p = provider_with(DedupRpc(status, slot, slot_fails))
-        p.broadcasted_txids['SIG'] = (*self.WANT, seen)
+        p.chain.broadcasted_txids['SIG'] = (*self.WANT, seen)
         return p
 
     def test_reuses_landed_prior(self):
         p = self._p({'err': None, 'slot': 123, 'confirmationStatus': 'confirmed'})
-        assert p._prior_broadcast(self.WANT) == ('SIG', 123)
+        assert p.chain.prior_broadcast(self.WANT) == ('SIG', 123)
 
     def test_reuses_finalized_prior(self):
         p = self._p({'err': None, 'slot': 123, 'confirmationStatus': 'finalized'})
-        assert p._prior_broadcast(self.WANT) == ('SIG', 123)
+        assert p.chain.prior_broadcast(self.WANT) == ('SIG', 123)
 
     def test_processed_only_prior_waits(self):
         # Q3: `processed` can sit on a minority fork that never settles. Reusing it would mark the
         # leg delivered while the user is never paid → slash. Wait for confirmed/finalized.
         p = self._p({'err': None, 'slot': 50, 'confirmationStatus': 'processed'})
         with pytest.raises(SolanaRpcError):
-            p._prior_broadcast(self.WANT)
-        assert 'SIG' in p.broadcasted_txids  # kept: re-probed next pass
+            p.chain.prior_broadcast(self.WANT)
+        assert 'SIG' in p.chain.broadcasted_txids  # kept: re-probed next pass
 
     def test_failed_at_processed_only_waits(self):
         # A failure seen only at `processed` is as unsettled as a success there — don't evict yet.
         p = self._p({'err': 'InstructionError', 'slot': 10, 'confirmationStatus': 'processed'})
         with pytest.raises(SolanaRpcError):
-            p._prior_broadcast(self.WANT)
-        assert 'SIG' in p.broadcasted_txids
+            p.chain.prior_broadcast(self.WANT)
+        assert 'SIG' in p.chain.broadcasted_txids
 
     def test_failed_prior_dropped_allows_fresh_send(self):
         p = self._p({'err': 'InstructionError', 'slot': 10, 'confirmationStatus': 'finalized'})
-        assert p._prior_broadcast(self.WANT) is None
-        assert 'SIG' not in p.broadcasted_txids
+        assert p.chain.prior_broadcast(self.WANT) is None
+        assert 'SIG' not in p.chain.broadcasted_txids
 
     def test_pending_recent_prior_waits(self):
         p = self._p(None, slot=1010)  # head 1010, seen 1000 → within TTL, not on chain → must wait
         with pytest.raises(SolanaRpcError):
-            p._prior_broadcast(self.WANT)
+            p.chain.prior_broadcast(self.WANT)
 
     def test_expired_unlanded_prior_allows_fresh_send(self):
         p = self._p(None, slot=2000)  # head-seen = 1000 > 150 TTL → blockhash expired, never landed
-        assert p._prior_broadcast(self.WANT) is None
-        assert 'SIG' not in p.broadcasted_txids
+        assert p.chain.prior_broadcast(self.WANT) is None
+        assert 'SIG' not in p.chain.broadcasted_txids
 
     def test_unknown_record_slot_waits_and_backfills(self):
         # Q2: get_slot failed at record time (seen=0). head - 0 >> TTL must NOT read as "expired" —
         # the tx may still be propagating. Backfill seen with the current head and wait.
         p = self._p(None, slot=2000, seen=0)
         with pytest.raises(SolanaRpcError):
-            p._prior_broadcast(self.WANT)
-        assert p.broadcasted_txids['SIG'] == (*self.WANT, 2000)
+            p.chain.prior_broadcast(self.WANT)
+        assert p.chain.broadcasted_txids['SIG'] == (*self.WANT, 2000)
 
     def test_backfilled_record_expires_after_a_real_ttl(self):
         # After the backfill the TTL counts from the backfill head, so eviction still happens.
         p = self._p(None, slot=2000, seen=0)
         with pytest.raises(SolanaRpcError):
-            p._prior_broadcast(self.WANT)
-        p.rpc._slot = 2000 + p._BROADCAST_TTL_SLOTS + 1
-        assert p._prior_broadcast(self.WANT) is None
-        assert 'SIG' not in p.broadcasted_txids
+            p.chain.prior_broadcast(self.WANT)
+        p.rpc._slot = 2000 + p.chain.BROADCAST_TTL_SLOTS + 1
+        assert p.chain.prior_broadcast(self.WANT) is None
+        assert 'SIG' not in p.chain.broadcasted_txids
 
     def test_head_unreadable_pending_prior_waits(self):
         # Q2: no status AND no head → nothing is resolvable; never evict, never re-send.
         p = self._p(None, seen=0, slot_fails=True)
         with pytest.raises(SolanaRpcError):
-            p._prior_broadcast(self.WANT)
-        assert p.broadcasted_txids['SIG'] == (*self.WANT, 0)  # no head to backfill from
+            p.chain.prior_broadcast(self.WANT)
+        assert p.chain.broadcasted_txids['SIG'] == (*self.WANT, 0)  # no head to backfill from
 
     def test_different_obligation_is_ignored(self):
         p = self._p({'err': None, 'slot': 5})
-        assert p._prior_broadcast(('RECIP', 5_000_000, 'swapB')) is None  # different dedup scope
+        assert p.chain.prior_broadcast(('RECIP', 5_000_000, 'swapB')) is None  # different dedup scope
 
 
 class TestSendGuard:
@@ -252,13 +252,13 @@ class TestVerifyTransactionPostChecks:
 class TestAddressValidity:
     def test_valid_pubkey(self):
         p = provider_with(FakeRpc())
-        assert p.is_valid_address(str(Keypair().pubkey())) is True
+        assert p.chain.is_valid_address(str(Keypair().pubkey())) is True
 
     def test_garbage_rejected(self):
         p = provider_with(FakeRpc())
-        assert p.is_valid_address('not-a-key') is False
-        assert p.is_valid_address('') is False
-        assert p.is_valid_address(None) is False
+        assert p.chain.is_valid_address('not-a-key') is False
+        assert p.chain.is_valid_address('') is False
+        assert p.chain.is_valid_address(None) is False
 
 
 class TestDeliveryGates:
@@ -313,7 +313,7 @@ class TestDeliveryGates:
         assert len(RESERVED_ACCOUNTS) == 31
         assert all(32 <= len(a) <= 44 for a in RESERVED_ACCOUNTS)
         p = provider_with(FakeRpc())
-        assert all(p.is_valid_address(a) for a in RESERVED_ACCOUNTS)
+        assert all(p.chain.is_valid_address(a) for a in RESERVED_ACCOUNTS)
 
 
 class TestProofRoundtrip:
@@ -322,39 +322,39 @@ class TestProofRoundtrip:
         p = provider_with(FakeRpc(), keypair=kp)
         addr = str(kp.pubkey())
         msg = 'allways-reserve:sol:42'
-        sig = p.sign_from_proof(addr, msg)
+        sig = p.chain.sign_from_proof(addr, msg)
         assert sig and len(sig) == 128  # 64-byte ed25519 sig, hex
-        assert p.verify_from_proof(addr, msg, sig) is True
+        assert p.chain.verify_from_proof(addr, msg, sig) is True
 
     def test_wrong_message_fails(self):
         kp = Keypair()
         p = provider_with(FakeRpc(), keypair=kp)
         addr = str(kp.pubkey())
-        sig = p.sign_from_proof(addr, 'one')
-        assert p.verify_from_proof(addr, 'two', sig) is False
+        sig = p.chain.sign_from_proof(addr, 'one')
+        assert p.chain.verify_from_proof(addr, 'two', sig) is False
 
     def test_wrong_signer_fails(self):
         kp, other = Keypair(), Keypair()
         p = provider_with(FakeRpc(), keypair=kp)
-        sig = p.sign_from_proof(str(kp.pubkey()), 'msg')
-        assert p.verify_from_proof(str(other.pubkey()), 'msg', sig) is False
+        sig = p.chain.sign_from_proof(str(kp.pubkey()), 'msg')
+        assert p.chain.verify_from_proof(str(other.pubkey()), 'msg', sig) is False
 
     def test_explicit_key_argument(self):
         signer = Keypair()
         p = provider_with(FakeRpc())  # provider has no keypair
-        sig = p.sign_from_proof(str(signer.pubkey()), 'msg', key=signer)
-        assert p.verify_from_proof(str(signer.pubkey()), 'msg', sig) is True
+        sig = p.chain.sign_from_proof(str(signer.pubkey()), 'msg', key=signer)
+        assert p.chain.verify_from_proof(str(signer.pubkey()), 'msg', sig) is True
 
     def test_0x_prefixed_signature(self):
         kp = Keypair()
         p = provider_with(FakeRpc(), keypair=kp)
         addr = str(kp.pubkey())
-        sig = p.sign_from_proof(addr, 'msg')
-        assert p.verify_from_proof(addr, 'msg', '0x' + sig) is True
+        sig = p.chain.sign_from_proof(addr, 'msg')
+        assert p.chain.verify_from_proof(addr, 'msg', '0x' + sig) is True
 
     def test_sign_without_key_returns_empty(self):
         p = provider_with(FakeRpc())
-        assert p.sign_from_proof('addr', 'msg') == ''
+        assert p.chain.sign_from_proof('addr', 'msg') == ''
 
 
 class TestBalanceAndHeight:
@@ -364,7 +364,7 @@ class TestBalanceAndHeight:
 
     def test_block_height(self):
         p = provider_with(FakeRpc(slot=4242))
-        assert p.get_current_block_height() == 4242
+        assert p.chain.get_current_block_height() == 4242
 
 
 class SendRpc(FakeRpc):

--- a/tests/test_solana_provider.py
+++ b/tests/test_solana_provider.py
@@ -6,13 +6,12 @@ address validity, the ed25519 proof sign/verify roundtrip, balance, and the Syst
 """
 
 import pytest
-import requests
 from solders.keypair import Keypair
 
 from allways.assets.asset import ProviderUnreachableError
 from allways.assets.sol import RESERVED_ACCOUNTS, Sol
 from allways.chains import CHAIN_SOL
-from allways.solana.rpc import SolanaRpcError
+from allways.solana.rpc import SolanaRpcError, SolanaRpcUnreachable
 
 
 def make_tx(recipient, credit, sender='SENDER', slot=100, block_time=5000, err=None, extra_keys=None):
@@ -41,7 +40,7 @@ class FakeRpc:
 
     def get_transaction(self, sig, commitment='confirmed'):
         if self._raise_conn:
-            raise requests.ConnectionError('down')
+            raise SolanaRpcUnreachable('down', url='http://fake')
         return self._tx
 
     def get_slot(self, commitment='confirmed'):

--- a/tests/test_solana_swap_loop.py
+++ b/tests/test_solana_swap_loop.py
@@ -406,6 +406,14 @@ def test_provider_unreachable_skips():
     assert loop.decide(make_swap(status='Fulfilled'), now=1500).decision == SwapDecision.SKIP
 
 
+def test_provider_unreachable_past_ceiling_times_out():
+    # An unjudgeable dest leg (RPC down, or meta with no token-balance arrays) defers only up to
+    # max_extend_at — same bound as a missing provider — else the collateral never frees.
+    loop, _ = loop_with(result='unreachable')
+    swap = make_swap(status='Fulfilled', timeout_at=1000, max_extend_at=1200)
+    assert loop.decide(swap, now=1500).decision == SwapDecision.TIMEOUT
+
+
 # ─── D3: deadline extensions for valid-but-unconfirmed legs ───
 
 

--- a/tests/test_solusdc_provider.py
+++ b/tests/test_solusdc_provider.py
@@ -2,7 +2,6 @@
 method→response stub injected through the composed chain; keypairs and ATA derivation are real."""
 
 import pytest
-import requests
 from solders.keypair import Keypair
 from solders.pubkey import Pubkey
 
@@ -21,7 +20,7 @@ from allways.assets.spl_token import (
 )
 from allways.chains import CHAIN_SOL, CHAIN_SOLUSDC, get_chain_def
 from allways.constants import CANCEL_REASON_SOL_RESERVED, CANCEL_REASON_SPL_FROZEN, LAUNCH_SPOKES
-from allways.solana.rpc import SOLANA_GENESIS_HASHES
+from allways.solana.rpc import SOLANA_GENESIS_HASHES, SolanaRpcUnreachable
 
 MAINNET_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
 DEVNET_MINT = '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU'
@@ -95,7 +94,7 @@ class FakeRpc:
 
     def get_transaction(self, sig, commitment='confirmed'):
         if self._raise:
-            raise requests.ConnectionError('down')
+            raise SolanaRpcUnreachable('down', url='http://fake')
         if self._txs is not None:
             return self._txs.get(sig)
         return self._tx
@@ -105,7 +104,7 @@ class FakeRpc:
 
     def get_parsed_account(self, pubkey, commitment='confirmed'):
         if self._raise:
-            raise requests.ConnectionError('down')
+            raise SolanaRpcUnreachable('down', url='http://fake')
         return self.accounts.get(str(pubkey))
 
     def get_balance(self, pubkey, commitment='confirmed'):

--- a/tests/test_solusdc_provider.py
+++ b/tests/test_solusdc_provider.py
@@ -215,6 +215,11 @@ class TestCheckConnection:
         with pytest.raises(ConnectionError, match='does not exist'):
             p.check_connection(require_send=False)
 
+    def test_unreachable_mint_probe_degrades_not_raises(self, monkeypatch):
+        # Transient probe failure must not drop the spoke for the process lifetime (Erc20 posture).
+        p = provider_with(FakeRpc(raise_conn=True), monkeypatch=monkeypatch)
+        p.check_connection(require_send=False)
+
 
 class TestVerification:
     RECIP = str(USER.pubkey())

--- a/tests/test_solusdc_provider.py
+++ b/tests/test_solusdc_provider.py
@@ -1,0 +1,400 @@
+"""SolUsdc — Circle USDC on Solana, the first SPL token beside native SOL. Offline: the RPC is a
+method→response stub injected through the composed chain; keypairs and ATA derivation are real."""
+
+import pytest
+import requests
+from solders.keypair import Keypair
+from solders.pubkey import Pubkey
+
+from allways.assets import ASSET_REGISTRY
+from allways.assets.asset import MissingTestnetDeployment, ProviderUnreachableError
+from allways.assets.sol import RESERVED_ACCOUNTS, SolanaChain
+from allways.assets.solusdc import SolUsdc
+from allways.assets.spl_token import (
+    ASSOCIATED_TOKEN_PROGRAM_ID,
+    ATA_RENT_LAMPORTS,
+    IX_CREATE_ATA_IDEMPOTENT,
+    IX_TRANSFER_CHECKED,
+    TOKEN_PROGRAM_ID,
+    TX_FEE_LAMPORTS,
+    associated_token_address,
+)
+from allways.chains import CHAIN_SOL, CHAIN_SOLUSDC, get_chain_def
+from allways.constants import CANCEL_REASON_SOL_RESERVED, CANCEL_REASON_SPL_FROZEN, LAUNCH_SPOKES
+from allways.solana.rpc import SOLANA_GENESIS_HASHES
+
+MAINNET_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+DEVNET_MINT = '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU'
+OTHER_MINT = 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB'  # USDT — an impostor for a USDC leg
+GENESIS = {v: k for k, v in SOLANA_GENESIS_HASHES.items()}
+MINER = Keypair()
+USER = Keypair()
+FEE_PAYER = Keypair()
+AMOUNT = 150_000_000  # 150 USDC
+
+
+def ata(owner: Keypair | str, mint: str = MAINNET_MINT) -> str:
+    owner = owner if isinstance(owner, str) else str(owner.pubkey())
+    return str(associated_token_address(owner, Pubkey.from_string(mint)))
+
+
+def token_tx(
+    recipient=USER,
+    credit=AMOUNT,
+    sender=MINER,
+    mint=MAINNET_MINT,
+    slot=100,
+    block_time=5000,
+    err=None,
+    fee_payer=None,
+    drop_token_balances=False,
+    sender_owner_field=True,
+):
+    """A getTransaction dict moving `credit` of `mint` from sender's ATA to recipient's ATA."""
+    payer = str((fee_payer or sender).pubkey())
+    src, dst = ata(sender, mint), ata(recipient, mint)
+    keys = [payer, src, dst, mint, str(TOKEN_PROGRAM_ID)]
+
+    def bal(idx, owner, amount):
+        e = {'accountIndex': idx, 'mint': mint, 'uiTokenAmount': {'amount': str(amount), 'decimals': 6}}
+        if sender_owner_field or idx != 1:
+            e['owner'] = str(owner.pubkey())
+        return e
+
+    pre = [bal(1, sender, 1_000_000_000), bal(2, recipient, 10)]
+    post = [bal(1, sender, 1_000_000_000 - credit), bal(2, recipient, 10 + credit)]
+    meta = {'err': err, 'preBalances': [1] * 5, 'postBalances': [1] * 5}
+    if not drop_token_balances:
+        meta['preTokenBalances'], meta['postTokenBalances'] = pre, post
+    return {'slot': slot, 'blockTime': block_time, 'meta': meta, 'transaction': {'message': {'accountKeys': keys}}}
+
+
+def parsed_token_account(amount=AMOUNT * 10, state='initialized', owner=None):
+    return {
+        'owner': str(TOKEN_PROGRAM_ID),
+        'lamports': ATA_RENT_LAMPORTS,
+        'data': {'parsed': {'info': {'tokenAmount': {'amount': str(amount)}, 'state': state, 'owner': owner}}},
+    }
+
+
+def parsed_mint(decimals=6, owner=str(TOKEN_PROGRAM_ID)):
+    return {'owner': owner, 'lamports': 1, 'data': {'parsed': {'info': {'decimals': decimals}}}}
+
+
+class FakeRpc:
+    def __init__(self, tx=None, slot=200, cluster='mainnet', accounts=None, lamports=10**9, raise_conn=False, txs=None):
+        self._tx, self._slot, self._cluster, self._raise = tx, slot, cluster, raise_conn
+        self._txs = txs  # sig -> tx, for the scanner
+        self.accounts = accounts if accounts is not None else {}
+        self._lamports = lamports
+        self.sent = []
+        self.sigs = []
+
+    def get_genesis_hash(self):
+        return GENESIS[self._cluster] if self._cluster in GENESIS else 'LoCaLnEt11111111111111111111111111111111111'
+
+    def get_transaction(self, sig, commitment='confirmed'):
+        if self._raise:
+            raise requests.ConnectionError('down')
+        if self._txs is not None:
+            return self._txs.get(sig)
+        return self._tx
+
+    def get_slot(self, commitment='confirmed'):
+        return self._slot
+
+    def get_parsed_account(self, pubkey, commitment='confirmed'):
+        if self._raise:
+            raise requests.ConnectionError('down')
+        return self.accounts.get(str(pubkey))
+
+    def get_balance(self, pubkey, commitment='confirmed'):
+        return self._lamports
+
+    def get_signatures_for_address(self, addr, limit=20):
+        return self.sigs
+
+    def get_signature_statuses(self, sigs):
+        return [None for _ in sigs]
+
+    def get_latest_blockhash(self, commitment='confirmed'):
+        return '11111111111111111111111111111111'
+
+    def send_transaction(self, raw):
+        self.sent.append(raw)
+        return 'SIG' * 20
+
+    def confirm(self, sig, timeout=30.0, poll=0.4):
+        return {'slot': self._slot}
+
+
+def provider_with(rpc, keypair=None, monkeypatch=None):
+    if monkeypatch is not None:
+        monkeypatch.delenv('SOLUSDC_TOKEN_MINT', raising=False)
+    p = SolUsdc(solana_rpc_url='fake://rpc', solana_keypair=keypair)
+    p.rpc = rpc
+    return p
+
+
+class TestRegistryRow:
+    def test_bound_to_its_row_and_composes_solana(self, monkeypatch):
+        p = provider_with(FakeRpc(), monkeypatch=monkeypatch)
+        assert p.chain_def is CHAIN_SOLUSDC is get_chain_def('solusdc')
+        assert 'solusdc' in LAUNCH_SPOKES
+        assert isinstance(p.chain, SolanaChain) and p.chain is not p
+        assert (CHAIN_SOLUSDC.decimals, CHAIN_SOLUSDC.native_unit) == (6, 'µUSDC')
+        assert CHAIN_SOLUSDC.min_confirmations == CHAIN_SOL.min_confirmations
+        assert CHAIN_SOLUSDC.host_chain == 'solana' and CHAIN_SOLUSDC.asset_locator == MAINNET_MINT
+
+    def test_registry_hands_it_the_solana_rpc_and_keypair(self):
+        spec = next(s for s in ASSET_REGISTRY if s.chain_id == 'solusdc')
+        assert spec.cls is SolUsdc and spec.kwarg_names == ('solana_rpc_url', 'solana_keypair')
+
+
+class TestMintResolution:
+    def test_mainnet_uses_the_registry_mint(self, monkeypatch):
+        p = provider_with(FakeRpc(cluster='mainnet'), monkeypatch=monkeypatch)
+        assert str(p.mint) == MAINNET_MINT
+
+    def test_devnet_uses_circles_devnet_mint(self, monkeypatch):
+        p = provider_with(FakeRpc(cluster='devnet'), monkeypatch=monkeypatch)
+        assert str(p.mint) == DEVNET_MINT
+
+    def test_unknown_cluster_without_override_is_a_missing_deployment(self, monkeypatch):
+        p = provider_with(FakeRpc(cluster='localnet'), monkeypatch=monkeypatch)
+        with pytest.raises(MissingTestnetDeployment):
+            p.mint
+
+    def test_env_override_wins_without_touching_the_rpc(self, monkeypatch):
+        monkeypatch.setenv('SOLUSDC_TOKEN_MINT', OTHER_MINT)
+        p = SolUsdc(solana_rpc_url='fake://rpc')
+        p.rpc = None  # any RPC use would blow up
+        assert str(p.mint) == OTHER_MINT
+
+    def test_construction_is_offline(self, monkeypatch):
+        p = provider_with(FakeRpc(cluster='localnet'), monkeypatch=monkeypatch)  # no raise at construction
+        assert p._mint is None
+
+
+class TestAta:
+    def test_matches_the_canonical_derivation(self):
+        # Known vector: the ATA is a PDA of the associated-token program, never the owner itself.
+        owner = str(USER.pubkey())
+        derived = associated_token_address(owner, Pubkey.from_string(MAINNET_MINT))
+        expect, _ = Pubkey.find_program_address(
+            [bytes(USER.pubkey()), bytes(TOKEN_PROGRAM_ID), bytes(Pubkey.from_string(MAINNET_MINT))],
+            ASSOCIATED_TOKEN_PROGRAM_ID,
+        )
+        assert derived == expect and str(derived) != owner
+
+
+class TestCheckConnection:
+    def test_happy_path(self, monkeypatch):
+        accounts = {MAINNET_MINT: parsed_mint(), ata(MINER): parsed_token_account()}
+        p = provider_with(FakeRpc(accounts=accounts), keypair=MINER, monkeypatch=monkeypatch)
+        p.check_connection(require_send=True)
+
+    def test_missing_keypair_fails_when_send_required(self, monkeypatch):
+        p = provider_with(FakeRpc(accounts={MAINNET_MINT: parsed_mint()}), monkeypatch=monkeypatch)
+        with pytest.raises(ConnectionError):
+            p.check_connection(require_send=True)
+        p.check_connection(require_send=False)
+
+    def test_token_2022_mint_is_rejected(self, monkeypatch):
+        accounts = {MAINNET_MINT: parsed_mint(owner='TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb')}
+        p = provider_with(FakeRpc(accounts=accounts), monkeypatch=monkeypatch)
+        with pytest.raises(ConnectionError, match='legacy SPL'):
+            p.check_connection(require_send=False)
+
+    def test_decimals_drift_is_rejected(self, monkeypatch):
+        p = provider_with(FakeRpc(accounts={MAINNET_MINT: parsed_mint(decimals=9)}), monkeypatch=monkeypatch)
+        with pytest.raises(ConnectionError, match='decimals'):
+            p.check_connection(require_send=False)
+
+    def test_absent_mint_is_rejected(self, monkeypatch):
+        p = provider_with(FakeRpc(accounts={}), monkeypatch=monkeypatch)
+        with pytest.raises(ConnectionError, match='does not exist'):
+            p.check_connection(require_send=False)
+
+
+class TestVerification:
+    RECIP = str(USER.pubkey())
+    SENDER = str(MINER.pubkey())
+
+    def test_settled_transfer_matches_with_sender_pinned(self, monkeypatch):
+        p = provider_with(FakeRpc(tx=token_tx(), slot=100 + 40), monkeypatch=monkeypatch)
+        info = p.verify_transaction('sig', self.RECIP, AMOUNT, expected_sender=self.SENDER)
+        assert info is not None and info.amount == AMOUNT and info.sender == self.SENDER
+        assert info.confirmed and info.block_time == 5000 and info.recipient == self.RECIP
+
+    def test_one_short_of_depth_is_unconfirmed(self, monkeypatch):
+        p = provider_with(FakeRpc(tx=token_tx(), slot=100 + 30), monkeypatch=monkeypatch)
+        info = p.fetch_matching_tx('sig', self.RECIP, AMOUNT)
+        assert info is not None and not info.confirmed
+
+    @pytest.mark.parametrize(
+        'tx',
+        [
+            token_tx(err={'InstructionError': [0, 'Custom']}),
+            token_tx(credit=AMOUNT - 1),
+            token_tx(mint=OTHER_MINT),  # the right ATA shape for the wrong mint never credits USDC
+            token_tx(recipient=FEE_PAYER),  # credited someone else's ATA
+            None,
+        ],
+        ids=['failed-on-chain', 'underpaid', 'wrong-mint', 'wrong-recipient', 'not-found'],
+    )
+    def test_rejections_are_authoritative(self, tx, monkeypatch):
+        p = provider_with(FakeRpc(tx=tx, slot=200), monkeypatch=monkeypatch)
+        assert p.fetch_matching_tx('sig', self.RECIP, AMOUNT) is None
+
+    def test_sender_is_the_token_owner_not_the_fee_payer(self, monkeypatch):
+        p = provider_with(FakeRpc(tx=token_tx(fee_payer=FEE_PAYER), slot=200), monkeypatch=monkeypatch)
+        info = p.fetch_matching_tx('sig', self.RECIP, AMOUNT)
+        assert info.sender == self.SENDER
+        assert p.verify_transaction('sig', self.RECIP, AMOUNT, expected_sender=str(FEE_PAYER.pubkey())) is None
+
+    def test_unknowable_sender_fails_closed(self, monkeypatch):
+        p = provider_with(FakeRpc(tx=token_tx(sender_owner_field=False), slot=200), monkeypatch=monkeypatch)
+        assert p.fetch_matching_tx('sig', self.RECIP, AMOUNT).sender == ''
+        assert p.verify_transaction('sig', self.RECIP, AMOUNT, expected_sender=self.SENDER) is None
+
+    def test_self_transfer_is_rejected(self, monkeypatch):
+        p = provider_with(FakeRpc(tx=token_tx(sender=USER), slot=200), monkeypatch=monkeypatch)
+        assert p.verify_transaction('sig', self.RECIP, AMOUNT) is None
+
+    def test_ata_pasted_as_recipient_never_matches(self, monkeypatch):
+        # The address is an OWNER; an ATA handed in derives a different (nonexistent) ATA.
+        p = provider_with(FakeRpc(tx=token_tx(), slot=200), monkeypatch=monkeypatch)
+        assert p.fetch_matching_tx('sig', ata(USER), AMOUNT) is None
+
+    def test_transport_failure_raises(self, monkeypatch):
+        p = provider_with(FakeRpc(raise_conn=True), monkeypatch=monkeypatch)
+        with pytest.raises(ProviderUnreachableError):
+            p.fetch_matching_tx('sig', self.RECIP, AMOUNT)
+
+    def test_missing_token_balances_is_unknown_not_absent(self, monkeypatch):
+        p = provider_with(FakeRpc(tx=token_tx(drop_token_balances=True), slot=200), monkeypatch=monkeypatch)
+        with pytest.raises(ProviderUnreachableError):
+            p.fetch_matching_tx('sig', self.RECIP, AMOUNT)
+
+
+class TestDeliveryGates:
+    RECIP = str(USER.pubkey())
+
+    def test_clean_destination_passes(self, monkeypatch):
+        p = provider_with(FakeRpc(accounts={ata(USER): parsed_token_account()}), monkeypatch=monkeypatch)
+        assert p.can_deliver_to(self.RECIP, AMOUNT) is True
+        assert p.delivery_refused(self.RECIP, 0) is False
+        assert p.cancel_evidence(self.RECIP, AMOUNT) is None
+
+    def test_no_ata_yet_is_deliverable(self, monkeypatch):
+        p = provider_with(FakeRpc(accounts={}), monkeypatch=monkeypatch)
+        assert p.can_deliver_to(self.RECIP, AMOUNT) is True
+        assert p.delivery_refused(self.RECIP, 0) is False
+
+    def test_frozen_ata_bounces_reserve_and_is_cancel_evidence(self, monkeypatch):
+        p = provider_with(FakeRpc(accounts={ata(USER): parsed_token_account(state='frozen')}), monkeypatch=monkeypatch)
+        assert p.can_deliver_to(self.RECIP, AMOUNT) is False
+        assert p.delivery_refused(self.RECIP, 0) is True
+        assert p.cancel_evidence(self.RECIP, AMOUNT) == CANCEL_REASON_SPL_FROZEN
+
+    def test_token_account_pasted_as_owner_bounces_reserve(self, monkeypatch):
+        p = provider_with(FakeRpc(accounts={ata(USER): parsed_token_account()}), monkeypatch=monkeypatch)
+        assert p.can_deliver_to(ata(USER), AMOUNT) is False
+
+    def test_reserved_owner_is_refused_offline(self, monkeypatch):
+        p = provider_with(FakeRpc(raise_conn=True), monkeypatch=monkeypatch)
+        reserved = next(iter(RESERVED_ACCOUNTS))
+        assert p.can_deliver_to(reserved, AMOUNT) is False
+        assert p.delivery_refused(reserved, 0) is True
+        assert p.cancel_evidence(reserved, AMOUNT) == CANCEL_REASON_SOL_RESERVED
+
+    def test_reserve_gate_fails_open_but_slash_gate_raises(self, monkeypatch):
+        p = provider_with(FakeRpc(raise_conn=True), monkeypatch=monkeypatch)
+        assert p.can_deliver_to(self.RECIP, AMOUNT) is True
+        with pytest.raises(Exception):
+            p.delivery_refused(self.RECIP, 0)
+        assert p.cancel_evidence(self.RECIP, AMOUNT) is None
+
+
+class TestBalance:
+    def test_reads_the_owners_ata(self, monkeypatch):
+        p = provider_with(FakeRpc(accounts={ata(USER): parsed_token_account(amount=42)}), monkeypatch=monkeypatch)
+        assert p.get_balance(str(USER.pubkey())) == 42
+
+    def test_missing_ata_and_rpc_failure_read_zero(self, monkeypatch):
+        assert provider_with(FakeRpc(accounts={}), monkeypatch=monkeypatch).get_balance(str(USER.pubkey())) == 0
+        assert provider_with(FakeRpc(raise_conn=True), monkeypatch=monkeypatch).get_balance(str(USER.pubkey())) == 0
+
+
+class TestSendGuards:
+    TO = str(USER.pubkey())
+
+    def rich(self, lamports=10**9, dst_ata=True):
+        accounts = {ata(MINER): parsed_token_account(amount=AMOUNT * 10)}
+        if dst_ata:
+            accounts[ata(USER)] = parsed_token_account(amount=0)
+        return FakeRpc(accounts=accounts, lamports=lamports)
+
+    def test_no_key_refuses(self, monkeypatch):
+        assert provider_with(self.rich(), monkeypatch=monkeypatch).send_amount(self.TO, AMOUNT) is None
+
+    def test_key_mismatch_refuses(self, monkeypatch):
+        p = provider_with(self.rich(), keypair=MINER, monkeypatch=monkeypatch)
+        assert p.send_amount(self.TO, AMOUNT, from_address=str(FEE_PAYER.pubkey())) is None
+        assert p.rpc.sent == []
+
+    def test_token_poor_refuses_before_broadcasting(self, monkeypatch):
+        rpc = self.rich()
+        rpc.accounts[ata(MINER)] = parsed_token_account(amount=AMOUNT - 1)
+        p = provider_with(rpc, keypair=MINER, monkeypatch=monkeypatch)
+        assert p.send_amount(self.TO, AMOUNT) is None and rpc.sent == []
+
+    def test_token_rich_sol_poor_refuses_before_broadcasting(self, monkeypatch):
+        # Enough SOL for the fee but not for the rent of a destination ATA that doesn't exist yet.
+        rpc = self.rich(lamports=TX_FEE_LAMPORTS + ATA_RENT_LAMPORTS - 1, dst_ata=False)
+        p = provider_with(rpc, keypair=MINER, monkeypatch=monkeypatch)
+        assert p.send_amount(self.TO, AMOUNT) is None and rpc.sent == []
+        # Same SOL is plenty once the destination ATA exists (no rent to pay).
+        rpc2 = self.rich(lamports=TX_FEE_LAMPORTS + ATA_RENT_LAMPORTS - 1, dst_ata=True)
+        p2 = provider_with(rpc2, keypair=MINER, monkeypatch=monkeypatch)
+        assert p2.send_amount(self.TO, AMOUNT) == ('SIG' * 20, 200)
+
+    def test_happy_path_emits_create_ata_then_transfer_checked(self, monkeypatch):
+        from solders.transaction import Transaction
+
+        rpc = self.rich(dst_ata=False)
+        p = provider_with(rpc, keypair=MINER, monkeypatch=monkeypatch)
+        assert p.send_amount(self.TO, AMOUNT, from_address=str(MINER.pubkey()), dedup_key='swap-1') == ('SIG' * 20, 200)
+        import base64
+
+        tx = Transaction.from_bytes(base64.b64decode(rpc.sent[0]))
+        ixs = tx.message.instructions
+        keys = tx.message.account_keys
+        assert len(ixs) == 2
+        assert keys[ixs[0].program_id_index] == ASSOCIATED_TOKEN_PROGRAM_ID and bytes(ixs[0].data) == bytes(
+            [IX_CREATE_ATA_IDEMPOTENT]
+        )
+        assert keys[ixs[1].program_id_index] == TOKEN_PROGRAM_ID
+        assert bytes(ixs[1].data) == bytes([IX_TRANSFER_CHECKED]) + AMOUNT.to_bytes(8, 'little') + bytes([6])
+        dst = keys[ixs[1].accounts[2]]
+        assert str(dst) == ata(USER)
+        # Recorded for the dedup guard under this obligation.
+        assert list(p.chain.broadcasted_txids.values())[0][:3] == (self.TO, AMOUNT, 'swap-1')
+
+    def test_prior_broadcast_is_reused_not_repaid(self, monkeypatch):
+        rpc = self.rich()
+        rpc.get_signature_statuses = lambda sigs: [{'confirmationStatus': 'finalized', 'err': None, 'slot': 7}]
+        p = provider_with(rpc, keypair=MINER, monkeypatch=monkeypatch)
+        p.chain.broadcasted_txids['OLD'] = (self.TO, AMOUNT, '', 150)
+        assert p.send_amount(self.TO, AMOUNT) == ('OLD', 7)
+        assert rpc.sent == []
+
+
+class TestScanner:
+    def test_finds_the_senders_payment_to_the_owners_ata(self, monkeypatch):
+        rpc = FakeRpc(txs={'A': token_tx(sender=FEE_PAYER), 'B': token_tx()}, slot=200)
+        rpc.sigs = [{'signature': 'A'}, {'signature': 'B'}]
+        p = provider_with(rpc, monkeypatch=monkeypatch)
+        assert p.find_recent_outgoing(str(MINER.pubkey()), str(USER.pubkey()), AMOUNT) == 'B'
+        assert p.find_recent_outgoing(str(MINER.pubkey()), str(USER.pubkey()), AMOUNT + 1) is None

--- a/tests/test_swap_now_reservation.py
+++ b/tests/test_swap_now_reservation.py
@@ -379,10 +379,10 @@ def test_can_send_from_gates_on_signer(monkeypatch):
     funds move (prevents the wrong-key deposit the validator would reject)."""
     from types import SimpleNamespace
 
-    from allways.assets.sol import Sol
+    from allways.assets.sol import SolanaChain
 
     kp = SimpleNamespace(pubkey=lambda: 'PINNED')
-    p = Sol.__new__(Sol)
+    p = SolanaChain.__new__(SolanaChain)
     p.keypair = kp
     assert p.can_send_from('PINNED') is True
     assert p.can_send_from('SOMEONE_ELSE') is False


### PR DESCRIPTION
## What

USDC on Solana (`solusdc`) as a spoke: `sol↔solusdc` and `tao↔solusdc`. No program change — chains are opaque strings to the swap manager. Two commits:

1. **Unfuse the Solana provider** — `Sol(Asset, Chain)` becomes `SolanaChain` + `Sol`, zero behavior change (existing `test_solana_provider.py` is the gate; only its dedup-internal assertions moved to `p.chain`). Needed because this is the first second-asset on a non-EVM host; the EVM family already had `EvmChain` for this.
2. **`SplToken` + `solusdc`** — the SPL sibling of `Erc20`.

## Design points worth a look

- **Addresses are owner wallets, never token accounts.** The leg lands in the derived ATA. Verification diffs `pre/postTokenBalances` at that ATA for the pinned mint; the sender is the owner of the debited token account, not the fee payer (fails closed to `''` if ambiguous).
- **Send** = idempotent `CreateAssociatedTokenAccount` + `TransferChecked` (mint + decimals bound on-chain). Refuses before broadcast when short on USDC *or* on the SOL for fee + ATA rent — `fulfillment.py` only checks the token balance.
- **Refusal surface**: USDC's mint has a freeze authority. A frozen destination ATA bounces the reservation and is no-fault cancel evidence — `CANCEL_REASON_SPL_FROZEN = 5`, Python-side now; the program doesn't bind the reason byte, so `constants.rs` gets the mirror next release.
- **Mint resolution is by genesis hash**, not a network name — Solana has no `SOL_NETWORK`. Mainnet = registry `asset_locator`, devnet = Circle's devnet mint, anything else needs `SOLUSDC_TOKEN_MINT` or the spoke disables at boot (same `MissingTestnetDeployment` path as an ERC-20 with no testnet pin). `MissingTestnetDeployment` moved to `assets/asset.py`.
- **Registry row**: `host_chain='solana'`, `env_prefix='SOL'`, `networks=()` (a declared tuple would spawn a dead `sol-network` CLI key), `min_confirmations` pinned to SOL's, `min_onchain_amount` 5 USDC like every USDC row, `replay_grace_secs=0` — the one spoke where hub and leg share a clock.
- **First same-ledger pair**: a `solusdc` leg defaults to the Solana signer in `alw swap` and `alw miner quotes` (`--solusdc-address` falls back to `--sol-address`).
- `test_chains.py` invariants widened: hosted ⇒ `EVM_NETWORKS` *or* `'solana'`; non-EVM hosts are exempt from the networks-declaring rule; new SPL-row test.

## Housekeeping in the same PR

README had seven stacked "Currently live with…" lines and `.env.example` three stacked Ethereum headers (merge artifacts on `test`); `test_chains.py` had three duplicated copies of one assertion block. All collapsed.

## Verified

- `uv run pytest tests/ -q` → 2006 passed; ruff clean.
- Live read-only vs mainnet RPC: mint check (legacy SPL, 6 decimals), a real USDC transfer verifies with owner-as-recipient + token-owner sender; ATA-as-recipient and wrong-sender reject.
- `create_assets(check=True)` against devnet resolves Circle's devnet mint.
- `alw miner quotes --help` shows `--solusdc-price/--solusdc-address`.

Adding a spoke dilutes every pair's zero-volume emission floor to (1−α)/pairs.

## Follow-ups (separate PRs)

das-allways `chains.config.ts` row + spec anchors (CI drift gate needs this merged first), alw-utils `sol-solusdc`/`solusdc-sol` suite rows, `allways-rates` source, devnet soak, red-team pass on the shared-address-space pair.