### PR TITLE
Ineligible miners are not crown candidates; under-floor TAO bond drops the hub bit

### DIFF
--- a/allways/solana/client.py
+++ b/allways/solana/client.py
@@ -779,7 +779,10 @@ class AllwaysSolanaClient:
             AccountMeta(validator, True, True),
             AccountMeta(pdas.config_pda(self.program_id), False, False),
             AccountMeta(m, False, False),
-            AccountMeta(pdas.miner_state_pda(m, self.program_id), False, False),
+            # Writable: a quorum write that lands a LOCKED bond under the hub's floor drops that hub's
+            # backing bit (the vaulted twin of apply_penalty's SOL rule). Marking it writable is harmless
+            # against a pre-upgrade program, which only reads it.
+            AccountMeta(pdas.miner_state_pda(m, self.program_id), False, True),
             # F5: this hub's reservation, read-only — a filled reservation's obligation floors a downward
             # write (an open pool alone does not). Always derivable; may be uninitialized on-chain.
             AccountMeta(pdas.reservation_pda(m, chain, self.program_id), False, False),

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -17,6 +17,7 @@ from allways.validator.relay.wiring import ensure_bond_relay
 from allways.validator.reserve_engine import finalize_won_seats
 from allways.validator.scoring import (
     due_for_scoring,
+    live_miner_states,
     score_and_reward_miners,
     snapshot_current_crown_holders,
     snapshot_current_miner_scores,
@@ -87,7 +88,11 @@ async def forward(self: Validator) -> None:
     # never propagates into the forward loop. Reads "now" on the unix-time axis,
     # matching the scoring window. No halt check here (that RPC is the expensive
     # one); halt-aware clearing happens once per round in `_flush_halt_window`.
-    crown_snapshot = snapshot_current_crown_holders(self)
+    # One MinerState read per step, shared by the crown snapshot and the score tip:
+    # eligibility now gates crown CANDIDACY (lane_eligible_hotkeys), so the live
+    # crown needs the same strike/settle view the round scorer applies.
+    live_states = live_miner_states(self.solana_client, self.metagraph)
+    crown_snapshot = snapshot_current_crown_holders(self, live_states=live_states)
     log_crown_winners(self.metagraph, self.block, crown_snapshot)
     dev_signal.emit('crown_snapshot', holders={f'{k[0]}-{k[1]}-{k[2]}': v for k, v in crown_snapshot.items()})
     if self.database_storage.is_enabled():
@@ -99,7 +104,9 @@ async def forward(self: Validator) -> None:
         # if the in-progress round flushed now. Same storage gate/cadence as
         # the crown snapshot; computed only when someone is reading (DB on).
         try:
-            self.database_storage.replace_current_miner_scores(snapshot_current_miner_scores(self))
+            self.database_storage.replace_current_miner_scores(
+                snapshot_current_miner_scores(self, live_states=live_states)
+            )
         except Exception as e:
             bt.logging.warning(f'current_miner_scores snapshot failed: {e}')
 

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -220,6 +220,29 @@ def direction_eligible(miner_state, from_chain: str, to_chain: str, now: int, ba
     return any(hub_free(miner_state, hub, now) for hub in hubs)
 
 
+def lane_eligible_hotkeys(
+    live_states: Dict[str, object],
+    rewardable_hotkeys: Set[str],
+    from_chain: str,
+    to_chain: str,
+    now: int,
+    backing: Optional[str] = None,
+) -> Set[str]:
+    """The crown-candidate set for one lane: on-metagraph hotkeys that also pass
+    ``direction_eligible`` right now. Ineligibility (strikes, or the lane's hub
+    mid-settle) removes a miner from candidacy rather than only zeroing its payout —
+    otherwise a struck/settling miner keeps *holding* the crown, the next-best
+    eligible rate earns nothing, and the lane's pool burns for the duration. Evaluated
+    at ``now`` over the whole window (the same at-scoring-time reading the payout gate
+    uses); a hotkey with no live ``MinerState`` is not a candidate, matching the
+    payout gate's absent-hotkey → not-eligible default."""
+    return {
+        hk
+        for hk in rewardable_hotkeys
+        if hk in live_states and direction_eligible(live_states[hk], from_chain, to_chain, now, backing=backing)
+    }
+
+
 def live_miner_states(solana_client, metagraph, attribution: Optional[Dict[str, str]] = None) -> Dict[str, object]:
     """``{hotkey: MinerState}`` for bound, on-metagraph miners — one chain read shared by
     the eligibility gate and the live-state reconcile. Each pubkey-keyed ``MinerState`` is
@@ -496,6 +519,10 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
             intervals = []
             intervals_by_dir[(from_chain, to_chain, backing)] = intervals
         min_swap_hub, max_swap_hub = swap_bounds.get(backing, (0, 0))
+        # Ineligible miners are not crown candidates on this lane (see lane_eligible_hotkeys).
+        lane_candidates = lane_eligible_hotkeys(
+            live_states, rewardable_hotkeys, from_chain, to_chain, current_time, backing=backing
+        )
         crown_time = replay_crown_time_window(
             store=self.state_store,
             event_index=self.event_index,
@@ -503,7 +530,7 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
             to_chain=to_chain,
             window_start=window_start,
             window_end=window_end,
-            rewardable_hotkeys=rewardable_hotkeys,
+            rewardable_hotkeys=lane_candidates,
             trace=trace,
             intervals_out=intervals,
             min_swap_hub=min_swap_hub,
@@ -606,7 +633,9 @@ def miner_score_tuples(score_rows: List[ScoreRow], ts: int) -> List[Tuple]:
     ]
 
 
-def snapshot_current_miner_scores(self: Validator, at_time: Optional[int] = None) -> List[Tuple]:
+def snapshot_current_miner_scores(
+    self: Validator, at_time: Optional[int] = None, live_states: Optional[Dict[str, object]] = None
+) -> List[Tuple]:
     """Mid-round live tip: the factors each crown holder would be paid on if
     the in-progress round [last_scored_time, now] flushed right now — the same
     replay + ``build_direction_score_rows`` math ``calculate_miner_rewards``
@@ -620,7 +649,8 @@ def snapshot_current_miner_scores(self: Validator, at_time: Optional[int] = None
     ts = int(time.time()) if at_time is None else at_time
     window_start, window_end = scoring_window_bounds(ts, self.last_scored_time)
     rewardable_hotkeys: Set[str] = set(self.metagraph.hotkeys)
-    live_states = live_miner_states(self.solana_client, self.metagraph)
+    if live_states is None:
+        live_states = live_miner_states(self.solana_client, self.metagraph)
     try:
         swap_bounds = bounds_from_config(self.solana_config_cache.config())
     except Exception as e:
@@ -631,6 +661,9 @@ def snapshot_current_miner_scores(self: Validator, at_time: Optional[int] = None
     for (from_chain, to_chain, backing), pool in pools.items():
         trace = DirectionTrace(pool=pool)
         min_swap_hub, max_swap_hub = swap_bounds.get(backing, (0, 0))
+        lane_candidates = lane_eligible_hotkeys(
+            live_states, rewardable_hotkeys, from_chain, to_chain, ts, backing=backing
+        )
         crown_time = replay_crown_time_window(
             store=self.state_store,
             event_index=self.event_index,
@@ -638,7 +671,7 @@ def snapshot_current_miner_scores(self: Validator, at_time: Optional[int] = None
             to_chain=to_chain,
             window_start=window_start,
             window_end=window_end,
-            rewardable_hotkeys=rewardable_hotkeys,
+            rewardable_hotkeys=lane_candidates,
             trace=trace,
             min_swap_hub=min_swap_hub,
             max_swap_hub=max_swap_hub,
@@ -1044,6 +1077,7 @@ def replay_crown_time_window(
 def snapshot_current_crown_holders(
     self: Validator,
     at_time: Optional[int] = None,
+    live_states: Optional[Dict[str, object]] = None,
 ) -> Dict[Tuple[str, str, str], List[Tuple[str, str, str, str, float, float, int]]]:
     """Cheap "who holds the crown right now" per lane. Used by the
     per-forward-step live-crown writer.
@@ -1057,6 +1091,11 @@ def snapshot_current_crown_holders(
     means "no qualifying holder right now" — instructs the storage layer
     to clear that lane's rows.
 
+    ``live_states`` (``live_miner_states``) gates candidacy per lane through
+    ``lane_eligible_hotkeys`` so the live table never names a holder the round
+    scorer would drop as ineligible. Pass the per-step snapshot in from the forward
+    loop (shared with the live score tip); None reads it here.
+
     Halt is not checked here — that RPC is expensive and halt is rare;
     instead ``_flush_halt_window`` clears the live table at the next
     scoring round when a halt is detected. Worst case the live table
@@ -1067,6 +1106,8 @@ def snapshot_current_crown_holders(
     # (blockTime) axis the event tables use. Tests pass an explicit instant.
     ts = int(time.time()) if at_time is None else at_time
     rewardable_hotkeys: Set[str] = set(self.metagraph.hotkeys)
+    if live_states is None:
+        live_states = live_miner_states(self.solana_client, self.metagraph)
     # Match the scoring path's executability filter so the live table never
     # credits an out-of-bounds-rate holder the ledger drops. Bounds from the
     # TTL cache (no per-step RPC); empty map on failure = permissive, as before.
@@ -1081,18 +1122,21 @@ def snapshot_current_crown_holders(
             min_swap_hub, max_swap_hub = swap_bounds.get(backing, (0, 0))
             bounds_set = min_swap_hub > 0 or max_swap_hub > 0
             purse_known = direction_purse_known(backing)
+            lane_candidates = lane_eligible_hotkeys(
+                live_states, rewardable_hotkeys, from_chain, to_chain, ts, backing=backing
+            )
             rates, activity, active_set, collaterals = reconstruct_window_start_state(
                 self.state_store,
                 self.event_index,
                 from_chain,
                 to_chain,
                 ts,
-                rewardable_hotkeys,
+                lane_candidates,
                 backing,
             )
             canon_from, _ = canonical_pair(from_chain, to_chain)
             lower_rate_wins = from_chain != canon_from
-            rewardable_by_state = rewardable_by_activity(activity, rewardable_hotkeys, lane_serving_hubs(backing))
+            rewardable_by_state = rewardable_by_activity(activity, lane_candidates, lane_serving_hubs(backing))
 
             # Same predicates the scoring replay uses, so the live table never
             # credits a holder the ledger drops. Built per lane so each
@@ -1103,7 +1147,7 @@ def snapshot_current_crown_holders(
 
             holders = crown_holders_at_instant(
                 rates,
-                rewardable_hotkeys,
+                lane_candidates,
                 rewardable_by_state=rewardable_by_state,
                 active=active_set,
                 lower_rate_wins=lower_rate_wins,

--- a/smart-contracts/solana/programs/allways_swap_manager/src/instructions/vote_set_attestation.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/instructions/vote_set_attestation.rs
@@ -7,6 +7,7 @@ use crate::constants::{
 };
 use crate::error::ErrorCode;
 use crate::events::BondAttested;
+use crate::penalty::drop_backing_under_floor;
 use crate::state::{BondAttestation, Config, MinerState, Reservation, VoteRound};
 
 /// Validators write a miner's effective bond on one backing chain. Solana can't read the vault holding
@@ -28,7 +29,10 @@ pub struct VoteSetAttestation<'info> {
 
     /// Read for this hub's in-flight-swap reserve — a downward write is refused only if it would drop
     /// the purse below a LIVE obligation (F5). Every attestable miner is registered, so this always exists.
+    /// Mutable: a quorum write that lands the purse under the hub's activation floor drops the hub's
+    /// backing bit (`drop_backing_under_floor`), the vaulted twin of `apply_penalty`'s SOL rule.
     #[account(
+        mut,
         seeds = [MINER_SEED, miner.key().as_ref()],
         bump = miner_state.bump,
         constraint = miner_state.miner == miner.key(),
@@ -141,12 +145,20 @@ pub fn handler(
         reset_round(&mut ctx.accounts.vote_round);
         emit!(BondAttested {
             miner: miner_key,
-            chain,
+            chain: chain.clone(),
             effective_balance,
             locked,
             epoch,
             attested_at: now,
         });
+        // A LOCKED bond under the hub's floor drops that hub's bit, same as a SOL purse slashed under
+        // `min_collateral` — re-entry is a fresh `vote_activate` once the bond is topped back up. An
+        // unlocked bond is left to its own gates (`BondNotLocked` refuses entry; the scorer reads it as
+        // an empty purse): unlocking is the miner's own exit, not a deficiency.
+        if locked {
+            let floor = backing::activation_floor(&ctx.accounts.config, &chain)?;
+            drop_backing_under_floor(&mut ctx.accounts.miner_state, bit, &chain, effective_balance, floor, now);
+        }
     }
     Ok(())
 }

--- a/smart-contracts/solana/programs/allways_swap_manager/src/penalty.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/penalty.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 
-use crate::constants::{BACKING_BIT_SOL, BACKING_CHAIN_SOL};
+use crate::constants::{BACKING_BIT_SOL, BACKING_BIT_TAO, BACKING_CHAIN_SOL, BACKING_CHAIN_TAO};
 use crate::error::ErrorCode;
 use crate::events::{MinerBackingChanged, MinerDeactivated};
 use crate::state::MinerState;
@@ -33,25 +33,109 @@ pub fn apply_penalty(
 
     // Only the SOL purse went deficient, so only its bit drops (D2: a deficient purse disables its own
     // quotes, not the miner). A miner still bonded on another hub keeps trading there.
-    if miner_state.collateral < min_collateral && miner_state.active_backings & BACKING_BIT_SOL != 0 {
-        let still_active = miner_state.set_backing(BACKING_BIT_SOL, false);
-        emit!(MinerBackingChanged {
-            miner: miner_state.miner,
-            backing: BACKING_CHAIN_SOL.to_string(),
-            enabled: false,
-            active_backings: miner_state.active_backings,
-            at: now,
-        });
+    let purse = miner_state.collateral;
+    if drop_backing_under_floor(miner_state, BACKING_BIT_SOL, BACKING_CHAIN_SOL, purse, min_collateral, now) {
         // The SOL bit just dropped, so the local-collateral cooldown starts here — same rule as
         // self-`deactivate`. Gating it on `!still_active` instead would let a slashed dual miner idle
         // the cooldown out on its TAO purse and withdraw the moment it drops the SOL one.
         miner_state.deactivation_at = now;
-        if !still_active {
-            // Without this emit the scorer — which rebuilds the active set purely from
-            // MinerActivated/MinerDeactivated events — keeps paying crown to a miner the chain
-            // already considers inactive, until some later vote event happens to fire.
-            emit!(MinerDeactivated { miner: miner_state.miner, at: now });
-        }
     }
     Ok(actual)
+}
+
+/// Clear one hub's backing bit when its purse sits under that hub's activation floor — the single
+/// auto-deactivation rule every purse shares. The SOL purse reaches it through `apply_penalty` (the
+/// local fee/slash path); a vaulted purse (TAO) reaches it through `vote_set_attestation`, the only
+/// place its balance lands on Solana. Without the latter a slashed-under-floor TAO bond stayed active
+/// forever: unreservable by takers (`open_or_request` checks the floor) yet still a crown candidate.
+/// Returns whether the bit was dropped. Emits `MinerBackingChanged`, and `MinerDeactivated` when no
+/// purse is left — the scorer rebuilds its active set purely from these events.
+pub fn drop_backing_under_floor(
+    miner_state: &mut MinerState,
+    bit: u8,
+    chain: &str,
+    purse: u64,
+    floor: u64,
+    now: i64,
+) -> bool {
+    if purse >= floor || miner_state.active_backings & bit == 0 {
+        return false;
+    }
+    let still_active = miner_state.set_backing(bit, false);
+    emit!(MinerBackingChanged {
+        miner: miner_state.miner,
+        backing: chain.to_string(),
+        enabled: false,
+        active_backings: miner_state.active_backings,
+        at: now,
+    });
+    if !still_active {
+        // Without this emit the scorer — which rebuilds the active set purely from
+        // MinerActivated/MinerDeactivated events — keeps paying crown to a miner the chain
+        // already considers inactive, until some later vote event happens to fire.
+        emit!(MinerDeactivated { miner: miner_state.miner, at: now });
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::MAX_BACKING_SLOTS;
+
+    fn miner(active_backings: u8) -> MinerState {
+        MinerState {
+            miner: Pubkey::default(),
+            collateral: 0,
+            active: active_backings != 0,
+            active_backings,
+            has_active_swap: false,
+            active_swap_backings: 0,
+            busy_until: [0; MAX_BACKING_SLOTS],
+            settling_until: [0; MAX_BACKING_SLOTS],
+            reserved_collateral: [0; MAX_BACKING_SLOTS],
+            deactivation_at: 0,
+            successful_swaps: 0,
+            failed_swaps: 0,
+            bump: 255,
+        }
+    }
+
+    #[test]
+    fn an_under_floor_tao_purse_drops_only_the_tao_bit() {
+        let mut ms = miner(BACKING_BIT_SOL | BACKING_BIT_TAO);
+        assert!(drop_backing_under_floor(&mut ms, BACKING_BIT_TAO, BACKING_CHAIN_TAO, 890_000_000, 1_000_000_000, 7));
+        assert_eq!(ms.active_backings, BACKING_BIT_SOL);
+        assert!(ms.active, "the SOL purse keeps the miner active");
+        assert_eq!(ms.deactivation_at, 0, "the local cooldown is a SOL-purse rule; the caller sets it");
+    }
+
+    #[test]
+    fn the_last_purse_under_floor_deactivates_the_miner() {
+        let mut ms = miner(BACKING_BIT_TAO);
+        assert!(drop_backing_under_floor(&mut ms, BACKING_BIT_TAO, BACKING_CHAIN_TAO, 0, 1, 7));
+        assert_eq!(ms.active_backings, 0);
+        assert!(!ms.active);
+    }
+
+    #[test]
+    fn at_or_above_floor_is_a_no_op() {
+        let mut ms = miner(BACKING_BIT_TAO);
+        assert!(!drop_backing_under_floor(&mut ms, BACKING_BIT_TAO, BACKING_CHAIN_TAO, 1_000_000_000, 1_000_000_000, 7));
+        assert_eq!(ms.active_backings, BACKING_BIT_TAO);
+    }
+
+    #[test]
+    fn an_already_inactive_bit_is_a_no_op() {
+        let mut ms = miner(BACKING_BIT_SOL);
+        assert!(!drop_backing_under_floor(&mut ms, BACKING_BIT_TAO, BACKING_CHAIN_TAO, 0, 1, 7));
+        assert_eq!(ms.active_backings, BACKING_BIT_SOL);
+    }
+
+    #[test]
+    fn a_zero_floor_never_drops() {
+        // Floor unset (0) mirrors the contract's "no floor" sentinel: nothing is under it.
+        let mut ms = miner(BACKING_BIT_TAO);
+        assert!(!drop_backing_under_floor(&mut ms, BACKING_BIT_TAO, BACKING_CHAIN_TAO, 0, 0, 7));
+    }
 }

--- a/smart-contracts/solana/programs/allways_swap_manager/tests/test_attestation.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/tests/test_attestation.rs
@@ -1867,20 +1867,58 @@ fn test_tao_backed_pool_entry_reads_the_tao_purse_not_the_local_vault() {
     light_tao_purse(&mut svm, &vals, &miner, TAO_MIN_COLLATERAL_RAO);
 
     // A slash lands: the attested bond drops under the TAO floor while the miner's SOL vault is
-    // untouched. The bid must die on the TAO purse, not pass on the lamports it still holds.
+    // untouched. The quorum write itself drops the TAO bit (the vaulted twin of `apply_penalty`'s
+    // SOL rule) — an under-floor purse is deactivated, not merely unreservable — while the SOL purse
+    // keeps the miner active. The bid then dies on the inactive backing, never on the lamports.
     attest(&mut svm, &vals, &m, TAO_MIN_COLLATERAL_RAO - 1, true, 2);
+    let ms = miner_state(&svm, &m);
+    assert_eq!(ms.active_backings & BACKING_BIT_TAO, 0, "under-floor bond drops the TAO bit");
+    assert_ne!(ms.active_backings & BACKING_BIT_SOL, 0, "the SOL purse is untouched");
+    assert!(ms.active, "still active on SOL");
+    assert_eq!(ms.deactivation_at, 0, "the local withdrawal cooldown is a SOL-purse rule");
+    assert_eq!(ms.collateral, COLLATERAL, "the local vault was never consulted");
     let err = send(&mut svm, open_backed_ix(&vals[0].pubkey(), &m, HUB_FROM, HUB_TO, TAO), &vals[0].pubkey(), &vals[0])
         .unwrap_err();
     assert!(
-        err.contains("InsufficientCollateral"),
+        err.contains("MinerNotActive"),
         "a bond below tao_min_collateral must not open a pool despite {COLLATERAL} lamports of SOL, got: {err}"
     );
-    assert_eq!(miner_state(&svm, &m).collateral, COLLATERAL, "the local vault was never consulted");
 
-    // Bond restored to the floor and the same bid goes through.
+    // Bond restored to the floor: the purse is sufficient again, but re-entry is a fresh
+    // `vote_activate` — a topped-up bond does not silently re-light the bit.
     attest(&mut svm, &vals, &m, TAO_MIN_COLLATERAL_RAO, true, 3);
+    assert_eq!(miner_state(&svm, &m).active_backings & BACKING_BIT_TAO, 0, "top-up alone does not re-activate");
+    let attest_key = Some(attest_pda(&m, TAO));
+    send(&mut svm, activate_ix(&vals[0].pubkey(), &m, TAO, attest_key), &vals[0].pubkey(), &vals[0]).expect("re0");
+    send(&mut svm, activate_ix(&vals[1].pubkey(), &m, TAO, attest_key), &vals[1].pubkey(), &vals[1]).expect("re1");
+    assert_ne!(miner_state(&svm, &m).active_backings & BACKING_BIT_TAO, 0, "re-activated at the floor");
     send(&mut svm, open_backed_ix(&vals[0].pubkey(), &m, HUB_FROM, HUB_TO, TAO), &vals[0].pubkey(), &vals[0])
         .expect("tao-backed open at the floor");
+}
+
+#[test]
+fn test_an_under_floor_bond_on_the_only_purse_deactivates_the_miner() {
+    // A TAO-only miner slashed under the floor has no purse left: the attestation quorum clears the
+    // last bit and the miner reads inactive — the state the scorer rebuilds from MinerDeactivated.
+    let (mut svm, _admin, vals, miner) = setup();
+    let m = miner.pubkey();
+    light_tao_purse(&mut svm, &vals, &miner, TAO_MIN_COLLATERAL_RAO);
+    send(&mut svm, self_deactivate_ix(&m, Some(SOL)), &m, &miner).expect("drop the SOL purse");
+    let ms = miner_state(&svm, &m);
+    assert_eq!(ms.active_backings, BACKING_BIT_TAO);
+    assert!(ms.active);
+
+    attest(&mut svm, &vals, &m, TAO_MIN_COLLATERAL_RAO - 1, true, 2);
+    let ms = miner_state(&svm, &m);
+    assert_eq!(ms.active_backings, 0, "the last purse under floor clears the mask");
+    assert!(!ms.active, "no purse left → inactive");
+
+    // At-floor and above-floor writes never touch the mask.
+    let (mut svm, _admin, vals, miner) = setup();
+    let m = miner.pubkey();
+    light_tao_purse(&mut svm, &vals, &miner, TAO_MIN_COLLATERAL_RAO);
+    attest(&mut svm, &vals, &m, TAO_MIN_COLLATERAL_RAO, true, 2);
+    assert_ne!(miner_state(&svm, &m).active_backings & BACKING_BIT_TAO, 0, "at the floor is not under it");
 }
 
 #[test]

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -2655,9 +2655,10 @@ class TestScoreSnapshots:
         np.testing.assert_allclose(reward, expected, atol=1e-9)
         np.testing.assert_allclose(reward, rewards[0], atol=1e-6)
 
-    def test_ineligible_holder_persists_factors_with_zero_reward(self, tmp_path: Path):
-        """The gate zeroes the reward but the factors are still recorded — the
-        dashboard can show WHY the eligible=false round paid nothing."""
+    def test_ineligible_miner_is_not_a_crown_candidate(self, tmp_path: Path):
+        """An ineligible miner (strikes / hub mid-settle) is removed from crown
+        CANDIDACY, not merely zeroed at payout: a lane whose only poster is
+        ineligible has no holder, no score row, and the pool recycles."""
         hotkeys = pad_hotkeys_to_cover_recycle(['hk_a'])
         v = make_validator(tmp_path, hotkeys, all_eligible=False)
         v.database_storage.is_enabled.return_value = True
@@ -2669,13 +2670,44 @@ class TestScoreSnapshots:
         conn.commit()
         rewards, _ = calculate_miner_rewards(v, v.block)
         rows = v.database_storage.flush_scoring_window.call_args.kwargs['miner_score_rows']
-        assert len(rows) == 1
-        (_ts, _hk, _from_c, _to_c, _backing, eligible, pool, crown_share, _cap, reward) = rows[0]
-        assert eligible is False
-        np.testing.assert_allclose(crown_share, 1.0)  # crown_share still recorded
-        assert pool > 0.0  # the pool the round would have paid on is recorded too
-        assert reward == 0.0
+        assert rows == []
         assert rewards[0] == 0.0
+        # The live crown table agrees: nobody holds the lane.
+        assert snapshot_current_crown_holders(v, v.block)[('btc', 'sol', 'sol')] == []
+        v.state_store.close()
+
+    def test_ineligible_best_rate_falls_through_to_eligible_runner_up(self, tmp_path: Path):
+        """The struck miner posts the best rate; the crown — and the whole lane
+        payout — goes to the next-best ELIGIBLE rate instead of burning, and the
+        live crown snapshot names the same holder the round scorer pays."""
+        hotkeys = pad_hotkeys_to_cover_recycle(['hk_struck', 'hk_ok'])
+        v = make_validator(
+            tmp_path,
+            hotkeys,
+            miner_counters={
+                'hk_struck': (MIN_SUCCESSFUL_SWAPS, MAX_FAILED_SWAPS + 1),
+                'hk_ok': (MIN_SUCCESSFUL_SWAPS, 0),
+            },
+        )
+        v.database_storage.is_enabled.return_value = True
+        conn = v.state_store.require_connection()
+        # btc→sol reads the canonical BTC-per-SOL rate, lower is better: the struck miner undercuts.
+        conn.executemany(
+            'INSERT INTO rate_events (hotkey, from_chain, to_chain, rate, block) VALUES (?, ?, ?, ?, ?)',
+            [('hk_struck', 'btc', 'sol', 0.00015, 0), ('hk_ok', 'btc', 'sol', 0.00020, 0)],
+        )
+        conn.commit()
+        rewards, _ = calculate_miner_rewards(v, v.block)
+        rows = [r for r in v.database_storage.flush_scoring_window.call_args.kwargs['miner_score_rows']]
+        lane_rows = [r for r in rows if (r[2], r[3]) == ('btc', 'sol')]
+        assert [r[1] for r in lane_rows] == ['hk_ok']
+        (_ts, _hk, _f, _t, _b, eligible, pool, crown_share, _cap, reward) = lane_rows[0]
+        assert eligible is True
+        np.testing.assert_allclose(crown_share, 1.0)
+        assert reward > 0.0
+        assert rewards[1] > 0.0 and rewards[0] == 0.0
+        holders = [row[3] for row in snapshot_current_crown_holders(v, v.block)[('btc', 'sol', 'sol')]]
+        assert holders == ['hk_ok']
         v.state_store.close()
 
     def test_live_tip_equals_round_rows_for_same_window(self, tmp_path: Path):

--- a/tests/test_solana_w2b_builders.py
+++ b/tests/test_solana_w2b_builders.py
@@ -216,7 +216,7 @@ def test_vote_set_attestation_builds_the_round_and_the_pda(client):
         (client.keypair.pubkey(), True, True),
         (pdas.config_pda(PID), False, False),
         (miner, False, False),
-        (pdas.miner_state_pda(miner, PID), False, False),
+        (pdas.miner_state_pda(miner, PID), False, True),  # writable: under-floor bond drops the hub bit
         (pdas.reservation_pda(miner, 'tao', PID), False, False),  # F5: filled-reservation obligation floor
         (pdas.bond_attestation_pda(miner, 'tao', PID), False, True),
         (pdas.attestation_round_pda(miner, 'tao', PID), False, True),


### PR DESCRIPTION
## Problem

Miner UID 56 showed 62 gold crowns in the UI header while the scoring table showed every TAO lane as `× not eligible`, reward 0. Both views were faithful to the validator — they expose two real gaps:

1. **Ineligibility didn't remove crown candidacy.** The replay picked the crown on rate/active/collateral only; `eligible` was applied afterwards as a 0/1 multiplier on the payout. An ineligible miner (strikes, or the lane's hub mid-settlement) kept *holding* the crown, the next-best eligible miner earned nothing, and the lane's pool burned for the duration. The live crown table (UI header) named a holder the round paid 0.
2. **A TAO bond slashed under `tao_min_collateral` never deactivated the tao purse.** `apply_penalty` only auto-deactivates the SOL purse; the floor sweep only scans on a floor *raise*. So an under-floor TAO miner stayed active on-chain — unreservable by takers (`open_or_request` checks the floor) yet still a crown candidate, earning again the moment the ~15 min settlement lock lapsed.

## Fix

**Validator (`2eb3d5a`)** — `lane_eligible_hotkeys()` intersects the on-metagraph set with `direction_eligible()` per lane and feeds that candidate set to the crown replay, the live score tip and the per-forward `current_crown_holders` snapshot. The crown falls through to the best *eligible* rate; the three views agree. The forward step reads `MinerState` once and shares it with both snapshots (no extra RPC).

**Solana program (`619b681`)** — the TAO bond reaches Solana solely through `vote_set_attestation`, so the quorum write now runs a shared `drop_backing_under_floor()` rule (extracted from `apply_penalty`; SOL behavior unchanged): a **locked** `effective_balance` under the hub's activation floor clears that hub's bit (`MinerBackingChanged`, plus `MinerDeactivated` when no purse is left). Re-entry is a fresh `vote_activate` after top-up. Unlocked bonds are left to `BondNotLocked`. `miner_state` is now writable in `VoteSetAttestation`; the Python client marks it so (harmless against the pre-upgrade program). No ink!/TAO-side change needed.

## Tests
- Python: 1962 passed, ruff clean. Replaced `test_ineligible_holder_persists_factors_with_zero_reward` (asserted the old behavior) with `test_ineligible_miner_is_not_a_crown_candidate` + `test_ineligible_best_rate_falls_through_to_eligible_runner_up`.
- Program: 53 unit + 180 LiteSVM tests passed (`cargo build-sbf` + `cargo test`). Added `drop_backing_under_floor` unit tests and `test_an_under_floor_bond_on_the_only_purse_deactivates_the_miner`; updated `test_tao_backed_pool_entry_reads_the_tao_purse_not_the_local_vault` for the deactivate → re-activate path.

## Deploy notes
- The validator change ships independently. The program change requires a **program upgrade** of 6JVB; until then an under-floor TAO miner is only excluded while settling.
- Worth confirming live `Config.tao_min_collateral` on finney (code default is 0.25 τ).