### PR TITLE
Serve timeout refund facts on the seam /status

### DIFF
--- a/allways/validator/event_index.py
+++ b/allways/validator/event_index.py
@@ -96,7 +96,7 @@ class SolanaEventIndex:
         return written
 
     def _record_unattributed_outcome(self, rec: EventRecord, block_time: int) -> bool:
-        """Persist only the swap_key-keyed terminal facts (delivery hash + terminal/stale outcome)
+        """Persist only the swap_key-keyed terminal facts (delivery hash, refund facts, and terminal/stale outcome)
         for an event whose miner pubkey is unbound at ingest. These rows credit no UID — they are
         the seam's post-close truth read by /status — so they must land even when every
         crown-relevant effect is dropped. Idempotent upserts, so a later re-bind + re-ingest is a
@@ -109,7 +109,7 @@ class SolanaEventIndex:
         outcome = _OUTCOME_BY_EVENT.get(rec.name)
         if outcome is not None:
             swap_key = bytes(rec.fields['swap_key']).hex()
-            self.state_store.record_swap_outcome(swap_key, outcome, block_time)
+            self.state_store.record_swap_outcome(swap_key, outcome, block_time, refund=self._refund_facts(rec))
             dev_signal.emit('swap_outcome', swap_key=swap_key, outcome=outcome)
             return True
         return False
@@ -143,7 +143,9 @@ class SolanaEventIndex:
             )
             outcome = _OUTCOME_BY_EVENT.get(name)
             if outcome is not None:
-                self.state_store.record_swap_outcome(bytes(rec.fields['swap_key']).hex(), outcome, block_time)
+                self.state_store.record_swap_outcome(
+                    bytes(rec.fields['swap_key']).hex(), outcome, block_time, refund=self._refund_facts(rec)
+                )
                 dev_signal.emit('swap_outcome', swap_key=bytes(rec.fields['swap_key']).hex(), outcome=outcome)
             # SwapCompleted is the only swap event carrying realized legs — persist
             # them as a clearing-rate sample for the windowed volume read, in
@@ -370,6 +372,14 @@ class SolanaEventIndex:
         """A backing/collateral-chain field, defaulting to the SOL numéraire when absent — pre-split
         events carried no backing and were all sol-backed by construction (F4)."""
         return str(rec.fields.get(key, 'sol')).lower()
+
+    @staticmethod
+    def _refund_facts(rec: EventRecord) -> Optional[Tuple[str, Optional[int], Optional[str]]]:
+        if rec.name != 'SwapTimedOut':
+            return None
+        chain = SolanaEventIndex._backing(rec, 'collateral_chain')
+        # Off-chain backings settle on Bittensor — no Solana signature proves that payout.
+        return (chain, rec.fields.get('reimbursement'), rec.signature if chain == 'sol' else None)
 
     # ─── read interface (consumed by scoring's crown replay) ────────────
 

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -797,6 +797,9 @@ def _swap_status_by_key(validator, swap_key_hex: str) -> SwapStatus:
         to_tx_hash = validator.state_store.get_swap_fulfillment(swap_key_hex)
         if to_tx_hash:
             detail['to_tx_hash'] = to_tx_hash
+        refund = validator.state_store.get_swap_refund(swap_key_hex)
+        if refund:
+            detail.update(refund)
         return SwapStatus(stage, swap_key=swap_key_hex, detail=detail)
     # Same detail shape as the reservation path — the Swap PDA carries the full legs.
     detail = {

--- a/allways/validator/state_store.py
+++ b/allways/validator/state_store.py
@@ -451,20 +451,55 @@ class ValidatorStateStore:
 
     # ─── swap_outcomes (terminal per-swap truth for the seam) ───────────
 
-    def record_swap_outcome(self, swap_key: str, outcome: str, block_time: int) -> None:
+    def record_swap_outcome(
+        self,
+        swap_key: str,
+        outcome: str,
+        block_time: int,
+        refund: Optional[Tuple[str, Optional[int], Optional[str]]] = None,
+    ) -> None:
         """Persist a swap's terminal outcome (``completed`` | ``timed_out``) keyed by
-        swap_key hex. Upsert: a cursor-reset re-ingest of the same event is a no-op."""
+        swap_key hex. Upsert: a cursor-reset re-ingest of the same event is a no-op; the
+        COALESCEs ensure a re-ingest or factless outcome write never blanks refund facts."""
+        refund_chain, refund_amount, refund_tx = refund or (None, None, None)
         self._execute(
             """
-            INSERT INTO swap_outcomes (swap_key, outcome, block_time) VALUES (?, ?, ?)
-            ON CONFLICT(swap_key) DO UPDATE SET outcome = excluded.outcome, block_time = excluded.block_time
+            INSERT INTO swap_outcomes
+                (swap_key, outcome, block_time, refund_chain, refund_amount, refund_tx)
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(swap_key) DO UPDATE SET
+                outcome = excluded.outcome,
+                block_time = excluded.block_time,
+                refund_chain = COALESCE(excluded.refund_chain, refund_chain),
+                refund_amount = COALESCE(excluded.refund_amount, refund_amount),
+                refund_tx = COALESCE(excluded.refund_tx, refund_tx)
             """,
-            (swap_key, outcome, block_time),
+            (
+                swap_key,
+                outcome,
+                block_time,
+                refund_chain,
+                str(refund_amount) if refund_amount is not None else None,
+                refund_tx,
+            ),
         )
 
     def get_swap_outcome(self, swap_key: str) -> Optional[str]:
         row = self._fetchone('SELECT outcome FROM swap_outcomes WHERE swap_key = ?', (swap_key,))
         return row['outcome'] if row is not None else None
+
+    def get_swap_refund(self, swap_key: str) -> Optional[dict]:
+        row = self._fetchone(
+            'SELECT refund_chain, refund_amount, refund_tx FROM swap_outcomes WHERE swap_key = ?', (swap_key,)
+        )
+        if row is None or row['refund_amount'] is None:
+            return None
+        refund = {'refund_amount': int(row['refund_amount'])}
+        if row['refund_chain'] is not None:
+            refund['refund_chain'] = row['refund_chain']
+        if row['refund_tx'] is not None:
+            refund['refund_tx_hash'] = row['refund_tx']
+        return refund
 
     def prune_swap_outcomes(self, cutoff_block: int) -> None:
         """Drop outcome (and fulfillment-hash) rows older than ``cutoff_block``. No anchor row —
@@ -912,6 +947,13 @@ class ValidatorStateStore:
             cols = [row[1] for row in conn.execute('PRAGMA table_info(swap_outcomes)')]
             if cols and 'outcome' not in cols:
                 conn.execute('DROP TABLE swap_outcomes')
+                cols = []
+            if cols and 'refund_chain' not in cols:
+                conn.execute('ALTER TABLE swap_outcomes ADD COLUMN refund_chain TEXT')
+            if cols and 'refund_amount' not in cols:
+                conn.execute('ALTER TABLE swap_outcomes ADD COLUMN refund_amount TEXT')
+            if cols and 'refund_tx' not in cols:
+                conn.execute('ALTER TABLE swap_outcomes ADD COLUMN refund_tx TEXT')
             # Pre-M2 deployments lack the clearing_rates idempotency key. Purge unkeyed rows:
             # NULL keys never collide with ON CONFLICT(swap_key), so a post-upgrade replay would
             # double-count them — a one-time <=2h volume gap buys a safe dedup invariant.
@@ -1042,7 +1084,10 @@ class ValidatorStateStore:
                 CREATE TABLE IF NOT EXISTS swap_outcomes (
                     swap_key    TEXT PRIMARY KEY,
                     outcome     TEXT NOT NULL,
-                    block_time  INTEGER NOT NULL
+                    block_time  INTEGER NOT NULL,
+                    refund_chain TEXT,
+                    refund_amount TEXT,
+                    refund_tx   TEXT
                 );
 
                 -- Delivery-leg tx hash per swap (SwapFulfilled), keyed by swap_key hex.

--- a/tests/test_event_index.py
+++ b/tests/test_event_index.py
@@ -591,11 +591,47 @@ class TestIngestSwapOutcomes:
         idx = SolanaEventIndex(store)
         key = bytes(range(32))
         idx.ingest(
-            [rec('SwapTimedOut', miner='pk_a', block_time=400, swap_key=key, collateral_amount=10, slash=1)],
+            [
+                rec(
+                    'SwapTimedOut',
+                    miner='pk_a',
+                    block_time=400,
+                    slot=7,
+                    swap_key=key,
+                    collateral_chain='sol',
+                    collateral_amount=10,
+                    reimbursement=11,
+                    slash=1,
+                )
+            ],
             ATTR,
         )
         assert store.get_swap_outcome(key.hex()) == 'timed_out'
+        assert store.get_swap_refund(key.hex()) == {
+            'refund_chain': 'sol',
+            'refund_amount': 11,
+            'refund_tx_hash': 'sig7',
+        }
         assert store.get_swap_outcome(DEFAULT_SWAP_KEY.hex()) is None  # only the event's key lands
+        store.close()
+
+    def test_tao_timeout_records_refund_without_transaction(self, tmp_path: Path):
+        store = make_store(tmp_path)
+        key = bytes(range(32))
+        SolanaEventIndex(store).ingest(
+            [
+                rec(
+                    'SwapTimedOut',
+                    miner='pk_a',
+                    block_time=400,
+                    swap_key=key,
+                    collateral_chain='tao',
+                    reimbursement=2**63,  # past sqlite's int64 bind limit — proves the TEXT store
+                )
+            ],
+            ATTR,
+        )
+        assert store.get_swap_refund(key.hex()) == {'refund_chain': 'tao', 'refund_amount': 2**63}
         store.close()
 
     def test_swap_cancelled_records_cancelled_outcome(self, tmp_path: Path):
@@ -618,6 +654,7 @@ class TestIngestSwapOutcomes:
             ATTR,
         )
         assert store.get_swap_outcome(key.hex()) == 'cancelled'
+        assert store.get_swap_refund(key.hex()) is None
         store.close()
 
     def test_stale_claim_closed_records_expired_outcome(self, tmp_path: Path):
@@ -657,15 +694,54 @@ class TestIngestSwapOutcomes:
         assert store.get_clearing_volumes(0, 1000) == {}  # no UID → no volume credited
         store.close()
 
+    def test_unbound_miner_timeout_records_refund(self, tmp_path: Path):
+        store = make_store(tmp_path)
+        key = bytes(range(32))
+        SolanaEventIndex(store).ingest(
+            [
+                rec(
+                    'SwapTimedOut',
+                    miner='pk_c',
+                    block_time=400,
+                    slot=8,
+                    swap_key=key,
+                    collateral_chain='sol',
+                    reimbursement=13,
+                )
+            ],
+            ATTR,
+        )
+        assert store.get_swap_refund(key.hex()) == {
+            'refund_chain': 'sol',
+            'refund_amount': 13,
+            'refund_tx_hash': 'sig8',
+        }
+        store.close()
+
     def test_reingest_of_same_event_is_a_noop_upsert(self, tmp_path: Path):
         """A cursor reset can replay history — the outcome row upserts instead of erroring."""
         store = make_store(tmp_path)
         idx = SolanaEventIndex(store)
         key = bytes(range(32))
-        event = rec('SwapTimedOut', miner='pk_a', block_time=400, swap_key=key, collateral_amount=10, slash=1)
+        event = rec(
+            'SwapTimedOut',
+            miner='pk_a',
+            block_time=400,
+            slot=9,
+            swap_key=key,
+            collateral_amount=10,
+            reimbursement=14,
+            slash=1,
+        )
         idx.ingest([event], ATTR)
         idx.ingest([event], ATTR)
+        store.record_swap_outcome(key.hex(), 'timed_out', 400)
         assert store.get_swap_outcome(key.hex()) == 'timed_out'
+        assert store.get_swap_refund(key.hex()) == {
+            'refund_chain': 'sol',
+            'refund_amount': 14,
+            'refund_tx_hash': 'sig9',
+        }
         store.close()
 
     def test_legacy_b35_table_is_dropped_and_recreated(self, tmp_path: Path):
@@ -678,6 +754,24 @@ class TestIngestSwapOutcomes:
         store = ValidatorStateStore(db_path=db)
         store.record_swap_outcome('ab' * 32, 'timed_out', 100)
         assert store.get_swap_outcome('ab' * 32) == 'timed_out'
+        store.close()
+
+    def test_legacy_outcome_table_gains_refund_columns(self, tmp_path: Path):
+        import sqlite3
+
+        db = tmp_path / 'state.db'
+        with sqlite3.connect(db) as conn:
+            conn.execute(
+                'CREATE TABLE swap_outcomes '
+                '(swap_key TEXT PRIMARY KEY, outcome TEXT NOT NULL, block_time INTEGER NOT NULL)'
+            )
+        store = ValidatorStateStore(db_path=db)
+        store.record_swap_outcome('ab' * 32, 'timed_out', 100, refund=('sol', 15, 'sig'))
+        assert store.get_swap_refund('ab' * 32) == {
+            'refund_chain': 'sol',
+            'refund_amount': 15,
+            'refund_tx_hash': 'sig',
+        }
         store.close()
 
     def test_prune_drops_old_outcomes(self, tmp_path: Path):

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -493,6 +493,18 @@ def test_closed_pda_by_key_with_recorded_slash_reports_timed_out(tmp_path):
     store.close()
 
 
+def test_closed_pda_by_key_carries_refund_facts(tmp_path):
+    from allways.validator.reserve_engine import swap_status
+
+    key = b'\x16' * 32
+    validator, store = _status_validator(tmp_path, StatusClient(swap=None))
+    store.record_swap_outcome(key.hex(), 'timed_out', 100, refund=('sol', 123, 'refundTx'))
+    s = swap_status(validator, HOTKEY, key.hex())
+    assert s.stage == 'timed_out'
+    assert s.detail == {'refund_chain': 'sol', 'refund_amount': 123, 'refund_tx_hash': 'refundTx'}
+    store.close()
+
+
 def test_closed_pda_by_key_with_unrecorded_outcome_reports_fulfilled(tmp_path):
     from allways.validator.reserve_engine import swap_status
 


### PR DESCRIPTION
The offering app (allways-access) needs proof of a timeout refund after the Swap PDA closes: how much, on which chain, and the Solana signature when the backing settled locally. `swap_outcomes` records the terminal stage but none of that, so the receipt could only say "refund on its way".

- `swap_outcomes` gains `refund_chain`, `refund_amount`, `refund_tx` (TEXT, wei-sized). PRAGMA-guarded ALTER for existing state DBs.
- `record_swap_outcome` takes an optional refund tuple; the upsert COALESCEs so a re-ingest or a factless outcome write never blanks the facts.
- `SwapTimedOut` ingest (attributed and unattributed) passes `(collateral_chain, reimbursement, signature)`; the signature only for `sol` backing — off-chain backings settle on Bittensor.
- By-key `/status` on a closed PDA merges `refund_chain`, `refund_amount`, `refund_tx_hash` into `detail`. No route change.

Tests: sol and tao backings, re-ingest keeps facts, unattributed path, legacy-table migration guard, amount past sqlite's int64 bind limit, by-key status detail.
