### PR TITLE
[BLOCKED: emissions redesign] Activate alpha-spoke pairs (PR3)

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -1,4 +1,5 @@
 import re
+from itertools import combinations
 
 from allways.classes import MinerActivity
 
@@ -149,11 +150,14 @@ LAUNCH_ALPHAS = (
     'sn74',
 )
 # Every launch pair in canonical order: each hub against every spoke and alpha (sol↔tao lands once,
-# under SOL, because sol never appears in LAUNCH_SPOKES). Alpha↔spoke pairs are gated on the
-# emissions redesign and deliberately absent.
-LAUNCH_PAIRS: tuple[tuple[str, str], ...] = tuple(
-    (hub, spoke) for hub in HUB_CHAINS for spoke in LAUNCH_SPOKES if spoke != hub
-) + tuple((hub, alpha) for hub in HUB_CHAINS for alpha in LAUNCH_ALPHAS)
+# under SOL, because sol never appears in LAUNCH_SPOKES), then each alpha against every spoke and
+# the other alphas — each alpha anchors its own scoring family.
+LAUNCH_PAIRS: tuple[tuple[str, str], ...] = (
+    tuple((hub, spoke) for hub in HUB_CHAINS for spoke in LAUNCH_SPOKES if spoke != hub)
+    + tuple((hub, alpha) for hub in HUB_CHAINS for alpha in LAUNCH_ALPHAS)
+    + tuple((alpha, spoke) for alpha in LAUNCH_ALPHAS for spoke in LAUNCH_SPOKES if not is_hub(spoke))
+    + tuple(combinations(LAUNCH_ALPHAS, 2))
+)
 # Fixed burn: pools sum to MINER_POOL_SHARE instead of 1.0, so at least
 # BURN_RATE of every round recycles to RECYCLE_UID before any shortfall.
 BURN_RATE = 0.90

--- a/tests/test_tao_hub_pairs.py
+++ b/tests/test_tao_hub_pairs.py
@@ -80,9 +80,10 @@ class TestHubSet:
         assert ('tao', 'sol') not in LAUNCH_PAIRS
         assert ('tao', 'eth') in LAUNCH_PAIRS and ('tao', 'btc') in LAUNCH_PAIRS
         assert len(LAUNCH_PAIRS) == len(set(LAUNCH_PAIRS))
-        assert all(hub in HUB_CHAINS and spoke != hub for hub, spoke in LAUNCH_PAIRS)
+        assert all(anchor == hub_leg(anchor, other) and other != anchor for anchor, other in LAUNCH_PAIRS)
         assert all(pair == canonical_pair(*pair) for pair in LAUNCH_PAIRS)
         assert all((hub, alpha) in LAUNCH_PAIRS for hub in HUB_CHAINS for alpha in LAUNCH_ALPHAS)
+        assert ('sn7', 'avax') in LAUNCH_PAIRS and ('sn7', 'sn74') in LAUNCH_PAIRS
 
     def test_direction_pools_span_both_families_and_conserve(self):
         assert len(DIRECTION_POOLS) == 2 * len(LAUNCH_PAIRS)


### PR DESCRIPTION
BLOCKED — merge gate. Do not merge until the emissions redesign answers O3.

Activates every alpha<->spoke pair and `sn7<->sn74` (one line in the `LAUNCH_PAIRS` generator). Stacked on #708, which ships the whole mechanism; this PR adds pairs, not mechanism.

Why it is held: each alpha becomes its own scoring family (`hub_leg` returns the alpha). On pair count alone, before any volume clears, `sol` 27% / `tao` 26% / `sn7` 24% / `sn74` 23% of 66 pairs — alpha takes 47% of miner emissions. Volume weighting redistributes only within a family, never across, so real volume elsewhere cannot claw it back.

Also required before merge (surfaced during implementation, not blockers for PR2):
- das `hubLeg`/direction maps need the family rule for alpha<->spoke directions (today they only know literal hubs).
- `swap_intake.hub_bounds` keys bounds by hub id; an alpha anchor reads `(0, 0)`, so `is_executable_rate` is permissive on alpha<->spoke pairs (the per-backing TAO size gate still applies).
- `scoring.py` passes the TAO purse bounds (rao) as the hub-leg bounds of an alpha-anchored lane, where `is_executable_rate` / `min_executable_hub_leg` read them as alpha units (same decimals hide it). Resolve with the emissions redesign before this merges.
- Pair count: 70 pairs after this PR (17 spokes today), not the 66 the spec estimated.

Spec: `SPEC_SUBNET_TOKENS.md` §6, §9, O3.
