### PR TITLE
Bound vault event catch-up so a restart after an outage cannot stall the validator

### DIFF
--- a/allways/validator/relay/engine.py
+++ b/allways/validator/relay/engine.py
@@ -49,6 +49,7 @@ VAULT_DIRTYING_EVENTS = {
 
 _ATTRIBUTION_TTL_SECS = 300
 _VAULT_CURSOR_KEY = 'vault_event_block'
+_VAULT_POLL_MAX_BLOCKS = 50  # two substrate reads per block; keeps one step's catch-up under the stall watchdog
 _EXIT_KEY_PREFIX = 'exit:'
 
 
@@ -424,8 +425,11 @@ class BondRelay:
         start = int(cursor) + 1
         if start > head:
             return
+        # A long outage is walked one window per step; the cursor advances each step instead of
+        # only once the whole gap is read, which never happened before the watchdog fired.
+        end = min(head, start + _VAULT_POLL_MAX_BLOCKS - 1)
         try:
-            events = self.vault.poll_events(start, head)
+            events = self.vault.poll_events(start, end)
         except Exception as e:
             bt.logging.warning(f'relay: vault event poll failed: {e}')
             return
@@ -436,7 +440,7 @@ class BondRelay:
             miner = self.miner_for(str(ev.fields.get(field)))
             if miner is not None:
                 self.mark_dirty(miner)
-        self.store.set_relay_meta(_VAULT_CURSOR_KEY, head)
+        self.store.set_relay_meta(_VAULT_CURSOR_KEY, end)
 
     def _vault_head(self) -> Optional[int]:
         try:

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -290,6 +290,7 @@ if __name__ == '__main__':
                     f'Forward progress stalled for {forward_age:.0f}s '
                     f'(>{FORWARD_STALL_THRESHOLD_SECONDS}s) — exiting for restart'
                 )
-                sys.exit(1)
+                # sys.exit would join the executor thread the stalled forward is blocked in.
+                os._exit(1)
             bt.logging.info(f'Validator running... step={validator.step} (last forward {forward_age:.0f}s ago)')
             time.sleep(60)

--- a/tests/test_bond_relay.py
+++ b/tests/test_bond_relay.py
@@ -92,6 +92,7 @@ class FakeVault:
         return VaultCallResult(ok=True)
 
     def poll_events(self, start, end):
+        self.calls.append(('poll_events', start, end))
         return self.events
 
 
@@ -1028,3 +1029,16 @@ def test_attestation_does_not_recharge_fees_the_retired_vault_settled():
     # A fee earned under the CURRENT generation still nets off, exactly as before.
     store.record_relay_fee('new', MINER, 'tao', 2_000_000, NOW, vault_generation=1)
     assert attestation_job.compute(relay, MINER, HOTKEY).effective_balance == 798_000_000
+
+
+def test_vault_event_poll_walks_a_long_gap_one_window_per_step():
+    vault = FakeVault()
+    vault.head = lambda: 1000
+    relay = _relay(vault=vault)
+    relay.store.set_relay_meta('vault_event_block', 0)
+
+    relay.poll_vault_events()
+    relay.poll_vault_events()
+
+    assert [c for c in vault.calls if c[0] == 'poll_events'] == [('poll_events', 1, 50), ('poll_events', 51, 100)]
+    assert relay.store.get_relay_meta('vault_event_block') == '100'


### PR DESCRIPTION
## Problem

After an outage the bond relay's vault event poll walks every missed block in one call, two substrate reads per block. On testnet a 12-day gap was ~112k blocks at ~1.4 blocks/s. The forward loop never finished step one, the 600 s stall watchdog fired, and \`sys.exit\` then joined the executor thread the poll was blocked in. The process never exited, the container never restarted, and the cursor never moved, so every manual restart replayed the same loop. Mainnet hits the same wall after any outage longer than roughly 3 hours.

## Fix

- \`poll_vault_events\` reads at most 50 blocks per step and advances the cursor to the end of that window. Catch-up finishes across steps while the validator keeps voting, heartbeating, and serving the seam.
- The stall watchdog exits with \`os._exit(1)\` so a blocked worker thread cannot pin the process.

## Test

\`test_vault_event_poll_walks_a_long_gap_one_window_per_step\`: cursor 0, head 1000, two polls read (1, 50) then (51, 100) and leave the cursor at 100.

## Ops note

A validator already stuck this way needs a one-time \`DELETE FROM relay_meta WHERE key='vault_event_block'\` and a restart; the relay re-seeds the cursor at head. Done on testnet 2026-09-09.