### PR TITLE
Size swaps on free collateral and report refused pool draws on /status

### DIFF
--- a/allways/__init__.py
+++ b/allways/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '3.3.2'
+__version__ = '3.3.3'
 version_split = __version__.split('.')
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))

--- a/allways/cli/swap_commands/quote.py
+++ b/allways/cli/swap_commands/quote.py
@@ -25,9 +25,9 @@ from allways.cli.swap_commands.helpers import (
 )
 from allways.cli.swap_commands.swap_intake import (
     MinerCandidate,
-    backing_purse,
     bounds_from_config,
     compute_intake_amounts,
+    free_purse,
     hub_bounds,
     rate_display_from_fixed,
     select_best_miner,
@@ -104,8 +104,8 @@ def quote_command(from_chain: str, to_chain: str, amount: Decimal, as_json: bool
             if q.from_chain == from_chain and q.to_chain == to_chain:
                 backing = getattr(q, 'collateral_chain', None) or 'sol'
                 # The purse the contract will check for THIS offer — local lamports for a
-                # sol-backed quote, the attested effective bond for any other.
-                purse = backing_purse(client, q.miner, e.state, backing)
+                # sol-backed quote, the attested effective bond for any other — net of in-flight swaps.
+                purse = free_purse(client, q.miner, e.state, backing)
                 if purse is None:
                     continue
                 candidates.append(

--- a/allways/cli/swap_commands/swap_intake.py
+++ b/allways/cli/swap_commands/swap_intake.py
@@ -22,6 +22,8 @@ from allways.constants import (
     hub_leg,
     required_collateral,
 )
+from allways.solana.layouts import hub_reserved_collateral
+from allways.solana.pdas import BACKING_BITS
 from allways.utils.rate import (
     calculate_to_amount,
     is_executable_rate,
@@ -94,7 +96,7 @@ def candidate_miners(client, from_chain: str, to_chain: str) -> List[MinerCandid
         if ms is None or not ms.active:
             continue
         backing = getattr(q, 'collateral_chain', NUMERAIRE_CHAIN) or NUMERAIRE_CHAIN
-        purse = backing_purse(client, q.miner, ms, backing)
+        purse = free_purse(client, q.miner, ms, backing)
         if purse is None:
             continue  # no locked bond behind the offer — the contract would refuse the reserve
         out.append(
@@ -122,6 +124,17 @@ def backing_purse(client, miner, miner_state, backing: str) -> Optional[int]:
     if attestation is None or not attestation.locked:
         return None
     return int(attestation.effective_balance)
+
+
+def free_purse(client, miner, miner_state, backing: str) -> Optional[int]:
+    """What a NEW swap can draw on: ``backing_purse`` net of collateral already obligated to in-flight
+    swaps on that hub. ``finalize_reservation`` gates on the same net figure, so a candidate sized on
+    the gross purse passes every pre-check here and is refused on-chain at the draw."""
+    bit = BACKING_BITS.get(backing)
+    purse = backing_purse(client, miner, miner_state, backing) if bit else None
+    if purse is None:
+        return None  # an unknown backing is one offer skipped, never a KeyError across every quote
+    return max(purse - hub_reserved_collateral(miner_state, bit), 0)
 
 
 def floors_from_config(cfg) -> Dict[str, int]:

--- a/allways/cli/swap_commands/view.py
+++ b/allways/cli/swap_commands/view.py
@@ -37,7 +37,7 @@ from allways.cli.swap_commands.helpers import (
     set_json_output,
     votes_needed,
 )
-from allways.cli.swap_commands.swap_intake import backing_purse, rate_display_from_fixed
+from allways.cli.swap_commands.swap_intake import free_purse, rate_display_from_fixed
 from allways.constants import FEE_DIVISOR
 from allways.solana.client import swap_from_solana
 from allways.utils.rate import apply_fee_deduction, directional_rate
@@ -243,7 +243,7 @@ def view_rates(pair, full, sort_by, min_capacity, search, as_json):
                 if needle not in hay:
                     continue
             backing = getattr(q, 'collateral_chain', None) or 'sol'
-            purse = backing_purse(client, q.miner, e.state, backing)
+            purse = free_purse(client, q.miner, e.state, backing)
             if purse is None:
                 continue
             capacity = from_rao(purse) if backing == 'tao' else from_lamports(purse)

--- a/allways/solana/layouts.py
+++ b/allways/solana/layouts.py
@@ -66,6 +66,14 @@ def hub_busy_until(state, bit: int) -> int:
     return int(arr or 0)
 
 
+def hub_reserved_collateral(state, bit: int) -> int:
+    """ONE hub's collateral already obligated to in-flight swaps (contract ``MinerState::reserved``), in
+    the backing's own units. A pre-v3.3 shape carries no array — nothing is reserved."""
+    arr = getattr(state, 'reserved_collateral', ())
+    idx = max(bit.bit_length() - 1, 0)
+    return int(arr[idx]) if idx < len(arr) else 0
+
+
 Pubkey32 = _Raw(32)
 Hash32 = _Raw(32)
 Sig64 = _Raw(64)

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -19,10 +19,10 @@ from allways.assets.asset import ProviderUnreachableError
 from allways.chains import SUPPORTED_CHAINS, canonical_pair, get_chain_def
 from allways.cli.swap_commands.swap_intake import (
     MinerCandidate,
-    backing_purse,
     bounds_from_config,
     candidate_miners,
     compute_intake_amounts,
+    free_purse,
     hub_bounds,
     max_intake_from_amount,
     rate_display_from_fixed,
@@ -71,7 +71,7 @@ def _best_offer(client, miner_pk, miner_state, from_chain: str, to_chain: str, f
         if q is None:
             continue
         backing = str(getattr(q, 'collateral_chain', NUMERAIRE_CHAIN) or NUMERAIRE_CHAIN)
-        purse = backing_purse(client, miner_pk, miner_state, backing)
+        purse = free_purse(client, miner_pk, miner_state, backing)
         if purse is None:
             continue  # no locked bond behind it — the contract's entry gate would refuse the bid
         offers[backing] = q
@@ -170,7 +170,7 @@ def reserve_on_behalf(
     if amts.to_amount <= 0:
         return ReserveResult(False, 'non-positive dest amount for that source amount')
 
-    purse = backing_purse(client, miner_pk, miner_state, backing)
+    purse = free_purse(client, miner_pk, miner_state, backing)
     if purse is None:
         return ReserveResult(False, f'no locked {backing} bond backs that offer')
     min_swap, max_swap = bounds.get(backing, (0, 0))

--- a/allways/validator/reserve_engine.py
+++ b/allways/validator/reserve_engine.py
@@ -86,6 +86,37 @@ def _best_offer(client, miner_pk, miner_state, from_chain: str, to_chain: str, f
 
 
 @dataclass
+class RoutedRejection:
+    """A finalize the contract refused. The whole queue on that pool lost the round with it."""
+
+    reason: str
+    users: list
+
+
+# Keyed per (miner pubkey, from_chain, to_chain); the next request on that pool clears it. Memory-only:
+# after a restart the offering falls back to its own backstop. The epoch counts every change so the
+# seam's /status memo (keyed on it) can never serve a verdict from across one.
+_routed_rejections: dict = {}
+_verdict_epoch = 0
+
+
+def verdict_epoch() -> int:
+    return _verdict_epoch
+
+
+def _publish_verdict(key: tuple, verdict: RoutedRejection) -> None:
+    global _verdict_epoch
+    _routed_rejections[key] = verdict
+    _verdict_epoch += 1
+
+
+def _clear_verdict(key: tuple) -> None:
+    global _verdict_epoch
+    if _routed_rejections.pop(key, None) is not None:
+        _verdict_epoch += 1
+
+
+@dataclass
 class ReserveResult:
     ok: bool
     reason: str = ''
@@ -235,6 +266,7 @@ def reserve_on_behalf(
     validator.state_store.upsert_routed_request(
         str(miner_pk), from_chain, to_chain, backing, str(user_pk), user_from_addr, user_to_addr, from_amount, now
     )
+    _clear_verdict((str(miner_pk), from_chain, to_chain))
     pool = client.get_pool(miner_pk, backing)
     closes_at = int(getattr(pool, 'closes_at', 0) or 0) if pool else 0
     if closes_at:
@@ -434,6 +466,11 @@ def finalize_won_seats(validator, now: int) -> list:
                 bt.logging.warning(f'routed sweep {miner[:8]}: finalize transport fault, retrying next step: {e}')
                 continue
             bt.logging.warning(f'routed sweep {miner[:8]}: finalize rejected ({reason}), dropping queue')
+            # Every queued user lost this round; /status carries the verdict so the offering can
+            # refund at once instead of waiting out its "reservation never landed" backstop. Published
+            # BEFORE the delete: a request landing in between clears it and is then dropped with the
+            # queue — the slow backstop, never a fast fail on a seat that could still land.
+            _publish_verdict((miner, from_chain, to_chain), RoutedRejection(reason, [q['user_pubkey'] for q in queue]))
             store.delete_routed_requests(miner, from_chain, to_chain, backing)
             continue
         bt.logging.info(f'routed sweep {miner[:8]}: finalized seat for {req["user_pubkey"][:8]} (FIFO of queue)')
@@ -776,9 +813,13 @@ class SwapStatus:
     swap directly — required for post-attestation stages, because ``vote_initiate`` consumes
     the reservation at attestation quorum, so the reservation stops referencing the swap the
     moment it goes ``active``. Without ``swap_key``, resolution walks the miner's reservation
-    and only the pre-attestation stages (``none``/``reserved``/``claimed``) are reliably visible."""
+    and only the pre-attestation stages (``none``/``reserved``/``claimed``) are reliably visible.
 
-    stage: str  # none | reserved | claimed | active | fulfilled | completed | timed_out | cancelled | expired
+    ``rejected`` replaces ``none`` while the pool's last draw was refused by the contract: ``detail``
+    carries the ``reason`` and the ``users`` who lost the round, so the offering fails them at once."""
+
+    # none | rejected | reserved | claimed | active | fulfilled | completed | timed_out | cancelled | expired
+    stage: str
     reserved_until: int = 0
     user: str = ''
     swap_key: str = ''
@@ -801,13 +842,13 @@ def swap_status(
         return SwapStatus('none')
     reservation = _freshest_reservation(client, miner_pk, from_chain, to_chain)
     if reservation is None or reservation.reserved_until == 0:
-        return SwapStatus('none')
+        return _idle_status(miner_pk, from_chain, to_chain)
     swap_key = bytes(reservation.claimed_swap_key)
     # An expired UNCLAIMED reservation is dead — the pool can be re-entered over it. Reporting it as
     # 'reserved' with its stale user makes the offering's win-detection read "another validator's user
     # holds this miner" and mark won draws lost. A claimed one still speaks through its swap's stage.
     if swap_key == EMPTY_SWAP_KEY and int(reservation.reserved_until) < time.time():
-        return SwapStatus('none')
+        return _idle_status(miner_pk, from_chain, to_chain)
     # detail carries what the offering needs to instruct the user (where + how much to send).
     detail = {
         'from_chain': reservation.from_chain,
@@ -825,6 +866,14 @@ def swap_status(
     stage = _swap_stage(validator, swap, swap_key)
     _add_reject_reason(validator, swap, stage, detail)
     return SwapStatus(stage, reservation.reserved_until, str(reservation.user), swap_key.hex(), detail)
+
+
+def _idle_status(miner_pk, from_chain: str, to_chain: str) -> SwapStatus:
+    """No live reservation: ``rejected`` if the pool's last draw was refused, else ``none``."""
+    rejection = _routed_rejections.get((str(miner_pk), from_chain, to_chain))
+    if rejection is None:
+        return SwapStatus('none')
+    return SwapStatus('rejected', detail={'reason': rejection.reason, 'users': rejection.users})
 
 
 def _swap_status_by_key(validator, swap_key_hex: str) -> SwapStatus:

--- a/allways/validator/seam_http.py
+++ b/allways/validator/seam_http.py
@@ -24,6 +24,7 @@ from allways.validator.reserve_engine import (
     reserve_on_behalf,
     scan_deposit,
     swap_status,
+    verdict_epoch,
 )
 
 SEAM_HOST = os.environ.get('ALLWAYS_SEAM_HOST', '127.0.0.1')
@@ -54,8 +55,10 @@ def _make_handler(validator, secret: str):
     # is not required to be hashable, and no module-level table pins it alive. lru_cache does not
     # store exceptions, so a transient RPC fault is retried rather than pinned for the bucket;
     # maxsize caps the table so a long-lived seam can't grow an entry per swap ever polled.
+    # `_epoch` keys the memo on the pool-verdict epoch: a read still in flight when a 'rejected' verdict
+    # is published or cleared lands under the old key, so the next poll re-reads instead of inheriting it.
     @lru_cache(maxsize=512)
-    def cached_status(miner_hotkey: str, swap_key: str, from_chain: str, to_chain: str, _bucket: int):
+    def cached_status(miner_hotkey: str, swap_key: str, from_chain: str, to_chain: str, _bucket: int, _epoch: int):
         return swap_status(validator, miner_hotkey, swap_key, from_chain, to_chain)
 
     @lru_cache(maxsize=512)
@@ -113,6 +116,7 @@ def _make_handler(validator, secret: str):
                         q.get('from_chain', ''),
                         q.get('to_chain', ''),
                         _ttl_bucket(),
+                        verdict_epoch(),
                     )
                     return self._send(200, status.__dict__)
                 if url.path == '/deposit-scan':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "allways"
-version = "3.3.2"
+version = "3.3.3"
 description = "Allways - Universal Transaction Layer: Collateral-backed cross-chain swaps on Bittensor Subnet 7"
 license = "MIT"
 requires-python = ">=3.10,<3.15"

--- a/tests/test_finalize_sweep.py
+++ b/tests/test_finalize_sweep.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 from solders.keypair import Keypair as SolKeypair
 
 from allways.constants import RATE_PRECISION
+from allways.validator import reserve_engine
 from allways.validator.reserve_engine import ROUTED_REQUEST_TTL_SECS, draw_pool_winner, finalize_won_seats
 from allways.validator.state_store import ValidatorStateStore
 
@@ -273,8 +274,12 @@ def test_contract_rejection_drops_queue(tmp_path):
     client.finalize_reservation = _raise
     v = _validator(tmp_path, client)
     _queue(v.state_store, USER_A)
+    _queue(v.state_store, USER_B)
     assert finalize_won_seats(v, NOW) == []
     assert v.state_store.distinct_routed_pools() == []
+    # The verdict outlives the queue so /status can fail every queued user at once.
+    verdict = reserve_engine._routed_rejections.pop((MINER, 'sol', 'btc'))
+    assert verdict.reason == 'Miner already has an active reservation' and verdict.users == [USER_A, USER_B]
     v.state_store.close()
 
 

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -112,6 +112,18 @@ def test_reserve_refuses_a_fill_the_in_flight_obligations_leave_uncovered():
     assert not r.ok and 'collateral too low' in r.reason
 
 
+def test_a_new_request_clears_the_pool_rejection_verdict():
+    from allways.validator import reserve_engine
+
+    key = (str(MINER_PK), 'sol', 'btc')
+    reserve_engine._routed_rejections[key] = reserve_engine.RoutedRejection('Insufficient collateral', ['u'])
+    try:
+        r, _ = _reserve(FakeClient())
+        assert r.ok and key not in reserve_engine._routed_rejections
+    finally:
+        reserve_engine._routed_rejections.clear()
+
+
 def test_open_happy_path_persists_routed_request():
     # Two-phase: reserve_on_behalf places a BID after a viability pre-check, then queues the
     # user's details for finalize_won_seats (the winner names the fill at finalize).
@@ -470,6 +482,24 @@ def test_expired_unclaimed_reservation_reports_none(tmp_path):
     client = StatusClient(reservation=_unclaimed_reservation(int(_time.time()) - 5))
     validator, _ = _status_validator(tmp_path, client)
     assert swap_status(validator, HOTKEY).stage == 'none'
+
+
+def test_pool_rejection_reports_rejected_with_its_users_until_a_seat_is_live(tmp_path):
+    from allways.validator import reserve_engine
+    from allways.validator.reserve_engine import swap_status
+
+    key = (str(MINER_PK), 'btc', 'sol')
+    reserve_engine._routed_rejections[key] = reserve_engine.RoutedRejection('Insufficient collateral', ['userA'])
+    try:
+        validator, _ = _status_validator(tmp_path, StatusClient(reservation=None))
+        s = swap_status(validator, HOTKEY, from_chain='btc', to_chain='sol')
+        assert s.stage == 'rejected' and s.detail == {'reason': 'Insufficient collateral', 'users': ['userA']}
+        assert swap_status(validator, HOTKEY, from_chain='sol', to_chain='btc').stage == 'none'  # other pool
+        # A live reservation is a newer round — it speaks, the stale verdict does not.
+        validator.solana_client = StatusClient(reservation=_unclaimed_reservation(FUTURE))
+        assert swap_status(validator, HOTKEY, from_chain='btc', to_chain='sol').stage == 'reserved'
+    finally:
+        reserve_engine._routed_rejections.clear()
 
 
 def test_live_unclaimed_reservation_reports_reserved(tmp_path):

--- a/tests/test_reserve_engine.py
+++ b/tests/test_reserve_engine.py
@@ -104,6 +104,14 @@ def _reserve(client, from_amount=1_000_000_000):
     return result, validator.state_store
 
 
+def test_reserve_refuses_a_fill_the_in_flight_obligations_leave_uncovered():
+    # 10**12 lamports gross, all but 1 SOL already obligated on the sol hub: a 1 SOL fill needs 1.1.
+    client = FakeClient()
+    client.miner_state.reserved_collateral = [10**12 - 10**9, 0]
+    r, _ = _reserve(client)
+    assert not r.ok and 'collateral too low' in r.reason
+
+
 def test_open_happy_path_persists_routed_request():
     # Two-phase: reserve_on_behalf places a BID after a viability pre-check, then queues the
     # user's details for finalize_won_seats (the winner names the fill at finalize).

--- a/tests/test_seam_read_cache.py
+++ b/tests/test_seam_read_cache.py
@@ -118,3 +118,22 @@ def test_failures_are_not_cached(counted, monkeypatch):
     state['fail'] = False
     # Same bucket: the retry reaches the producer instead of replaying the failure.
     assert _get(server, '/status?miner_hotkey=hk')['user'] == 'recovered'
+
+
+def test_a_verdict_change_is_never_served_from_the_memo(counted):
+    # A 'rejected' verdict published or cleared mid-bucket must reach the very next poll.
+    from allways.validator import reserve_engine
+
+    server, calls = counted
+    key = ('m', 'a', 'b')
+    try:
+        _get(server, '/status?miner_hotkey=hk')
+        reserve_engine._publish_verdict(key, reserve_engine.RoutedRejection('refused', []))
+        assert _get(server, '/status?miner_hotkey=hk')['user'] == 'user-2'
+        reserve_engine._clear_verdict(key)
+        assert _get(server, '/status?miner_hotkey=hk')['user'] == 'user-3'
+        reserve_engine._clear_verdict(key)  # nothing to clear: no epoch bump, the memo holds
+        assert _get(server, '/status?miner_hotkey=hk')['user'] == 'user-3'
+        assert calls['status'] == 3
+    finally:
+        reserve_engine._clear_verdict(key)

--- a/tests/test_swap_intake.py
+++ b/tests/test_swap_intake.py
@@ -264,3 +264,28 @@ def test_max_intake_spoke_source_respects_max_swap():
     at_max = compute_intake_amounts('btc', 'sol', max_from, '0.5')
     past_max = compute_intake_amounts('btc', 'sol', max_from + 1, '0.5')
     assert at_max.collateral_amount <= MAX < past_max.collateral_amount
+
+
+def test_candidate_purse_is_net_of_in_flight_reservations():
+    # The finalize gate nets `reserved_collateral[hub]` off the purse; a candidate sized on the gross
+    # purse would pass every pre-check and be refused on-chain at the draw.
+    from types import SimpleNamespace
+
+    from allways.cli.swap_commands.swap_intake import candidate_miners
+
+    q = SimpleNamespace(miner='m', from_chain='tao', to_chain='sol', rate=15 * 10**17)
+    busy = SimpleNamespace(active=True, collateral=3 * SOL, reserved_collateral=[2 * SOL, 7 * SOL])
+    out = candidate_miners(_FakeCandClient(quotes=[q], states={'m': busy}), 'tao', 'sol')
+    assert out[0].collateral == SOL  # sol hub is slot 0; the tao slot's obligation does not count
+
+
+def test_candidate_purse_floors_at_zero_and_tolerates_a_pre_v33_state():
+    from types import SimpleNamespace
+
+    from allways.cli.swap_commands.swap_intake import candidate_miners
+
+    q = SimpleNamespace(miner='m', from_chain='tao', to_chain='sol', rate=15 * 10**17)
+    over = SimpleNamespace(active=True, collateral=SOL, reserved_collateral=[2 * SOL])
+    old = SimpleNamespace(active=True, collateral=SOL)
+    assert candidate_miners(_FakeCandClient([q], {'m': over}), 'tao', 'sol')[0].collateral == 0
+    assert candidate_miners(_FakeCandClient([q], {'m': old}), 'tao', 'sol')[0].collateral == SOL

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "allways"
-version = "3.3.2"
+version = "3.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "base58" },


### PR DESCRIPTION
## Summary
Size swaps on the miner's free collateral, and tell the offering at once when the contract refuses a pool draw.

## Motivation
Prod 2026-09-05 12:23 ET: a 1.98 TAO -> ARBUSDC swap passed the routed reserve pre-check, then `finalize_reservation` refused it with `InsufficientCollateral`. The off-chain purse is gross; the program gate is `purse - reserved_collateral[hub]`. The validator dropped the queue silently, so the offering saw `none` and waited out its 15 minute backstop.

## Changes
- `free_purse`: `backing_purse` net of `reserved_collateral[hub]` (`hub_reserved_collateral`, same slot rule as `hub_busy_until`). Candidate building, the reserve pre-check and CLI quote/view size on it. Activation keeps the gross read, as `vote_activate` does.
- A refused finalize is kept per (miner, pair), published before the queue drop. Seam `/status` answers `rejected` with `detail.reason` and `detail.users` while no live reservation exists; the next request on that pool clears it; the status memo keys on a verdict epoch so no poll straddles a change. Memory only: after a restart the offering falls back to its backstop.
- Tests: net purse, zero floor, pre-v3.3 state, reserve refusal, verdict recorded and cleared, `/status` precedence.
- Version bump to 3.3.3.

Pairs with e35VenturaLabs/allways-access#188 (fail the seat at once on `rejected`). Either side deploys first.