### PR TITLE
CLI: --send verifies source-address control before the bid

### DIFF
--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -409,6 +409,21 @@ def swap_now_command(
     if _src_gate is not None:
         user_from_addr = _src_gate.chain.normalize_address(user_from_addr)
 
+    # `--send` is an explicit promise to drive the deposit in-process, so prove the configured
+    # wallet can actually sign for the pinned source address BEFORE any fee is spent. The old
+    # order only discovered a mismatch inside _auto_send_wizard — post-bid, post-finalize — and
+    # dropped the taker onto the manual deadline path with a live reservation and real money
+    # committed (hit live on a tao source 2026-09-02: config wallet vs a different --from-address).
+    if auto_send is True and not uses_solana_wallet(from_chain):
+        _pre = _source_provider(from_chain, client, config)
+        if _pre is None or not _pre.can_send_from(user_from_addr):
+            hint = f" (configured TAO wallet: '{config.get('wallet', '?')}')" if from_chain == 'tao' else ''
+            fail(
+                f'--send: this CLI cannot send {from_chain.upper()} from {user_from_addr}{hint}. '
+                'No bid was placed and no fee was spent. Fix --from-address or the configured '
+                'wallet/creds, or re-run without --send to use the manual deposit flow deliberately.'
+            )
+
     cfg = client.get_config()
     bounds = bounds_from_config(cfg) if cfg else {}
     min_swap, max_swap = hub_bounds(bounds, from_chain, to_chain)

--- a/tests/test_swap_now_reservation.py
+++ b/tests/test_swap_now_reservation.py
@@ -579,3 +579,36 @@ def test_screen_rejection_aborts_swap_now_before_any_bid():
     assert 'cannot accept' in result.output
     client.open_or_request.assert_not_called()
     client.get_reservation.assert_not_called()
+
+
+def test_send_with_uncontrolled_source_aborts_before_any_bid():
+    """Regression: `--send` with a source address the configured wallet can't sign for must abort
+    BEFORE the bid. The old order spent the reservation fee, finalized, and only then (inside
+    _auto_send_wizard) noticed can_send_from was false — stranding the taker on the manual
+    deadline path with real money committed (live tao incident, 2026-09-02)."""
+    from click.testing import CliRunner
+
+    from allways.cli.swap_commands.swap import swap_now_command
+
+    user = '68ToGUYjjYpqi7Atx7QyhbybR2RCfo2tkmgcoNR3DxYF'
+    client = MagicMock()
+    client.keypair.pubkey.return_value = user
+    bad_provider = MagicMock()
+    bad_provider.can_send_from.return_value = False
+
+    argv = ['--from', 'tao', '--to', 'aster', '--amount', '0.15']
+    argv += ['--from-address', 'tao-source-we-cannot-sign-for', '--receive-address', '0xUs']
+    argv += ['--yes', '--send']
+
+    with (
+        patch('allways.cli.swap_commands.swap.get_solana_cli_context', return_value=(None, client)),
+        patch('allways.cli.swap_commands.swap._gate_provider', return_value=None),
+        patch('allways.cli.swap_commands.swap._source_provider', return_value=bad_provider),
+    ):
+        result = CliRunner().invoke(swap_now_command, argv)
+
+    assert result.exit_code != 0
+    assert 'cannot send TAO from' in result.output
+    assert 'No bid was placed' in result.output
+    client.open_or_request.assert_not_called()  # the money-touching call never happened
+    client.get_config.assert_not_called()  # aborted before even reading chain config


### PR DESCRIPTION
## Problem

`alw swap now --send` only discovers that the configured wallet cannot sign for the pinned `--from-address` **inside `_auto_send_wizard`** — after the bid, draw, and finalize. By then the reservation fee is spent and the taker is dropped onto the manual send + `post-tx` path with the 480s TTL running and real money committed.

Hit live 2026-09-02 on a tao-source swap: config `wallet: miner` (whose TAO coldkey isn't on the box), vali coldkey passed as `--from-address`. The CLI's check was *correct* — but it fired at the worst possible moment. The deposit was saved by hand with ~6 minutes to spare (btcli transfer + extrinsic-hash spelunking + post-tx).

## Fix

When `--send` is explicit and the source is not the Solana signer itself, build the source provider and check `can_send_from(--from-address)` **before any fee is spent**. On failure, abort with the remedies spelled out (fix `--from-address` / the configured wallet or creds, or re-run without `--send` to take the manual flow deliberately) and an explicit "no bid was placed, no fee was spent."

The wizard's post-finalize `can_send_from` check stays as defense in depth for the interactive default path (no explicit `--send`), whose manual fallback remains a legitimate flow (e.g. sending from an exchange).

## Test

`test_send_with_uncontrolled_source_aborts_before_any_bid` drives the CliRunner path with a provider whose `can_send_from` is false and asserts the abort happens before `open_or_request` (the money-touching call) and before `get_config`. Full `test_swap_now_reservation.py` + `test_swap_now_send_ordering.py`: 39 passed.

https://claude.ai/code/session_01GxaF4CWkNHSDCb6fCmh4Ki