### PR TITLE
CLI: compress blob-length validator rejections; quiet vault success output

### DIFF
--- a/allways/cli/swap_commands/vault.py
+++ b/allways/cli/swap_commands/vault.py
@@ -79,7 +79,8 @@ def _report(result, ok_msg: str):
             console.print(f'[red]Call failed[/red]{f" [dim]({result.error})[/dim]" if result.error else ""}')
     else:
         console.print(f'[green]{ok_msg}[/green]')
-    if result.events:
+    # The raw event list is a diagnostic — only worth the noise when the call failed.
+    if not result.ok and result.events:
         console.print(f'  [dim]events: {", ".join(result.events)}[/dim]')
     console.print(f'  [dim]extrinsic: {result.extrinsic_hash}[/dim]\n')
 

--- a/allways/cli/validator_rejections.py
+++ b/allways/cli/validator_rejections.py
@@ -12,10 +12,28 @@ prefix-match falls through to the raw string — so adding a new validator-side
 rejection still surfaces something useful, just untranslated.
 """
 
+import re
 from dataclasses import dataclass, field
 from typing import Callable, Optional
 
 from rich.console import Console
+
+# Rejection strings are meant to be terse identifiers, but an RPC failure can smuggle a whole
+# JSON-RPC error dict through — pull the human sentence out of the blob instead of printing it.
+_MAX_RAW_LEN = 140
+_ANCHOR_MSG_RE = re.compile(r'Error Message:\s*([^\'"]+)')  # Anchor error text inside sim logs
+_RPC_MSG_RE = re.compile(r"'message':\s*'([^']+)'")
+
+
+def _terse(raw: str) -> str:
+    """Compress a blob-length rejection to '<prefix>: <human message>'; short reasons pass through."""
+    if len(raw) <= _MAX_RAW_LEN:
+        return raw
+    m = _ANCHOR_MSG_RE.search(raw) or _RPC_MSG_RE.search(raw)
+    if m:
+        prefix = raw[: raw.index(':')] if ':' in raw[:40] else 'validator error'
+        return f'{prefix}: {m.group(1).strip().rstrip(".")}'
+    return raw[: _MAX_RAW_LEN - 1] + '…'
 
 
 @dataclass
@@ -355,7 +373,7 @@ def render_and_aggregate(
             console.print(f'  {label}{i}: [yellow]no response[/yellow] [dim]— timeout or validator down[/dim]')
         else:
             info.rejected += 1
-            console.print(f'  {label}{i}: [red]no[/red] [dim]{raw}[/dim]')
+            console.print(f'  {label}{i}: [red]no[/red] [dim]{_terse(raw)}[/dim]')
 
     # Rate-limited (429) with no accepts: transient by nature — a short backoff
     # and retry clears it. Set this before the no-response early-return below so
@@ -399,7 +417,7 @@ def render_and_aggregate(
         # so the user still gets *something* actionable. Treat as transient by default
         # so the user can choose to retry.
         info.category = 'unmatched'
-        info.headline = last_raw or 'Validators rejected the request.'
+        info.headline = _terse(last_raw) if last_raw else 'Validators rejected the request.'
         info.deterministic = False
         return info
 
@@ -411,7 +429,7 @@ def render_and_aggregate(
         return info
 
     category, _, det, builder = last_match
-    ctx.setdefault('raw_reason', last_raw)
+    ctx.setdefault('raw_reason', _terse(last_raw))
     info.category = category
     info.deterministic = det
     try:

--- a/tests/test_cli_vault_admin.py
+++ b/tests/test_cli_vault_admin.py
@@ -147,3 +147,20 @@ def test_on_record_or_unknown_network_vault_address_stays_quiet(capsys):
     vault_cli._warn_if_off_record('5AnyVault', 'local')  # no of-record entry
     vault_cli._warn_if_off_record('5AnyVault', None)
     assert capsys.readouterr().out == ''
+
+
+def test_success_report_hides_the_event_dump(capsys):
+    """Success reads as one green line + extrinsic; the raw event list is failure diagnostics."""
+    result = VaultCallResult(ok=True, events=['Balances.Withdraw', 'System.ExtrinsicSuccess'], extrinsic_hash='0xabc')
+    vault_cli._report(result, 'Posted 2.200000000 τ')
+    out = capsys.readouterr().out
+    assert 'Posted 2.200000000' in out
+    assert 'events:' not in out
+    assert '0xabc' in out
+
+
+def test_failure_report_keeps_the_event_dump(capsys):
+    result = VaultCallResult(ok=False, error='Unknown', events=['System.ExtrinsicFailed'], extrinsic_hash='0xdef')
+    vault_cli._report(result, 'unused')
+    out = capsys.readouterr().out
+    assert 'events: System.ExtrinsicFailed' in out

--- a/tests/test_validator_rejections.py
+++ b/tests/test_validator_rejections.py
@@ -224,3 +224,41 @@ def test_the_sol_collateral_refusal_is_untouched():
     info = _reason('Insufficient collateral: 10 < 1000000')
     assert info.category == 'insufficient_collateral'
     assert info.deterministic is True and 'alw collateral deposit' in info.headline
+
+
+# ─── blob-length rejections are compressed to one human line ─────────────────
+
+_ANCHOR_BLOB = (
+    "sendTransaction: {'code': -32002, 'message': 'Transaction simulation failed: Error processing "
+    "Instruction 0: custom program error: 0x1777', 'data': {'accounts': None, 'err': "
+    "{'InstructionError': [0, {'Custom': 6007}]}, 'logs': ['Program log: AnchorError thrown in "
+    'programs/allways_swap_manager/src/consensus.rs:67. Error Code: NotValidator. Error Number: 6007. '
+    "Error Message: Signer is not a whitelisted validator.'], 'unitsConsumed': 17165}}"
+)
+
+_RPC_BLOB = (
+    "sendTransaction: {'code': -32002, 'message': 'Transaction simulation failed: Attempt to debit an "
+    "account but found no record of a prior credit.', 'data': {'accounts': None, 'err': "
+    "'AccountNotFound', 'fee': None, 'innerInstructions': None, 'loadedAccountsDataSize': 0, "
+    "'logs': [], 'postBalances': None, 'preBalances': None, 'unitsConsumed': 0}}"
+)
+
+
+def test_anchor_error_blob_compresses_to_its_error_message():
+    info = render_and_aggregate(_silent_console(), [FakeResp(accepted=False, rejection_reason=_ANCHOR_BLOB)])
+    assert info.category == 'unmatched'
+    assert info.headline == 'sendTransaction: Signer is not a whitelisted validator'
+    assert '{' not in info.headline
+
+
+def test_rpc_error_blob_compresses_to_its_message():
+    info = render_and_aggregate(_silent_console(), [FakeResp(accepted=False, rejection_reason=_RPC_BLOB)])
+    assert 'Attempt to debit an account' in info.headline
+    assert '{' not in info.headline
+
+
+def test_unstructured_long_reason_is_clipped():
+    raw = 'x' * 500
+    info = render_and_aggregate(_silent_console(), [FakeResp(accepted=False, rejection_reason=raw)])
+    assert len(info.headline) <= 141
+    assert info.headline.endswith('…')


### PR DESCRIPTION
Two small operator-UX fixes (tickets from today's mainnet swap session).

## Blob-length validator rejections → one human line

A validator-side RPC failure stuffs the entire JSON-RPC error dict into `rejection_reason`, so `alw swap now` / `post-tx` printed walls of JSON per validator (the V1–V6 spew). `_terse()` in `validator_rejections.py` now compresses any reason over 140 chars:

- Anchor sim-log blobs → the `Error Message` text: `V5: no sendTransaction: Signer is not a whitelisted validator`
- Plain RPC errors → the `'message'` field: `V1: no sendTransaction: Transaction simulation failed: Attempt to debit an account but found no record of a prior credit`
- Unstructured long strings → clipped with an ellipsis

Applied to the per-validator lines, the unmatched-headline fallback, and the `raw_reason` context that rule builders interpolate. Short reasons pass through byte-identical, so the prefix-match rules table and all existing translations are unaffected (the full raw string is still what gets matched).

This is the CLI half of the spew ticket; the validator-side half (not stuffing the dict in at the source, `rpc.py`'s `SolanaRpcError`) is a follow-up.

## `alw vault` success output

`post-collateral` (and every `_report` caller) dumped the raw event-name list on success. Events are failure diagnostics — they now print only when the call failed. Success = green line + extrinsic hash.

## Tests

- `test_validator_rejections.py`: +3, using the verbatim V1/V5 blobs from the mainnet session as fixtures.
- `test_cli_vault_admin.py`: +2 (success hides events, failure keeps them).

Full suite: 2048 passed; the 3 `test_bitcoin_signing.py` failures are the known pre-existing order-dependent ones on `test`.

https://claude.ai/code/session_01QHBu426sa8enr9bYN5gnDX