### PR TITLE
CLI: relay deposit confirms to the validator quorum only, stop waiting at quorum

### DIFF
--- a/allways/cli/dendrite_lite.py
+++ b/allways/cli/dendrite_lite.py
@@ -63,6 +63,38 @@ def discover_validators(
     return axons
 
 
+def discover_quorum_axons(client, subtensor: bt.Subtensor, netuid: int, cfg=None):
+    """Axons of the contract's whitelisted validators, plus a hotkey→label map for rendering.
+
+    Resolution chain: ``Config.validators`` → Binding (validator Solana pubkey → hotkey) →
+    metagraph axon. Only quorum members can ``submit_swap_claim``, so a confirm relayed anywhere
+    else buys noise, not progress. Returns only the members that fully resolve to a serving
+    axon — the caller decides whether that covers ``votes_needed`` or falls back to the
+    permissionless broadcast-all."""
+    from scalecodec.utils.ss58 import ss58_encode
+    from solders.pubkey import Pubkey
+
+    cfg = cfg or client.get_config()
+    hotkeys = set()
+    for entry in cfg.validators:
+        binding = client.get_binding(Pubkey.from_bytes(bytes(entry.key)))
+        if binding is None:
+            continue
+        hotkeys.add(ss58_encode(bytes(binding.hotkey), ss58_format=42))
+
+    axons: List[bt.AxonInfo] = []
+    names: dict = {}
+    if not hotkeys:
+        return axons, names
+    metagraph = subtensor.metagraph(netuid=netuid)
+    for uid in range(metagraph.n):
+        hotkey = metagraph.hotkeys[uid]
+        if hotkey in hotkeys and metagraph.axons[uid].is_serving:
+            axons.append(metagraph.axons[uid])
+            names[hotkey] = f'vali {uid}'
+    return axons, names
+
+
 def find_validator_axon(
     subtensor_factory: Callable[[], bt.Subtensor],
     netuid: int,

--- a/allways/cli/swap_commands/post_tx.py
+++ b/allways/cli/swap_commands/post_tx.py
@@ -1,7 +1,8 @@
 """alw swap post-tx - Confirm a swap by relaying your source-chain deposit to the validators.
 
 After `alw swap now` reserves a miner and you've sent the source funds to that miner's address, this
-command relays the source-tx hash to every serving validator via a ``SwapConfirmSynapse``. Each
+command relays the source-tx hash to the contract's validator quorum (falling back to every serving
+validator when the quorum can't be resolved from chain) via a ``SwapConfirmSynapse``. Each
 validator independently verifies the deposit against the pinned on-chain ``Reservation`` — recipient =
 the reserved miner address, amount = the reserved amount, and crucially **sender = the reservation's
 pinned taker address** — then submits ``submit_swap_claim`` on-chain (→ ``PendingAttestation``).
@@ -18,9 +19,11 @@ import time
 import click
 
 from allways.cli.dendrite_lite import (
-    broadcast_synapse,
+    broadcast_until_quorum,
+    discover_quorum_axons,
     discover_validators,
     get_ephemeral_wallet,
+    resolve_dendrite_timeout,
 )
 from allways.cli.help import StyledCommand
 from allways.cli.swap_commands.helpers import (
@@ -33,6 +36,7 @@ from allways.cli.swap_commands.helpers import (
     live_unclaimed,
     load_pending_swap,
     loading,
+    votes_needed,
 )
 from allways.cli.validator_rejections import render_and_aggregate
 from allways.solana import pdas
@@ -178,8 +182,41 @@ def post_tx_command(tx_hash: str, tx_block: int, miner_hint: str):
     console.print(f'[dim]Track it with `alw view swap {swap_key} --watch`.[/dim]')
 
 
+def resolve_relay_axons(client, subtensor, netuid: int):
+    """The targets for the confirm relay: (axons, hotkey→label names, accepts needed).
+
+    Preferred: just the contract's validator quorum — non-members can't submit claims (the
+    program rejects them with NotValidator), so relaying to them only spammed their errors and
+    held the relay for the full timeout on dead axons. Falls back LOUDLY to every serving
+    validator when the quorum can't be fully resolved from chain (unbound validator, axon not
+    serving, config unreadable) — a noisier round beats missing the one validator that matters."""
+    try:
+        cfg = client.get_config()
+        needed = votes_needed(cfg)
+        axons, names = discover_quorum_axons(client, subtensor, netuid, cfg=cfg)
+        if len(axons) >= needed:
+            return axons, names, needed
+        console.print(
+            f'[yellow]Resolved only {len(axons)} of the {needed} quorum validator(s) from chain — '
+            'relaying to every serving validator instead.[/yellow]'
+        )
+    except Exception as e:  # noqa: BLE001 - the fallback must survive any decode/RPC hiccup
+        console.print(f'[yellow]Quorum resolution failed ({e}) — relaying to every serving validator instead.[/yellow]')
+    return discover_validators(subtensor, netuid), {}, 1
+
+
 def relay_deposit(
-    client, resv, miner_pk, miner_hotkey, tx_hash, tx_block=0, *, on_behalf_of=None, validator_axons=None
+    client,
+    resv,
+    miner_pk,
+    miner_hotkey,
+    tx_hash,
+    tx_block=0,
+    *,
+    on_behalf_of=None,
+    validator_axons=None,
+    validator_names=None,
+    accepts_needed=1,
 ) -> str | None:
     """Relay a source deposit to the validators (the shared core of ``post-tx`` and the ``swap now``
     auto-send). Returns the swap_key hex on acceptance, else None. Idempotent: validators re-verify the
@@ -219,17 +256,28 @@ def relay_deposit(
 
     if validator_axons is None:
         config, _wallet, subtensor, _ = get_cli_context(need_wallet=False)
-        validator_axons = discover_validators(subtensor, int(config['netuid']))
+        validator_axons, validator_names, accepts_needed = resolve_relay_axons(client, subtensor, int(config['netuid']))
     if not validator_axons:
         console.print('[red]No serving validators found on the metagraph.[/red]')
         return None
 
-    wallet = get_ephemeral_wallet()  # transport-only throwaway hotkey; auth is the on-chain deposit
+    import bittensor as bt  # lazy — only the relay needs a dendrite
+
+    # Transport-only throwaway hotkey; auth is the on-chain deposit.
+    dendrite = bt.Dendrite(wallet=get_ephemeral_wallet())
+    timeout = resolve_dendrite_timeout(60.0)
     info = None
     for attempt in range(_RELAY_ATTEMPTS):
         with loading(f'Relaying deposit to {len(validator_axons)} validator(s)...'):
-            responses = broadcast_synapse(wallet, validator_axons, synapse, timeout=60.0)
-        info = render_and_aggregate(console, responses, label='V', context={'miner_hotkey': miner_hotkey})
+            responses = broadcast_until_quorum(
+                dendrite, validator_axons, synapse, needed=accepts_needed, timeout=timeout
+            )
+        info = render_and_aggregate(
+            console, responses, label='V', context={'miner_hotkey': miner_hotkey}, names=validator_names
+        )
+        skipped = len(validator_axons) - len(responses)
+        if skipped > 0 and info.accepted >= accepts_needed:
+            console.print(f'  [dim]Quorum reached — stopped waiting on {skipped} slower validator(s).[/dim]')
         if attempt == _RELAY_ATTEMPTS - 1 or not _should_retry_relay(info):
             break
         console.print(

--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -19,7 +19,6 @@ import click
 from allways.chains import SUPPORTED_CHAINS, get_chain_def, uses_solana_wallet
 from allways.cli.dendrite_lite import (
     broadcast_synapse,
-    discover_validators,
     find_validator_axon,
     get_ephemeral_wallet,
     invalidate_axon_cache,
@@ -760,7 +759,7 @@ def _auto_send_wizard(client, config, resv, miner_pk, from_chain, to_chain, from
     if from_chain == 'tao' and not _unlock_coldkey_for_send(provider.wallet):
         return False
 
-    from allways.cli.swap_commands.post_tx import relay_deposit
+    from allways.cli.swap_commands.post_tx import relay_deposit, resolve_relay_axons
 
     # Resolve validators BEFORE moving funds. This is the fragile network step — a subtensor websocket
     # connect + metagraph read — and it needs nothing from the send. Doing it first means a transient
@@ -768,7 +767,9 @@ def _auto_send_wizard(client, config, resv, miner_pk, from_chain, to_chain, from
     # money is out (which stranded a deposit past its reservation TTL, with no claim, Swap, or refund).
     try:
         vconfig, _vw, subtensor, _ = get_cli_context(need_wallet=False)
-        validator_axons = discover_validators(subtensor, int(vconfig['netuid']))
+        validator_axons, validator_names, accepts_needed = resolve_relay_axons(
+            client, subtensor, int(vconfig['netuid'])
+        )
     except Exception as e:  # noqa: BLE001 - funds still safe → clean fallback, nothing lost
         console.print(f'[yellow]  Could not reach the chain to resolve validators ({e}); no funds moved.[/yellow]')
         return False
@@ -794,7 +795,16 @@ def _auto_send_wizard(client, config, resv, miner_pk, from_chain, to_chain, from
     # relay, so any failure must become a recoverable "re-run post-tx" instruction inside the TTL.
     miner_hotkey = _miner_hotkey(client, miner_pk)
     try:
-        swap_key = relay_deposit(client, resv, miner_pk, miner_hotkey, tx_hash, validator_axons=validator_axons)
+        swap_key = relay_deposit(
+            client,
+            resv,
+            miner_pk,
+            miner_hotkey,
+            tx_hash,
+            validator_axons=validator_axons,
+            validator_names=validator_names,
+            accepts_needed=accepts_needed,
+        )
     except Exception as e:  # noqa: BLE001 - money committed; convert any error into a re-run, never a crash
         fail(
             f'  Deposit sent ({tx_hash}) but the confirm relay errored: {e}. '

--- a/allways/cli/validator_rejections.py
+++ b/allways/cli/validator_rejections.py
@@ -329,6 +329,7 @@ def render_and_aggregate(
     *,
     label: str = 'V',
     context: Optional[dict] = None,
+    names: Optional[dict] = None,
 ) -> RejectionInfo:
     """Print per-validator status lines and return aggregate counts + headline.
 
@@ -338,6 +339,10 @@ def render_and_aggregate(
       ``{label}{i}: no <raw reason>``       (rejected)
       ``{label}{i}: no response — timeout`` (no rejection_reason returned)
 
+    ``names`` (axon hotkey → display label, e.g. 'vali 194') replaces the positional
+    ``{label}{i}`` tag when the response's target hotkey is known — indexes stop meaning
+    anything once the relay targets a filtered set.
+
     When ``accepted == 0`` and every rejection prefix-matches the same rule,
     a translated headline is set on the returned info. Mixed-reason failures
     fall back to ``headline=''`` so the caller can render a generic line.
@@ -346,16 +351,20 @@ def render_and_aggregate(
     info = RejectionInfo()
 
     for i, resp in enumerate(responses, 1):
+        tag = f'{label}{i}'
+        if names:
+            axon_hotkey = getattr(getattr(resp, 'axon', None), 'hotkey', '') or ''
+            tag = names.get(axon_hotkey, tag)
         accepted = bool(getattr(resp, 'accepted', None))
         raw = (getattr(resp, 'rejection_reason', '') or '').strip()
         if accepted:
             info.accepted += 1
             if raw and 'queued' in raw.lower():
                 info.queued += 1
-                console.print(f'  {label}{i}: [yellow]queued[/yellow] {raw}')
+                console.print(f'  {tag}: [yellow]queued[/yellow] {raw}')
             else:
                 # Blank reason on accept is normal — don't print the no-response fallback.
-                console.print(f'  {label}{i}: [green]ok[/green]')
+                console.print(f'  {tag}: [green]ok[/green]')
             continue
 
         # A 429 from the edge proxy carries no synapse rejection_reason — the
@@ -364,16 +373,16 @@ def render_and_aggregate(
         status_code = str(getattr(getattr(resp, 'dendrite', None), 'status_code', '') or '')
         if not raw and status_code == '429':
             info.rate_limited += 1
-            console.print(f'  {label}{i}: [yellow]rate limited[/yellow] [dim]— retry in a few seconds[/dim]')
+            console.print(f'  {tag}: [yellow]rate limited[/yellow] [dim]— retry in a few seconds[/dim]')
             continue
 
         info.raw_reasons.append(raw)
         if not raw:
             info.no_response += 1
-            console.print(f'  {label}{i}: [yellow]no response[/yellow] [dim]— timeout or validator down[/dim]')
+            console.print(f'  {tag}: [yellow]no response[/yellow] [dim]— timeout or validator down[/dim]')
         else:
             info.rejected += 1
-            console.print(f'  {label}{i}: [red]no[/red] [dim]{_terse(raw)}[/dim]')
+            console.print(f'  {tag}: [red]no[/red] [dim]{_terse(raw)}[/dim]')
 
     # Rate-limited (429) with no accepts: transient by nature — a short backoff
     # and retry clears it. Set this before the no-response early-return below so

--- a/tests/test_quorum_relay.py
+++ b/tests/test_quorum_relay.py
@@ -1,0 +1,168 @@
+"""The confirm relay targets the contract's validator quorum, not every serving validator.
+
+discover_quorum_axons resolves Config.validators → Binding → metagraph axon; resolve_relay_axons
+falls back LOUDLY to broadcast-all whenever that chain breaks — the relay may get noisier on a
+resolution failure, never narrower than the quorum.
+"""
+
+import io
+import re
+from types import SimpleNamespace
+
+from rich.console import Console
+from scalecodec.utils.ss58 import ss58_encode
+
+from allways.cli.dendrite_lite import discover_quorum_axons
+from allways.cli.swap_commands import post_tx
+from allways.cli.validator_rejections import render_and_aggregate
+
+VALI_PUBKEY = b'\x07' * 32
+VALI_HOTKEY = b'\x11' * 32
+VALI_SS58 = ss58_encode(VALI_HOTKEY, ss58_format=42)
+
+
+def _plain(out: str) -> str:
+    """Captured console text minus ANSI codes and line wraps — FORCE_COLOR in the environment
+    makes rich emit style codes mid-phrase at wrap points, which breaks substring asserts."""
+    return ' '.join(re.sub(r'\x1b\[[0-9;]*m', '', out).split())
+
+
+def _cfg(validators=None, threshold=67):
+    entries = validators if validators is not None else [SimpleNamespace(key=VALI_PUBKEY, weight=82)]
+    return SimpleNamespace(validators=entries, consensus_threshold_percent=threshold)
+
+
+def _client(cfg=None, binding_hotkey=VALI_HOTKEY):
+    client = SimpleNamespace()
+    client.get_config = lambda: cfg if cfg is not None else _cfg()
+    client.get_binding = lambda pk: SimpleNamespace(hotkey=binding_hotkey) if binding_hotkey else None
+    return client
+
+
+def _metagraph(hotkeys, serving=True):
+    axons = [SimpleNamespace(is_serving=serving, hotkey=hk) for hk in hotkeys]
+    return SimpleNamespace(n=len(hotkeys), hotkeys=hotkeys, axons=axons)
+
+
+def _subtensor(metagraph):
+    return SimpleNamespace(metagraph=lambda netuid: metagraph)
+
+
+# ─── discover_quorum_axons ───────────────────────────────────────────────────
+
+
+def test_resolves_whitelisted_validator_to_its_axon():
+    sub = _subtensor(_metagraph(['5SomeoneElse', VALI_SS58]))
+    axons, names = discover_quorum_axons(_client(), sub, netuid=7)
+    assert len(axons) == 1
+    assert axons[0].hotkey == VALI_SS58
+    assert names == {VALI_SS58: 'vali 1'}
+
+
+def test_unbound_validator_resolves_to_nothing():
+    sub = _subtensor(_metagraph([VALI_SS58]))
+    axons, names = discover_quorum_axons(_client(binding_hotkey=None), sub, netuid=7)
+    assert axons == [] and names == {}
+
+
+def test_non_serving_axon_is_excluded():
+    sub = _subtensor(_metagraph([VALI_SS58], serving=False))
+    axons, _names = discover_quorum_axons(_client(), sub, netuid=7)
+    assert axons == []
+
+
+# ─── resolve_relay_axons ─────────────────────────────────────────────────────
+
+
+def test_full_quorum_resolution_filters_the_relay():
+    sub = _subtensor(_metagraph(['5SomeoneElse', VALI_SS58]))
+    axons, names, needed = post_tx.resolve_relay_axons(_client(), sub, netuid=7)
+    assert [a.hotkey for a in axons] == [VALI_SS58]
+    assert names == {VALI_SS58: 'vali 1'}
+    assert needed == 1  # ceil(67% of 1 validator)
+
+
+def test_partial_resolution_falls_back_to_broadcast_all(monkeypatch, capsys):
+    sentinel = [SimpleNamespace(hotkey='5All1'), SimpleNamespace(hotkey='5All2')]
+    monkeypatch.setattr(post_tx, 'discover_validators', lambda subtensor, netuid: sentinel)
+    sub = _subtensor(_metagraph([VALI_SS58]))
+
+    axons, names, needed = post_tx.resolve_relay_axons(_client(binding_hotkey=None), sub, netuid=7)
+
+    assert axons is sentinel
+    assert names == {} and needed == 1
+    assert 'every serving validator' in _plain(capsys.readouterr().out)
+
+
+def test_config_read_failure_falls_back_to_broadcast_all(monkeypatch, capsys):
+    sentinel = [SimpleNamespace(hotkey='5All1')]
+    monkeypatch.setattr(post_tx, 'discover_validators', lambda subtensor, netuid: sentinel)
+    client = SimpleNamespace(get_config=lambda: (_ for _ in ()).throw(RuntimeError('rpc down')))
+
+    axons, names, needed = post_tx.resolve_relay_axons(client, _subtensor(None), netuid=7)
+
+    assert axons is sentinel and needed == 1
+    assert 'Quorum resolution failed' in _plain(capsys.readouterr().out)
+
+
+# ─── identity-labeled rendering ──────────────────────────────────────────────
+
+
+def _recording_console():
+    return Console(file=io.StringIO(), width=200, force_terminal=False)
+
+
+def test_named_response_renders_by_identity():
+    console = _recording_console()
+    resp = SimpleNamespace(accepted=True, rejection_reason='', axon=SimpleNamespace(hotkey=VALI_SS58))
+    render_and_aggregate(console, [resp], names={VALI_SS58: 'vali 194'})
+    out = console.file.getvalue()
+    assert 'vali 194: ok' in out
+    assert 'V1' not in out
+
+
+def test_unnamed_response_keeps_the_positional_tag():
+    console = _recording_console()
+    resp = SimpleNamespace(accepted=True, rejection_reason='', axon=SimpleNamespace(hotkey='5Unknown'))
+    render_and_aggregate(console, [resp], names={VALI_SS58: 'vali 194'})
+    assert 'V1: ok' in console.file.getvalue()
+
+
+# ─── relay_deposit wiring ────────────────────────────────────────────────────
+
+
+def test_relay_deposit_stops_at_quorum(monkeypatch, capsys):
+    calls = {}
+    accept = SimpleNamespace(accepted=True, rejection_reason='', axon=SimpleNamespace(hotkey=VALI_SS58))
+
+    def fake_broadcast(dendrite, axons, synapse, needed, timeout):
+        calls['needed'] = needed
+        return [accept]  # the second axon never answered — early return already fired
+
+    monkeypatch.setattr(post_tx, 'broadcast_until_quorum', fake_broadcast)
+    monkeypatch.setattr(post_tx, 'get_ephemeral_wallet', lambda: None)
+    monkeypatch.setattr('bittensor.Dendrite', lambda wallet=None: object())
+    monkeypatch.setattr(post_tx, 'clear_pending_swap', lambda: None)
+    monkeypatch.setattr(post_tx, 'swap_key_from_tx_hash', lambda h: b'\x01' * 32)
+
+    client = SimpleNamespace(rpc=SimpleNamespace(get_transaction=lambda h: {'slot': 1}))
+    resv = SimpleNamespace(from_chain='sol', to_chain='eth', from_addr='src', user_to_addr='dst', user='u')
+    axons = [SimpleNamespace(hotkey=VALI_SS58), SimpleNamespace(hotkey='5Slow')]
+
+    key = post_tx.relay_deposit(
+        client,
+        resv,
+        'MinerPk',
+        '5MinerHot',
+        'txhash',
+        1,
+        validator_axons=axons,
+        validator_names={VALI_SS58: 'vali 194'},
+        accepts_needed=1,
+    )
+
+    assert calls['needed'] == 1
+    assert key == (b'\x01' * 32).hex()
+    out = _plain(capsys.readouterr().out)
+    assert 'stopped waiting on 1 slower validator' in out
+    assert 'vali 194: ok' in out

--- a/tests/test_swap_now_send_ordering.py
+++ b/tests/test_swap_now_send_ordering.py
@@ -51,11 +51,11 @@ def test_chain_unreachable_during_validator_resolve_moves_no_funds():
     with (
         patch.object(swap_mod, '_source_provider', return_value=provider),
         patch.object(swap_mod, 'get_cli_context', side_effect=TimeoutError('timed out')),
-        patch.object(swap_mod, 'discover_validators') as disc,
+        patch('allways.cli.swap_commands.post_tx.resolve_relay_axons') as resolver,
     ):
         assert _wizard(provider) is False  # clean fallback, not a crash
     provider.send_amount.assert_not_called()  # THE invariant: funds untouched
-    disc.assert_not_called()
+    resolver.assert_not_called()
 
 
 def test_relay_error_after_send_is_recoverable_not_a_traceback():
@@ -63,7 +63,7 @@ def test_relay_error_after_send_is_recoverable_not_a_traceback():
     with (
         patch.object(swap_mod, '_source_provider', return_value=provider),
         patch.object(swap_mod, 'get_cli_context', return_value=({'netuid': 1}, None, MagicMock(), None)),
-        patch.object(swap_mod, 'discover_validators', return_value=['axon']),
+        patch('allways.cli.swap_commands.post_tx.resolve_relay_axons', return_value=(['axon'], {}, 1)),
         patch.object(swap_mod, '_miner_hotkey', return_value='miner-hotkey'),
         patch('allways.cli.swap_commands.post_tx.relay_deposit', side_effect=TimeoutError('timed out')),
         pytest.raises(SystemExit),
@@ -79,7 +79,10 @@ def test_happy_path_passes_preresolved_axons_into_relay():
     with (
         patch.object(swap_mod, '_source_provider', return_value=provider),
         patch.object(swap_mod, 'get_cli_context', return_value=({'netuid': 1}, None, MagicMock(), None)),
-        patch.object(swap_mod, 'discover_validators', return_value=['axon-a', 'axon-b']),
+        patch(
+            'allways.cli.swap_commands.post_tx.resolve_relay_axons',
+            return_value=(['axon-a', 'axon-b'], {'hk': 'vali 1'}, 1),
+        ),
         patch.object(swap_mod, '_miner_hotkey', return_value='miner-hotkey'),
         patch.object(swap_mod, '_watch_swap'),
         patch('allways.cli.swap_commands.post_tx.relay_deposit', return_value='swapkeyhex') as relay,
@@ -88,3 +91,5 @@ def test_happy_path_passes_preresolved_axons_into_relay():
     # Validators resolved once, pre-send, and handed to relay_deposit so it does NOT reconnect after
     # the money is out.
     assert relay.call_args.kwargs['validator_axons'] == ['axon-a', 'axon-b']
+    assert relay.call_args.kwargs['validator_names'] == {'hk': 'vali 1'}
+    assert relay.call_args.kwargs['accepts_needed'] == 1


### PR DESCRIPTION
**Stacked on #714** (shares the rejection-renderer changes) — merge that first; GitHub will retarget this to `test`.

Fixes both halves of the deposit-relay pain from today's mainnet session:

- **Slow** (`A`): `broadcast_synapse` gathered ALL responses on a 60s timeout, so dead/foreign axons held the relay long after the real validator accepted.
- **Confusing** (`B`): 5 of 6 serving validators aren't in the contract quorum, can't `submit_swap_claim` (program rejects `NotValidator`), and their errors were rendered as if they mattered.

## What changed

**`discover_quorum_axons`** (`dendrite_lite.py`): resolves the contract's whitelist to axons — `Config.validators` → Binding (validator Solana pubkey → hotkey) → metagraph axon — returning only members that fully resolve to a serving axon, plus a hotkey→label map. Verified live on mainnet: `AuRf6Y…` → `5DtUJ9…` → uid 194.

**`resolve_relay_axons`** (`post_tx.py`): uses the quorum set when it covers `votes_needed(cfg)`; otherwise **falls back loudly to broadcast-all** (yellow warning naming what didn't resolve). The relay can get noisier on a resolution failure — never narrower than the quorum. Both `post-tx` and the `swap now --send` pre-resolve path (funds-safety ordering preserved: resolution still happens before money moves) go through it.

**Early return**: the relay now uses `broadcast_until_quorum` (the same machinery miner activation has used all along) with `needed=votes_needed(cfg)` — one accept ends the wait today, and prints `Quorum reached — stopped waiting on N slower validator(s)`. Protocol-safe: attestation is chain-driven (`solana_swap_loop` scans `PendingAttestation` from chain state), so quorum members that didn't get the synapse still find the claim.

**No failure is papered over**: zero accepts → exactly the old path (rejections rendered, 3×30s retry, exit 1). Quorum-member rejections still print in full and still fail the run.

**Identity labels**: responses render as `vali 194: ok` instead of `V6: ok` when the target is known — positional indexes stop meaning anything on a filtered set.

## Tests

`test_quorum_relay.py` (+10): resolution happy path, unbound validator, non-serving axon, partial-resolution fallback, config-read-failure fallback, identity vs positional labels, and a `relay_deposit` wiring test (quorum count flows through, early-stop line prints). `test_swap_now_send_ordering.py` updated to the resolver API — the funds-safety invariants (resolve-before-send, recoverable relay errors) still pin.

Full suite: 2057 passed; the 3 `test_bitcoin_signing.py` failures are the known pre-existing order-dependent set.

## Local test plan (before merge)

1. `alw swap quote` sanity, then a small mainnet swap with `--send`: expect `Relaying deposit to 1 validator(s)`, `vali 194: ok`, and a fast relay (no 60s tail).
2. Kill the quorum path deliberately (e.g. `ALLWAYS_PROGRAM_ID` pointed at a dead program in a scratch config) to see the loud fallback.
3. Standalone `alw swap post-tx <sig>` re-relay of an already-confirmed deposit (idempotent) to exercise the non-`--send` path.

https://claude.ai/code/session_01QHBu426sa8enr9bYN5gnDX