### PR TITLE
Let seam /status resolve a reservation by pair

### DIFF
--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -483,13 +483,18 @@ def _live_unclaimed_slots(client, miner_pk, now):
     return slots, 'No reservation for this miner'
 
 
-def _freshest_reservation(client, miner_pk):
+def _freshest_reservation(client, miner_pk, from_chain: str = '', to_chain: str = ''):
     """The miner's most-alive reservation across per-hub slots (v3.1) — ranked by max(reserved_until,
-    finalize_by) — so a tao-hub seat is seen by status, not just the SOL slot."""
+    finalize_by) — so a tao-hub seat is seen by status, not just the SOL slot. With a pair, only
+    the slot carrying that pair counts: a consumer tracking its own seat must not be answered with
+    the miner's OTHER hub (a fresher stranger there read as "our seat was lost", and a same-pubkey
+    stranger there was adopted as ours)."""
     best, best_at = None, -1
     for backing in BACKING_BITS:
         resv = client.get_reservation(miner_pk, backing)
         if resv is None:
+            continue
+        if from_chain and (resv.from_chain != from_chain or resv.to_chain != to_chain):
             continue
         at = max(int(getattr(resv, 'reserved_until', 0) or 0), int(getattr(resv, 'finalize_by', 0) or 0))
         if at > best_at:
@@ -735,18 +740,21 @@ class SwapStatus:
     detail: dict = field(default_factory=dict)
 
 
-def swap_status(validator, miner_hotkey: str, swap_key_hex: str = '') -> SwapStatus:
+def swap_status(
+    validator, miner_hotkey: str, swap_key_hex: str = '', from_chain: str = '', to_chain: str = ''
+) -> SwapStatus:
     """Current lifecycle stage for a reservation/swap — the offering polls this.
 
     With ``swap_key_hex`` the swap resolves by key (survives the reservation being consumed at
-    attestation quorum); without it, via the miner's live reservation (pre-attestation stages)."""
+    attestation quorum); without it, via the miner's live reservation (pre-attestation stages) —
+    the slot carrying ``from_chain``/``to_chain`` when given, else the freshest slot."""
     if swap_key_hex:
         return _swap_status_by_key(validator, swap_key_hex)
     client = validator.solana_client
     miner_pk = resolve_miner_pubkey(validator, miner_hotkey)
     if miner_pk is None:
         return SwapStatus('none')
-    reservation = _freshest_reservation(client, miner_pk)
+    reservation = _freshest_reservation(client, miner_pk, from_chain, to_chain)
     if reservation is None or reservation.reserved_until == 0:
         return SwapStatus('none')
     swap_key = bytes(reservation.claimed_swap_key)

--- a/allways/validator/seam_http.py
+++ b/allways/validator/seam_http.py
@@ -55,8 +55,8 @@ def _make_handler(validator, secret: str):
     # store exceptions, so a transient RPC fault is retried rather than pinned for the bucket;
     # maxsize caps the table so a long-lived seam can't grow an entry per swap ever polled.
     @lru_cache(maxsize=512)
-    def cached_status(miner_hotkey: str, swap_key: str, _bucket: int):
-        return swap_status(validator, miner_hotkey, swap_key)
+    def cached_status(miner_hotkey: str, swap_key: str, from_chain: str, to_chain: str, _bucket: int):
+        return swap_status(validator, miner_hotkey, swap_key, from_chain, to_chain)
 
     @lru_cache(maxsize=512)
     def cached_deposit_scan(miner_hotkey: str, _bucket: int):
@@ -100,8 +100,15 @@ def _make_handler(validator, secret: str):
                 if url.path == '/status':
                     # Optional swap_key (hex, persisted by the consumer at claim time) resolves the
                     # swap directly — the only route to post-attestation stages, since vote_initiate
-                    # consumes the reservation at quorum.
-                    status = cached_status(q['miner_hotkey'], q.get('swap_key', ''), _ttl_bucket())
+                    # consumes the reservation at quorum. Optional from_chain/to_chain pick the
+                    # reservation slot carrying that pair (v3.1 holds one per hub).
+                    status = cached_status(
+                        q['miner_hotkey'],
+                        q.get('swap_key', ''),
+                        q.get('from_chain', ''),
+                        q.get('to_chain', ''),
+                        _ttl_bucket(),
+                    )
                     return self._send(200, status.__dict__)
                 if url.path == '/deposit-scan':
                     # Hash-finder for the offering's deposit watcher — /confirm stays the verifier.

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -949,6 +949,23 @@ def test_swap_status_reads_tao_slot_when_sol_empty(tmp_path):
     store.close()
 
 
+def test_swap_status_by_pair_reads_that_pairs_slot_not_the_freshest(tmp_path):
+    # The offering tracks ONE seat; answering with the miner's other hub made it refund a won seat
+    # ("another user holds this miner") or adopt a stranger's reservation under the same pubkey.
+    from allways.validator.reserve_engine import swap_status
+
+    sol = _unclaimed_reservation(FUTURE + 500)  # fresher, btc->sol, a stranger
+    tao = SimpleNamespace(
+        **{**vars(_unclaimed_reservation(FUTURE)), 'user': 'ourTaoUser', 'from_chain': 'tao', 'to_chain': 'btc'}
+    )
+    client = StatusClient(reservation={'sol': sol, 'tao': tao})
+    validator, store = _status_validator(tmp_path, client)
+    assert swap_status(validator, HOTKEY).user == 'staleUserSOLpk'  # no pair: freshest, as before
+    assert swap_status(validator, HOTKEY, from_chain='tao', to_chain='btc').user == 'ourTaoUser'
+    assert swap_status(validator, HOTKEY, from_chain='eth', to_chain='sol').stage == 'none'
+    store.close()
+
+
 def test_status_by_key_detail_carries_leg_hashes(tmp_path):
     from allways.validator.reserve_engine import swap_status
 

--- a/tests/test_seam_http.py
+++ b/tests/test_seam_http.py
@@ -136,8 +136,8 @@ def test_status_forwards_optional_swap_key(server, monkeypatch):
     (and default it to '' when absent, preserving the reservation-path behavior)."""
     seen = []
 
-    def fake_status(validator, miner_hotkey, swap_key_hex=''):
-        seen.append((miner_hotkey, swap_key_hex))
+    def fake_status(validator, miner_hotkey, swap_key_hex='', from_chain='', to_chain=''):
+        seen.append((miner_hotkey, swap_key_hex, from_chain, to_chain))
         return SwapStatus('timed_out', 0, '', swap_key_hex)
 
     monkeypatch.setattr(seam_http, 'swap_status', fake_status)
@@ -145,4 +145,5 @@ def test_status_forwards_optional_swap_key(server, monkeypatch):
     code, payload = _req(server, 'GET', f'/status?miner_hotkey=hk&swap_key={key}')
     assert code == 200 and payload['stage'] == 'timed_out' and payload['swap_key'] == key
     _req(server, 'GET', '/status?miner_hotkey=hk')
-    assert seen == [('hk', key), ('hk', '')]
+    _req(server, 'GET', '/status?miner_hotkey=hk&from_chain=tao&to_chain=btc')
+    assert seen == [('hk', key, '', ''), ('hk', '', '', ''), ('hk', '', 'tao', 'btc')]

--- a/tests/test_seam_read_cache.py
+++ b/tests/test_seam_read_cache.py
@@ -31,7 +31,7 @@ def counted(monkeypatch):
     """A seam whose chain reads are counted — each fixture builds a fresh memo."""
     calls = {'status': 0, 'scan': 0}
 
-    def fake_status(_validator, miner_hotkey, swap_key=''):
+    def fake_status(_validator, miner_hotkey, swap_key='', from_chain='', to_chain=''):
         calls['status'] += 1
         return SwapStatus('reserved', 999, f'user-{calls["status"]}', swap_key)
 
@@ -106,7 +106,7 @@ def test_failures_are_not_cached(counted, monkeypatch):
     server, calls = counted
     state = {'fail': True}
 
-    def flaky(_validator, _miner_hotkey, swap_key=''):
+    def flaky(_validator, _miner_hotkey, swap_key='', from_chain='', to_chain=''):
         if state['fail']:
             raise RuntimeError('getAccountInfo: HTTP 429')
         calls['status'] += 1


### PR DESCRIPTION
Companion to the ventura-labs-allways-app red-team round (2026-08-26). Validator seam only.

## Failure mode

`/status` without a `swap_key` walks the miner's per-hub reservation slots and answers with the *freshest* one. A consumer tracking one seat (the app) has no way to ask for *its* slot, so a stranger reserved on the miner's other hub was read as "another user holds this miner" — the app refunded a seat that had just been finalized for its user and left the reservation live and untracked — and a same-pubkey stranger there (a declared SOL address is not proof of ownership) was adopted as the consumer's own reservation.

`/status` now takes optional `from_chain`/`to_chain` and returns the slot carrying that pair (`none` if no such slot), unchanged behaviour without them. The read cache keys on the pair too.

Checks: ruff clean; `pytest tests/` 2033 pass — the 3 `test_bitcoin_signing` failures are order-dependent and present on `test` already (they pass in isolation).
