### PR TITLE
Bump allways to 3.3.0

### DIFF
--- a/allways/__init__.py
+++ b/allways/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '3.2.0'
+__version__ = '3.3.0'
 version_split = __version__.split('.')
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "allways"
-version = "3.2.0"
+version = "3.3.0"
 description = "Allways - Universal Transaction Layer: Collateral-backed cross-chain swaps on Bittensor Subnet 7"
 license = "MIT"
 requires-python = ">=3.10,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "allways"
-version = "3.2.0"
+version = "3.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "base58" },


### PR DESCRIPTION
## Summary
- \`3.2.0\` → \`3.3.0\` in \`pyproject.toml\` + \`allways/__init__.py\` (\`__spec_version__\` 3020 → 3030)

Minor bump for the release that promotes #698–#704 to main: solusdc spoke, Blockstream Explorer OAuth (Maestro sunset), tip-gated BTC verify cache, event-driven crank, flat eligibility gate + under-floor bond hub drop (program upgrade), log persistence. Gives external operators a visible version to be behind, and moves the weights version_key.