### PR TITLE
Add min_from_amount and candidates to the seam rate quote

### DIFF
--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -8,6 +8,7 @@ invariants before it signs — the caller (offering or CLI) is never trusted.
 import threading
 import time
 from dataclasses import dataclass, field
+from itertools import islice
 from typing import Optional
 
 import bittensor as bt
@@ -30,7 +31,7 @@ from allways.cli.swap_commands.swap_intake import (
     unviable_reason,
     viable_intakes,
 )
-from allways.constants import NUMERAIRE_CHAIN
+from allways.constants import NUMERAIRE_CHAIN, hub_leg
 from allways.solana.client import contract_reject_reason, swap_key_from_tx_hash
 from allways.solana.pdas import BACKING_BITS
 from allways.utils.rate import max_from_for_to_cap
@@ -659,10 +660,8 @@ class RateQuote:
     reason: str  # why quote is None ('' on a hit)
     levels: list  # top rate rungs [{rate_display, max_from_amount}], best first
     max_from_amount: int  # largest executable source amount across ALL quotes, not just shown rungs
-    min_from_amount: int  # smallest executable source amount across ALL quotes; 0 = no floor
-    # Top executable intakes for the asked size, selector order — lets a consumer walk a tolerance
-    # band without another scan: [{miner_hotkey, rate_display, to_amount, max_from_amount}].
-    candidates: list
+    min_from_amount: int  # the pair's hub minimum in source units; 0 = unset or unpriceable
+    candidates: list  # top bound intakes for the asked size, selector order — a tolerance band in one scan
 
 
 def rate_quote(validator, from_chain: str, to_chain: str, from_amount: int) -> RateQuote:
@@ -676,17 +675,15 @@ def rate_quote(validator, from_chain: str, to_chain: str, from_amount: int) -> R
     bounds = bounds_from_config(cfg)
     min_swap, max_swap = hub_bounds(bounds, from_chain, to_chain)
     cands = candidate_miners(client, from_chain, to_chain)
-    ranked = _ranked_intakes(cands, from_chain, to_chain, from_amount, min_swap, max_swap, bounds)[:RATE_LEVELS_LIMIT]
-    hotkeys = [_miner_hotkey_for(validator, cand.miner) for cand, _ in ranked]
-    bq = _best_quote(ranked[0], hotkeys[0]) if hotkeys and hotkeys[0] else None
+    ranked = _ranked_intakes(cands, from_chain, to_chain, from_amount, min_swap, max_swap, bounds)
+    bound = list(islice(_bound_intakes(validator, ranked), RATE_LEVELS_LIMIT))
+    bq = _best_quote(*bound[0]) if bound else None
     reason = '' if bq else unviable_reason(cands, from_chain, to_chain, from_amount, min_swap, max_swap, bounds)
     depth: dict = {}
-    floors = []
     for cand in cands:
         cap = max_intake_from_amount(cand, from_chain, to_chain, min_swap, max_swap, bounds)
         if cap > 0:
             depth[cand.rate_display] = max(depth.get(cand.rate_display, 0), cap)
-            floors.append(_min_intake_from_amount(cand, from_chain, to_chain, bounds))
     # Rates are canonical 'dest per 1 canonical-source': when the taker sends the canonical
     # source (the hub leg), higher is better; sending the spoke side, lower is better.
     from_is_canon = from_chain == canonical_pair(from_chain, to_chain)[0]
@@ -699,32 +696,37 @@ def rate_quote(validator, from_chain: str, to_chain: str, from_amount: int) -> R
             'to_amount': amts.to_amount,
             'max_from_amount': max_intake_from_amount(cand, from_chain, to_chain, min_swap, max_swap, bounds),
         }
-        for (cand, amts), hotkey in zip(ranked, hotkeys)
-        if hotkey  # an unbound miner cannot be reserved through the seam — skip, the rest still ride
+        for cand, amts, hotkey in bound
     ]
-    return RateQuote(bq, reason, levels, max(depth.values(), default=0), min(floors, default=0), candidates)
+    min_from = _min_from_amount(min_swap, bq.rate_display if bq else None, from_chain, to_chain)
+    return RateQuote(bq, reason, levels, max(depth.values(), default=0), min_from, candidates)
 
 
 def _ranked_intakes(cands, from_chain: str, to_chain: str, from_amount: int, min_swap: int, max_swap: int, bounds):
-    """``viable_intakes`` in ``select_best_miner``'s order — most dest first, exact tie → "sol"
-    backing, then input order (stable sort) — so the first entry IS the selector's pick."""
+    """``viable_intakes`` in ``select_best_miner``'s order (most dest, tie → "sol", then input order)."""
     viable = viable_intakes(cands, from_chain, to_chain, from_amount, min_swap, max_swap, bounds)
     return sorted(viable, key=lambda p: (p[1].to_amount, p[0].backing == NUMERAIRE_CHAIN), reverse=True)
 
 
-def _min_intake_from_amount(cand: MinerCandidate, from_chain: str, to_chain: str, bounds) -> int:
-    """Smallest source amount this candidate's size gate admits — ``max_intake_from_amount``'s floor
-    twin: the backing's min bound, carried to the source leg through the same exact maths."""
-    lo = bounds.get(cand.backing, (0, 0))[0]
-    if lo <= 0 or cand.backing == from_chain:
-        return lo
-    if cand.backing != to_chain:
+def _bound_intakes(validator, ranked):
+    """``ranked`` with each miner's hotkey; an unbound miner cannot be reserved through the seam, so it is skipped."""
+    for cand, amts in ranked:
+        hotkey = _miner_hotkey_for(validator, cand.miner)
+        if hotkey:
+            yield cand, amts, hotkey
+
+
+def _min_from_amount(min_swap: int, best_rate: Optional[str], from_chain: str, to_chain: str) -> int:
+    """The hub minimum in source units: as-is on the hub leg, else inverted at the best bound rate (0 if none)."""
+    if min_swap <= 0 or from_chain == hub_leg(from_chain, to_chain):
+        return min_swap
+    if best_rate is None:
         return 0
     canon_from, canon_to = canonical_pair(from_chain, to_chain)
-    # One past the largest source whose dest leg still falls short of the bound.
+    # One past the largest source whose hub leg still falls short of the minimum.
     under = max_from_for_to_cap(
-        lo - 1,
-        cand.rate_display,
+        min_swap - 1,
+        best_rate,
         from_chain != canon_from,
         get_chain_def(canon_to).decimals,
         get_chain_def(canon_from).decimals,
@@ -732,8 +734,7 @@ def _min_intake_from_amount(cand: MinerCandidate, from_chain: str, to_chain: str
     return under + 1
 
 
-def _best_quote(best, hotkey: str) -> BestQuote:
-    cand, amts = best
+def _best_quote(cand: MinerCandidate, amts, hotkey: str) -> BestQuote:
     return BestQuote(
         hotkey,
         str(cand.miner),

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -698,7 +698,7 @@ def rate_quote(validator, from_chain: str, to_chain: str, from_amount: int) -> R
         }
         for cand, amts, hotkey in bound
     ]
-    min_from = _min_from_amount(min_swap, bq.rate_display if bq else None, from_chain, to_chain)
+    min_from = _min_from_amount(min_swap, best_first[0][0] if best_first else None, from_chain, to_chain)
     return RateQuote(bq, reason, levels, max(depth.values(), default=0), min_from, candidates)
 
 
@@ -717,7 +717,7 @@ def _bound_intakes(validator, ranked):
 
 
 def _min_from_amount(min_swap: int, best_rate: Optional[str], from_chain: str, to_chain: str) -> int:
-    """The hub minimum in source units: as-is on the hub leg, else inverted at the best bound rate (0 if none)."""
+    """The hub minimum in source units: as-is on the hub leg, else inverted at the best level rate (0 if no depth)."""
     if min_swap <= 0 or from_chain == hub_leg(from_chain, to_chain):
         return min_swap
     if best_rate is None:

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -15,7 +15,7 @@ from bittensor import Keypair
 from solders.pubkey import Pubkey
 
 from allways.assets.asset import ProviderUnreachableError
-from allways.chains import SUPPORTED_CHAINS, canonical_pair
+from allways.chains import SUPPORTED_CHAINS, canonical_pair, get_chain_def
 from allways.cli.swap_commands.swap_intake import (
     MinerCandidate,
     backing_purse,
@@ -28,10 +28,12 @@ from allways.cli.swap_commands.swap_intake import (
     select_best_miner,
     swap_viable,
     unviable_reason,
+    viable_intakes,
 )
 from allways.constants import NUMERAIRE_CHAIN
 from allways.solana.client import contract_reject_reason, swap_key_from_tx_hash
 from allways.solana.pdas import BACKING_BITS
+from allways.utils.rate import max_from_for_to_cap
 from allways.validator.binding import hotkey_ss58, verify_binding
 
 EMPTY_SWAP_KEY = b'\x00' * 32
@@ -657,40 +659,81 @@ class RateQuote:
     reason: str  # why quote is None ('' on a hit)
     levels: list  # top rate rungs [{rate_display, max_from_amount}], best first
     max_from_amount: int  # largest executable source amount across ALL quotes, not just shown rungs
+    min_from_amount: int  # smallest executable source amount across ALL quotes; 0 = no floor
+    # Top executable intakes for the asked size, selector order — lets a consumer walk a tolerance
+    # band without another scan: [{miner_hotkey, rate_display, to_amount, max_from_amount}].
+    candidates: list
 
 
 def rate_quote(validator, from_chain: str, to_chain: str, from_amount: int) -> RateQuote:
     """Everything ``/rate`` serves, from ONE candidate scan: the best executable quote for
     ``from_amount`` (source smallest-units; mirrors ``select_best_miner`` so the displayed rate ==
-    the reservable rate) plus the depth behind it. Rung order matches the selector's ranking (most
-    dest per source); same-rate quotes collapse to the deepest. Capacities are per-rung maxima,
-    never cumulative — a swap fills against a single miner."""
+    the reservable rate), the runners-up for that size, and the depth behind them. Rung order
+    matches the selector's ranking (most dest per source); same-rate quotes collapse to the deepest.
+    Capacities are per-rung maxima, never cumulative — a swap fills against a single miner."""
     client = validator.solana_client
     cfg = client.get_config()
     bounds = bounds_from_config(cfg)
     min_swap, max_swap = hub_bounds(bounds, from_chain, to_chain)
     cands = candidate_miners(client, from_chain, to_chain)
-    best = select_best_miner(cands, from_chain, to_chain, from_amount, min_swap, max_swap, bounds)
-    bq = _best_quote_result(validator, best) if best else None
+    ranked = _ranked_intakes(cands, from_chain, to_chain, from_amount, min_swap, max_swap, bounds)[:RATE_LEVELS_LIMIT]
+    hotkeys = [_miner_hotkey_for(validator, cand.miner) for cand, _ in ranked]
+    bq = _best_quote(ranked[0], hotkeys[0]) if hotkeys and hotkeys[0] else None
     reason = '' if bq else unviable_reason(cands, from_chain, to_chain, from_amount, min_swap, max_swap, bounds)
     depth: dict = {}
+    floors = []
     for cand in cands:
         cap = max_intake_from_amount(cand, from_chain, to_chain, min_swap, max_swap, bounds)
         if cap > 0:
             depth[cand.rate_display] = max(depth.get(cand.rate_display, 0), cap)
+            floors.append(_min_intake_from_amount(cand, from_chain, to_chain, bounds))
     # Rates are canonical 'dest per 1 canonical-source': when the taker sends the canonical
     # source (the hub leg), higher is better; sending the spoke side, lower is better.
     from_is_canon = from_chain == canonical_pair(from_chain, to_chain)[0]
     best_first = sorted(depth.items(), key=lambda kv: float(kv[0]), reverse=from_is_canon)
     levels = [{'rate_display': r, 'max_from_amount': m} for r, m in best_first[:RATE_LEVELS_LIMIT]]
-    return RateQuote(bq, reason, levels, max(depth.values(), default=0))
+    candidates = [
+        {
+            'miner_hotkey': hotkey,
+            'rate_display': cand.rate_display,
+            'to_amount': amts.to_amount,
+            'max_from_amount': max_intake_from_amount(cand, from_chain, to_chain, min_swap, max_swap, bounds),
+        }
+        for (cand, amts), hotkey in zip(ranked, hotkeys)
+        if hotkey  # an unbound miner cannot be reserved through the seam — skip, the rest still ride
+    ]
+    return RateQuote(bq, reason, levels, max(depth.values(), default=0), min(floors, default=0), candidates)
 
 
-def _best_quote_result(validator, best) -> Optional[BestQuote]:
+def _ranked_intakes(cands, from_chain: str, to_chain: str, from_amount: int, min_swap: int, max_swap: int, bounds):
+    """``viable_intakes`` in ``select_best_miner``'s order — most dest first, exact tie → "sol"
+    backing, then input order (stable sort) — so the first entry IS the selector's pick."""
+    viable = viable_intakes(cands, from_chain, to_chain, from_amount, min_swap, max_swap, bounds)
+    return sorted(viable, key=lambda p: (p[1].to_amount, p[0].backing == NUMERAIRE_CHAIN), reverse=True)
+
+
+def _min_intake_from_amount(cand: MinerCandidate, from_chain: str, to_chain: str, bounds) -> int:
+    """Smallest source amount this candidate's size gate admits — ``max_intake_from_amount``'s floor
+    twin: the backing's min bound, carried to the source leg through the same exact maths."""
+    lo = bounds.get(cand.backing, (0, 0))[0]
+    if lo <= 0 or cand.backing == from_chain:
+        return lo
+    if cand.backing != to_chain:
+        return 0
+    canon_from, canon_to = canonical_pair(from_chain, to_chain)
+    # One past the largest source whose dest leg still falls short of the bound.
+    under = max_from_for_to_cap(
+        lo - 1,
+        cand.rate_display,
+        from_chain != canon_from,
+        get_chain_def(canon_to).decimals,
+        get_chain_def(canon_from).decimals,
+    )
+    return under + 1
+
+
+def _best_quote(best, hotkey: str) -> BestQuote:
     cand, amts = best
-    hotkey = _miner_hotkey_for(validator, cand.miner)
-    if hotkey is None:
-        return None
     return BestQuote(
         hotkey,
         str(cand.miner),

--- a/allways/validator/seam_http.py
+++ b/allways/validator/seam_http.py
@@ -90,10 +90,15 @@ def _make_handler(validator, secret: str):
             q = {k: v[0] for k, v in parse_qs(url.query).items()}
             try:
                 if url.path == '/rate':
-                    # Depth rides along on hit AND miss — the offering's oversize copy ("max right
-                    # now is X") needs the true max exactly when no quote fits the asked size.
+                    # Depth rides along on hit AND miss — the offering's size copy ("min/max right
+                    # now is X") needs the true bounds exactly when no quote fits the asked size.
                     rq = rate_quote(validator, q['from'], q['to'], int(q['amount']))
-                    depth = {'levels': rq.levels, 'max_from_amount': rq.max_from_amount}
+                    depth = {
+                        'levels': rq.levels,
+                        'max_from_amount': rq.max_from_amount,
+                        'min_from_amount': rq.min_from_amount,
+                        'candidates': rq.candidates,
+                    }
                     if rq.quote is None:
                         return self._send(404, {'error': rq.reason, **depth})
                     return self._send(200, {**rq.quote.__dict__, **depth})

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -575,7 +575,7 @@ class TestRateQuoteCandidates:
             get_binding=lambda pk: SimpleNamespace(hotkey=hotkeys[str(pk)]) if str(pk) in hotkeys else None,
         )
         return SimpleNamespace(solana_client=client), [
-            hotkey_ss58(hotkeys[str(pk)]) for pk in miners if str(pk) in hotkeys
+            hotkey_ss58(hotkeys[str(pk)]) if str(pk) in hotkeys else None for pk in miners
         ]
 
     def test_candidates_follow_selector_order_capped(self):
@@ -593,7 +593,7 @@ class TestRateQuoteCandidates:
             'max_from_amount': self.MAX,
         }
         assert rq.candidates[1]['to_amount'] == 55_000_000
-        assert rq.min_from_amount == self.MIN
+        assert rq.min_from_amount == self.MIN  # hub source: min_swap as-is
 
     def test_miss_carries_min_and_no_candidates(self):
         validator, _ = self._validator('sol', 'btc', ['0.5'])
@@ -602,19 +602,24 @@ class TestRateQuoteCandidates:
         assert rq.candidates == []
         assert rq.min_from_amount == self.MIN and rq.max_from_amount == self.MAX
 
-    def test_unbound_candidate_is_skipped_others_ride(self):
-        rates = ['0.5', '0.6', '0.55']
-        validator, hotkeys = self._validator('sol', 'btc', rates, unbound={2})
+    def test_unbound_miners_backfill_before_the_cap(self):
+        # 7 viable, the selector's top pick unbound: the quote is the best BOUND intake, the
+        # unbound one never rides, and the next bound miner backfills the fifth slot.
+        rates = ['0.5', '0.6', '0.5', '0.55', '0.45', '0.4', '0.3']
+        validator, hotkeys = self._validator('sol', 'btc', rates, unbound={1})
         rq = rate_quote(validator, 'sol', 'btc', self.SOL)
-        assert rq.quote.miner_hotkey == hotkeys[1]
-        assert [c['miner_hotkey'] for c in rq.candidates] == [hotkeys[1], hotkeys[0]]
+        assert rq.quote.miner_hotkey == hotkeys[3] == rq.candidates[0]['miner_hotkey']
+        assert rq.quote.to_amount == 55_000_000 == rq.candidates[0]['to_amount']
+        assert [c['miner_hotkey'] for c in rq.candidates] == [hotkeys[i] for i in (3, 0, 2, 4, 5)]
 
     def test_min_from_amount_is_in_source_units_for_a_spoke_source(self):
-        # btc→sol: the bound is on the SOL (dest) leg. The floor is the smallest BTC amount whose
-        # SOL leg reaches min_swap under the best rate — exact, so its predecessor falls short.
+        # btc→sol: the minimum is on the SOL (hub) leg. The floor is the smallest BTC amount whose
+        # SOL leg reaches min_swap at the best bound rate — exact, so its predecessor falls short.
         validator, _ = self._validator('btc', 'sol', ['0.5', '0.25'])
         rq = rate_quote(validator, 'btc', 'sol', 10_000_000)
         floor = rq.min_from_amount
         assert floor == 2_500_000  # 0.025 BTC at 0.25 BTC/SOL → exactly 0.1 SOL
         assert compute_intake_amounts('btc', 'sol', floor, '0.25').collateral_amount >= self.MIN
         assert compute_intake_amounts('btc', 'sol', floor - 1, '0.25').collateral_amount < self.MIN
+        # No bound candidate to price it at → 0.
+        assert rate_quote(validator, 'btc', 'sol', floor - 1).min_from_amount == 0

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -614,12 +614,21 @@ class TestRateQuoteCandidates:
 
     def test_min_from_amount_is_in_source_units_for_a_spoke_source(self):
         # btc→sol: the minimum is on the SOL (hub) leg. The floor is the smallest BTC amount whose
-        # SOL leg reaches min_swap at the best bound rate — exact, so its predecessor falls short.
+        # SOL leg reaches min_swap at the best level rate — exact, so its predecessor falls short.
         validator, _ = self._validator('btc', 'sol', ['0.5', '0.25'])
         rq = rate_quote(validator, 'btc', 'sol', 10_000_000)
         floor = rq.min_from_amount
         assert floor == 2_500_000  # 0.025 BTC at 0.25 BTC/SOL → exactly 0.1 SOL
         assert compute_intake_amounts('btc', 'sol', floor, '0.25').collateral_amount >= self.MIN
         assert compute_intake_amounts('btc', 'sol', floor - 1, '0.25').collateral_amount < self.MIN
-        # No bound candidate to price it at → 0.
-        assert rate_quote(validator, 'btc', 'sol', floor - 1).min_from_amount == 0
+
+    def test_spoke_source_miss_below_min_still_carries_the_floor(self):
+        # The level rate prices the floor even when nothing fits the asked size.
+        validator, _ = self._validator('btc', 'sol', ['0.5', '0.25'])
+        rq = rate_quote(validator, 'btc', 'sol', 2_500_000 - 1)
+        assert rq.quote is None and 'below min swap' in rq.reason
+        assert rq.min_from_amount == 2_500_000 and rq.candidates == []
+
+    def test_spoke_source_min_is_zero_without_depth(self):
+        validator, _ = self._validator('btc', 'sol', [])
+        assert rate_quote(validator, 'btc', 'sol', 10_000_000).min_from_amount == 0

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -1,10 +1,15 @@
-"""Tests for allways.utils.rate — to_amount calculation and fee deduction math."""
+"""Tests for allways.utils.rate — to_amount calculation and fee deduction math — and the
+seam's ``rate_quote`` candidates built on top of it."""
 
 from dataclasses import replace
 from decimal import Decimal
+from types import SimpleNamespace
 from unittest.mock import patch
 
+from solders.keypair import Keypair as SolKeypair
+
 from allways.chains import get_chain_def
+from allways.cli.swap_commands.swap_intake import compute_intake_amounts
 from allways.constants import BTC_TO_SAT, RATE_PRECISION, TAO_TO_RAO
 from allways.utils.rate import (
     apply_fee_deduction,
@@ -15,6 +20,8 @@ from allways.utils.rate import (
     quantize_rate_display,
     quantize_rate_fixed,
 )
+from allways.validator.binding import hotkey_ss58
+from allways.validator.reserve_engine import RATE_LEVELS_LIMIT, rate_quote
 
 # Chain decimals
 TAO_DEC = 9
@@ -537,3 +544,77 @@ class TestQuantizeRate:
         assert quantize_rate_display(5.00001) == 5.0
         assert quantize_rate_display(1.23459) == 1.2345
         assert quantize_rate_display(0.0) == 0.0
+
+
+class TestRateQuoteCandidates:
+    """``rate_quote`` candidates: the selector's ranking for the asked size, served whole so a
+    consumer can walk a tolerance band with no second scan. Bounds 0.1–5 SOL, deep collateral."""
+
+    MIN = 100_000_000
+    MAX = 5_000_000_000
+    SOL = 1_000_000_000
+
+    def _validator(self, from_chain, to_chain, rates, unbound=()):
+        """One sol-backed miner per rate, in that order; ``unbound`` indexes have no Binding PDA."""
+        miners = [SolKeypair().pubkey() for _ in rates]
+        hotkeys = {str(pk): bytes([i + 1]) * 32 for i, pk in enumerate(miners) if i not in unbound}
+        quotes = [
+            SimpleNamespace(
+                miner=pk,
+                from_chain=from_chain,
+                to_chain=to_chain,
+                rate=int(Decimal(rate) * RATE_PRECISION),
+                collateral_chain='sol',
+            )
+            for pk, rate in zip(miners, rates)
+        ]
+        client = SimpleNamespace(
+            get_config=lambda: SimpleNamespace(min_swap_amount=self.MIN, max_swap_amount=self.MAX),
+            get_all=lambda kind: [(q.miner, q) for q in quotes],
+            get_miner_state=lambda pk: SimpleNamespace(active=True, collateral=100 * self.SOL),
+            get_binding=lambda pk: SimpleNamespace(hotkey=hotkeys[str(pk)]) if str(pk) in hotkeys else None,
+        )
+        return SimpleNamespace(solana_client=client), [
+            hotkey_ss58(hotkeys[str(pk)]) for pk in miners if str(pk) in hotkeys
+        ]
+
+    def test_candidates_follow_selector_order_capped(self):
+        # 6 quotes, sol→btc for 1 SOL: most BTC first, an exact tie keeps input order, 6th cut.
+        rates = ['0.5', '0.6', '0.5', '0.55', '0.45', '0.4']
+        validator, hotkeys = self._validator('sol', 'btc', rates)
+        rq = rate_quote(validator, 'sol', 'btc', self.SOL)
+        assert [c['rate_display'] for c in rq.candidates] == ['0.6', '0.55', '0.5', '0.5', '0.45']
+        assert [c['miner_hotkey'] for c in rq.candidates] == [hotkeys[i] for i in (1, 3, 0, 2, 4)]
+        assert len(rq.candidates) == RATE_LEVELS_LIMIT
+        assert rq.candidates[0] == {
+            'miner_hotkey': rq.quote.miner_hotkey,
+            'rate_display': rq.quote.rate_display,
+            'to_amount': rq.quote.to_amount,
+            'max_from_amount': self.MAX,
+        }
+        assert rq.candidates[1]['to_amount'] == 55_000_000
+        assert rq.min_from_amount == self.MIN
+
+    def test_miss_carries_min_and_no_candidates(self):
+        validator, _ = self._validator('sol', 'btc', ['0.5'])
+        rq = rate_quote(validator, 'sol', 'btc', self.MIN - 1)
+        assert rq.quote is None and 'below min swap' in rq.reason
+        assert rq.candidates == []
+        assert rq.min_from_amount == self.MIN and rq.max_from_amount == self.MAX
+
+    def test_unbound_candidate_is_skipped_others_ride(self):
+        rates = ['0.5', '0.6', '0.55']
+        validator, hotkeys = self._validator('sol', 'btc', rates, unbound={2})
+        rq = rate_quote(validator, 'sol', 'btc', self.SOL)
+        assert rq.quote.miner_hotkey == hotkeys[1]
+        assert [c['miner_hotkey'] for c in rq.candidates] == [hotkeys[1], hotkeys[0]]
+
+    def test_min_from_amount_is_in_source_units_for_a_spoke_source(self):
+        # btc→sol: the bound is on the SOL (dest) leg. The floor is the smallest BTC amount whose
+        # SOL leg reaches min_swap under the best rate — exact, so its predecessor falls short.
+        validator, _ = self._validator('btc', 'sol', ['0.5', '0.25'])
+        rq = rate_quote(validator, 'btc', 'sol', 10_000_000)
+        floor = rq.min_from_amount
+        assert floor == 2_500_000  # 0.025 BTC at 0.25 BTC/SOL → exactly 0.1 SOL
+        assert compute_intake_amounts('btc', 'sol', floor, '0.25').collateral_amount >= self.MIN
+        assert compute_intake_amounts('btc', 'sol', floor - 1, '0.25').collateral_amount < self.MIN

--- a/tests/test_seam_http.py
+++ b/tests/test_seam_http.py
@@ -11,6 +11,10 @@ from allways.validator import seam_http
 from allways.validator.reserve_engine import BestQuote, ConfirmResult, RateQuote, ReserveResult, SwapStatus
 
 SECRET = 'test-secret'
+CANDIDATES = [
+    {'miner_hotkey': 'hk', 'rate_display': '0.0021', 'to_amount': 210000, 'max_from_amount': 2_000_000_000},
+    {'miner_hotkey': 'hk2', 'rate_display': '0.0020', 'to_amount': 200000, 'max_from_amount': 900_000_000},
+]
 
 
 @pytest.fixture
@@ -25,6 +29,8 @@ def server(monkeypatch):
             '',
             [{'rate_display': '0.0021', 'max_from_amount': 2_000_000_000}],
             2_000_000_000,
+            100_000_000,
+            CANDIDATES,
         ),
     )
     monkeypatch.setattr(seam_http, 'swap_status', lambda *a, **k: SwapStatus('reserved', 999, 'user', ''))
@@ -107,10 +113,11 @@ def test_rate(server):
     assert code == 200 and payload['to_amount'] == 210000 and payload['miner_hotkey'] == 'hk'
     assert payload['levels'] == [{'rate_display': '0.0021', 'max_from_amount': 2_000_000_000}]
     assert payload['max_from_amount'] == 2_000_000_000
+    assert payload['min_from_amount'] == 100_000_000 and payload['candidates'] == CANDIDATES
 
 
 def test_rate_miss_carries_depth(server, monkeypatch):
-    """The oversize UX needs the true max exactly when nothing fits — depth must ride the 404 too."""
+    """The size UX needs the true min/max exactly when nothing fits — depth must ride the 404 too."""
     monkeypatch.setattr(
         seam_http,
         'rate_quote',
@@ -119,11 +126,14 @@ def test_rate_miss_carries_depth(server, monkeypatch):
             'miner collateral too low (needs 1.1000 SOL)',
             [{'rate_display': '0.0021', 'max_from_amount': 900_000_000}],
             900_000_000,
+            100_000_000,
+            [],
         ),
     )
     code, payload = _req(server, 'GET', '/rate?from=sol&to=btc&amount=1000000000')
     assert code == 404 and 'collateral too low' in payload['error']
     assert payload['max_from_amount'] == 900_000_000 and len(payload['levels']) == 1
+    assert payload['min_from_amount'] == 100_000_000 and payload['candidates'] == []
 
 
 def test_status(server):


### PR DESCRIPTION
Seam change for the Allways Access public API v1 (allways-access docs/specs/public-api.md §9).

GET /rate now carries, on 200 and 404:
- min_from_amount: the pair's hub minimum in source units (converted at the best level rate when the source is the spoke; 0 with no depth).
- candidates: up to 5 bound miners in select_best_miner order, each with the executable to_amount for the asked size and its max_from_amount. candidates[0] is the quote.

Bindings resolve before the cap, so an unbound best miner no longer turns a quotable pair into a 404. Older consumers ignore both fields.