### PR TITLE
Hard-exit the neuron when its forward loop stalls

### DIFF
--- a/neurons/base/neuron.py
+++ b/neurons/base/neuron.py
@@ -1,5 +1,7 @@
 import copy
 import os
+import sys
+import threading
 import time
 from abc import ABC, abstractmethod
 from typing import Callable
@@ -14,6 +16,16 @@ from allways.utils.config import add_args, check_config, config
 from allways.utils.misc import ttl_get_block
 
 VALIDATOR_MODES = ('full', 'vote', 'watch')
+
+
+def exit_for_restart(reason: str, grace_secs: float = 30.0) -> None:
+    """Log and exit so the supervisor restarts the neuron."""
+    bt.logging.error(f'{reason} — exiting for restart')
+    # A wedged non-daemon thread would hold the interpreter at shutdown forever; the timer will not.
+    timer = threading.Timer(grace_secs, lambda: os._exit(1))
+    timer.daemon = True
+    timer.start()
+    sys.exit(1)
 
 
 def validator_mode() -> str:

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -7,7 +7,6 @@ Usage:
 """
 
 import os
-import sys
 import time
 from pathlib import Path
 from typing import Dict
@@ -29,6 +28,7 @@ from allways.solana import keys  # noqa: E402
 from allways.solana.client import AllwaysSolanaClient  # noqa: E402
 from allways.solana.rpc import assert_cluster_safe, resolve_rpc_url  # noqa: E402
 from neurons.base.miner import BaseMinerNeuron  # noqa: E402
+from neurons.base.neuron import exit_for_restart  # noqa: E402
 
 
 class Miner(BaseMinerNeuron):
@@ -271,13 +271,10 @@ if __name__ == '__main__':
         while True:
             forward_age = time.time() - miner.last_forward_time
             if not miner.thread.is_alive():
-                bt.logging.error(f'Forward thread is dead (last forward {forward_age:.0f}s ago) — exiting for restart')
-                sys.exit(1)
+                exit_for_restart(f'Forward thread is dead (last forward {forward_age:.0f}s ago)')
             if forward_age > FORWARD_STALL_THRESHOLD_SECONDS:
-                bt.logging.error(
-                    f'Forward progress stalled for {forward_age:.0f}s '
-                    f'(>{FORWARD_STALL_THRESHOLD_SECONDS}s) — exiting for restart'
+                exit_for_restart(
+                    f'Forward progress stalled for {forward_age:.0f}s (>{FORWARD_STALL_THRESHOLD_SECONDS}s)'
                 )
-                sys.exit(1)
             bt.logging.info(f'Miner running... step={miner.step} (last forward {forward_age:.0f}s ago)')
             time.sleep(60)

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -9,7 +9,6 @@ Usage:
 """
 
 import os
-import sys
 import threading
 import time
 from functools import partial
@@ -60,7 +59,7 @@ from allways.validator.seam_http import maybe_start_seam  # noqa: E402
 from allways.validator.solana_swap_loop import SolanaSwapLoop  # noqa: E402
 from allways.validator.state_store import ValidatorStateStore  # noqa: E402
 from allways.validator.storage import DatabaseStorage  # noqa: E402
-from neurons.base.neuron import validator_mode  # noqa: E402
+from neurons.base.neuron import exit_for_restart, validator_mode  # noqa: E402
 from neurons.base.validator import BaseValidatorNeuron  # noqa: E402
 
 WANDB_ENTITY = os.getenv('WANDB_ENTITY', 'entrius-gittensor')
@@ -283,13 +282,10 @@ if __name__ == '__main__':
         while True:
             forward_age = time.time() - validator.last_forward_time
             if not validator.thread.is_alive():
-                bt.logging.error(f'Forward thread is dead (last forward {forward_age:.0f}s ago) — exiting for restart')
-                sys.exit(1)
+                exit_for_restart(f'Forward thread is dead (last forward {forward_age:.0f}s ago)')
             if forward_age > FORWARD_STALL_THRESHOLD_SECONDS:
-                bt.logging.error(
-                    f'Forward progress stalled for {forward_age:.0f}s '
-                    f'(>{FORWARD_STALL_THRESHOLD_SECONDS}s) — exiting for restart'
+                exit_for_restart(
+                    f'Forward progress stalled for {forward_age:.0f}s (>{FORWARD_STALL_THRESHOLD_SECONDS}s)'
                 )
-                sys.exit(1)
             bt.logging.info(f'Validator running... step={validator.step} (last forward {forward_age:.0f}s ago)')
             time.sleep(60)

--- a/tests/test_exit_for_restart.py
+++ b/tests/test_exit_for_restart.py
@@ -1,0 +1,45 @@
+import os
+import threading
+
+import pytest
+
+from neurons.base.neuron import exit_for_restart
+
+
+def test_exit_for_restart_raises_and_arms_a_daemon_hard_exit(monkeypatch):
+    armed = {}
+
+    class FakeTimer:
+        def __init__(self, secs, fn):
+            armed['secs'], armed['fn'] = secs, fn
+            self.daemon = False
+
+        def start(self):
+            armed['daemon'] = self.daemon
+
+    hard = []
+    monkeypatch.setattr(threading, 'Timer', FakeTimer)
+    monkeypatch.setattr(os, '_exit', lambda code: hard.append(code))
+
+    with pytest.raises(SystemExit) as raised:
+        exit_for_restart('Forward progress stalled for 655s', grace_secs=30)
+
+    assert raised.value.code == 1
+    assert armed['secs'] == 30 and armed['daemon'] is True
+    armed['fn']()
+    assert hard == [1]
+
+
+def test_exit_for_restart_kills_a_process_held_by_a_wedged_thread(tmp_path):
+    import subprocess
+    import sys
+
+    script = tmp_path / 'wedged.py'
+    script.write_text(
+        'import threading\n'
+        'from neurons.base.neuron import exit_for_restart\n'
+        'threading.Thread(target=threading.Event().wait).start()\n'
+        'exit_for_restart("stalled", grace_secs=0.5)\n'
+    )
+    done = subprocess.run([sys.executable, str(script)], timeout=20, capture_output=True)
+    assert done.returncode == 1


### PR DESCRIPTION
The stall watchdog in neurons/validator.py and neurons/miner.py calls sys.exit(1), but a stalled forward thread is wedged inside a socket read that never returns. The interpreter then waits for that thread at shutdown (concurrent.futures atexit join), so the process never exits, docker's restart policy never fires, and the neuron sits dead with the container reported Up.

Seen three times on the testnet validator today: the relay's vault event poll blocks forever in websockets recv under async_substrate_interface (stack in the linked issue), the watchdog logs "exiting for restart", the thread stops, the process stays alive.

exit_for_restart() logs, arms a daemon Timer that calls os._exit(1) after 30 s, then raises SystemExit so the normal cleanup still runs when it can. Both neurons use it for the dead-thread and stalled-forward cases.

Stopgap only. The root cause (no read timeout on the vault subtensor websocket in allways/vault/client.py poll_events) is filed separately.