### PR TITLE
perf(btc): tip-gated verify cache for pending legs

### DIFF
--- a/allways/assets/btc.py
+++ b/allways/assets/btc.py
@@ -160,6 +160,9 @@ class Bitcoin(Asset, Chain):
     """
 
     def __init__(self):
+        # Tip-gated verify cache: pending legs only, dropped whenever the tip moves (see api_verify_transaction).
+        self._verify_cache: dict[tuple[str, str, int], TransactionInfo] = {}
+        self._verify_cache_tip: Optional[int] = None
         # Local-node mode was removed; warn (don't fail) if a stale BTC_MODE=node lingers.
         legacy_mode = os.environ.get('BTC_MODE', '').lower()
         if legacy_mode and legacy_mode != 'lightweight':
@@ -288,7 +291,29 @@ class Bitcoin(Asset, Chain):
     def api_verify_transaction(
         self, tx_hash: str, expected_recipient: str, expected_amount: int
     ) -> Optional[TransactionInfo]:
-        """Verify via Esplora API; raises ProviderUnreachableError if unreachable."""
+        """Verify via Esplora API; raises ProviderUnreachableError if unreachable.
+
+        Tip-gated: a ``pending`` (seen, under min_confirmations) result is reused until the chain tip
+        moves, since mempool→mined and every extra confirmation need a new block. Absent (None) and
+        confirmed results are never cached — a payout can enter the mempool without a tip change, and a
+        confirm must always re-run the live reorg check — so every slash and confirm path fetches live."""
+        key = (tx_hash, expected_recipient, expected_amount)
+        tip = self.chain.cached_block_height()
+        if tip is not None and tip != self._verify_cache_tip:
+            self._verify_cache.clear()
+            self._verify_cache_tip = tip
+        cached = self._verify_cache.get(key) if tip is not None else None
+        if cached is not None:
+            bt.logging.debug(f'{LOG_ESPLORA} tx {tx_hash[:16]}... pending @tip {tip} (cached, no refetch)')
+            return cached
+        info = self._fetch_verify_transaction(tx_hash, expected_recipient, expected_amount)
+        if info is not None and not info.confirmed and tip is not None:
+            self._verify_cache[key] = info
+        return info
+
+    def _fetch_verify_transaction(
+        self, tx_hash: str, expected_recipient: str, expected_amount: int
+    ) -> Optional[TransactionInfo]:
         try:
             resp = self.btc_api_get(f'/tx/{tx_hash}', timeout=15)
             if resp.status_code == 404:

--- a/tests/test_btc_verify_tip_cache.py
+++ b/tests/test_btc_verify_tip_cache.py
@@ -31,8 +31,11 @@ def _tx(confirmed=False, height=None):
     status = {'confirmed': confirmed}
     if confirmed:
         status.update(block_height=height, block_hash='h' * 64, block_time=1_700_000_000)
-    return {'status': status, 'vin': [{'prevout': {'scriptpubkey_address': 'bc1qsender'}}],
-            'vout': [{'scriptpubkey_address': RECIP, 'value': 5000}]}
+    return {
+        'status': status,
+        'vin': [{'prevout': {'scriptpubkey_address': 'bc1qsender'}}],
+        'vout': [{'scriptpubkey_address': RECIP, 'value': 5000}],
+    }
 
 
 class _Session:

--- a/tests/test_btc_verify_tip_cache.py
+++ b/tests/test_btc_verify_tip_cache.py
@@ -1,0 +1,147 @@
+"""Tip-gated BTC verify cache: a pending leg is refetched only when the chain tip moves.
+
+Safety rule pinned here: only ``pending`` results are ever served from cache. Absent (None) and confirmed
+results always hit the API, so no slash or confirm decision can be made on a stale view. Backend mocked.
+"""
+
+import json
+
+from allways.assets.asset import ProviderUnreachableError, TransactionInfo
+
+TX = 'ab' * 32
+RECIP = 'bc1qrecipient'
+
+
+class _Resp:
+    def __init__(self, status_code=200, body=None, text=''):
+        self.status_code = status_code
+        self.ok = status_code < 400
+        self._body = body
+        self.text = text if text else json.dumps(body)
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(str(self.status_code))
+
+    def json(self):
+        return self._body
+
+
+def _tx(confirmed=False, height=None):
+    status = {'confirmed': confirmed}
+    if confirmed:
+        status.update(block_height=height, block_hash='h' * 64, block_time=1_700_000_000)
+    return {'status': status, 'vin': [{'prevout': {'scriptpubkey_address': 'bc1qsender'}}],
+            'vout': [{'scriptpubkey_address': RECIP, 'value': 5000}]}
+
+
+class _Session:
+    """Scripted Esplora: tip from ``tip`` (mutable), ``tx`` body from ``tx`` (mutable); counts /tx calls."""
+
+    def __init__(self, tip=100, tx='default'):
+        self.tip = tip
+        self.tx = _tx() if tx == 'default' else tx
+        self.tx_calls = 0
+
+    def request(self, method, url, timeout=None, headers=None, **kw):
+        if url.endswith('/blocks/tip/height'):
+            return _Resp(text=str(self.tip)) if self.tip is not None else _Resp(status_code=503, text='down')
+        if url.endswith(f'/tx/{TX}'):
+            self.tx_calls += 1
+            if self.tx is None:
+                return _Resp(status_code=404, body={}, text='not found')
+            return _Resp(body=self.tx)
+        if '/block/' in url and url.endswith('/status'):
+            return _Resp(body={'in_best_chain': True})
+        raise AssertionError(url)
+
+
+def _provider(monkeypatch, session):
+    monkeypatch.setenv('BTC_MODE', 'lightweight')
+    monkeypatch.setenv('BTC_NETWORK', 'mainnet')
+    monkeypatch.setenv('BTC_ESPLORA_URLS', 'https://bs/api')
+    from allways.assets.btc import Bitcoin
+
+    p = Bitcoin()
+    p.http = session
+    return p
+
+
+def _verify(p):
+    p.chain.clear_pass_tip()  # the validator clears the pass tip every forward step
+    return p.api_verify_transaction(TX, RECIP, 5000)
+
+
+def test_pending_served_from_cache_while_tip_unchanged(monkeypatch):
+    s = _Session()
+    p = _provider(monkeypatch, s)
+    a = _verify(p)
+    b = _verify(p)
+    assert isinstance(a, TransactionInfo) and not a.confirmed
+    assert b is a
+    assert s.tx_calls == 1
+
+
+def test_tip_move_refetches_and_sees_confirmation(monkeypatch):
+    s = _Session(tip=100, tx=_tx(confirmed=True, height=100))  # 1 conf: pending (min_confirmations=2)
+    p = _provider(monkeypatch, s)
+    assert _verify(p).confirmed is False
+    assert _verify(p).confirmed is False and s.tx_calls == 1
+    s.tip = 101  # new block → refetch → 2 confs → confirmed
+    assert _verify(p).confirmed is True
+    assert s.tx_calls == 2
+
+
+def test_absent_is_never_cached(monkeypatch):
+    s = _Session(tx=None)
+    p = _provider(monkeypatch, s)
+    assert _verify(p) is None
+    s.tx = _tx()  # payout enters the mempool with no tip change
+    assert _verify(p) is not None
+    assert s.tx_calls == 2
+
+
+def test_confirmed_is_never_cached(monkeypatch):
+    s = _Session(tip=105, tx=_tx(confirmed=True, height=100))
+    p = _provider(monkeypatch, s)
+    assert _verify(p).confirmed is True
+    assert _verify(p).confirmed is True
+    assert s.tx_calls == 2  # live fetch (+ reorg check) on every confirm
+
+
+def test_cache_key_includes_recipient_and_amount(monkeypatch):
+    s = _Session()
+    p = _provider(monkeypatch, s)
+    _verify(p)
+    p.chain.clear_pass_tip()
+    assert p.api_verify_transaction(TX, RECIP, 9000) is None  # vout pays 5000 < 9000 → must hit the API
+    assert s.tx_calls == 2
+
+
+def test_no_tip_bypasses_cache(monkeypatch):
+    s = _Session()
+    p = _provider(monkeypatch, s)
+    _verify(p)
+    s.tip = None  # tip fetch failing → no gate → live fetch
+    _verify(p)
+    assert s.tx_calls == 2
+
+
+def test_unreachable_is_not_cached(monkeypatch):
+    import requests
+
+    s = _Session()
+    p = _provider(monkeypatch, s)
+
+    def boom(method, url, **kw):
+        if url.endswith(f'/tx/{TX}'):
+            raise requests.ConnectionError('down')
+        return _Session.request(s, method, url, **kw)
+
+    s.request = boom
+    try:
+        _verify(p)
+        raise AssertionError('expected ProviderUnreachableError')
+    except ProviderUnreachableError:
+        pass
+    assert p._verify_cache == {}


### PR DESCRIPTION
## Why
The validator re-fetches every in-flight BTC leg's `/tx` on every 12 s forward pass while it waits for `min_confirmations=2` (~20 min) — ~100 Esplora calls per BTC swap, and the only place the BTC budget goes now that the tip is hoisted and Fulfilled/Active never re-read the source. Nothing about a waiting leg can improve without a new block.

## What
`Bitcoin.api_verify_transaction` keeps a `{(tx_hash, recipient, amount): TransactionInfo}` map tagged with the tip height it was fetched at (the already-hoisted per-pass tip — no extra call). Same tip → reuse; tip moved → drop the map and refetch. With N waiting legs a pass costs 1 call instead of N+1; per BTC swap ≈ 100 → ~4.

**Safety rule — only `pending` results are ever cached:**
- `None` (absent/mismatch) is never cached: a payout can enter the mempool without a tip change, and a cached absent + overdue Fulfilled would TIMEOUT (slash) a miner whose tx is sitting in the mempool.
- Confirmed (`ok`) is never cached: a same-height reorg doesn't move the tip, and the confirm path must re-run the live `/block/{hash}/status` reorg check. (Caching it saves nothing anyway — an `ok` leg gets voted that pass.)
- A cached `pending` can only get *more* lenient vs reality (eviction/RBF): it yields WAIT/EXTEND, never CONFIRM; at overdue+extension-exhausted it TIMEOUTs exactly as a live fetch would, since confs can't have advanced without a block.
- Tip fetch failed → no gate → live fetch. `ProviderUnreachableError` → nothing cached.

No change to `solana_swap_loop` / `reserve_engine` decision code.

## Tests
`tests/test_btc_verify_tip_cache.py` (7): hit on same tip, refetch on tip move (1→2 confs seen), absent never cached, confirmed never cached, key includes recipient+amount, no-tip bypass, unreachable not cached. BTC + swap-loop + reserve suites: 231 passed.

Live against Blockstream Explorer API (mainnet, real mempool tx): 3 passes on one tip → 1 `/tx` call; tip change → refetch.