### PR TITLE
Harden destination address handling at attestation and settlement

### DIFF
--- a/allways/cli/swap_commands/swap.py
+++ b/allways/cli/swap_commands/swap.py
@@ -249,27 +249,20 @@ def _send_reserve_synapse(axon, synapse) -> tuple:
     return accepted, reason, int(getattr(resp, 'pool_closes_at', 0) or 0)
 
 
-def _reserve_routed(client, miner, user, router_hotkey, netuid, synapse, pool_window, finalize_window):
+def _reserve_routed(client, miner, user, router_hotkey, netuid, synapse, pool_window, finalize_window, subtensor):
     """Validator-routed reservation: ask ``router_hotkey`` to enter the pool for us, then wait for the
     seat to go live with OUR pubkey pinned — no self-crank, no finalize (the router does both, #558).
     Raises ``_RoutedUnavailable`` for any failure before a pool was entered; terminal post-entry
-    outcomes (lost, unresolved) ``fail`` with re-run guidance. The subtensor connection is lazy —
-    a fresh axon-cache hit sends the synapse without ever syncing the chain."""
-    memo = {}
-
-    def _subtensor():
-        if 'st' not in memo:
-            _cfg, _wallet, memo['st'], _ = get_cli_context(need_wallet=False)
-        return memo['st']
-
-    axon = find_validator_axon(_subtensor, netuid, router_hotkey)
+    outcomes (lost, unresolved) ``fail`` with re-run guidance. ``subtensor`` is the caller's lazy getter —
+    a fresh axon-cache hit sends the synapse without this function ever syncing the chain."""
+    axon = find_validator_axon(subtensor, netuid, router_hotkey)
     if axon is None:
         raise _RoutedUnavailable(f'router {router_hotkey[:8]}… is not a serving validator on netuid {netuid}')
 
     accepted, reason, pool_closes_at = _send_reserve_synapse(axon, synapse)
     if not accepted:
         # A cached axon may be stale (validators move IPs): refresh once, then retry the send.
-        fresh_axon = find_validator_axon(_subtensor, netuid, router_hotkey, fresh=True)
+        fresh_axon = find_validator_axon(subtensor, netuid, router_hotkey, fresh=True)
         if fresh_axon is not None and (fresh_axon.ip, fresh_axon.port) != (axon.ip, axon.port):
             accepted, reason, pool_closes_at = _send_reserve_synapse(fresh_axon, synapse)
         if not accepted:
@@ -392,6 +385,13 @@ def swap_now_command(
 
     config, client = get_solana_cli_context(need_keypair=True)
     config = config or {}
+    memo = {}
+
+    def _subtensor():
+        if 'st' not in memo:
+            _cfg, _wallet, memo['st'], _ = get_cli_context(need_wallet=False)
+        return memo['st']
+
     user = client.keypair.pubkey()
     router_hotkey = (router_opt or config.get('router') or '').strip()
     routed = bool(router_hotkey) and not no_router
@@ -405,7 +405,7 @@ def swap_now_command(
         fail(f'--from-address (your source-chain address) is required for a non-{NUMERAIRE_CHAIN.upper()} source.')
     # Canonical source form before anything commits it: the finalize hash + source-lock PDA are
     # byte-keyed on this string (V-C2), so a cased variant would mint a divergent lock on-chain.
-    _src_gate = _gate_provider(from_chain, client, config)
+    _src_gate = _gate_provider(from_chain, client, config, _subtensor)
     if _src_gate is not None:
         user_from_addr = _src_gate.chain.normalize_address(user_from_addr)
 
@@ -460,7 +460,9 @@ def swap_now_command(
         cand, amts = best
 
     # Deliverability screens — before the fee-charging entry AND before sending into a doomed swap.
-    _screen_deliverability(client, config, cand, from_chain, to_chain, receive_address_opt, user_from_addr, from_amount)
+    _screen_deliverability(
+        client, config, cand, from_chain, to_chain, receive_address_opt, user_from_addr, from_amount, _subtensor
+    )
 
     # Resume a seat this taker already holds rather than paying for a second bid: a prior run may have
     # bid + drawn (or even finalized) but crashed on a transient RPC before instructing the send. The
@@ -549,7 +551,7 @@ def swap_now_command(
             )
             netuid = int(config.get('netuid') or NETUID_FINNEY)
             resv = _reserve_routed(
-                client, cand.miner, user, router_hotkey, netuid, synapse, pool_window, finalize_window
+                client, cand.miner, user, router_hotkey, netuid, synapse, pool_window, finalize_window, _subtensor
             )
         except _RoutedUnavailable as e:
             console.print(f'  [yellow]Routing failed[/yellow]: {e}')
@@ -644,7 +646,7 @@ def _deadline_lines(reserved_until: int, want_send: bool, now: Optional[int] = N
     return lines
 
 
-def _gate_provider(chain: str, client, config):
+def _gate_provider(chain: str, client, config, subtensor):
     """Read-only provider for deliverability screens (no send creds, no startup check).
     None when it can't be built — the screens fail open; routed flows are re-gated by the
     validator either way."""
@@ -653,14 +655,21 @@ def _gate_provider(chain: str, client, config):
     spec = next((s for s in ASSET_REGISTRY if s.chain_id == chain), None)
     if spec is None:
         return None
-    avail = {'solana_rpc_url': client.rpc.url, 'solana_keypair': client.keypair}
+    avail = {
+        'solana_rpc_url': lambda: client.rpc.url,
+        'solana_keypair': lambda: client.keypair,
+        'subtensor': subtensor,
+    }
     try:
-        return spec.cls(**{k: avail[k] for k in spec.kwarg_names if k in avail})
+        return spec.cls(**{k: avail[k]() for k in spec.kwarg_names if k in avail})
     except Exception:  # noqa: BLE001 - unbuildable provider (missing env) → screens fail open
+        console.print(f'  [yellow]could not check {chain.upper()} address here[/yellow]')
         return None
 
 
-def _screen_deliverability(client, config, cand, from_chain, to_chain, receive_addr, user_from_addr, from_amount):
+def _screen_deliverability(
+    client, config, cand, from_chain, to_chain, receive_addr, user_from_addr, from_amount, subtensor
+):
     """Pre-reserve deliverability screens — bounce BEFORE any fee is spent.
 
     Self-represented flows have no validator to gate for them (F7), so mirror the
@@ -669,14 +678,14 @@ def _screen_deliverability(client, config, cand, from_chain, to_chain, receive_a
     miner's receive address must accept the source funds (T18). The source-address probe is a
     courtesy warning only — a frozen source just means the deposit fails and the reservation
     lapses unclaimed. A leg whose provider can't be built read-only fails open, as before."""
-    dest_provider = _gate_provider(to_chain, client, config)
+    dest_provider = _gate_provider(to_chain, client, config, subtensor)
     quote = client.get_quote(cand.miner, from_chain, to_chain, cand.backing)
     if dest_provider is not None:
         # Validity only — deliverability is NOT predicted at reserve time (not a boundary; the sound
         # check is the delivery-time reverted-tx proof). A malformed address can never be delivered to.
         if not dest_provider.chain.is_valid_address(receive_addr):
             fail(f'  {receive_addr!r} is not a valid {to_chain.upper()} address. No funds moved.')
-    src_provider = _gate_provider(from_chain, client, config)
+    src_provider = _gate_provider(from_chain, client, config, subtensor)
     if src_provider is None:
         return
     miner_addr = getattr(quote, 'miner_from_addr', '') if quote else ''

--- a/allways/constants.py
+++ b/allways/constants.py
@@ -57,8 +57,10 @@ CANCEL_REASON_SOL_RESERVED = 3
 # honest delivery on the token would false-slash — a hub-wide, no-fault condition (V-M2/PAXG).
 CANCEL_REASON_ERC20_FEE_ENABLED = 4
 # The issuer froze the destination's SPL token account (USDC's mint carries a freeze authority):
-# undeliverable through no fault of the miner. Python-side first; mirror into constants.rs next release.
+# undeliverable through no fault of the miner.
 CANCEL_REASON_SPL_FROZEN = 5
+# The destination fails the chain's offline format check: unpayable by construction, never the miner's fault.
+CANCEL_REASON_INVALID_DEST = 6
 CANCEL_REASON_OTHER = 255
 
 BTC_MIN_FEE_RATE = 5

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -36,6 +36,7 @@ from allways.solana.client import contract_reject_reason, swap_key_from_tx_hash
 from allways.solana.pdas import BACKING_BITS
 from allways.utils.rate import max_from_for_to_cap
 from allways.validator.binding import hotkey_ss58, verify_binding
+from allways.validator.solana_swap_loop import attest_reject_reason
 
 EMPTY_SWAP_KEY = b'\x00' * 32
 
@@ -822,6 +823,7 @@ def swap_status(
         detail['from_tx_hash'] = swap.from_tx_hash
         detail['to_tx_hash'] = swap.to_tx_hash
     stage = _swap_stage(validator, swap, swap_key)
+    _add_reject_reason(validator, swap, stage, detail)
     return SwapStatus(stage, reservation.reserved_until, str(reservation.user), swap_key.hex(), detail)
 
 
@@ -855,7 +857,18 @@ def _swap_status_by_key(validator, swap_key_hex: str) -> SwapStatus:
         'from_tx_hash': swap.from_tx_hash,
         'to_tx_hash': swap.to_tx_hash,
     }
+    _add_reject_reason(validator, swap, stage, detail)
     return SwapStatus(stage, 0, str(swap.user), swap_key_hex, detail)
+
+
+def _add_reject_reason(validator, swap, stage: str, detail: dict) -> None:
+    """While a live claim awaits attestation, surface why the loop refuses it (absent when it doesn't)."""
+    if swap is None or stage != 'claimed':
+        return
+    loop = validator.solana_swap_loop
+    reason = attest_reject_reason(loop.providers, swap, loop.fee_divisor)
+    if reason is not None:
+        detail['reject_reason'] = reason
 
 
 # On-chain Swap.status is a borsh enum object; map by its variant name (not int()).

--- a/allways/validator/solana_swap_loop.py
+++ b/allways/validator/solana_swap_loop.py
@@ -19,7 +19,7 @@ from solders.pubkey import Pubkey
 from allways import dev_signal
 from allways.assets.asset import ProviderUnreachableError
 from allways.chains import compute_extension_target_secs, get_chain_def
-from allways.constants import CANCEL_REASON_OTHER, EXTENSION_PADDING_SECONDS
+from allways.constants import CANCEL_REASON_INVALID_DEST, CANCEL_REASON_OTHER, EXTENSION_PADDING_SECONDS
 from allways.solana import pdas
 from allways.solana.client import benign_marker, swap_from_solana, swap_key_from_tx_hash
 from allways.utils.rate import apply_fee_deduction, expected_swap_amounts
@@ -35,7 +35,7 @@ class SwapDecision(Enum):
     EXTEND_TIMEOUT = 'extend_timeout'  # dest valid-but-unconfirmed near timeout -> slide timeout_at
     WAIT = 'wait'  # in-flight, nothing to do yet
     SKIP = 'skip'  # provider unreachable / unverifiable this round
-    REJECT = 'reject'  # to_amount inconsistent with pinned rate -> never attest (terminal no-op)
+    REJECT = 'reject'  # PendingAttestation that can never attest (attest_reject_reason) -> terminal no-op
 
 
 class SwapAction(NamedTuple):
@@ -108,6 +108,24 @@ def is_tx_fresh(info: Any, floor_unix: int, grace: int = 0) -> bool:
     return block_time >= floor_unix - grace
 
 
+def attest_reject_reason(providers: Dict[str, Any], swap: Any, fee_divisor: int) -> Optional[str]:
+    """Why a PendingAttestation claim must never attest, or None. Offline and deterministic (quorum
+    votes); shared by the loop and the seam's /status."""
+    to_provider = providers.get(swap.to_chain)
+    # A malformed dest is unpayable by construction.
+    if to_provider is not None and not to_provider.chain.is_valid_address(swap.user_to_addr):
+        return 'dest address invalid — refusing to attest'
+    # D1: to_amount must agree with the pinned (unforgeable) miner rate.
+    expected_to, _ = expected_swap_amounts(swap, fee_divisor)
+    if expected_to == 0 or abs(int(swap.to_amount) - expected_to) > 1:
+        return f'to_amount {swap.to_amount} != pinned-rate {expected_to}'
+    # V-H1: a self-transfer is slashed; normalize per chain to catch the EVM checksum-variants a raw compare misses.
+    norm = to_provider.chain.normalize_address if to_provider is not None else (lambda a: a)
+    if swap.miner_to_addr and norm(swap.user_to_addr) == norm(swap.miner_to_addr):
+        return 'dest == miner delivery address (poisoned) — refusing to attest'
+    return None
+
+
 class SolanaSwapLoop:
     def __init__(
         self,
@@ -125,7 +143,7 @@ class SolanaSwapLoop:
         # cannot get anywhere else: the reimbursement address of a live off-chain-backed swap
         # (the Swap PDA closes at the verdict), and the moment to refuse an initiate.
         self.relay = relay
-        self.reject_warned: Set[str] = set()  # dedupe rate-reject warnings, one per swap key
+        self.reject_warned: Set[str] = set()  # dedupe reject warnings, one per swap key
 
     def expected_user_receives(self, swap: Any) -> int:
         """Dest amount the miner must deliver = 99% of the pinned to_amount (Option A)."""
@@ -184,17 +202,10 @@ class SolanaSwapLoop:
         return True
 
     def _dest_refuses(self, swap: Any) -> bool:
-        """Evidence the dest can't receive (or the check is unavailable) — either way, never slash on it.
-
-        Beyond issuer refusal (blacklist/pause), a malformed dest address is undeliverable by
-        construction and never the miner's fault. A self-represented taker reserves on-chain directly,
-        bypassing the reserve-time address gate, so this slash-side check is the miner's only guard
-        against a poisoned (e.g. zero-address) reservation."""
+        """Evidence the dest can't receive (or the check is unavailable) — either way, never slash on it."""
         provider = self.providers.get(swap.to_chain)
         if provider is None:
             return False
-        if not provider.chain.is_valid_address(swap.user_to_addr):
-            return True
         try:
             return provider.delivery_refused(swap.user_to_addr, int(swap.initiated_at))
         except Exception as e:
@@ -323,7 +334,7 @@ class SolanaSwapLoop:
         if not overdue:
             return SwapAction(SwapDecision.WAIT, reason=f'{why} — awaiting a verifiable+fresh dest leg')
         if self._dest_refuses(swap):
-            # No SOUND cancel evidence, but the dest may refuse (getCode / malformed / check unreachable):
+            # No SOUND cancel evidence, but the dest may refuse (getCode / check unreachable):
             # defer the slash to protect a live miner. An undeliverable dest never recovers, so at the
             # max_extend_at ceiling still TIMEOUT — else has_active_swap never clears and collateral freezes.
             # A dest that GENUINELY refuses yields sound evidence → REFUSE above, well before the ceiling; so
@@ -338,17 +349,15 @@ class SolanaSwapLoop:
             )
         return SwapAction(SwapDecision.TIMEOUT, reason=f'{why} + overdue — dest unverifiable, slashing')
 
-    def _reject_logged(self, swap: Any, expected_to: int) -> None:
-        """Warn once per swap key that to_amount diverges from the pinned rate (security-relevant, greppable)."""
+    def _reject_logged(self, swap: Any, reason: str) -> None:
+        """Warn once per swap key why the claim will never attest (greppable)."""
         key = _swap_key_hex(swap.swap_key)
         if key in self.reject_warned:
             return
         self.reject_warned.add(key)
-        bt.logging.warning(
-            f'{self._label(swap)}: REJECT — to_amount {swap.to_amount} inconsistent with pinned rate '
-            f'{swap.rate} (expected {expected_to}); refusing to attest [swap_key {key}]'
-        )
-        dev_signal.emit('d1_reject', swap_key=key, expected=expected_to, got=int(swap.to_amount))
+        bt.logging.warning(f'{self._label(swap)}: REJECT — {reason} [swap_key {key}]')
+        # Event name is load-bearing: the alw-utils E2E suite waits on 'd1_reject'.
+        dev_signal.emit('d1_reject', swap_key=key, reason=reason)
 
     def _claim_is_stale(self, reservation: Any, swap: Any, now: int) -> bool:
         """A PendingAttestation claim is orphaned when its reservation can no longer carry it to attestation:
@@ -368,21 +377,10 @@ class SolanaSwapLoop:
         # source landing after the ceiling is the taker's tail risk (nothing moved on our side to refund).
         if self._claim_is_stale(reservation, swap, now):
             return SwapAction(SwapDecision.CANCEL, reason='reservation expired/superseded — reaping stale claim')
-        # D1: refuse to attest if to_amount is inconsistent with the pinned (unforgeable) miner rate.
-        expected_to, _ = expected_swap_amounts(swap, self.fee_divisor)
-        if expected_to == 0 or abs(int(swap.to_amount) - expected_to) > 1:
-            self._reject_logged(swap, expected_to)
-            return SwapAction(SwapDecision.REJECT, reason=f'to_amount {swap.to_amount} != pinned-rate {expected_to}')
-        # V-H1 (authoritative, chain-aware): never attest a swap whose payout address equals the miner's
-        # own delivery address — normalized per-chain, so it catches the EVM checksum-variants the on-chain
-        # raw compare misses. Equal addresses force a self-transfer the anti-wash verifier slashes; the
-        # taker poisoned it, so refuse before the miner is obligated (routed + self-represented alike).
-        to_provider = self.providers.get(swap.to_chain)
-        norm = to_provider.chain.normalize_address if to_provider is not None else (lambda a: a)
-        if swap.miner_to_addr and norm(swap.user_to_addr) == norm(swap.miner_to_addr):
-            return SwapAction(
-                SwapDecision.REJECT, reason='dest == miner delivery address (poisoned) — refusing to attest'
-            )
+        reason = attest_reject_reason(self.providers, swap, self.fee_divisor)
+        if reason:
+            self._reject_logged(swap, reason)
+            return SwapAction(SwapDecision.REJECT, reason=reason)
         # Source deposit must exist, confirm, be sent BY the reserved user, AND be fresh vs the
         # Reservation before we'd attest — sender pin matches the relay's confirm_deposit check.
         s_status, info = self._fetch_leg(
@@ -436,13 +434,24 @@ class SolanaSwapLoop:
         # No dest provider here → can't verify locally. SKIP below the ceiling (a re-enabled spoke or a
         # provider-equipped peer still resolves it); past max_extend_at TIMEOUT so a permanently unverifiable
         # pair frees the collateral instead of freezing it forever (only network-wide gaps reach quorum).
-        if status in ('Active', 'Fulfilled') and self.providers.get(swap.to_chain) is None:
-            if now < int(swap.max_extend_at):
-                return SwapAction(SwapDecision.SKIP, reason=f'no provider for dest {swap.to_chain} — cannot verify yet')
-            return SwapAction(
-                SwapDecision.TIMEOUT,
-                reason=f'no provider for dest {swap.to_chain} past max_extend_at — terminal, else collateral freezes',
-            )
+        if status in ('Active', 'Fulfilled'):
+            provider = self.providers.get(swap.to_chain)
+            if provider is None:
+                if now < int(swap.max_extend_at):
+                    return SwapAction(
+                        SwapDecision.SKIP, reason=f'no provider for dest {swap.to_chain} — cannot verify yet'
+                    )
+                return SwapAction(
+                    SwapDecision.TIMEOUT,
+                    reason=f'no provider for dest {swap.to_chain} past max_extend_at — terminal, else collateral freezes',
+                )
+            # Offline and before any RPC, so an unreachable provider can never turn a malformed dest into a slash.
+            if not provider.chain.is_valid_address(swap.user_to_addr):
+                return SwapAction(
+                    SwapDecision.REFUSE,
+                    reason='dest address invalid — cancel, no slash/fee/strike',
+                    reason_code=CANCEL_REASON_INVALID_DEST,
+                )
         if status == 'PendingAttestation':
             return self._decide_pending_attestation(swap, now)
         if status == 'Active':

--- a/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
+++ b/smart-contracts/solana/programs/allways_swap_manager/src/constants.rs
@@ -109,6 +109,11 @@ pub const CANCEL_REASON_SOL_RESERVED: u8 = 3;
 /// An issuer-enabled ERC-20 transfer fee shaves every honest delivery's log below the pinned
 /// amount — a hub-wide no-fault condition, cancelled rather than slashed (V-M2/PAXG).
 pub const CANCEL_REASON_ERC20_FEE_ENABLED: u8 = 4;
+/// The issuer froze the destination's SPL token account: undeliverable through no fault of the miner.
+pub const CANCEL_REASON_SPL_FROZEN: u8 = 5;
+/// The destination fails the chain's offline format check: unpayable by construction, never the
+/// miner's fault.
+pub const CANCEL_REASON_INVALID_DEST: u8 = 6;
 pub const CANCEL_REASON_OTHER: u8 = 255;
 
 /// Slots the draw's seed slot is pinned ahead of the arming crank. Three leader windows (4 slots

--- a/tests/test_address_validity_offline.py
+++ b/tests/test_address_validity_offline.py
@@ -1,0 +1,93 @@
+"""Registry-wide proof that address validation is offline and the CLI gate builds every asset.
+
+Blocks sockets before constructing each registered asset; no chain, no RPC."""
+
+import socket
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import bittensor as bt
+import pytest
+from solders.keypair import Keypair
+
+from allways.assets import ASSET_REGISTRY
+from allways.chains import get_chain_def
+from allways.cli.swap_commands import swap
+
+BTC_ADDRESS = 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh'
+TAO_ADDRESS = bt.Keypair.create_from_seed('0x' + '11' * 32).ss58_address
+SOL_ADDRESS = str(Keypair().pubkey())
+EVM_ADDRESS = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+
+
+def _good_address(chain_id):
+    if chain_id == 'btc':
+        return BTC_ADDRESS
+    if chain_id == 'tao':
+        return TAO_ADDRESS
+    if chain_id in ('sol', 'solusdc'):
+        return SOL_ADDRESS
+    return EVM_ADDRESS
+
+
+def _constructor_kwargs(spec):
+    available = {
+        'solana_rpc_url': 'http://offline.invalid',
+        'solana_keypair': MagicMock(),
+        'subtensor': MagicMock(),
+    }
+    return {name: available[name] for name in spec.kwarg_names if name in available}
+
+
+@pytest.fixture(autouse=True)
+def stable_network_env(monkeypatch):
+    for spec in ASSET_REGISTRY:
+        prefix = get_chain_def(spec.chain_id).env_prefix
+        if prefix:
+            monkeypatch.setenv(f'{prefix}_NETWORK', 'mainnet')
+
+
+@pytest.mark.parametrize('spec', ASSET_REGISTRY, ids=lambda spec: spec.chain_id)
+def test_registered_asset_address_validation_is_offline(monkeypatch, spec):
+    def offline(*args, **kwargs):
+        raise AssertionError('network access during address validation')
+
+    monkeypatch.setattr(socket, 'socket', offline)
+    monkeypatch.setattr(socket, 'create_connection', offline)
+    monkeypatch.setattr(socket, 'getaddrinfo', offline)
+    provider = spec.cls(**_constructor_kwargs(spec))
+    chain = provider.chain
+    for entry_point in ('eth_rpc', 'btc_api_get'):
+        monkeypatch.setattr(chain, entry_point, offline, raising=False)
+
+    good = chain.is_valid_address(_good_address(spec.chain_id))
+    bad = chain.is_valid_address('not-an-address')
+    assert good is True
+    assert bad is False
+
+
+@pytest.mark.parametrize('spec', ASSET_REGISTRY, ids=lambda spec: spec.chain_id)
+def test_gate_provider_builds_every_registered_asset(spec):
+    client = MagicMock()
+    client.rpc.url = 'http://offline.invalid'
+    client.keypair = MagicMock()
+    assert swap._gate_provider(spec.chain_id, client, {}, lambda: MagicMock()) is not None
+
+
+def test_gate_provider_reports_constructor_failure(monkeypatch):
+    class Broken:
+        def __init__(self):
+            raise RuntimeError('cannot build')
+
+    monkeypatch.setattr('allways.assets.ASSET_REGISTRY', (SimpleNamespace(chain_id='bad', cls=Broken, kwarg_names=()),))
+    console = MagicMock()
+    monkeypatch.setattr(swap, 'console', console)
+
+    assert swap._gate_provider('bad', MagicMock(), {}, lambda: MagicMock()) is None
+    console.print.assert_called_once_with('  [yellow]could not check BAD address here[/yellow]')
+
+
+def test_non_tao_gate_provider_does_not_get_subtensor():
+    getter = MagicMock(side_effect=AssertionError('subtensor requested for a non-tao chain'))
+    swap._gate_provider('btc', MagicMock(), {}, getter)
+    getter.assert_not_called()

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -422,6 +422,9 @@ def _live_swap(variant: str):
         from_amount=1_000_000_000,
         to_amount=210_000,
         miner_from_addr='minerSOLaddr',
+        miner_to_addr='minerBTCaddr',
+        user_to_addr='userBTCaddr',
+        rate='0.0021',
         from_tx_hash='srcTxHash',
         to_tx_hash='',
     )
@@ -430,6 +433,9 @@ def _live_swap(variant: str):
 def _status_validator(tmp_path, client):
     validator, store = _stage_validator(tmp_path)
     validator.solana_client = client
+    validator.solana_swap_loop = SimpleNamespace(
+        providers={'btc': _gate_asset(lambda addr, amt: True)}, fee_divisor=100
+    )
     return validator, store
 
 
@@ -479,6 +485,37 @@ def test_initiated_swap_resolves_by_key_after_reservation_consumed(tmp_path):
     assert s.stage == 'active' and s.swap_key == key.hex() and s.reserved_until == 0
     assert s.detail['from_chain'] == 'sol' and s.detail['to_amount'] == 210_000
     assert client.swap_keys_queried == [key]
+    store.close()
+
+
+def test_reject_reason_only_surfaces_for_invalid_pending_attestation(tmp_path):
+    from allways.validator.reserve_engine import swap_status
+
+    key = b'\x15' * 32
+    reservation = SimpleNamespace(
+        reserved_until=FUTURE,
+        claimed_swap_key=key,
+        user='userSOLpk',
+        from_chain='sol',
+        to_chain='btc',
+        from_amount=1_000_000_000,
+        to_amount=210_000,
+        miner_from_addr='minerSOLaddr',
+    )
+    swap = _live_swap('PendingAttestation')
+    validator, store = _status_validator(tmp_path, StatusClient(swap=swap, reservation=reservation))
+
+    validator.solana_swap_loop.providers['btc'].chain.is_valid_address = lambda address: False
+    reason = 'dest address invalid — refusing to attest'
+    assert swap_status(validator, HOTKEY).detail['reject_reason'] == reason
+    assert swap_status(validator, HOTKEY, key.hex()).detail['reject_reason'] == reason
+
+    validator.solana_swap_loop.providers['btc'].chain.is_valid_address = lambda address: True
+    assert 'reject_reason' not in swap_status(validator, HOTKEY).detail
+
+    swap.status = type('Active', (), {})()
+    validator.solana_swap_loop.providers['btc'].chain.is_valid_address = lambda address: False
+    assert 'reject_reason' not in swap_status(validator, HOTKEY, key.hex()).detail
     store.close()
 
 

--- a/tests/test_solana_swap_loop.py
+++ b/tests/test_solana_swap_loop.py
@@ -8,6 +8,7 @@ Mocks the solana client (get_swaps / get_reservation) + chain providers; no chai
 from types import SimpleNamespace
 
 from allways.assets.asset import ProviderUnreachableError
+from allways.constants import CANCEL_REASON_INVALID_DEST
 from allways.solana.client import benign_marker, swap_key_from_tx_hash
 from allways.validator.solana_swap_loop import (
     _BENIGN_RESOLVE_MARKERS,
@@ -209,12 +210,12 @@ def test_active_overdue_refusing_dest_waits_no_slash():
     assert loop.decide(make_swap(status='Active', timeout_at=1000), now=1500).decision == SwapDecision.WAIT
 
 
-def test_overdue_malformed_dest_addr_waits_no_slash():
-    # A self-represented taker can reserve with a poison dest (e.g. 0x0) the reserve gate never saw.
-    # A malformed dest is undeliverable through no fault of the miner — the slash gate must not fire.
+def test_active_invalid_dest_refuses_before_ceiling():
     loop, providers = loop_with(result=None)
     providers['sol'].valid_addr = False
-    assert loop.decide(make_swap(status='Active', timeout_at=1000), now=1500).decision == SwapDecision.WAIT
+    action = loop.decide(make_swap(status='Active', timeout_at=1000), now=1500)
+    assert action.decision == SwapDecision.REFUSE
+    assert action.reason_code == CANCEL_REASON_INVALID_DEST
 
 
 def test_fulfilled_sound_cancel_evidence_refuses_no_slash():
@@ -263,12 +264,21 @@ def test_active_refusing_dest_past_ceiling_times_out():
     assert loop.decide(swap, now=1500).decision == SwapDecision.TIMEOUT
 
 
-def test_active_malformed_dest_addr_past_ceiling_times_out():
-    # Same terminal exit for a malformed (undeliverable) dest address once past the ceiling.
+def test_active_invalid_dest_refuses_past_ceiling():
     loop, providers = loop_with(result=None)
     providers['sol'].valid_addr = False
     swap = make_swap(status='Active', timeout_at=1000, max_extend_at=1200)
-    assert loop.decide(swap, now=1500).decision == SwapDecision.TIMEOUT
+    action = loop.decide(swap, now=1500)
+    assert action.decision == SwapDecision.REFUSE
+    assert action.reason_code == CANCEL_REASON_INVALID_DEST
+
+
+def test_fulfilled_invalid_dest_refuses_when_provider_is_reachable():
+    loop, providers = loop_with(result=True)
+    providers['sol'].valid_addr = False
+    action = loop.decide(make_swap(status='Fulfilled'), now=1500)
+    assert action.decision == SwapDecision.REFUSE
+    assert action.reason_code == CANCEL_REASON_INVALID_DEST
 
 
 def test_fulfilled_overdue_but_verifiable_still_confirms():
@@ -292,6 +302,22 @@ def test_fulfilled_pending_dest_at_ceiling_overdue_times_out():
 def test_pending_attestation_source_ok_attests():
     loop, _ = loop_with(result=True)
     assert loop.decide(make_swap(status='PendingAttestation'), now=1500).decision == SwapDecision.ATTEST
+
+
+def test_pending_attestation_invalid_dest_rejects_once_without_a_vote():
+    swap = make_swap(status='PendingAttestation')
+    providers = {'btc': RecordingProvider(True), 'sol': RecordingProvider(True, valid_addr=False)}
+    client = VoteRecordingClient([('pk1', swap)])
+    loop = SolanaSwapLoop(client, providers, fee_divisor=100)
+
+    action = loop.decide(swap, now=1500)
+    assert action.decision == SwapDecision.REJECT
+    assert action.reason == 'dest address invalid — refusing to attest'
+    assert len(loop.reject_warned) == 1
+    loop.decide(swap, now=1500)
+    assert len(loop.reject_warned) == 1
+    loop.run_once(now=1500)
+    assert client.calls == []
 
 
 def test_pending_attestation_rejects_dest_equal_to_miner_delivery():

--- a/tests/test_swap_now_reservation.py
+++ b/tests/test_swap_now_reservation.py
@@ -497,7 +497,9 @@ def _screen(gate, from_chain, to_chain, client=None):
 
     cand = types.SimpleNamespace(miner='miner-pk', rate_display='150', backing='sol')
     with patch('allways.cli.swap_commands.swap._gate_provider', return_value=gate):
-        _screen_deliverability(client or MagicMock(), {}, cand, from_chain, to_chain, 'recvaddr', 'useraddr', 10**6)
+        _screen_deliverability(
+            client or MagicMock(), {}, cand, from_chain, to_chain, 'recvaddr', 'useraddr', 10**6, lambda: MagicMock()
+        )
     return gate
 
 


### PR DESCRIPTION
Harden how the validator treats a destination address that fails the chain's format check.

- Attestation refuses a claim whose payout address is malformed, so the miner is never obligated.
- An already-active swap with a malformed payout address closes as a no-fault cancel instead of waiting out the extension ceiling.
- The seam reports the refusal reason while the claim is pending, so a client can show it.
- The CLI now screens every destination chain before a seat is taken, and says so when it cannot.

Offline checks only; no program change.