### PR TITLE
fix(validator): non-earner trace reads live quotes, not dead last_known_rates

### DIFF
--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -478,8 +478,10 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
     # Rate-liveness backstop: a lost QuoteRemoved would otherwise freeze a lane's crown
     # credit forever (the prune keeps the last rate as the lane's anchor). Best-effort —
     # the reconcile is a safety net, so a failed quote read never sinks the round.
+    live_rates: Dict[Tuple[str, str, str, str], float] = {}
     try:
-        self.event_index.reconcile_live_quotes(live_quote_rates(self.solana_client, attribution), now=current_time)
+        live_rates = live_quote_rates(self.solana_client, attribution)
+        self.event_index.reconcile_live_quotes(live_rates, now=current_time)
     except Exception as e:
         bt.logging.warning(f'quote reconcile failed, skipping this round: {e}')
     # The global (strike) view feeds the trace log; rows gate per lane so a TAO settle zeroes
@@ -587,6 +589,7 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
         recycled=recycled,
         weighting_traces=weighting_traces,
         swap_bounds=swap_bounds,
+        live_rates=live_rates,
     )
 
     if storage_enabled:

--- a/allways/validator/scoring_trace.py
+++ b/allways/validator/scoring_trace.py
@@ -57,6 +57,7 @@ def log_scoring_trace(
     recycled: float,
     weighting_traces: Optional[Dict[str, 'WeightingTrace']] = None,
     swap_bounds: Optional[Dict[str, Tuple[int, int]]] = None,
+    live_rates: Optional[Dict[Tuple[str, str, str, str], float]] = None,
 ) -> None:
     hotkeys = self.metagraph.hotkeys
     recycle_uid = RECYCLE_UID if RECYCLE_UID < len(rewards) else 0
@@ -113,6 +114,7 @@ def log_scoring_trace(
             collaterals,
             swap_bounds,
             covered=crown_holders,
+            live_rates=live_rates,
         )
     )
 
@@ -139,6 +141,7 @@ def non_earner_lines(
     collaterals: Optional[Dict[str, int]] = None,
     swap_bounds: Optional[Dict[str, Tuple[int, int]]] = None,
     covered: Optional[Set[str]] = None,
+    live_rates: Optional[Dict[Tuple[str, str, str, str], float]] = None,
 ) -> List[str]:
     collaterals = collaterals or {}
     covered = covered or set()
@@ -147,8 +150,10 @@ def non_earner_lines(
         if e['active']:
             ever_active.add(e['hotkey'])
 
+    # Live on-chain quotes (the round's reconcile read), collapsed across backings:
+    # the diagnosis anchors on the pair's hub leg, so one rate per pair is enough.
     rates_by_hotkey: Dict[str, Dict[Tuple[str, str], float]] = {}
-    for (hk, from_c, to_c), r in (getattr(self, 'last_known_rates', {}) or {}).items():
+    for (hk, from_c, to_c, _backing), r in (live_rates or {}).items():
         if r > 0:
             rates_by_hotkey.setdefault(hk, {})[(from_c, to_c)] = r
 
@@ -195,7 +200,7 @@ def diagnose_non_earner(
 
     outbid_parts: List[str] = []
     for (from_c, to_c), own in latest_rates.items():
-        # last_known_rates carries no backing, so diagnose against the pair's hub-leg
+        # latest_rates carries no backing, so diagnose against the pair's hub-leg
         # lane (its pricing anchor); the plain pair key keeps direct callers working.
         trace = direction_traces.get((from_c, to_c, hub_leg(from_c, to_c))) or direction_traces.get((from_c, to_c))
         if trace is None or trace.best_rate <= 0:

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -2508,6 +2508,56 @@ class TestNonEarnerDiagnosis:
         assert reason.startswith('competitive_but_unfilled'), reason
 
 
+class TestNonEarnerLinesUseLiveRates:
+    """non_earner_lines must source rates from the round's live on-chain quotes.
+    It used to read a dead ``last_known_rates`` attribute (writer deleted in the
+    B3.6 substrate teardown), so every non-earner — including a struck-out miner
+    with a live quote — was mislabelled ``no_rate_posted``."""
+
+    def _stub(self, hotkeys):
+        from unittest.mock import MagicMock
+
+        ei = MagicMock()
+        ei.get_active_miners_at.return_value = list(hotkeys)
+        ei.get_active_events_in_range.return_value = []
+        return SimpleNamespace(metagraph=SimpleNamespace(hotkeys=list(hotkeys)), event_index=ei)
+
+    def test_struck_out_miner_with_live_quote_reads_ineligible(self):
+        from allways.validator.scoring import DirectionTrace
+        from allways.validator.scoring_trace import non_earner_lines
+
+        v = self._stub(['hk_owner', 'hk_struck'])
+        lines = non_earner_lines(
+            v,
+            0,
+            100,
+            rewards=np.zeros(2),
+            eligibility={'hk_struck': False},
+            direction_traces={('sol', 'btc', 'sol'): DirectionTrace(pool=0.5)},
+            recycle_uid=0,
+            live_rates={('hk_struck', 'sol', 'btc', 'sol'): 0.0011357},
+        )
+        assert len(lines) == 1
+        assert 'uid=1' in lines[0] and 'reason="ineligible"' in lines[0], lines[0]
+
+    def test_no_live_quote_still_reads_no_rate_posted(self):
+        from allways.validator.scoring import DirectionTrace
+        from allways.validator.scoring_trace import non_earner_lines
+
+        v = self._stub(['hk_owner', 'hk_quiet'])
+        lines = non_earner_lines(
+            v,
+            0,
+            100,
+            rewards=np.zeros(2),
+            eligibility={'hk_quiet': True},
+            direction_traces={('sol', 'btc', 'sol'): DirectionTrace(pool=0.5)},
+            recycle_uid=0,
+            live_rates={},
+        )
+        assert len(lines) == 1 and 'reason="no_rate_posted"' in lines[0], lines
+
+
 class TestScoringCadenceAndWindow:
     """Block-based scoring gate + cursor-anchored, gap-free window tiling —
     guards the step-vs-block fix (a multi-block forward pass made the old


### PR DESCRIPTION
## Problem

The scoring trace labelled **every** non-earner \`reason="no_rate_posted"\`, regardless of actual cause. \`non_earner_lines\` read \`getattr(self, 'last_known_rates', {})\` — but every writer of that attribute was deleted in the B3.6 substrate teardown (87a6732). The \`getattr\` default masked the dead reference, so the dict was always empty and \`diagnose_non_earner\` short-circuited on its first branch.

Seen on testnet 2026-08-22: uid 12 (50 ok / 3 fail → struck out, correct per #699) with a live sol→btc quote logged as \`no_rate_posted eligible=False\`, which sent a debugging session chasing a restart/rate-replay theory that didn't exist. The true reason was \`ineligible\`.

## Fix

- \`calculate_miner_rewards\` already fetches \`live_quote_rates(...)\` for the quote reconcile; hoist that result and pass it as \`live_rates\` through \`log_scoring_trace\` → \`non_earner_lines\`.
- \`non_earner_lines\` builds its per-hotkey rate map from those 4-tuple lanes, collapsing the backing dimension (the diagnosis already anchors on the pair's hub leg via \`hub_leg()\`).
- Dead \`last_known_rates\` lookup removed.

No change to reward math or crown logic — diagnostic text only.

## Tests

\`TestNonEarnerLinesUseLiveRates\`: a struck-out miner with a live quote reads \`ineligible\`; a miner with no live quote still reads \`no_rate_posted\`.