### PR TITLE
Persist neuron logs + score state under data/allways (10 MB x 5 rotation)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ WALLET_PATH=~/.bittensor/wallets
 SUBTENSOR_NETWORK=finney            # finney | test | local | ws://host:9944 (validators: local lite node)
 PORT=8091
 LOG_LEVEL=info
-# Rotating log file under data/allways/logs/ (survives container rebuilds): size per file, files kept.
+# Rotating log file data/allways/bittensor.log (survives container rebuilds): size per file, files kept.
 LOG_FILE_MAX_MB=10
 LOG_FILE_BACKUPS=3
 # OPTIONAL loopback-bind axon behind a reverse proxy; unset = public

--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ WALLET_PATH=~/.bittensor/wallets
 SUBTENSOR_NETWORK=finney            # finney | test | local | ws://host:9944 (validators: local lite node)
 PORT=8091
 LOG_LEVEL=info
+# Rotating log file under data/allways/logs/ (survives container rebuilds): size per file, files kept.
+LOG_FILE_MAX_MB=10
+LOG_FILE_BACKUPS=3
 # OPTIONAL loopback-bind axon behind a reverse proxy; unset = public
 # AXON_PUBLISH=127.0.0.1:9000
 

--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ PORT=8091
 LOG_LEVEL=info
 # Rotating log file data/allways/bittensor.log (survives container rebuilds): size per file, files kept.
 LOG_FILE_MAX_MB=10
-LOG_FILE_BACKUPS=3
+LOG_FILE_BACKUPS=4
 # OPTIONAL loopback-bind axon behind a reverse proxy; unset = public
 # AXON_PUBLISH=127.0.0.1:9000
 

--- a/docker-compose.miner.yml
+++ b/docker-compose.miner.yml
@@ -15,5 +15,11 @@ services:
       # ./data/solana/id.json and fund it; ro so a missing file errors loudly at startup
       # instead of load_or_create silently minting a throwaway key.
       - ./data/solana:/root/.solana:ro
+    # Keep at most 4 x 3 MB of logs per container (3 rotated + the live file): a hard 12 MB cap.
+    logging:
+      driver: json-file
+      options:
+        max-size: "3m"
+        max-file: "4"
     labels:
       - "com.centurylinklabs.watchtower.enable=true"

--- a/docker-compose.miner.yml
+++ b/docker-compose.miner.yml
@@ -15,11 +15,12 @@ services:
       # ./data/solana/id.json and fund it; ro so a missing file errors loudly at startup
       # instead of load_or_create silently minting a throwaway key.
       - ./data/solana:/root/.solana:ro
-    # Keep at most 4 x 3 MB of logs per container (3 rotated + the live file): a hard 12 MB cap.
+    # `docker logs` buffer: 3 x 10 MB, oldest dropped. Dies with the container — the durable copy is
+    # the rotating file the entrypoint writes under ./data/allways/logs (LOG_FILE_MAX_MB / LOG_FILE_BACKUPS).
     logging:
       driver: json-file
       options:
-        max-size: "3m"
-        max-file: "4"
+        max-size: "10m"
+        max-file: "3"
     labels:
       - "com.centurylinklabs.watchtower.enable=true"

--- a/docker-compose.miner.yml
+++ b/docker-compose.miner.yml
@@ -16,7 +16,7 @@ services:
       # instead of load_or_create silently minting a throwaway key.
       - ./data/solana:/root/.solana:ro
     # `docker logs` buffer: 3 x 10 MB, oldest dropped. Dies with the container — the durable copy is
-    # the rotating file the entrypoint writes under ./data/allways/logs (LOG_FILE_MAX_MB / LOG_FILE_BACKUPS).
+    # ./data/allways/bittensor.log, rotated by the neuron (LOG_FILE_MAX_MB / LOG_FILE_BACKUPS).
     logging:
       driver: json-file
       options:

--- a/docker-compose.vali.yml
+++ b/docker-compose.vali.yml
@@ -18,12 +18,13 @@ services:
     # (requires STORE_DB_RESULTS=true and DB_* vars in .env)
     # networks:
     #   - allways_network
-    # Keep at most 4 x 3 MB of logs per container (3 rotated + the live file): a hard 12 MB cap.
+    # `docker logs` buffer: 3 x 10 MB, oldest dropped. Dies with the container — the durable copy is
+    # the rotating file the entrypoint writes under ./data/allways/logs (LOG_FILE_MAX_MB / LOG_FILE_BACKUPS).
     logging:
       driver: json-file
       options:
-        max-size: "3m"
-        max-file: "4"
+        max-size: "10m"
+        max-file: "3"
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
 

--- a/docker-compose.vali.yml
+++ b/docker-compose.vali.yml
@@ -19,7 +19,7 @@ services:
     # networks:
     #   - allways_network
     # `docker logs` buffer: 3 x 10 MB, oldest dropped. Dies with the container — the durable copy is
-    # the rotating file the entrypoint writes under ./data/allways/logs (LOG_FILE_MAX_MB / LOG_FILE_BACKUPS).
+    # ./data/allways/bittensor.log, rotated by the neuron (LOG_FILE_MAX_MB / LOG_FILE_BACKUPS).
     logging:
       driver: json-file
       options:

--- a/docker-compose.vali.yml
+++ b/docker-compose.vali.yml
@@ -18,6 +18,12 @@ services:
     # (requires STORE_DB_RESULTS=true and DB_* vars in .env)
     # networks:
     #   - allways_network
+    # Keep at most 4 x 3 MB of logs per container (3 rotated + the live file): a hard 12 MB cap.
+    logging:
+      driver: json-file
+      options:
+        max-size: "3m"
+        max-file: "4"
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
 

--- a/neurons/base/neuron.py
+++ b/neurons/base/neuron.py
@@ -77,7 +77,7 @@ class BaseNeuron(ABC):
         # --logging.record_log keeps a rotating copy at the mounted ~/.allways/bittensor.log (and the neuron's
         # state.npz under it) that outlives the container; bittensor hard-codes 25 MB x 10, so size it first.
         bt_loggingmachine.DEFAULT_MAX_ROTATING_LOG_FILE_SIZE = int(os.getenv('LOG_FILE_MAX_MB', '10')) * 1024 * 1024
-        bt_loggingmachine.DEFAULT_LOG_BACKUP_COUNT = int(os.getenv('LOG_FILE_BACKUPS', '3'))
+        bt_loggingmachine.DEFAULT_LOG_BACKUP_COUNT = int(os.getenv('LOG_FILE_BACKUPS', '4'))
         bt.logging.set_config(config=self.config.logging)
 
         self.device = self.config.neuron.device

--- a/neurons/base/neuron.py
+++ b/neurons/base/neuron.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 from typing import Callable
 
 import bittensor as bt
+from bittensor.utils.btlogging import loggingmachine as bt_loggingmachine
 from websockets.exceptions import ConnectionClosedError
 
 from allways import __spec_version__ as spec_version
@@ -73,6 +74,10 @@ class BaseNeuron(ABC):
         self.config.merge(base_config)
         self.check_config(self.config)
 
+        # --logging.record_log keeps a rotating copy under the mounted ~/.allways/logs that outlives the
+        # container; bittensor hard-codes 25 MB x 10, so size it from env before the handler is built.
+        bt_loggingmachine.DEFAULT_MAX_ROTATING_LOG_FILE_SIZE = int(os.getenv('LOG_FILE_MAX_MB', '10')) * 1024 * 1024
+        bt_loggingmachine.DEFAULT_LOG_BACKUP_COUNT = int(os.getenv('LOG_FILE_BACKUPS', '3'))
         bt.logging.set_config(config=self.config.logging)
 
         self.device = self.config.neuron.device

--- a/neurons/base/neuron.py
+++ b/neurons/base/neuron.py
@@ -74,8 +74,8 @@ class BaseNeuron(ABC):
         self.config.merge(base_config)
         self.check_config(self.config)
 
-        # --logging.record_log keeps a rotating copy under the mounted ~/.allways/logs that outlives the
-        # container; bittensor hard-codes 25 MB x 10, so size it from env before the handler is built.
+        # --logging.record_log keeps a rotating copy at the mounted ~/.allways/bittensor.log (and the neuron's
+        # state.npz under it) that outlives the container; bittensor hard-codes 25 MB x 10, so size it first.
         bt_loggingmachine.DEFAULT_MAX_ROTATING_LOG_FILE_SIZE = int(os.getenv('LOG_FILE_MAX_MB', '10')) * 1024 * 1024
         bt_loggingmachine.DEFAULT_LOG_BACKUP_COUNT = int(os.getenv('LOG_FILE_BACKUPS', '3'))
         bt.logging.set_config(config=self.config.logging)

--- a/scripts/miner-entrypoint.sh
+++ b/scripts/miner-entrypoint.sh
@@ -7,9 +7,6 @@ if [ -z "$SUBTENSOR_NETWORK" ]; then echo "SUBTENSOR_NETWORK is not set" && exit
 if [ -z "$PORT" ]; then echo "PORT is not set" && exit 1; fi
 if [ -z "$LOG_LEVEL" ]; then echo "LOG_LEVEL is not set" && exit 1; fi
 
-# bittensor opens the rotating log file without creating its directory.
-mkdir -p /root/.allways/logs
-
 exec python neurons/miner.py \
   --netuid ${NETUID} \
   --wallet.name ${WALLET_NAME} \
@@ -17,5 +14,5 @@ exec python neurons/miner.py \
   --subtensor.network ${SUBTENSOR_NETWORK} \
   --axon.port ${PORT} \
   --logging.${LOG_LEVEL} \
-  --logging.record_log --logging.logging_dir /root/.allways/logs \
+  --logging.record_log --logging.logging_dir /root/.allways \
   "$@"

--- a/scripts/miner-entrypoint.sh
+++ b/scripts/miner-entrypoint.sh
@@ -7,6 +7,9 @@ if [ -z "$SUBTENSOR_NETWORK" ]; then echo "SUBTENSOR_NETWORK is not set" && exit
 if [ -z "$PORT" ]; then echo "PORT is not set" && exit 1; fi
 if [ -z "$LOG_LEVEL" ]; then echo "LOG_LEVEL is not set" && exit 1; fi
 
+# bittensor opens the rotating log file without creating its directory.
+mkdir -p /root/.allways/logs
+
 exec python neurons/miner.py \
   --netuid ${NETUID} \
   --wallet.name ${WALLET_NAME} \
@@ -14,4 +17,5 @@ exec python neurons/miner.py \
   --subtensor.network ${SUBTENSOR_NETWORK} \
   --axon.port ${PORT} \
   --logging.${LOG_LEVEL} \
+  --logging.record_log --logging.logging_dir /root/.allways/logs \
   "$@"

--- a/scripts/vali-entrypoint.sh
+++ b/scripts/vali-entrypoint.sh
@@ -7,9 +7,6 @@ if [ -z "$SUBTENSOR_NETWORK" ]; then echo "SUBTENSOR_NETWORK is not set" && exit
 if [ -z "$PORT" ]; then echo "PORT is not set" && exit 1; fi
 if [ -z "$LOG_LEVEL" ]; then echo "LOG_LEVEL is not set" && exit 1; fi
 
-# bittensor opens the rotating log file without creating its directory.
-mkdir -p /root/.allways/logs
-
 exec python neurons/validator.py \
   --netuid ${NETUID} \
   --wallet.name ${WALLET_NAME} \
@@ -17,5 +14,5 @@ exec python neurons/validator.py \
   --subtensor.network ${SUBTENSOR_NETWORK} \
   --axon.port ${PORT} \
   --logging.${LOG_LEVEL} \
-  --logging.record_log --logging.logging_dir /root/.allways/logs \
+  --logging.record_log --logging.logging_dir /root/.allways \
   "$@"

--- a/scripts/vali-entrypoint.sh
+++ b/scripts/vali-entrypoint.sh
@@ -7,6 +7,9 @@ if [ -z "$SUBTENSOR_NETWORK" ]; then echo "SUBTENSOR_NETWORK is not set" && exit
 if [ -z "$PORT" ]; then echo "PORT is not set" && exit 1; fi
 if [ -z "$LOG_LEVEL" ]; then echo "LOG_LEVEL is not set" && exit 1; fi
 
+# bittensor opens the rotating log file without creating its directory.
+mkdir -p /root/.allways/logs
+
 exec python neurons/validator.py \
   --netuid ${NETUID} \
   --wallet.name ${WALLET_NAME} \
@@ -14,4 +17,5 @@ exec python neurons/validator.py \
   --subtensor.network ${SUBTENSOR_NETWORK} \
   --axon.port ${PORT} \
   --logging.${LOG_LEVEL} \
+  --logging.record_log --logging.logging_dir /root/.allways/logs \
   "$@"


### PR DESCRIPTION
Neither compose file set a logging policy, so the validator/miner `json-file` logs grew without bound — and that log lives in the container's own directory, so every image bump (`docker compose up -d` recreate) deleted it anyway.

Two sinks now, both capped:

- **`docker logs` buffer** (ephemeral, for `-f`/`--since`): `json-file`, `max-size: 10m`, `max-file: 3` → 30 MB cap per container, oldest dropped.
- **Durable file**: entrypoints pass `--logging.record_log --logging.logging_dir /root/.allways`, so bittensor's own `RotatingFileHandler` writes `bittensor.log` into the `./data/allways` volume both neurons already mount → `tail -f data/allways/bittensor.log` on the host. Survives recreate/rebuild/image change. Bittensor hard-codes 25 MB × 10, so `neurons/base/neuron.py` sizes it from `LOG_FILE_MAX_MB` / `LOG_FILE_BACKUPS` (defaults 10 / 4 → 50 MB cap (live + 4 rotated)) before the handler is built. Level follows `LOG_LEVEL` as before.

**Side effect, and a good one:** bittensor derives `neuron.full_path` from `logging_dir` (`allways/utils/config.py`), so the neuron's `state.npz` (score moving average) and `events.log` move from the unmounted `/root/.bittensor/miners/…` to `data/allways/<wallet>/<hotkey>/netuid<N>/validator/`. Until now that state was reset on every image bump — the boot log's `No state file found … starting fresh` on each deploy. It now persists.

Verified by building the image from this branch and running the validator entrypoint against a scratch `./data/allways` mount: `bittensor.log` and the state dir appear on the host before the run reaches the (absent) wallet; rotation verified separately at 1 MB × 3. Measured validator rate ~1.3 MB/day idle, ~5 MB/day under swap load → 50 MB ≈ 10 days–5 weeks.

Takes effect on the next container recreate.

