### PR TITLE
feat(btc): OAuth client-credentials auth for Blockstream Explorer API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,10 +30,12 @@ SOLANA_RPC_URL=
 
 # ─── Chain: Bitcoin (BTC pairs) ────────────────────────────
 BTC_NETWORK=mainnet                 # mainnet | testnet | testnet4
-# OPTIONAL ordered esplora endpoints, URL or URL|API_KEY; unset = public (blockstream, mempool.space)
-# keyed entries send the key via the header below; "Authorization" adds a Bearer prefix
-# BTC_ESPLORA_API_KEY_HEADER=api-key
-# BTC_ESPLORA_URLS=https://host/esplora|your_key,https://mempool.space/api
+# OPTIONAL ordered esplora endpoints; unset = public (blockstream, mempool.space). Entry forms:
+#   URL                              anonymous
+#   URL|API_KEY                      static key via BTC_ESPLORA_API_KEY_HEADER ("Authorization" adds Bearer)
+#   URL|oauth:CLIENT_ID:CLIENT_SECRET Blockstream Explorer API (5-min tokens, auto-refreshed)
+# BTC_ESPLORA_API_KEY_HEADER=Authorization
+# BTC_ESPLORA_URLS=https://enterprise.blockstream.info/api|oauth:CLIENT_ID:CLIENT_SECRET,https://mempool.space/api
 # WIF — required for miners; optional local signing for `alw swap`
 BTC_PRIVATE_KEY=
 

--- a/allways/assets/btc.py
+++ b/allways/assets/btc.py
@@ -1,4 +1,5 @@
 import os
+import threading
 import time
 from typing import Any, Optional, Tuple
 from urllib.parse import urlparse
@@ -84,6 +85,7 @@ class OAuthClientCredentials:
         self.token_url = token_url
         self._token: Optional[str] = None
         self._expires_at = 0.0
+        self._lock = threading.Lock()
 
     def invalidate(self) -> None:
         self._token = None
@@ -91,7 +93,9 @@ class OAuthClientCredentials:
 
     def headers(self, http: requests.Session, timeout: int = 10) -> dict:
         """Return ``{'Authorization': 'Bearer …'}``; raises on token-endpoint failure."""
-        if not self._token or time.time() >= self._expires_at - OAUTH_REFRESH_MARGIN_S:
+        with self._lock:  # one mint per expiry, not one per racing thread
+            if self._token and time.time() < self._expires_at - OAUTH_REFRESH_MARGIN_S:
+                return {'Authorization': f'Bearer {self._token}'}
             resp = http.post(
                 self.token_url,
                 data={
@@ -107,7 +111,7 @@ class OAuthClientCredentials:
             self._token = body['access_token']
             self._expires_at = time.time() + float(body.get('expires_in', 300))
             bt.logging.debug(f'{LOG_ESPLORA} oauth token refreshed (expires_in={body.get("expires_in")})')
-        return {'Authorization': f'Bearer {self._token}'}
+            return {'Authorization': f'Bearer {self._token}'}
 
 
 EsploraAuth = Optional[dict | OAuthClientCredentials]

--- a/allways/assets/btc.py
+++ b/allways/assets/btc.py
@@ -387,12 +387,15 @@ class Bitcoin(Asset, Chain):
     def failover_reason(self, resp: requests.Response) -> Optional[str]:
         """Reason to fall through to the next provider, or None to use this response.
 
-        Retries past rate limits (429), bad/expired keys (401/403), and server
-        errors (5xx). 404 (not found) is authoritative; other 4xx are returned.
+        Retries past rate limits (429), bad/expired keys (401/403), exhausted
+        quota (402), and server errors (5xx). 404 is authoritative; other 4xx
+        are returned.
         """
         code = resp.status_code
         if code in (401, 403):
             return f'auth failed ({code})'
+        if code == 402:
+            return f'quota exhausted ({code})'
         if code == 429:
             return f'rate-limited ({code})'
         if code >= 500:

--- a/allways/assets/btc.py
+++ b/allways/assets/btc.py
@@ -68,13 +68,57 @@ def to_mainnet_address(address: str) -> str:
         return address
 
 
-def parse_esplora_urls(raw: str, auth_header: str = 'Authorization') -> list[tuple[str, Optional[dict]]]:
+# Blockstream Explorer API keys are OAuth2 client_credentials: tokens expire after 300 s and there is no
+# refresh token, so the client id/secret are re-POSTed here whenever the cached token nears expiry.
+BLOCKSTREAM_TOKEN_URL = 'https://login.blockstream.com/realms/blockstream-public/protocol/openid-connect/token'
+OAUTH_KEY_PREFIX = 'oauth:'
+OAUTH_REFRESH_MARGIN_S = 60
+
+
+class OAuthClientCredentials:
+    """Cached bearer token for one Esplora endpoint; ``headers()`` refreshes it when within the margin."""
+
+    def __init__(self, client_id: str, client_secret: str, token_url: str = BLOCKSTREAM_TOKEN_URL):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.token_url = token_url
+        self._token: Optional[str] = None
+        self._expires_at = 0.0
+
+    def invalidate(self) -> None:
+        self._token = None
+        self._expires_at = 0.0
+
+    def headers(self, http: requests.Session, timeout: int = 10) -> dict:
+        """Return ``{'Authorization': 'Bearer …'}``; raises on token-endpoint failure."""
+        if not self._token or time.time() >= self._expires_at - OAUTH_REFRESH_MARGIN_S:
+            resp = http.post(
+                self.token_url,
+                data={
+                    'client_id': self.client_id,
+                    'client_secret': self.client_secret,
+                    'grant_type': 'client_credentials',
+                    'scope': 'openid',
+                },
+                timeout=timeout,
+            )
+            resp.raise_for_status()
+            body = resp.json()
+            self._token = body['access_token']
+            self._expires_at = time.time() + float(body.get('expires_in', 300))
+            bt.logging.debug(f'{LOG_ESPLORA} oauth token refreshed (expires_in={body.get("expires_in")})')
+        return {'Authorization': f'Bearer {self._token}'}
+
+
+EsploraAuth = Optional[dict | OAuthClientCredentials]
+
+
+def parse_esplora_urls(raw: str, auth_header: str = 'Authorization') -> list[tuple[str, EsploraAuth]]:
     """Parse BTC_ESPLORA_URLS into (base_url, headers) pairs, tried in order.
 
-    Comma-separated; each entry is ``url`` or ``url|api_key``. A keyed entry
-    sends the key via ``auth_header`` to that endpoint only — others stay
-    anonymous. The default ``Authorization`` header carries a ``Bearer`` prefix;
-    any other header (e.g. Maestro's ``api-key``) sends the raw key.
+    Comma-separated; each entry is ``url``, ``url|api_key`` or ``url|oauth:CLIENT_ID:CLIENT_SECRET``.
+    A static key is sent via ``auth_header`` (``Authorization`` adds a ``Bearer`` prefix); an ``oauth:``
+    entry exchanges the credentials for a short-lived bearer token (Blockstream Explorer API).
     """
     bases = []
     for entry in raw.split(','):
@@ -85,6 +129,11 @@ def parse_esplora_urls(raw: str, auth_header: str = 'Authorization') -> list[tup
         key = key.strip()
         if not key:
             bases.append((url, None))
+        elif key.startswith(OAUTH_KEY_PREFIX):
+            client_id, _, client_secret = key[len(OAUTH_KEY_PREFIX) :].partition(':')
+            if not client_id or not client_secret:
+                raise ValueError(f'BTC_ESPLORA_URLS oauth entry for {url} must be oauth:CLIENT_ID:CLIENT_SECRET')
+            bases.append((url, OAuthClientCredentials(client_id, client_secret)))
         elif auth_header.lower() == 'authorization':
             bases.append((url, {auth_header: f'Bearer {key}'}))
         else:
@@ -316,8 +365,8 @@ class Bitcoin(Asset, Chain):
         """Get balance for a Bitcoin address in satoshis via the Esplora API."""
         return self.api_get_balance(address)
 
-    def btc_api_bases(self) -> list[tuple[str, Optional[dict]]]:
-        """Esplora (base_url, headers) pairs tried in order.
+    def btc_api_bases(self) -> list[tuple[str, EsploraAuth]]:
+        """Esplora (base_url, auth) pairs tried in order.
 
         Defaults to public blockstream → mempool. Override with BTC_ESPLORA_URLS
         (comma-separated ``url`` or ``url|api_key``) to use paid/private endpoints.
@@ -358,13 +407,19 @@ class Bitcoin(Asset, Chain):
         """
         bases = self.btc_api_bases()
         last_err: Optional[Exception] = None
-        for i, (base, headers) in enumerate(bases):
+        for i, (base, auth) in enumerate(bases):
             pos = f'[{i + 1}/{len(bases)}]'
             tag = esplora_tag(base)
             nxt = esplora_tag(bases[i + 1][0]) if i + 1 < len(bases) else None
             tail = f'falling back to: {nxt}' if nxt else 'no providers left, giving up'
+            oauth = auth if isinstance(auth, OAuthClientCredentials) else None
             try:
-                resp = self.http.request(method, f'{base}{path}', timeout=timeout, headers=headers, **kwargs)
+                resp = self._request_with_auth(method, f'{base}{path}', timeout, auth, **kwargs)
+                # A rejected bearer may just be stale: mint a fresh token and retry this rung once.
+                if oauth and resp.status_code in (401, 403):
+                    bt.logging.info(f'Esplora {pos} {tag}{path} → {resp.status_code}; refreshing oauth token')
+                    oauth.invalidate()
+                    resp = self._request_with_auth(method, f'{base}{path}', timeout, auth, **kwargs)
             except Exception as e:
                 last_err = e
                 bt.logging.warning(f'Esplora {pos} {tag}{path} → request error: {e}; {tail}')
@@ -384,6 +439,10 @@ class Bitcoin(Asset, Chain):
                 bt.logging.debug(f'Esplora {pos} {tag}{path} → {resp.status_code}')
             return resp
         raise last_err or RuntimeError('all BTC APIs failed')
+
+    def _request_with_auth(self, method: str, url: str, timeout: int, auth: EsploraAuth, **kwargs) -> requests.Response:
+        headers = auth.headers(self.http) if isinstance(auth, OAuthClientCredentials) else auth
+        return self.http.request(method, url, timeout=timeout, headers=headers, **kwargs)
 
     def btc_api_get(self, path: str, timeout: int = 15) -> requests.Response:
         return self.btc_api_request('GET', path, timeout)

--- a/tests/test_btc_esplora_oauth.py
+++ b/tests/test_btc_esplora_oauth.py
@@ -5,6 +5,9 @@ Blockstream issues OAuth2 client_credentials tokens that expire after 300 s with
 rung once on 401 before failing over. Static ``url|key`` entries are unchanged. Backend mocked — no network.
 """
 
+import threading
+import time
+
 import pytest
 
 import allways.assets.btc as btc_mod
@@ -142,3 +145,19 @@ def test_402_quota_exhausted_fails_over(monkeypatch):
     p = _provider(monkeypatch, 'https://bs/api|oauth:id:sec,https://mempool.space/api', s)
     assert p.btc_api_get('/blocks/tip/height').text == 'pub'
     assert s.token_posts == 1  # 402 is not an auth failure: no token refresh
+
+
+def test_concurrent_cold_start_mints_once():
+    class SlowSession(_Session):
+        def post(self, *a, **k):
+            time.sleep(0.05)  # widen the race window
+            return super().post(*a, **k)
+
+    s = SlowSession([_token('t1')] + [_token('dup')] * 20, [])
+    auth = OAuthClientCredentials('id', 'sec')
+    seen = []
+    ts = [threading.Thread(target=lambda: seen.append(auth.headers(s))) for _ in range(20)]
+    [t.start() for t in ts]
+    [t.join() for t in ts]
+    assert s.token_posts == 1
+    assert seen == [{'Authorization': 'Bearer t1'}] * 20

--- a/tests/test_btc_esplora_oauth.py
+++ b/tests/test_btc_esplora_oauth.py
@@ -1,0 +1,136 @@
+"""Blockstream Explorer API auth on the Esplora ladder (Maestro sunset, 2026-09-18).
+
+Blockstream issues OAuth2 client_credentials tokens that expire after 300 s with no refresh token, so a
+``url|oauth:ID:SECRET`` entry mints a bearer lazily, caches it, refreshes inside the margin, and retries the
+rung once on 401 before failing over. Static ``url|key`` entries are unchanged. Backend mocked — no network.
+"""
+
+import pytest
+
+import allways.assets.btc as btc_mod
+from allways.assets.btc import OAUTH_REFRESH_MARGIN_S, OAuthClientCredentials, parse_esplora_urls
+
+
+class _Resp:
+    def __init__(self, *, status_code=200, body=None, text=''):
+        self.status_code = status_code
+        self.ok = status_code < 400
+        self._body = body
+        self.text = text
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(str(self.status_code))
+
+    def json(self):
+        return self._body
+
+
+class _Session:
+    """Records token POSTs and API requests; scripted per-test via ``api_responses``."""
+
+    def __init__(self, token_responses, api_responses):
+        self.token_responses = list(token_responses)
+        self.api_responses = list(api_responses)
+        self.token_posts = 0
+        self.requests = []  # (url, headers)
+
+    def post(self, url, data=None, timeout=None):
+        self.token_posts += 1
+        assert data['grant_type'] == 'client_credentials'
+        return self.token_responses.pop(0)
+
+    def request(self, method, url, timeout=None, headers=None, **kwargs):
+        self.requests.append((url, headers))
+        return self.api_responses.pop(0)
+
+
+def _token(tok='tok', expires_in=300):
+    return _Resp(body={'access_token': tok, 'expires_in': expires_in})
+
+
+def _provider(monkeypatch, urls, session):
+    monkeypatch.setenv('BTC_MODE', 'lightweight')
+    monkeypatch.setenv('BTC_ESPLORA_URLS', urls)
+    from allways.assets.btc import Bitcoin
+
+    p = Bitcoin()
+    p.http = session
+    return p
+
+
+# --- parsing ---
+
+
+def test_parse_static_key_unchanged():
+    bases = parse_esplora_urls('https://a/api|k1,https://b/api', 'api-key')
+    assert bases == [('https://a/api', {'api-key': 'k1'}), ('https://b/api', None)]
+
+
+def test_parse_oauth_entry_builds_credentials():
+    [(url, auth)] = parse_esplora_urls('https://enterprise.blockstream.info/api|oauth:cid:sec:ret')
+    assert url == 'https://enterprise.blockstream.info/api'
+    assert isinstance(auth, OAuthClientCredentials)
+    assert (auth.client_id, auth.client_secret) == ('cid', 'sec:ret')  # secret may contain ':'
+
+
+def test_parse_oauth_entry_requires_both_parts():
+    with pytest.raises(ValueError):
+        parse_esplora_urls('https://x/api|oauth:only-id')
+
+
+# --- token lifecycle ---
+
+
+def test_token_minted_once_and_reused(monkeypatch):
+    s = _Session([_token('t1')], [_Resp(text='1'), _Resp(text='2')])
+    p = _provider(monkeypatch, 'https://bs/api|oauth:id:sec', s)
+    p.btc_api_get('/blocks/tip/height')
+    p.btc_api_get('/blocks/tip/height')
+    assert s.token_posts == 1
+    assert all(h == {'Authorization': 'Bearer t1'} for _, h in s.requests)
+
+
+def test_token_refreshed_inside_margin(monkeypatch):
+    now = [1_000.0]
+    monkeypatch.setattr(btc_mod.time, 'time', lambda: now[0])
+    s = _Session([_token('t1', 300), _token('t2', 300)], [_Resp(text='1'), _Resp(text='2')])
+    p = _provider(monkeypatch, 'https://bs/api|oauth:id:sec', s)
+    p.btc_api_get('/blocks/tip/height')
+    now[0] += 300 - OAUTH_REFRESH_MARGIN_S + 1  # past the refresh point, before hard expiry
+    p.btc_api_get('/blocks/tip/height')
+    assert s.token_posts == 2
+    assert s.requests[-1][1] == {'Authorization': 'Bearer t2'}
+
+
+def test_stale_token_401_refreshes_and_retries_same_rung(monkeypatch):
+    s = _Session([_token('old'), _token('new')], [_Resp(status_code=401), _Resp(text='ok')])
+    p = _provider(monkeypatch, 'https://bs/api|oauth:id:sec,https://mempool.space/api', s)
+    resp = p.btc_api_get('/blocks/tip/height')
+    assert resp.text == 'ok'
+    assert s.token_posts == 2
+    assert [u for u, _ in s.requests] == ['https://bs/api/blocks/tip/height'] * 2  # no failover needed
+
+
+def test_persistent_401_fails_over_after_one_retry(monkeypatch):
+    s = _Session([_token(), _token()], [_Resp(status_code=401), _Resp(status_code=401), _Resp(text='pub')])
+    p = _provider(monkeypatch, 'https://bs/api|oauth:id:sec,https://mempool.space/api', s)
+    resp = p.btc_api_get('/blocks/tip/height')
+    assert resp.text == 'pub'
+    assert s.requests[-1] == ('https://mempool.space/api/blocks/tip/height', None)
+
+
+def test_token_endpoint_down_fails_over_to_next_rung(monkeypatch):
+    s = _Session([_Resp(status_code=503)], [_Resp(text='pub')])
+    p = _provider(monkeypatch, 'https://bs/api|oauth:id:sec,https://mempool.space/api', s)
+    resp = p.btc_api_get('/blocks/tip/height')
+    assert resp.text == 'pub'
+    assert [u for u, _ in s.requests] == ['https://mempool.space/api/blocks/tip/height']
+
+
+def test_static_key_401_does_not_retry_rung(monkeypatch):
+    s = _Session([], [_Resp(status_code=401), _Resp(text='pub')])
+    p = _provider(monkeypatch, 'https://m/api|k,https://mempool.space/api', s)
+    assert p.btc_api_get('/blocks/tip/height').text == 'pub'
+    assert s.token_posts == 0
+    assert len(s.requests) == 2

--- a/tests/test_btc_esplora_oauth.py
+++ b/tests/test_btc_esplora_oauth.py
@@ -134,3 +134,11 @@ def test_static_key_401_does_not_retry_rung(monkeypatch):
     assert p.btc_api_get('/blocks/tip/height').text == 'pub'
     assert s.token_posts == 0
     assert len(s.requests) == 2
+
+
+def test_402_quota_exhausted_fails_over(monkeypatch):
+    # Blockstream answers 402 when credits run out or the plan lacks the network (e.g. testnet4)
+    s = _Session([_token()], [_Resp(status_code=402, text='Payment Required'), _Resp(text='pub')])
+    p = _provider(monkeypatch, 'https://bs/api|oauth:id:sec,https://mempool.space/api', s)
+    assert p.btc_api_get('/blocks/tip/height').text == 'pub'
+    assert s.token_posts == 1  # 402 is not an auth failure: no token refresh


### PR DESCRIPTION
## Why
Maestro emailed that its Bitcoin API shuts down on **2026-09-18**. It is the paid first rung in prod's `BTC_ESPLORA_URLS`. Blockstream Explorer API (native Esplora, Advanced 1M credits/\$100) replaces it; Dwellir and SN19 Blockmachine have no Bitcoin, mempool.space enterprise starts at \$1,499/mo, and every other hosted BTC vendor sells Core JSON-RPC/Blockbook, not the Esplora dialect `btc.py` speaks.

Blockstream's keyed endpoint authenticates with OAuth2 `client_credentials`: tokens expire after 300 s and there is no refresh token, so our static `url|key` → `Authorization: Bearer` scheme can't be used unmodified.

## What
- New `BTC_ESPLORA_URLS` entry form `url|oauth:CLIENT_ID:CLIENT_SECRET` → `OAuthClientCredentials`, which mints a bearer lazily, caches it, and refreshes 60 s before expiry.
- `btc_api_request`: an OAuth rung that returns 401/403 invalidates the token and retries **that rung once** before the existing failover; a token-endpoint failure is treated like any request error (fails over to the next rung).
- Static `url|key` entries, `BTC_ESPLORA_API_KEY_HEADER`, and the public blockstream → mempool defaults are unchanged. No response parsing / verify-path code touched.
- `.env.example` documents the three entry forms.

## Tests
`tests/test_btc_esplora_oauth.py` (9): parsing (static unchanged, oauth, secret containing `:`, malformed), token minted once and reused, refresh inside the margin, stale-token 401 → refresh + same-rung retry, persistent 401 → one retry then failover, token endpoint 503 → failover, static-key 401 does not retry. Full BTC suite: 111 passed. Live probe of Blockstream's token endpoint with bogus creds returns `invalid_client` (request shape accepted).

## Rollout
1. Blockstream dashboard → Manage Keys → one key per environment.
2. lena: `BTC_ESPLORA_URLS=https://enterprise.blockstream.info/api|oauth:ID:SECRET,https://mempool.space/api,https://blockstream.info/api`; restart; watch `[Esplora]` logs.
3. isaiah (testnet4): Blockstream documents only mainnet + testnet3 — keep public mempool testnet4 unless the dashboard offers testnet4.
4. Remove the Maestro entry before 9/18 either way.