### PR TITLE
Crank routed pools off the program's pushed events

### DIFF
--- a/allways/solana/program_feed.py
+++ b/allways/solana/program_feed.py
@@ -1,0 +1,124 @@
+"""Pushed program events over a Solana WebSocket (`logsSubscribe`).
+
+One daemon thread holds a `logsSubscribe(mentions=[program])` session on the RPC's wss twin (a keyed Helius
+HTTP URL derives its keyed wss endpoint), decodes every `Program data:` line through the canonical event
+decoder, and hands (name, event) to the handlers registered per event name. A dropped socket reconnects
+with jittered backoff; a handler exception is logged, never fatal. Consumers that need "did I miss
+something while the socket was down" keep their own poll as the backstop — the feed is latency, not truth.
+"""
+
+import asyncio
+import base64
+import json
+import random
+import threading
+from collections import defaultdict
+from typing import Any, Callable, Dict, List, Optional
+
+import bittensor as bt
+
+from allways.solana.events import PROGRAM_DATA_PREFIX, decode_event
+
+Handler = Callable[[str, Any], None]
+
+RECONNECT_MIN_SECS = 1.0
+RECONNECT_MAX_SECS = 30.0
+
+
+def _mask(url: str) -> str:
+    head, sep, _ = url.partition('api-key=')
+    return f'{head}{sep}…' if sep else url
+
+
+def events_from_logs(logs: List[str]) -> List[tuple]:
+    """Decode the program's `Program data:` lines of one tx into [(name, event)], skipping foreign/unknown."""
+    out = []
+    for line in logs or []:
+        if not line.startswith(PROGRAM_DATA_PREFIX):
+            continue
+        try:
+            decoded = decode_event(base64.b64decode(line[len(PROGRAM_DATA_PREFIX) :]))
+        except Exception:
+            continue
+        if decoded is not None:
+            out.append(decoded)
+    return out
+
+
+class ProgramEventFeed:
+    """`logsSubscribe` on one program, dispatched to per-event handlers on the feed thread (keep them short —
+    hand real work to a timer/executor). `connected` tells a consumer whether to trust the push path or
+    fall back to polling."""
+
+    def __init__(self, ws_url: str, program_id) -> None:
+        self.ws_url = ws_url
+        self.program_id = str(program_id)
+        self._handlers: Dict[str, List[Handler]] = defaultdict(list)
+        self._connected = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    @property
+    def connected(self) -> bool:
+        return self._connected.is_set()
+
+    def on(self, event_name: str, handler: Handler) -> None:
+        self._handlers[event_name].append(handler)
+
+    def start(self) -> 'ProgramEventFeed':
+        if self._thread is None:
+            self._thread = threading.Thread(target=self._run, name='program-feed', daemon=True)
+            self._thread.start()
+        return self
+
+    # ── dispatch ────────────────────────────────────────────────────────────
+
+    def handle_notification(self, msg: dict) -> int:
+        """Dispatch one logsNotification frame; a failed tx commits no events. Returns events dispatched."""
+        value = (((msg or {}).get('params') or {}).get('result') or {}).get('value') or {}
+        if value.get('err') is not None:
+            return 0
+        n = 0
+        for name, event in events_from_logs(value.get('logs')):
+            for handler in self._handlers.get(name, ()):
+                try:
+                    handler(name, event)
+                except Exception as e:
+                    bt.logging.warning(f'program feed: {name} handler failed: {e}')
+            n += 1
+        return n
+
+    # ── transport ───────────────────────────────────────────────────────────
+
+    async def _session(self) -> None:
+        import websockets
+
+        sub = {
+            'jsonrpc': '2.0',
+            'id': 1,
+            'method': 'logsSubscribe',
+            'params': [{'mentions': [self.program_id]}, {'commitment': 'confirmed'}],
+        }
+        async with websockets.connect(self.ws_url, ping_interval=20, ping_timeout=20, max_size=None) as ws:
+            await ws.send(json.dumps(sub))
+            self._connected.set()
+            bt.logging.info(f'program feed: logsSubscribe({self.program_id}) @ {_mask(self.ws_url)}')
+            async for raw in ws:
+                try:
+                    msg = json.loads(raw)
+                except (ValueError, TypeError):
+                    continue
+                if msg.get('method') == 'logsNotification':
+                    self.handle_notification(msg)
+
+    def _run(self) -> None:
+        backoff = RECONNECT_MIN_SECS
+        while True:
+            try:
+                asyncio.run(self._session())
+                backoff = RECONNECT_MIN_SECS
+            except Exception as e:
+                bt.logging.warning(f'program feed: socket down ({e}); reconnecting in ~{backoff:.0f}s')
+            finally:
+                self._connected.clear()
+            threading.Event().wait(backoff * random.uniform(0.8, 1.2))
+            backoff = min(backoff * 2, RECONNECT_MAX_SECS)

--- a/allways/solana/rpc.py
+++ b/allways/solana/rpc.py
@@ -27,6 +27,20 @@ def resolve_rpc_url(explicit: Optional[str] = None) -> str:
     return url
 
 
+def resolve_ws_url(rpc_url: str, explicit: Optional[str] = None) -> str:
+    """The WebSocket twin of an RPC endpoint: ``explicit`` (or ``SOLANA_WS_URL``) if set, else the RPC URL
+    with its scheme swapped (https→wss, http→ws). Host + query survive, so a keyed Helius HTTP URL derives
+    its matching keyed wss endpoint — the same rule the dashboard indexer uses."""
+    override = explicit or os.environ.get('SOLANA_WS_URL')
+    if override:
+        return override
+    if rpc_url.startswith('https://'):
+        return 'wss://' + rpc_url[len('https://') :]
+    if rpc_url.startswith('http://'):
+        return 'ws://' + rpc_url[len('http://') :]
+    return rpc_url
+
+
 # A Solana cluster is identified by its immutable genesis hash, not its RPC URL: a real paid
 # mainnet endpoint (Helius/QuickNode subdomain, bare IP, ?api-key= URL) rarely contains the
 # literal string "mainnet", so a substring check misses exactly the dangerous case. These three

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -46,8 +46,7 @@ async def forward(self: Validator) -> None:
     # Solana `timeout_at`/`created_at` are unix seconds, not substrate blocks.
     # run_once casts on-chain votes (network I/O), so run it off the event loop.
     now = int(time.time())
-    # Permissionless crank: turn closed reservation pools into winner Reservations, then sweep any
-    # routed seat we won — the same crank reserve_on_behalf schedules at each pool's close.
+    # Backstop for the crank reserve_on_behalf schedules at each pool close.
     resolved, finalized = await asyncio.to_thread(crank, self, now)
     if resolved:
         bt.logging.info(f'forward step #{self.step}: resolved {len(resolved)} reservation pool(s)')

--- a/allways/validator/forward.py
+++ b/allways/validator/forward.py
@@ -14,7 +14,7 @@ from allways.validator.binding import build_attribution
 from allways.validator.floor_sweep import maybe_sweep_floor
 from allways.validator.relay.engine import maybe_relay
 from allways.validator.relay.wiring import ensure_bond_relay
-from allways.validator.reserve_engine import finalize_won_seats
+from allways.validator.reserve_engine import crank
 from allways.validator.scoring import (
     due_for_scoring,
     live_miner_states,
@@ -46,13 +46,11 @@ async def forward(self: Validator) -> None:
     # Solana `timeout_at`/`created_at` are unix seconds, not substrate blocks.
     # run_once casts on-chain votes (network I/O), so run it off the event loop.
     now = int(time.time())
-    # Permissionless crank: turn closed reservation pools into winner Reservations before processing swaps.
-    resolved = await asyncio.to_thread(self.solana_swap_loop.resolve_pools_once, now)
+    # Permissionless crank: turn closed reservation pools into winner Reservations, then sweep any
+    # routed seat we won — the same crank reserve_on_behalf schedules at each pool's close.
+    resolved, finalized = await asyncio.to_thread(crank, self, now)
     if resolved:
         bt.logging.info(f'forward step #{self.step}: resolved {len(resolved)} reservation pool(s)')
-    # Routed-reservation sweep right after the crank: won seats are freshest here, spending
-    # the least of the finalize window on queued on-behalf users.
-    finalized = await asyncio.to_thread(finalize_won_seats, self, now)
     if finalized:
         bt.logging.info(f'forward step #{self.step}: finalized {len(finalized)} routed seat(s)')
     decisions = await asyncio.to_thread(self.solana_swap_loop.run_once, now)

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -5,6 +5,7 @@ One source of truth for reserve / confirm / rate / status, shared by the axon sy
 invariants before it signs — the caller (offering or CLI) is never trusted.
 """
 
+import threading
 import time
 from dataclasses import dataclass, field
 from typing import Optional
@@ -232,7 +233,41 @@ def reserve_on_behalf(
     )
     pool = client.get_pool(miner_pk, backing)
     closes_at = int(getattr(pool, 'closes_at', 0) or 0) if pool else 0
+    if closes_at:
+        schedule_crank(validator, closes_at)
     return ReserveResult(True, '', closes_at, sig)
+
+
+# The forward step cranks on its poll cadence (~12s): a pool that closes just after a step waits most
+# of a step to resolve, then another to finalize. The router knows closes_at the moment it enters the
+# pool, so it fires the same crank right when the window ends. One lock serializes it with the step.
+CRANK_SKEW_SECS = 1
+
+
+def crank(validator, now: int) -> tuple:
+    """Resolve closed pools, then finalize any seat this validator won — under the crank lock."""
+    with validator.crank_lock:
+        resolved = validator.solana_swap_loop.resolve_pools_once(now)
+        finalized = finalize_won_seats(validator, now)
+    return resolved, finalized
+
+
+def schedule_crank(validator, closes_at: int) -> threading.Timer:
+    """Fire ``crank`` once, just after ``closes_at``. A failure here is harmless: the next forward
+    step runs the same crank."""
+    delay = max(0.0, closes_at - time.time()) + CRANK_SKEW_SECS
+
+    def fire():
+        try:
+            resolved, finalized = crank(validator, int(time.time()))
+            bt.logging.info(f'scheduled crank: resolved {len(resolved)} pool(s), finalized {len(finalized)} seat(s)')
+        except Exception as e:
+            bt.logging.warning(f'scheduled crank failed (forward step will retry): {e}')
+
+    timer = threading.Timer(delay, fire)
+    timer.daemon = True
+    timer.start()
+    return timer
 
 
 # Staleness backstop for queued routed requests: pool window + finalize window + generous slack.

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -238,7 +238,9 @@ def reserve_on_behalf(
     return ReserveResult(True, '', closes_at, sig)
 
 
-CRANK_SKEW_SECS = 1
+CRANK_SKEW_SECS = 2
+CRANK_RETRY_SECS = 3
+CRANK_RETRIES = 4
 
 
 def crank(validator, now: int) -> tuple:
@@ -248,19 +250,27 @@ def crank(validator, now: int) -> tuple:
 
 
 def schedule_crank(validator, closes_at: int) -> threading.Timer:
-    """Fire crank once right after the pool closes; the forward step remains the backstop."""
+    """Crank right after the pool closes, retrying briefly until a seat finalizes; the forward step backstops."""
 
-    def fire():
+    def fire(attempt: int = 0):
+        finalized = []
         try:
             resolved, finalized = crank(validator, int(time.time()))
-            bt.logging.info(f'scheduled crank: {len(resolved)} pool(s) resolved, {len(finalized)} seat(s) finalized')
+            bt.logging.info(
+                f'scheduled crank #{attempt}: {len(resolved)} pool(s) resolved, {len(finalized)} seat(s) finalized'
+            )
         except Exception as e:
-            bt.logging.warning(f'scheduled crank failed, forward step retries: {e}')
+            bt.logging.warning(f'scheduled crank #{attempt} failed: {e}')
+        if not finalized and attempt < CRANK_RETRIES:
+            start(CRANK_RETRY_SECS, attempt + 1)
 
-    timer = threading.Timer(max(0.0, closes_at - time.time()) + CRANK_SKEW_SECS, fire)
-    timer.daemon = True
-    timer.start()
-    return timer
+    def start(delay: float, attempt: int) -> threading.Timer:
+        timer = threading.Timer(delay, fire, [attempt])
+        timer.daemon = True
+        timer.start()
+        return timer
+
+    return start(max(0.0, closes_at - time.time()) + CRANK_SKEW_SECS, 0)
 
 
 # Staleness backstop for queued routed requests: pool window + finalize window + generous slack.

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -234,13 +234,19 @@ def reserve_on_behalf(
     pool = client.get_pool(miner_pk, backing)
     closes_at = int(getattr(pool, 'closes_at', 0) or 0) if pool else 0
     if closes_at:
-        schedule_crank(validator, closes_at)
+        schedule_crank(validator, closes_at, miner_pk)
     return ReserveResult(True, '', closes_at, sig)
 
 
-CRANK_SKEW_SECS = 2
+CRANK_SKEW_SECS = 2  # the chain clock can trail wall time; fire a touch after the window shuts
 CRANK_RETRY_SECS = 3
 CRANK_RETRIES = 4
+SLOT_SECS = 0.4  # nominal slot time; the draw waits for the armed seed slot to be produced
+DRAW_SKEW_SECS = 0.5
+DRAW_RETRY_SECS = 1
+# Staleness backstop for queued routed requests: pool window + finalize window + generous slack.
+# A queue whose reservation never materializes (miner never drawn, RPC blind spot) dies here.
+ROUTED_REQUEST_TTL_SECS = 900
 
 
 def crank(validator, now: int) -> tuple:
@@ -249,33 +255,127 @@ def crank(validator, now: int) -> tuple:
         return validator.solana_swap_loop.resolve_pools_once(now), finalize_won_seats(validator, now)
 
 
-def schedule_crank(validator, closes_at: int) -> threading.Timer:
-    """Crank right after the pool closes, retrying briefly until a seat finalizes; the forward step backstops."""
+def _timer(delay: float, fn, *args) -> threading.Timer:
+    timer = threading.Timer(max(0.0, delay), fn, args)
+    timer.daemon = True
+    timer.start()
+    return timer
 
-    def fire(attempt: int = 0):
-        finalized = []
+
+# Per crank stage: the tracked pool state it keeps retrying in, and its (interval, max retries).
+_STAGE_WAITS_ON = {'arm': 'arm', 'draw': 'armed', 'finalize': 'resolved'}
+_STAGE_RETRY = {
+    'arm': (CRANK_RETRY_SECS, CRANK_RETRIES),
+    'draw': (DRAW_RETRY_SECS, CRANK_RETRIES * 3),
+    'finalize': (CRANK_RETRY_SECS, CRANK_RETRIES),
+}
+
+
+class CrankScheduler:
+    """Drives each routed pool from close to settled seat off the program's pushed events: close → arm the
+    draw; `PoolDrawArmed` → draw the moment its seed slot is produced; `PoolResolved` → finalize at once
+    (whoever resolved it). Only pools we reserved on are tracked. Without a connected feed every stage
+    degrades to a brief polling retry; the forward step's crank remains the backstop either way."""
+
+    def __init__(self, validator, feed=None) -> None:
+        self.validator = validator
+        self.feed = feed
+        self._lock = threading.Lock()
+        self._pools: dict = {}  # miner → {'stage': arm|armed|resolved, 'deadline': unix}
+        if feed is not None:
+            feed.on('PoolDrawArmed', self._on_armed)
+            feed.on('PoolResolved', self._on_resolved)
+
+    @property
+    def live(self) -> bool:
+        return self.feed is not None and self.feed.connected
+
+    def schedule(self, miner, closes_at: int) -> threading.Timer:
+        miner = str(miner)
+        with self._lock:
+            self._pools[miner] = {'stage': 'arm', 'deadline': int(time.time()) + ROUTED_REQUEST_TTL_SECS}
+        return _timer(closes_at - time.time() + CRANK_SKEW_SECS, self._fire, miner, 'arm', 0)
+
+    # ── feed handlers (feed thread: record + hand off, no RPC here) ───────────
+
+    def _advance(self, miner: str, stage: str) -> bool:
+        """Move a tracked pool to `stage`; False (ignored) for pools we never reserved on or that expired."""
+        with self._lock:
+            entry = self._pools.get(miner)
+            if entry is None:
+                return False
+            if entry['deadline'] < time.time():
+                del self._pools[miner]
+                return False
+            entry['stage'] = stage
+            return True
+
+    def _on_armed(self, _name: str, ev) -> None:
+        miner = str(ev.miner)
+        if self._advance(miner, 'armed'):
+            _timer(0, self._schedule_draw, miner, int(ev.seed_slot))
+
+    def _on_resolved(self, _name: str, ev) -> None:
+        miner = str(ev.miner)
+        if self._advance(miner, 'resolved'):
+            _timer(0, self._fire, miner, 'finalize', 0)
+
+    def _schedule_draw(self, miner: str, seed_slot: int) -> None:
         try:
-            resolved, finalized = crank(validator, int(time.time()))
+            behind = seed_slot - self.validator.solana_client.rpc.get_slot()
+        except Exception as e:
+            bt.logging.warning(f'pool {miner}: slot read failed ({e}); drawing on retry cadence')
+            behind = 0
+        _timer(behind * SLOT_SECS + DRAW_SKEW_SECS, self._fire, miner, 'draw', 0)
+
+    # ── the crank itself (timer threads) ──────────────────────────────────────
+
+    def _stage(self, miner: str) -> Optional[str]:
+        with self._lock:
+            entry = self._pools.get(miner)
+            return entry['stage'] if entry else None
+
+    def _settled(self, miner: str) -> bool:
+        """The seat is done with: finalized, or the queue was dropped (lost / lapsed), so nothing is pending."""
+        try:
+            return all(m != miner for m, _, _, _ in self.validator.state_store.distinct_routed_pools())
+        except Exception:
+            return False
+
+    def _handed_off(self, miner: str, stage: str) -> bool:
+        """Live feed: the chain's event already moved this pool past `stage`, so its next stage owns it."""
+        return self.live and self._stage(miner) != _STAGE_WAITS_ON[stage]
+
+    def _fire(self, miner: str, stage: str, attempt: int) -> None:
+        if attempt and self._handed_off(miner, stage):
+            return  # a retry queued before the event landed — nothing left for this stage to do
+        finalized: list = []
+        try:
+            resolved, finalized = crank(self.validator, int(time.time()))
             bt.logging.info(
-                f'scheduled crank #{attempt}: {len(resolved)} pool(s) resolved, {len(finalized)} seat(s) finalized'
+                f'crank[{stage}#{attempt}] {miner[:8]}: {len(resolved)} pool(s) resolved, '
+                f'{len(finalized)} seat(s) finalized'
             )
         except Exception as e:
-            bt.logging.warning(f'scheduled crank #{attempt} failed: {e}')
-        if not finalized and attempt < CRANK_RETRIES:
-            start(CRANK_RETRY_SECS, attempt + 1)
+            bt.logging.warning(f'crank[{stage}#{attempt}] {miner[:8]} failed: {e}')
+        if miner in finalized or self._settled(miner):
+            with self._lock:
+                self._pools.pop(miner, None)
+            return
+        # Polling fallback (no feed): retry on cadence until the seat settles.
+        if self._handed_off(miner, stage):
+            return
+        retry, cap = _STAGE_RETRY[stage]
+        if attempt < cap:
+            _timer(retry, self._fire, miner, stage, attempt + 1)
 
-    def start(delay: float, attempt: int) -> threading.Timer:
-        timer = threading.Timer(delay, fire, [attempt])
-        timer.daemon = True
-        timer.start()
-        return timer
 
-    return start(max(0.0, closes_at - time.time()) + CRANK_SKEW_SECS, 0)
-
-
-# Staleness backstop for queued routed requests: pool window + finalize window + generous slack.
-# A queue whose reservation never materializes (miner never drawn, RPC blind spot) dies here.
-ROUTED_REQUEST_TTL_SECS = 900
+def schedule_crank(validator, closes_at: int, miner=None) -> threading.Timer:
+    """Crank this pool from its close to a settled seat (see CrankScheduler); the forward step backstops."""
+    scheduler = getattr(validator, 'crank_scheduler', None)
+    if scheduler is None:
+        scheduler = validator.crank_scheduler = CrankScheduler(validator)
+    return scheduler.schedule(miner, closes_at)
 
 
 def draw_pool_winner(requests: list) -> dict:

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -239,11 +239,9 @@ def reserve_on_behalf(
 
 
 CRANK_SKEW_SECS = 2  # the chain clock can trail wall time; fire a touch after the window shuts
-CRANK_RETRY_SECS = 3
-CRANK_RETRIES = 4
 SLOT_SECS = 0.4  # nominal slot time; the draw waits for the armed seed slot to be produced
 DRAW_SKEW_SECS = 0.5
-DRAW_RETRY_SECS = 1
+DRAW_RETRY_SECS = 1  # one extra crank if the seed slot hadn't been produced by the nominal time
 # Staleness backstop for queued routed requests: pool window + finalize window + generous slack.
 # A queue whose reservation never materializes (miner never drawn, RPC blind spot) dies here.
 ROUTED_REQUEST_TTL_SECS = 900
@@ -262,120 +260,63 @@ def _timer(delay: float, fn, *args) -> threading.Timer:
     return timer
 
 
-# Per crank stage: the tracked pool state it keeps retrying in, and its (interval, max retries).
-_STAGE_WAITS_ON = {'arm': 'arm', 'draw': 'armed', 'finalize': 'resolved'}
-_STAGE_RETRY = {
-    'arm': (CRANK_RETRY_SECS, CRANK_RETRIES),
-    'draw': (DRAW_RETRY_SECS, CRANK_RETRIES * 3),
-    'finalize': (CRANK_RETRY_SECS, CRANK_RETRIES),
-}
-
-
 class CrankScheduler:
-    """Drives each routed pool from close to settled seat off the program's pushed events: close → arm the
-    draw; `PoolDrawArmed` → draw the moment its seed slot is produced; `PoolResolved` → finalize at once
-    (whoever resolved it). Only pools we reserved on are tracked. Without a connected feed every stage
-    degrades to a brief polling retry; the forward step's crank remains the backstop either way."""
+    """Cranks each routed pool we reserved on exactly when its next stage is due, off the program's pushed
+    events: close → arm the draw; `PoolDrawArmed` → draw once its seed slot is produced; `PoolResolved` →
+    finalize at once, whoever resolved it. Missed events (socket down) are covered by the forward step's
+    crank, which runs the same `crank()` every step."""
 
-    def __init__(self, validator, feed=None) -> None:
+    def __init__(self, validator, feed) -> None:
         self.validator = validator
-        self.feed = feed
         self._lock = threading.Lock()
-        self._pools: dict = {}  # miner → {'stage': arm|armed|resolved, 'deadline': unix}
-        if feed is not None:
-            feed.on('PoolDrawArmed', self._on_armed)
-            feed.on('PoolResolved', self._on_resolved)
-
-    @property
-    def live(self) -> bool:
-        return self.feed is not None and self.feed.connected
+        self._pools: dict = {}  # miner → tracking deadline (unix)
+        feed.on('PoolDrawArmed', self._on_armed)
+        feed.on('PoolResolved', self._on_resolved)
 
     def schedule(self, miner, closes_at: int) -> threading.Timer:
-        miner = str(miner)
         with self._lock:
-            self._pools[miner] = {'stage': 'arm', 'deadline': int(time.time()) + ROUTED_REQUEST_TTL_SECS}
-        return _timer(closes_at - time.time() + CRANK_SKEW_SECS, self._fire, miner, 'arm', 0)
+            self._pools[str(miner)] = int(time.time()) + ROUTED_REQUEST_TTL_SECS
+        return _timer(closes_at - time.time() + CRANK_SKEW_SECS, self._crank, 'arm')
 
-    # ── feed handlers (feed thread: record + hand off, no RPC here) ───────────
-
-    def _advance(self, miner: str, stage: str) -> bool:
-        """Move a tracked pool to `stage`; False (ignored) for pools we never reserved on or that expired."""
+    def _tracked(self, miner) -> bool:
         with self._lock:
-            entry = self._pools.get(miner)
-            if entry is None:
+            deadline = self._pools.get(str(miner))
+            if deadline is not None and deadline < time.time():
+                del self._pools[str(miner)]
                 return False
-            if entry['deadline'] < time.time():
-                del self._pools[miner]
-                return False
-            entry['stage'] = stage
-            return True
+            return deadline is not None
 
+    # Feed handlers run on the feed thread: record, then hand the RPC work to a timer thread.
     def _on_armed(self, _name: str, ev) -> None:
-        miner = str(ev.miner)
-        if self._advance(miner, 'armed'):
-            _timer(0, self._schedule_draw, miner, int(ev.seed_slot))
+        if self._tracked(ev.miner):
+            _timer(0, self._schedule_draw, int(ev.seed_slot))
 
     def _on_resolved(self, _name: str, ev) -> None:
-        miner = str(ev.miner)
-        if self._advance(miner, 'resolved'):
-            _timer(0, self._fire, miner, 'finalize', 0)
+        if self._tracked(ev.miner):
+            with self._lock:
+                self._pools.pop(str(ev.miner), None)
+            _timer(0, self._crank, 'finalize')
 
-    def _schedule_draw(self, miner: str, seed_slot: int) -> None:
+    def _schedule_draw(self, seed_slot: int) -> None:
         try:
             behind = seed_slot - self.validator.solana_client.rpc.get_slot()
         except Exception as e:
-            bt.logging.warning(f'pool {miner}: slot read failed ({e}); drawing on retry cadence')
+            bt.logging.warning(f'crank: slot read failed ({e}); drawing now')
             behind = 0
-        _timer(behind * SLOT_SECS + DRAW_SKEW_SECS, self._fire, miner, 'draw', 0)
+        _timer(behind * SLOT_SECS + DRAW_SKEW_SECS, self._crank, 'draw')
+        _timer(behind * SLOT_SECS + DRAW_SKEW_SECS + DRAW_RETRY_SECS, self._crank, 'draw-retry')
 
-    # ── the crank itself (timer threads) ──────────────────────────────────────
-
-    def _stage(self, miner: str) -> Optional[str]:
-        with self._lock:
-            entry = self._pools.get(miner)
-            return entry['stage'] if entry else None
-
-    def _settled(self, miner: str) -> bool:
-        """The seat is done with: finalized, or the queue was dropped (lost / lapsed), so nothing is pending."""
-        try:
-            return all(m != miner for m, _, _, _ in self.validator.state_store.distinct_routed_pools())
-        except Exception:
-            return False
-
-    def _handed_off(self, miner: str, stage: str) -> bool:
-        """Live feed: the chain's event already moved this pool past `stage`, so its next stage owns it."""
-        return self.live and self._stage(miner) != _STAGE_WAITS_ON[stage]
-
-    def _fire(self, miner: str, stage: str, attempt: int) -> None:
-        if attempt and self._handed_off(miner, stage):
-            return  # a retry queued before the event landed — nothing left for this stage to do
-        finalized: list = []
+    def _crank(self, stage: str) -> None:
         try:
             resolved, finalized = crank(self.validator, int(time.time()))
-            bt.logging.info(
-                f'crank[{stage}#{attempt}] {miner[:8]}: {len(resolved)} pool(s) resolved, '
-                f'{len(finalized)} seat(s) finalized'
-            )
+            bt.logging.info(f'crank[{stage}]: {len(resolved)} pool(s) resolved, {len(finalized)} seat(s) finalized')
         except Exception as e:
-            bt.logging.warning(f'crank[{stage}#{attempt}] {miner[:8]} failed: {e}')
-        if miner in finalized or self._settled(miner):
-            with self._lock:
-                self._pools.pop(miner, None)
-            return
-        # Polling fallback (no feed): retry on cadence until the seat settles.
-        if self._handed_off(miner, stage):
-            return
-        retry, cap = _STAGE_RETRY[stage]
-        if attempt < cap:
-            _timer(retry, self._fire, miner, stage, attempt + 1)
+            bt.logging.warning(f'crank[{stage}] failed: {e}')
 
 
-def schedule_crank(validator, closes_at: int, miner=None) -> threading.Timer:
-    """Crank this pool from its close to a settled seat (see CrankScheduler); the forward step backstops."""
-    scheduler = getattr(validator, 'crank_scheduler', None)
-    if scheduler is None:
-        scheduler = validator.crank_scheduler = CrankScheduler(validator)
-    return scheduler.schedule(miner, closes_at)
+def schedule_crank(validator, closes_at: int, miner) -> threading.Timer:
+    """Crank this pool at each stage as the chain reaches it (see CrankScheduler)."""
+    return validator.crank_scheduler.schedule(miner, closes_at)
 
 
 def draw_pool_winner(requests: list) -> dict:

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -238,33 +238,26 @@ def reserve_on_behalf(
     return ReserveResult(True, '', closes_at, sig)
 
 
-# The forward step cranks on its poll cadence (~12s): a pool that closes just after a step waits most
-# of a step to resolve, then another to finalize. The router knows closes_at the moment it enters the
-# pool, so it fires the same crank right when the window ends. One lock serializes it with the step.
 CRANK_SKEW_SECS = 1
 
 
 def crank(validator, now: int) -> tuple:
-    """Resolve closed pools, then finalize any seat this validator won — under the crank lock."""
+    """Resolve closed pools, then finalize seats we won. Serialized with the forward step."""
     with validator.crank_lock:
-        resolved = validator.solana_swap_loop.resolve_pools_once(now)
-        finalized = finalize_won_seats(validator, now)
-    return resolved, finalized
+        return validator.solana_swap_loop.resolve_pools_once(now), finalize_won_seats(validator, now)
 
 
 def schedule_crank(validator, closes_at: int) -> threading.Timer:
-    """Fire ``crank`` once, just after ``closes_at``. A failure here is harmless: the next forward
-    step runs the same crank."""
-    delay = max(0.0, closes_at - time.time()) + CRANK_SKEW_SECS
+    """Fire crank once right after the pool closes; the forward step remains the backstop."""
 
     def fire():
         try:
             resolved, finalized = crank(validator, int(time.time()))
-            bt.logging.info(f'scheduled crank: resolved {len(resolved)} pool(s), finalized {len(finalized)} seat(s)')
+            bt.logging.info(f'scheduled crank: {len(resolved)} pool(s) resolved, {len(finalized)} seat(s) finalized')
         except Exception as e:
-            bt.logging.warning(f'scheduled crank failed (forward step will retry): {e}')
+            bt.logging.warning(f'scheduled crank failed, forward step retries: {e}')
 
-    timer = threading.Timer(delay, fire)
+    timer = threading.Timer(max(0.0, closes_at - time.time()) + CRANK_SKEW_SECS, fire)
     timer.daemon = True
     timer.start()
     return timer

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -36,7 +36,8 @@ from allways.constants import (  # noqa: E402
 from allways.solana import keys  # noqa: E402
 from allways.solana.client import AllwaysSolanaClient  # noqa: E402
 from allways.solana.events import SolanaEventIngest  # noqa: E402
-from allways.solana.rpc import assert_cluster_safe, resolve_rpc_url  # noqa: E402
+from allways.solana.program_feed import ProgramEventFeed  # noqa: E402
+from allways.solana.rpc import assert_cluster_safe, resolve_rpc_url, resolve_ws_url  # noqa: E402
 from allways.validator.axon_handlers import (  # noqa: E402
     blacklist_miner_activate,
     blacklist_swap_confirm,
@@ -54,6 +55,7 @@ from allways.validator.event_index import SolanaEventIndex  # noqa: E402
 from allways.validator.floor_sweep import CollateralFloorSweep  # noqa: E402
 from allways.validator.forward import forward  # noqa: E402
 from allways.validator.relay.wiring import build_bond_relay  # noqa: E402
+from allways.validator.reserve_engine import CrankScheduler  # noqa: E402
 from allways.validator.seam_http import maybe_start_seam  # noqa: E402
 from allways.validator.solana_swap_loop import SolanaSwapLoop  # noqa: E402
 from allways.validator.state_store import ValidatorStateStore  # noqa: E402
@@ -189,6 +191,11 @@ class Validator(BaseValidatorNeuron):
         # handler, and running it unlocked would race the locked reads' recv (#456).
         self.axon_lock = threading.RLock()
         self.crank_lock = threading.Lock()  # forward step vs scheduled crank
+        # Routed pools are cranked off the program's pushed events (PoolDrawArmed/PoolResolved over the
+        # RPC's wss twin) the moment each stage lands; the forward step's crank stays the backstop.
+        self.program_feed = ProgramEventFeed(resolve_ws_url(solana_rpc_url), self.solana_client.program_id)
+        self.crank_scheduler = CrankScheduler(self, self.program_feed)
+        self.program_feed.start()
         self.axon_subtensor = bt.Subtensor(config=self.config)
         axon_assets = create_assets(subtensor=bt.Subtensor(config=self.config), solana_rpc_url=solana_rpc_url)
         self.axon_assets = {chain: provider for chain, provider in axon_assets.items() if chain in self.assets}

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -188,6 +188,8 @@ class Validator(BaseValidatorNeuron):
         # blocks for seconds, so holding axon_lock across it would stall every other
         # handler, and running it unlocked would race the locked reads' recv (#456).
         self.axon_lock = threading.RLock()
+        # Serializes the pool crank between the forward step and reserve_on_behalf's scheduled fire.
+        self.crank_lock = threading.Lock()
         self.axon_subtensor = bt.Subtensor(config=self.config)
         axon_assets = create_assets(subtensor=bt.Subtensor(config=self.config), solana_rpc_url=solana_rpc_url)
         self.axon_assets = {chain: provider for chain, provider in axon_assets.items() if chain in self.assets}

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -188,8 +188,7 @@ class Validator(BaseValidatorNeuron):
         # blocks for seconds, so holding axon_lock across it would stall every other
         # handler, and running it unlocked would race the locked reads' recv (#456).
         self.axon_lock = threading.RLock()
-        # Serializes the pool crank between the forward step and reserve_on_behalf's scheduled fire.
-        self.crank_lock = threading.Lock()
+        self.crank_lock = threading.Lock()  # forward step vs scheduled crank
         self.axon_subtensor = bt.Subtensor(config=self.config)
         axon_assets = create_assets(subtensor=bt.Subtensor(config=self.config), solana_rpc_url=solana_rpc_url)
         self.axon_assets = {chain: provider for chain, provider in axon_assets.items() if chain in self.assets}

--- a/tests/test_program_feed.py
+++ b/tests/test_program_feed.py
@@ -1,0 +1,59 @@
+import base64
+import os
+
+from solders.pubkey import Pubkey
+
+from allways.solana.layouts import EVENT_DISCRIMINATORS, EVENT_LAYOUTS
+from allways.solana.program_feed import ProgramEventFeed, events_from_logs
+from allways.solana.rpc import resolve_ws_url
+
+MINER = Pubkey.from_bytes(b'\x01' * 32)
+WINNER = Pubkey.from_bytes(b'\x02' * 32)
+
+
+def _program_data(name: str, **fields) -> str:
+    raw = EVENT_DISCRIMINATORS[name] + EVENT_LAYOUTS[name].build(fields)
+    return 'Program data: ' + base64.b64encode(raw).decode()
+
+
+def _frame(logs, err=None) -> dict:
+    return {
+        'method': 'logsNotification',
+        'params': {'result': {'value': {'signature': 'sig', 'err': err, 'logs': logs}}},
+    }
+
+
+def test_events_from_logs_decodes_program_events_and_skips_the_rest():
+    logs = [
+        'Program 6JVB invoke [1]',
+        _program_data('PoolResolved', miner=bytes(MINER), winner=bytes(WINNER), requests=2, collateral_chain='sol'),
+        'Program data: AAAA',  # too short / foreign
+        'Program log: Instruction: ResolvePool',
+    ]
+    events = events_from_logs(logs)
+    assert [n for n, _ in events] == ['PoolResolved']
+    ev = events[0][1]
+    assert ev.miner == MINER and ev.winner == WINNER and ev.requests == 2 and ev.collateral_chain == 'sol'
+
+
+def test_feed_dispatches_to_handlers_by_name_and_drops_failed_txs():
+    feed = ProgramEventFeed('ws://x', 'prog')
+    seen = []
+    feed.on('PoolDrawArmed', lambda name, ev: seen.append((name, int(ev.seed_slot))))
+    feed.on('PoolResolved', lambda name, ev: (_ for _ in ()).throw(RuntimeError('boom')))  # never fatal
+    logs = [
+        _program_data('PoolDrawArmed', miner=bytes(MINER), seed_slot=4242, collateral_chain='tao'),
+        _program_data('PoolResolved', miner=bytes(MINER), winner=bytes(WINNER), requests=1, collateral_chain='sol'),
+    ]
+    assert feed.handle_notification(_frame(logs)) == 2
+    assert feed.handle_notification(_frame(logs, err={'InstructionError': [0, 'Custom']})) == 0
+    assert seen == [('PoolDrawArmed', 4242)]
+
+
+def test_resolve_ws_url_swaps_scheme_and_keeps_the_key(monkeypatch):
+    monkeypatch.delenv('SOLANA_WS_URL', raising=False)
+    assert resolve_ws_url('https://devnet.helius-rpc.com/?api-key=k') == 'wss://devnet.helius-rpc.com/?api-key=k'
+    assert resolve_ws_url('http://127.0.0.1:8899') == 'ws://127.0.0.1:8899'
+    monkeypatch.setenv('SOLANA_WS_URL', 'wss://override')
+    assert resolve_ws_url('https://x') == 'wss://override'
+    assert os.environ['SOLANA_WS_URL'] == 'wss://override'

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -966,3 +966,45 @@ def test_closed_pda_by_key_serves_delivery_hash_from_fulfillment_index(tmp_path)
     s = swap_status(validator, HOTKEY, key.hex())
     assert s.stage == 'completed' and s.detail == {'to_tx_hash': 'destTx'}
     store.close()
+
+
+# ── event-driven crank ───────────────────────────────────────────────────────
+
+
+def test_schedule_crank_fires_resolve_then_finalize_under_the_lock(monkeypatch):
+    import allways.validator.reserve_engine as engine
+
+    calls = []
+    lock = threading.Lock()
+
+    class Loop:
+        def resolve_pools_once(self, now):
+            assert lock.locked()
+            calls.append('resolve')
+            return ['miner']
+
+    def fake_finalize(validator, now):
+        assert lock.locked()
+        calls.append('finalize')
+        return []
+
+    monkeypatch.setattr(engine, 'finalize_won_seats', fake_finalize)
+    validator = SimpleNamespace(solana_swap_loop=Loop(), crank_lock=lock)
+    timer = engine.schedule_crank(validator, closes_at=int(time.time()))
+    timer.join(timeout=engine.CRANK_SKEW_SECS + 2)
+    assert calls == ['resolve', 'finalize']
+
+
+def test_reserve_schedules_a_crank_at_the_pool_close(monkeypatch):
+    import allways.validator.reserve_engine as engine
+
+    scheduled = []
+    monkeypatch.setattr(engine, 'schedule_crank', lambda validator, closes_at: scheduled.append(closes_at))
+    client = FakeClient()
+    closes = int(time.time()) + 30
+    client.get_pool = lambda miner, backing='sol': SimpleNamespace(
+        miner=MINER_PK, opened_at=0, requests=[], closes_at=closes
+    )
+    result, _ = _reserve(client)
+    assert result.ok
+    assert scheduled == [closes]

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -971,40 +971,112 @@ def test_closed_pda_by_key_serves_delivery_hash_from_fulfillment_index(tmp_path)
 # ── event-driven crank ───────────────────────────────────────────────────────
 
 
-def test_schedule_crank_retries_until_a_seat_finalizes(monkeypatch):
+class _Loop:
+    def __init__(self, lock, calls):
+        self.lock, self.calls = lock, calls
+
+    def resolve_pools_once(self, now):
+        assert self.lock.locked()
+        self.calls.append('resolve')
+        return []
+
+
+class _FakeFeed:
+    """Stands in for ProgramEventFeed: records handlers, lets a test push decoded events."""
+
+    def __init__(self, connected=True):
+        self.connected = connected
+        self.handlers = {}
+
+    def on(self, name, handler):
+        self.handlers[name] = handler
+
+    def push(self, name, **fields):
+        self.handlers[name](name, SimpleNamespace(**fields))
+
+
+def _wait(cond, secs=2.0):
+    deadline = time.time() + secs
+    while not cond() and time.time() < deadline:
+        time.sleep(0.02)
+    return cond()
+
+
+def test_schedule_crank_without_a_feed_retries_until_the_seat_settles(monkeypatch):
     import allways.validator.reserve_engine as engine
 
     monkeypatch.setattr(engine, 'CRANK_SKEW_SECS', 0)
-    monkeypatch.setattr(engine, 'CRANK_RETRY_SECS', 0.05)
+    monkeypatch.setitem(engine._STAGE_RETRY, 'arm', (0.05, 4))
     calls = []
     lock = threading.Lock()
-
-    class Loop:
-        def resolve_pools_once(self, now):
-            assert lock.locked()
-            calls.append('resolve')
-            return []
 
     def fake_finalize(validator, now):
         assert lock.locked()
         calls.append('finalize')
-        return ['seat'] if calls.count('finalize') == 2 else []
+        return [str(MINER_PK)] if calls.count('finalize') == 2 else []
 
     monkeypatch.setattr(engine, 'finalize_won_seats', fake_finalize)
-    validator = SimpleNamespace(solana_swap_loop=Loop(), crank_lock=lock)
-    engine.schedule_crank(validator, closes_at=int(time.time()))
-    deadline = time.time() + 2
-    while calls.count('finalize') < 2 and time.time() < deadline:
-        time.sleep(0.02)
+    validator = SimpleNamespace(solana_swap_loop=_Loop(lock, calls), crank_lock=lock)
+    engine.schedule_crank(validator, int(time.time()), MINER_PK)
+    assert _wait(lambda: calls.count('finalize') >= 2)
     time.sleep(0.2)
     assert calls == ['resolve', 'finalize'] * 2
+    assert validator.crank_scheduler._pools == {}
+
+
+def test_feed_events_drive_arm_draw_finalize(monkeypatch):
+    """With the feed live: one crank at close (arm), one at the seed slot (draw), one on PoolResolved
+    (finalize) — no blind retries in between because each event hands off to the next stage."""
+    import allways.validator.reserve_engine as engine
+
+    monkeypatch.setattr(engine, 'CRANK_SKEW_SECS', 0)
+    monkeypatch.setattr(engine, 'SLOT_SECS', 0.01)
+    monkeypatch.setattr(engine, 'DRAW_SKEW_SECS', 0)
+    monkeypatch.setitem(engine._STAGE_RETRY, 'arm', (0.2, 4))
+    monkeypatch.setitem(engine._STAGE_RETRY, 'draw', (0.2, 0))  # single-shot draw keeps the count exact
+    calls, finalized = [], []
+    lock = threading.Lock()
+    monkeypatch.setattr(engine, 'finalize_won_seats', lambda v, now: (calls.append('finalize'), list(finalized))[1])
+    feed = _FakeFeed()
+    validator = SimpleNamespace(
+        solana_swap_loop=_Loop(lock, calls),
+        crank_lock=lock,
+        solana_client=SimpleNamespace(rpc=SimpleNamespace(get_slot=lambda: 100)),
+        state_store=SimpleNamespace(distinct_routed_pools=lambda: [(str(MINER_PK), 'sol', 'btc', 'sol')]),
+    )
+    scheduler = engine.CrankScheduler(validator, feed)
+    assert set(feed.handlers) == {'PoolDrawArmed', 'PoolResolved'}
+
+    scheduler.schedule(MINER_PK, int(time.time()))
+    assert _wait(lambda: calls.count('resolve') >= 1)
+    feed.push('PoolDrawArmed', miner=MINER_PK, seed_slot=110, collateral_chain='sol')  # arm landed → stop arm retries
+    assert _wait(lambda: calls.count('resolve') >= 2)  # the draw, ~10 slots later
+    finalized.append(str(MINER_PK))
+    feed.push('PoolResolved', miner=MINER_PK, winner=MINER_PK, requests=1, collateral_chain='sol')
+    assert _wait(lambda: scheduler._pools == {})
+    time.sleep(0.5)
+    assert calls.count('resolve') == 3, calls  # arm, draw, finalize — one crank per stage, no blind retries
+
+
+def test_feed_events_for_untracked_pools_are_ignored():
+    import allways.validator.reserve_engine as engine
+
+    feed = _FakeFeed()
+    calls = []
+    validator = SimpleNamespace(crank_lock=threading.Lock(), solana_swap_loop=_Loop(threading.Lock(), calls))
+    engine.CrankScheduler(validator, feed)
+    feed.push('PoolResolved', miner=MINER_PK, winner=MINER_PK, requests=1, collateral_chain='sol')
+    time.sleep(0.1)
+    assert calls == []
 
 
 def test_reserve_schedules_a_crank_at_the_pool_close(monkeypatch):
     import allways.validator.reserve_engine as engine
 
     scheduled = []
-    monkeypatch.setattr(engine, 'schedule_crank', lambda validator, closes_at: scheduled.append(closes_at))
+    monkeypatch.setattr(
+        engine, 'schedule_crank', lambda validator, closes_at, miner: scheduled.append((closes_at, miner))
+    )
     client = FakeClient()
     closes = int(time.time()) + 30
     client.get_pool = lambda miner, backing='sol': SimpleNamespace(
@@ -1012,4 +1084,4 @@ def test_reserve_schedules_a_crank_at_the_pool_close(monkeypatch):
     )
     result, _ = _reserve(client)
     assert result.ok
-    assert scheduled == [closes]
+    assert scheduled == [(closes, MINER_PK)]

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -89,7 +89,12 @@ class FakeClient:
 
 def _validator(client):
     store = ValidatorStateStore(db_path=Path(tempfile.mkdtemp()) / 'state.db')
-    return SimpleNamespace(solana_client=client, axon_lock=threading.RLock(), state_store=store)
+    scheduler = SimpleNamespace(
+        scheduled=[], schedule=lambda miner, closes_at: scheduler.scheduled.append((miner, closes_at))
+    )
+    return SimpleNamespace(
+        solana_client=client, axon_lock=threading.RLock(), state_store=store, crank_scheduler=scheduler
+    )
 
 
 def _reserve(client, from_amount=1_000_000_000):
@@ -984,8 +989,7 @@ class _Loop:
 class _FakeFeed:
     """Stands in for ProgramEventFeed: records handlers, lets a test push decoded events."""
 
-    def __init__(self, connected=True):
-        self.connected = connected
+    def __init__(self):
         self.handlers = {}
 
     def on(self, name, handler):
@@ -1002,60 +1006,50 @@ def _wait(cond, secs=2.0):
     return cond()
 
 
-def test_schedule_crank_without_a_feed_retries_until_the_seat_settles(monkeypatch):
-    import allways.validator.reserve_engine as engine
-
-    monkeypatch.setattr(engine, 'CRANK_SKEW_SECS', 0)
-    monkeypatch.setitem(engine._STAGE_RETRY, 'arm', (0.05, 4))
-    calls = []
+def _crank_validator(calls):
     lock = threading.Lock()
+    return SimpleNamespace(
+        solana_swap_loop=_Loop(lock, calls),
+        crank_lock=lock,
+        solana_client=SimpleNamespace(rpc=SimpleNamespace(get_slot=lambda: 100)),
+    )
 
-    def fake_finalize(validator, now):
-        assert lock.locked()
-        calls.append('finalize')
-        return [str(MINER_PK)] if calls.count('finalize') == 2 else []
 
-    monkeypatch.setattr(engine, 'finalize_won_seats', fake_finalize)
-    validator = SimpleNamespace(solana_swap_loop=_Loop(lock, calls), crank_lock=lock)
-    engine.schedule_crank(validator, int(time.time()), MINER_PK)
-    assert _wait(lambda: calls.count('finalize') >= 2)
-    time.sleep(0.2)
-    assert calls == ['resolve', 'finalize'] * 2
-    assert validator.crank_scheduler._pools == {}
+def _crank_crank_validator(calls):
+    lock = threading.Lock()
+    return SimpleNamespace(
+        solana_swap_loop=_Loop(lock, calls),
+        crank_lock=lock,
+        solana_client=SimpleNamespace(rpc=SimpleNamespace(get_slot=lambda: 100)),
+    )
 
 
 def test_feed_events_drive_arm_draw_finalize(monkeypatch):
-    """With the feed live: one crank at close (arm), one at the seed slot (draw), one on PoolResolved
-    (finalize) — no blind retries in between because each event hands off to the next stage."""
+    """One crank at close (arm), one at the seed slot (+ one retry), one on PoolResolved (finalize)."""
     import allways.validator.reserve_engine as engine
 
     monkeypatch.setattr(engine, 'CRANK_SKEW_SECS', 0)
     monkeypatch.setattr(engine, 'SLOT_SECS', 0.01)
     monkeypatch.setattr(engine, 'DRAW_SKEW_SECS', 0)
-    monkeypatch.setitem(engine._STAGE_RETRY, 'arm', (0.2, 4))
-    monkeypatch.setitem(engine._STAGE_RETRY, 'draw', (0.2, 0))  # single-shot draw keeps the count exact
-    calls, finalized = [], []
-    lock = threading.Lock()
-    monkeypatch.setattr(engine, 'finalize_won_seats', lambda v, now: (calls.append('finalize'), list(finalized))[1])
+    monkeypatch.setattr(engine, 'DRAW_RETRY_SECS', 0.05)
+    calls = []
+    monkeypatch.setattr(engine, 'finalize_won_seats', lambda v, now: (calls.append('finalize'), [])[1])
     feed = _FakeFeed()
-    validator = SimpleNamespace(
-        solana_swap_loop=_Loop(lock, calls),
-        crank_lock=lock,
-        solana_client=SimpleNamespace(rpc=SimpleNamespace(get_slot=lambda: 100)),
-        state_store=SimpleNamespace(distinct_routed_pools=lambda: [(str(MINER_PK), 'sol', 'btc', 'sol')]),
-    )
+    validator = _crank_validator(calls)
     scheduler = engine.CrankScheduler(validator, feed)
     assert set(feed.handlers) == {'PoolDrawArmed', 'PoolResolved'}
 
     scheduler.schedule(MINER_PK, int(time.time()))
-    assert _wait(lambda: calls.count('resolve') >= 1)
-    feed.push('PoolDrawArmed', miner=MINER_PK, seed_slot=110, collateral_chain='sol')  # arm landed → stop arm retries
-    assert _wait(lambda: calls.count('resolve') >= 2)  # the draw, ~10 slots later
-    finalized.append(str(MINER_PK))
+    assert _wait(lambda: calls.count('resolve') == 1)
+    time.sleep(0.2)
+    assert calls.count('resolve') == 1, 'no blind retries after the arm'
+    feed.push('PoolDrawArmed', miner=MINER_PK, seed_slot=110, collateral_chain='sol')
+    assert _wait(lambda: calls.count('resolve') == 3)  # draw + its one retry, ~10 slots later
     feed.push('PoolResolved', miner=MINER_PK, winner=MINER_PK, requests=1, collateral_chain='sol')
-    assert _wait(lambda: scheduler._pools == {})
-    time.sleep(0.5)
-    assert calls.count('resolve') == 3, calls  # arm, draw, finalize — one crank per stage, no blind retries
+    assert _wait(lambda: calls.count('resolve') == 4)
+    assert scheduler._pools == {}
+    time.sleep(0.2)
+    assert calls.count('resolve') == 4, calls
 
 
 def test_feed_events_for_untracked_pools_are_ignored():
@@ -1063,25 +1057,20 @@ def test_feed_events_for_untracked_pools_are_ignored():
 
     feed = _FakeFeed()
     calls = []
-    validator = SimpleNamespace(crank_lock=threading.Lock(), solana_swap_loop=_Loop(threading.Lock(), calls))
-    engine.CrankScheduler(validator, feed)
+    engine.CrankScheduler(_crank_validator(calls), feed)
+    feed.push('PoolDrawArmed', miner=MINER_PK, seed_slot=110, collateral_chain='sol')
     feed.push('PoolResolved', miner=MINER_PK, winner=MINER_PK, requests=1, collateral_chain='sol')
     time.sleep(0.1)
     assert calls == []
 
 
-def test_reserve_schedules_a_crank_at_the_pool_close(monkeypatch):
-    import allways.validator.reserve_engine as engine
-
-    scheduled = []
-    monkeypatch.setattr(
-        engine, 'schedule_crank', lambda validator, closes_at, miner: scheduled.append((closes_at, miner))
-    )
+def test_reserve_schedules_a_crank_at_the_pool_close():
     client = FakeClient()
     closes = int(time.time()) + 30
     client.get_pool = lambda miner, backing='sol': SimpleNamespace(
         miner=MINER_PK, opened_at=0, requests=[], closes_at=closes
     )
-    result, _ = _reserve(client)
+    validator = _validator(client)
+    result = reserve_on_behalf(validator, HOTKEY, 'sol', 'btc', USER_PK, str(USER_PK), 'userBTCaddr', 1_000_000_000)
     assert result.ok
-    assert scheduled == [(closes, MINER_PK)]
+    assert validator.crank_scheduler.scheduled == [(MINER_PK, closes)]

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -971,9 +971,11 @@ def test_closed_pda_by_key_serves_delivery_hash_from_fulfillment_index(tmp_path)
 # ── event-driven crank ───────────────────────────────────────────────────────
 
 
-def test_schedule_crank_fires_resolve_then_finalize_under_the_lock(monkeypatch):
+def test_schedule_crank_retries_until_a_seat_finalizes(monkeypatch):
     import allways.validator.reserve_engine as engine
 
+    monkeypatch.setattr(engine, 'CRANK_SKEW_SECS', 0)
+    monkeypatch.setattr(engine, 'CRANK_RETRY_SECS', 0.05)
     calls = []
     lock = threading.Lock()
 
@@ -981,18 +983,21 @@ def test_schedule_crank_fires_resolve_then_finalize_under_the_lock(monkeypatch):
         def resolve_pools_once(self, now):
             assert lock.locked()
             calls.append('resolve')
-            return ['miner']
+            return []
 
     def fake_finalize(validator, now):
         assert lock.locked()
         calls.append('finalize')
-        return []
+        return ['seat'] if calls.count('finalize') == 2 else []
 
     monkeypatch.setattr(engine, 'finalize_won_seats', fake_finalize)
     validator = SimpleNamespace(solana_swap_loop=Loop(), crank_lock=lock)
-    timer = engine.schedule_crank(validator, closes_at=int(time.time()))
-    timer.join(timeout=engine.CRANK_SKEW_SECS + 2)
-    assert calls == ['resolve', 'finalize']
+    engine.schedule_crank(validator, closes_at=int(time.time()))
+    deadline = time.time() + 2
+    while calls.count('finalize') < 2 and time.time() < deadline:
+        time.sleep(0.02)
+    time.sleep(0.2)
+    assert calls == ['resolve', 'finalize'] * 2
 
 
 def test_reserve_schedules_a_crank_at_the_pool_close(monkeypatch):


### PR DESCRIPTION
A routed seat waited up to two forward steps (~12 s each) after its pool closed: one to resolve, one to finalize. `resolve_pool` is two-phase on-chain — the first call arms (`PoolDrawArmed`, pins a seed slot 12 slots out), the second draws against it (`PoolResolved`) — so a timer had to guess three landings (arm, draw, finalize read). This drives them off the program's own events instead.

- `ProgramEventFeed` (`allways/solana/program_feed.py`): one daemon thread holding `logsSubscribe(mentions=[program])` on the RPC's wss twin — a keyed Helius HTTP URL derives its keyed wss endpoint (`resolve_ws_url`; `SOLANA_WS_URL` overrides), the same rule the dashboard indexer uses. Decodes `Program data:` lines through the canonical `decode_event` and dispatches by event name (`feed.on('EventName', handler)`, any number of subscribers — other validator components can hang off the same socket). Jittered-backoff reconnect; handler errors logged, never fatal.
- `CrankScheduler` (`reserve_engine.py`): for pools we reserved on — close → arm; `PoolDrawArmed(seed_slot)` → draw the moment that slot is produced (one retry for slot-timing slop); `PoolResolved` → finalize at once, whoever resolved it. No polling loop: the forward step's unchanged `crank()` covers anything missed while the socket is down.
- Validator wiring: `program_feed` + `crank_scheduler` built next to `crank_lock`.

Securing a routed seat: pool window + ~1–2 s, was pool window + up to ~24 s; no `getProgramAccounts` sweeps in between.

Tests: `test_program_feed.py` (decode from real layouts, dispatch, failed-tx drop, ws url derivation) and the crank tests in `test_reserve_engine.py` (event-driven arm→draw→finalize, untracked pools ignored, reserve schedules at close). 2014 pass, ruff clean. Feed live-verified holding a subscription on Helius devnet.
