### PR TITLE
Set miner burn to 0% (v3.3.1)

### DIFF
--- a/allways/__init__.py
+++ b/allways/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '3.3.0'
+__version__ = '3.3.1'
 version_split = __version__.split('.')
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -138,7 +138,7 @@ LAUNCH_PAIRS: tuple[tuple[str, str], ...] = tuple(
 )
 # Fixed burn: pools sum to MINER_POOL_SHARE instead of 1.0, so at least
 # BURN_RATE of every round recycles to RECYCLE_UID before any shortfall.
-BURN_RATE = 0.25
+BURN_RATE = 0.0
 MINER_POOL_SHARE = 1.0 - BURN_RATE
 # Direction registry and the equal-split fallback: one entry per hub↔spoke direction
 # (both ways). The per-round pool values are volume-weighted at pair level

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -138,7 +138,7 @@ LAUNCH_PAIRS: tuple[tuple[str, str], ...] = tuple(
 )
 # Fixed burn: pools sum to MINER_POOL_SHARE instead of 1.0, so at least
 # BURN_RATE of every round recycles to RECYCLE_UID before any shortfall.
-BURN_RATE = 0.90
+BURN_RATE = 0.25
 MINER_POOL_SHARE = 1.0 - BURN_RATE
 # Direction registry and the equal-split fallback: one entry per hub↔spoke direction
 # (both ways). The per-round pool values are volume-weighted at pair level

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "allways"
-version = "3.3.0"
+version = "3.3.1"
 description = "Allways - Universal Transaction Layer: Collateral-backed cross-chain swaps on Bittensor Subnet 7"
 license = "MIT"
 requires-python = ">=3.10,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "allways"
-version = "3.3.0"
+version = "3.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "base58" },


### PR DESCRIPTION
## Summary
- `BURN_RATE` 0.90 → 0.0 in `allways/constants.py`; `MINER_POOL_SHARE` goes from 10% → 100% of each round. Nothing recycles to `RECYCLE_UID` by default anymore.
- Rationale: miners have not shown up for a 10% pool. Go all the way while the validator product and routing miner come online; revisit once real quoting is live.
- Patch bump 3.3.0 → 3.3.1 (`pyproject.toml`, `allways/__init__.py`, `uv.lock` version line only) so the neuron image carries the change.

## Test plan
- [x] `tests/test_scoring_v1.py` + `tests/test_tao_hub_pairs.py`: 181 passed (all pool assertions derive from the constant)
- [x] Full suite earlier at 0.25: 2032 passed. The 3 `test_bitcoin_signing` failures are pre-existing on `test` (order-dependent; the file passes in isolation) and unrelated.