### PR TITLE
Pay direction pools to live pairs only

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -147,8 +147,8 @@ LAUNCH_PAIRS: tuple[tuple[str, str], ...] = tuple(
 BURN_RATE = 0.0
 MINER_POOL_SHARE = 1.0 - BURN_RATE
 # Direction registry and the equal-split fallback: one entry per hub↔spoke direction
-# (both ways). The per-round pool values are volume-weighted at pair level
-# (scoring.compute_direction_pools); these constants are what zero volume falls back to.
+# (both ways). The per-round pool values are volume-weighted at pair level over LIVE pairs
+# (scoring.compute_direction_pools); these constants are what a silent network falls back to.
 DIRECTION_POOLS: dict[tuple[str, str], float] = {
     pair: MINER_POOL_SHARE / (2 * len(LAUNCH_PAIRS))
     for hub, spoke in LAUNCH_PAIRS
@@ -156,9 +156,11 @@ DIRECTION_POOLS: dict[tuple[str, str], float] = {
 }
 # Volume-weighted pools: each pair's emission share follows the QUALIFIED hub-leg notional it
 # cleared over the trailing window (fills reserved on a crown-holding miner — clearing_rates
-# .qualified), blended with the equal split so a quiet pair never starves and a busy one is
-# capped at α + (1−α)/pairs. Weighting sits at PAIR level and splits evenly between the two
-# legs — one leg can't be inflated without inflating the pair.
+# .qualified), blended with an equal split over the family's LIVE pairs (≥1 qualified fill in
+# the window) so a small live pair never starves and a busy one is capped at α + (1−α)/live.
+# A pair with no qualified fill this window is dead: no pool, and it dilutes nobody — the floor
+# scales with activity, not registry size. Weighting sits at PAIR level and splits evenly
+# between the two legs — one leg can't be inflated without inflating the pair.
 POOL_VOLUME_WINDOW_SECS = 24 * 3600  # flat trailing window the pool volumes sum over
 POOL_VOLUME_ALPHA = 0.66  # blend dial: 0 = frozen equal split, 1 = pure volume share
 # Quality-volume slice: each lane pool pays (1−β) on crown time and β on qualified volume share

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -731,6 +731,7 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
             crown_window_bounds_by_direction={lane: (window_start, window_end) for lane in pools},
             miner_score_rows=miner_score_tuples(score_rows, cursor_ts),
             crown_holders_max_ts=cursor_ts,
+            direction_pool_rows=direction_pool_tuples(direction_traces, cursor_ts),
         )
 
     return rewards, set(range(n_uids))
@@ -755,6 +756,16 @@ def miner_score_tuples(score_rows: List[ScoreRow], ts: int) -> List[Tuple]:
             r.qvol_share,
         )
         for r in score_rows
+    ]
+
+
+def direction_pool_tuples(direction_traces: Dict[Tuple[str, str, str], DirectionTrace], ts: int) -> List[Tuple]:
+    """Shape the round's pools for the ``direction_pools`` ledger: one row per lane,
+    dead lanes included at pool 0 — ``(round_ts, from, to, backing, pool, qualified_volume,
+    live)``. Hub / pair emission over time is a plain sum over these."""
+    return [
+        (ts, from_chain, to_chain, backing, trace.pool, int(trace.qualified_volume), trace.pool > 0)
+        for (from_chain, to_chain, backing), trace in direction_traces.items()
     ]
 
 

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -762,9 +762,25 @@ def miner_score_tuples(score_rows: List[ScoreRow], ts: int) -> List[Tuple]:
 def direction_pool_tuples(direction_traces: Dict[Tuple[str, str, str], DirectionTrace], ts: int) -> List[Tuple]:
     """Shape the round's pools for the ``direction_pools`` ledger: one row per lane,
     dead lanes included at pool 0 — ``(round_ts, from, to, backing, pool, qualified_volume,
-    live)``. Hub / pair emission over time is a plain sum over these."""
+    live)``. Hub / pair emission over time is a plain sum over these.
+
+    ``live`` is the PAIR's liveness — qualified volume on any of its lanes, the same test
+    ``compute_direction_pools`` pays on — not ``pool > 0``: the silent-network fallback pays
+    every lane with no pair live, and the ledger must say so."""
+    pair_volume: Dict[Tuple[str, str], int] = {}
+    for (from_chain, to_chain, _backing), trace in direction_traces.items():
+        pair = canonical_pair(from_chain, to_chain)
+        pair_volume[pair] = pair_volume.get(pair, 0) + int(trace.qualified_volume)
     return [
-        (ts, from_chain, to_chain, backing, trace.pool, int(trace.qualified_volume), trace.pool > 0)
+        (
+            ts,
+            from_chain,
+            to_chain,
+            backing,
+            trace.pool,
+            int(trace.qualified_volume),
+            pair_volume[canonical_pair(from_chain, to_chain)] > 0,
+        )
         for (from_chain, to_chain, backing), trace in direction_traces.items()
     ]
 

--- a/allways/validator/scoring.py
+++ b/allways/validator/scoring.py
@@ -475,22 +475,27 @@ def qualified_volume_shares(
 def compute_direction_pools(
     clearing_volumes: Dict[Tuple[str, str], Dict[str, Tuple[int, int]]],
 ) -> Dict[Tuple[str, str, str], float]:
-    """Volume-weighted pools from a trailing window of realized swaps
+    """Volume-weighted pools from a trailing window of QUALIFIED swaps
     (``get_clearing_volumes`` shape), keyed by lane ``(from, to, backing)``.
-    Each hub↔spoke *pair* earns ``(1−α)/pairs + α × its share of hub-leg
-    notional``, split evenly between its two directions — weighting at pair
-    level means one leg can't be inflated without inflating the whole pair —
-    then evenly again across each direction's backing lanes (F4, budget-
-    neutral: sol↔tao's pair pool splits across its two lanes, spokes carry
-    one). No volume anywhere → the equal split. Pools sum to
-    ``MINER_POOL_SHARE``, not 1.0 — the burn lives here.
+    A pair is LIVE iff it cleared qualified volume in the window; only live
+    pairs are paid. Each live pair earns ``(1−α)/live_pairs_in_family + α × its
+    share of the family's hub-leg notional``, split evenly between its two
+    directions — weighting at pair level means one leg can't be inflated
+    without inflating the whole pair — then evenly again across each
+    direction's backing lanes (F4, budget-neutral: sol↔tao's pair pool splits
+    across its two lanes, spokes carry one). A dead pair's lanes are present at
+    0.0. No volume anywhere → the equal split over the whole registry (the
+    day-one / silent-network fallback). Pools sum to ``MINER_POOL_SHARE``,
+    not 1.0 — the burn lives here.
 
     Volumes are the pair's HUB-leg notional, so they are only comparable
     within one hub's family (lamports vs rao — converting across would smuggle
-    a price oracle in). Each hub family therefore holds a FIXED share of the
-    pool (proportional to its pair count) and the α-blend runs within it; a
-    single-family registry reduces exactly to the old global blend. Volume is
-    never split by backing — same non-comparability argument."""
+    a price oracle in). Each hub family therefore holds a share of the pool
+    proportional to its LIVE pair count — oracle-free, and a registered-but-
+    unfilled pair moves nothing — and the α-blend runs within it. So the floor
+    scales with activity, not registry size: adding dead pairs changes nobody's
+    pool, and keeping a pair funded costs one qualified fill per window. Volume
+    is never split by backing — same non-comparability argument."""
     pair_directions: Dict[Tuple[str, str], List[Tuple[str, str]]] = {}
     for from_chain, to_chain in DIRECTION_POOLS:
         pair_directions.setdefault(canonical_pair(from_chain, to_chain), []).append((from_chain, to_chain))
@@ -505,7 +510,8 @@ def compute_direction_pools(
             volume += sum(sums[leg] for sums in clearing_volumes.get((from_chain, to_chain), {}).values())
         pair_volumes[pair] = volume
 
-    if sum(pair_volumes.values()) <= 0:
+    live_pairs = {pair for pair, volume in pair_volumes.items() if volume > 0}
+    if not live_pairs:
         return {
             (from_chain, to_chain, backing): pool / len(declarable_backings(from_chain, to_chain))
             for (from_chain, to_chain), pool in DIRECTION_POOLS.items()
@@ -517,14 +523,14 @@ def compute_direction_pools(
         families.setdefault(hub_leg(*pair) or pair[0], []).append(pair)
 
     pools: Dict[Tuple[str, str, str], float] = {}
-    total_pairs = len(pair_directions)
     for family_pairs in families.values():
-        family_share = len(family_pairs) / total_pairs
-        family_volume = sum(pair_volumes[p] for p in family_pairs)
-        equal_pair_share = 1.0 / len(family_pairs)
+        family_live = [p for p in family_pairs if p in live_pairs]
+        family_share = len(family_live) / len(live_pairs)
+        family_volume = sum(pair_volumes[p] for p in family_live)
+        equal_pair_share = 1.0 / len(family_live) if family_live else 0.0
         for pair in family_pairs:
-            if family_volume <= 0:
-                pair_share = equal_pair_share
+            if pair not in live_pairs:
+                pair_share = 0.0  # dead this window: no qualified fill, no pool
             else:
                 volume_share = pair_volumes[pair] / family_volume
                 pair_share = (1.0 - POOL_VOLUME_ALPHA) * equal_pair_share + POOL_VOLUME_ALPHA * volume_share
@@ -618,6 +624,8 @@ def calculate_miner_rewards(self: Validator, current_time: int) -> Tuple[np.ndar
         if storage_enabled:
             intervals = []
             intervals_by_dir[(from_chain, to_chain, backing)] = intervals
+        if pool <= 0:
+            continue  # dead pair this window — nothing to pay; the trace still lists it at pool=0
         min_swap_hub, max_swap_hub = swap_bounds.get(backing, (0, 0))
         # Ineligible miners are not crown candidates on this lane (see lane_eligible_hotkeys).
         lane_candidates = lane_eligible_hotkeys(
@@ -780,6 +788,8 @@ def snapshot_current_miner_scores(
     for (from_chain, to_chain, backing), pool in pools.items():
         trace = DirectionTrace(pool=pool)
         qvol, _ = qualified_volume_shares(lane_volumes.get((from_chain, to_chain, backing), {}), from_chain, to_chain)
+        if pool <= 0:
+            continue  # dead pair this window — nothing to pay; the trace still lists it at pool=0
         min_swap_hub, max_swap_hub = swap_bounds.get(backing, (0, 0))
         lane_candidates = lane_eligible_hotkeys(
             live_states, rewardable_hotkeys, from_chain, to_chain, ts, backing=backing, recent_fills=recent_fills

--- a/allways/validator/scoring_trace.py
+++ b/allways/validator/scoring_trace.py
@@ -206,12 +206,15 @@ def diagnose_non_earner(
         return 'ineligible'  # > MAX_FAILED_SWAPS timeouts, or no completed fill in the activity window
 
     outbid_parts: List[str] = []
+    dead_parts: List[str] = []
     for (from_c, to_c), own in latest_rates.items():
         # latest_rates carries no backing, so diagnose against the pair's hub-leg
         # lane (its pricing anchor); the plain pair key keeps direct callers working.
         trace = direction_traces.get((from_c, to_c, hub_leg(from_c, to_c))) or direction_traces.get((from_c, to_c))
         if trace is not None and trace.pool <= 0:
-            return f'dead_pair ({from_c}→{to_c}: no qualified fill in the pool window, pool=0)'
+            # Most of the registry is dead at any time — a live pair's real reason outranks it.
+            dead_parts.append(f'{from_c}→{to_c}')
+            continue
         if trace is None or trace.best_rate <= 0:
             continue
         best = trace.best_rate
@@ -239,4 +242,8 @@ def diagnose_non_earner(
         # Competitive and funded — lost to a tie split, busy, or active-flag timing.
         return f'competitive_but_unfilled ({from_c}→{to_c}: own={own:g} vs best={best:g})'
 
-    return 'outbid (' + '; '.join(outbid_parts) + ')' if outbid_parts else 'no_competing_winner'
+    if outbid_parts:
+        return 'outbid (' + '; '.join(outbid_parts) + ')'
+    if dead_parts:
+        return 'dead_pair (' + '; '.join(dead_parts) + ': no qualified fill in the pool window, pool=0)'
+    return 'no_competing_winner'

--- a/allways/validator/scoring_trace.py
+++ b/allways/validator/scoring_trace.py
@@ -210,6 +210,8 @@ def diagnose_non_earner(
         # latest_rates carries no backing, so diagnose against the pair's hub-leg
         # lane (its pricing anchor); the plain pair key keeps direct callers working.
         trace = direction_traces.get((from_c, to_c, hub_leg(from_c, to_c))) or direction_traces.get((from_c, to_c))
+        if trace is not None and trace.pool <= 0:
+            return f'dead_pair ({from_c}→{to_c}: no qualified fill in the pool window, pool=0)'
         if trace is None or trace.best_rate <= 0:
             continue
         best = trace.best_rate

--- a/allways/validator/storage/queries.py
+++ b/allways/validator/storage/queries.py
@@ -83,6 +83,18 @@ DO UPDATE SET eligible    = EXCLUDED.eligible,
               vol_share   = EXCLUDED.vol_share
 """
 
+# direction_pools: per-round pool ledger, EVERY lane every round (dead lanes at
+# pool=0) — flushed with miner_scores so the dashboard can chart emission per
+# hub / pair / lane over time from one table. Idempotent on retry of the round.
+BULK_UPSERT_DIRECTION_POOLS = """
+INSERT INTO direction_pools (round_ts, from_chain, to_chain, backing, pool, qualified_volume, live)
+VALUES (%s, %s, %s, %s, %s, %s, %s)
+ON CONFLICT (round_ts, from_chain, to_chain, backing)
+DO UPDATE SET pool             = EXCLUDED.pool,
+              qualified_volume = EXCLUDED.qualified_volume,
+              live             = EXCLUDED.live
+"""
+
 # current_miner_scores: the live mid-round tip of miner_scores, wiped and
 # rewritten every forward step. The table only ever holds the in-progress round,
 # so the wipe is unconditional (no per-direction bookkeeping needed).

--- a/allways/validator/storage/repository.py
+++ b/allways/validator/storage/repository.py
@@ -13,6 +13,7 @@ from .queries import (
     BULK_INSERT_CURRENT_MINER_SCORES,
     BULK_UPSERT_CROWN_HOLDERS,
     BULK_UPSERT_CURRENT_CROWN_HOLDERS,
+    BULK_UPSERT_DIRECTION_POOLS,
     BULK_UPSERT_MINER_SCORES,
     DELETE_CROWN_IN_RANGE,
     DELETE_CURRENT_CROWN_BY_DIRECTION,
@@ -133,6 +134,27 @@ class Repository(BaseRepository):
             if commit:
                 self.db.rollback()
             self.logger.error(f'Error in bulk miner_scores storage: {e}')
+            return 0
+
+    def store_direction_pools_bulk(
+        self,
+        rows: List[Tuple],
+        commit: bool = True,
+    ) -> int:
+        """Upsert the round's per-lane pools. Rows: (round_ts, from_chain, to_chain,
+        backing, pool, qualified_volume, live) — one per lane, dead lanes included."""
+        if not rows:
+            return 0
+        try:
+            with self.get_cursor() as cursor:
+                cursor.executemany(BULK_UPSERT_DIRECTION_POOLS, rows)
+                if commit:
+                    self.db.commit()
+                return len(rows)
+        except Exception as e:
+            if commit:
+                self.db.rollback()
+            self.logger.error(f'Error in bulk direction_pools storage: {e}')
             return 0
 
     def replace_current_miner_scores(

--- a/allways/validator/storage/storage.py
+++ b/allways/validator/storage/storage.py
@@ -8,7 +8,7 @@ disabled-state result.
 import os
 import time
 from dataclasses import dataclass, field
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import bittensor as bt
 
@@ -124,6 +124,7 @@ class DatabaseStorage:
         crown_window_bounds_by_direction: Dict[Tuple[str, str, str], Tuple[int, int]],
         miner_score_rows: List[Tuple],
         crown_holders_max_ts: int,
+        direction_pool_rows: Optional[List[Tuple]] = None,
     ) -> StorageResult:
         """All-or-nothing flush for one scoring window.
 
@@ -136,6 +137,8 @@ class DatabaseStorage:
           two can never disagree about a round.
         - `crown_holders_max_ts` advances the sync_cursor watermark so the
           dashboard can render an "as-of <unix ts>" freshness signal.
+        - `direction_pool_rows`: the round's pool per lane, every lane (dead
+          lanes at 0) — the emission-over-time ledger, same transaction.
 
         rate_history is not written here — the indexer owns it (real-time,
         per QuoteSet event), including its freshness cursor.
@@ -163,6 +166,10 @@ class DatabaseStorage:
                 result.stored_counts['crown_holders'] = crown_inserted
 
                 result.stored_counts['miner_scores'] = self.repo.store_miner_scores_bulk(miner_score_rows, commit=False)
+                if direction_pool_rows:
+                    result.stored_counts['direction_pools'] = self.repo.store_direction_pools_bulk(
+                        direction_pool_rows, commit=False
+                    )
 
                 self.repo.set_sync_cursor('crown_holders_max_ts', crown_holders_max_ts, commit=False)
 

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -3075,6 +3075,23 @@ class TestScoreSnapshots:
         np.testing.assert_allclose(reward, expected, atol=1e-9)
         np.testing.assert_allclose(reward, rewards[0], atol=1e-6)
 
+    def test_round_flush_writes_every_lane_pool(self, tmp_path: Path):
+        """direction_pools rows: one per lane every round, dead lanes at pool 0 / live
+        False, live lanes carrying the qualified volume the β slice paid on; the
+        pools sum to the miner pool share."""
+        v = self._solo_with_storage(tmp_path)
+        calculate_miner_rewards(v, v.block)
+        rows = v.database_storage.flush_scoring_window.call_args.kwargs['direction_pool_rows']
+        by_lane = {(r[1], r[2], r[3]): r for r in rows}
+        assert set(by_lane) == set(compute_direction_pools({}))  # every lane, every round
+        assert all(r[0] == v.block for r in rows)
+        live = by_lane[('btc', 'sol', 'sol')]
+        assert live[4] == pytest.approx(POOL_BUSY_PAIR_LEG) and live[5] == 1_000_000_000 and live[6] is True
+        dead = by_lane[('sol', 'eth', 'sol')]
+        assert dead[4] == 0.0 and dead[5] == 0 and dead[6] is False
+        assert sum(r[4] for r in rows) == pytest.approx(MINER_POOL_SHARE)
+        v.state_store.close()
+
     def test_ineligible_miner_is_not_a_crown_candidate(self, tmp_path: Path):
         """An ineligible miner (strikes / hub mid-settle) is removed from crown
         CANDIDACY, not merely zeroed at payout: a lane whose only poster is

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -28,6 +28,7 @@ from allways.utils.rate import is_executable_rate, min_executable_hub_leg
 from allways.validator import scoring as scoring_mod
 from allways.validator.event_index import SolanaEventIndex
 from allways.validator.scoring import (
+    DirectionTrace,
     build_direction_score_rows,
     build_eligibility,
     calculate_miner_rewards,
@@ -36,6 +37,7 @@ from allways.validator.scoring import (
     crown_depth_shares,
     crown_holders_at_instant,
     direction_eligible,
+    direction_pool_tuples,
     due_for_scoring,
     fill_held_crown,
     is_eligible,
@@ -3087,10 +3089,20 @@ class TestScoreSnapshots:
         assert all(r[0] == v.block for r in rows)
         live = by_lane[('btc', 'sol', 'sol')]
         assert live[4] == pytest.approx(POOL_BUSY_PAIR_LEG) and live[5] == 1_000_000_000 and live[6] is True
+        quiet_leg = by_lane[('sol', 'btc', 'sol')]  # no fill of its own, rides its live pair
+        assert quiet_leg[5] == 0 and quiet_leg[6] is True
         dead = by_lane[('sol', 'eth', 'sol')]
         assert dead[4] == 0.0 and dead[5] == 0 and dead[6] is False
         assert sum(r[4] for r in rows) == pytest.approx(MINER_POOL_SHARE)
         v.state_store.close()
+
+    def test_silent_network_fallback_pays_every_lane_with_no_pair_live(self):
+        """The fallback pays every lane (pool > 0) but no pair cleared a qualified fill, so
+        the ledger's live flag stays False everywhere — live is pair volume, not pool > 0."""
+        traces = {lane: DirectionTrace(pool=pool) for lane, pool in compute_direction_pools({}).items()}
+        rows = direction_pool_tuples(traces, 4_600)
+        assert all(r[4] > 0 for r in rows)
+        assert not any(r[6] for r in rows)
 
     def test_ineligible_miner_is_not_a_crown_candidate(self, tmp_path: Path):
         """An ineligible miner (strikes / hub mid-settle) is removed from crown

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -57,16 +57,11 @@ from allways.validator.state_store import ValidatorStateStore
 CROWN_SLICE = 1.0 - QUALITY_VOLUME_BETA
 POOL_BTC_SOL = DIRECTION_POOLS[('btc', 'sol')]
 POOL_SOL_BTC = DIRECTION_POOLS[('sol', 'btc')]
-# Leg pool when one pair carried ALL the window's clearing volume: the pair
-# share tilts to (1−α)/pairs + α and splits evenly across its two directions.
+# Leg pool when one pair carried ALL the window's qualified volume: it is the only LIVE
+# pair, so its family holds the whole miner pool and the pair takes all of it —
+# (1−α)/1 + α = 1 — split evenly across its two directions.
 N_PAIRS = len(LAUNCH_PAIRS)
-# Volume weighting runs within a hub family (lamports and rao are not comparable):
-# a sol-family pair carrying ALL the family's volume gets family_share × ((1−α)/family + α).
-SOL_FAMILY_PAIRS = sum(1 for hub, _spoke in LAUNCH_PAIRS if hub == 'sol')
-SOL_FAMILY_SHARE = SOL_FAMILY_PAIRS / N_PAIRS
-POOL_BUSY_PAIR_LEG = (
-    MINER_POOL_SHARE * SOL_FAMILY_SHARE * ((1 - POOL_VOLUME_ALPHA) / SOL_FAMILY_PAIRS + POOL_VOLUME_ALPHA) / 2
-)
+POOL_BUSY_PAIR_LEG = MINER_POOL_SHARE / 2
 MIN_COLLATERAL = 100_000_000  # 0.1 TAO
 
 METADATA_PATH = Path(__file__).parent.parent / 'allways' / 'metadata' / 'allways_swap_manager.json'
@@ -469,16 +464,13 @@ class TestGetClearingVolumes:
 
 
 class TestComputeDirectionPools:
-    """Pair-level volume weighting WITHIN a hub family: each family holds a fixed
-    share ∝ its pair count (hub-leg volumes aren't comparable across hubs), a pair's
-    share within it is (1−α)/family_pairs + α·family_volume_share, split evenly
-    between its two legs, then evenly across each leg's backing lanes (F4 — two on
-    sol↔tao, one on spokes); zero volume falls back to the same lane split of
+    """Pair-level volume weighting over LIVE pairs (≥1 qualified fill in the window)
+    within a hub family: each family's share ∝ its live pair count (hub-leg volumes
+    aren't comparable across hubs), a live pair's share within it is
+    (1−α)/live_pairs + α·family_volume_share, split evenly between its two legs, then
+    evenly across each leg's backing lanes (F4 — two on sol↔tao, one on spokes). Dead
+    pairs are present at 0.0; no volume anywhere falls back to the equal split of
     DIRECTION_POOLS. Keys are lanes: (from, to, backing)."""
-
-    # A pair's floor leg is the same under family or global blending:
-    # family_share × (1−α)/family_pairs == (1−α)/total_pairs.
-    FLOOR_LEG = MINER_POOL_SHARE * (1 - POOL_VOLUME_ALPHA) / N_PAIRS / 2
 
     def test_no_volume_falls_back_to_equal_split(self):
         pools = compute_direction_pools({})
@@ -490,43 +482,55 @@ class TestComputeDirectionPools:
         assert pools[('sol', 'tao', 'tao')] == pools[('sol', 'tao', 'sol')]
         assert sum(pools.values()) == pytest.approx(MINER_POOL_SHARE)
 
-    def test_single_pair_volume_tilts_both_its_legs_equally(self):
+    def test_single_live_pair_takes_the_whole_pool(self):
+        """One qualified fill on btc↔sol and nothing else: that pair is the only live pair
+        in the registry, so it holds the whole miner pool (half per leg) and every other
+        lane — including the TAO family — is dead at 0.0."""
         pools = compute_direction_pools({('btc', 'sol'): {'hk_a': (5, 100)}})
-        busy = self.FLOOR_LEG + MINER_POOL_SHARE * SOL_FAMILY_SHARE * POOL_VOLUME_ALPHA / 2
-        assert pools[('btc', 'sol', 'sol')] == pytest.approx(busy)
+        assert pools[('btc', 'sol', 'sol')] == pytest.approx(MINER_POOL_SHARE / 2)
         assert pools[('sol', 'btc', 'sol')] == pools[('btc', 'sol', 'sol')]  # quiet leg rides its pair
-        # The hub↔hub pair's floor leg is contested per backing lane, half each.
-        assert pools[('sol', 'tao', 'sol')] == pytest.approx(self.FLOOR_LEG / 2)
-        assert pools[('sol', 'tao', 'tao')] == pytest.approx(self.FLOOR_LEG / 2)
-        assert pools[('tao', 'sol', 'sol')] == pytest.approx(self.FLOOR_LEG / 2)
-        assert pools[('tao', 'sol', 'tao')] == pytest.approx(self.FLOOR_LEG / 2)
-        # SOL-family volume never leaks into the TAO family's fixed share.
-        assert pools[('tao', 'btc', 'tao')] == pytest.approx(MINER_POOL_SHARE / (2 * N_PAIRS))
+        dead = {lane: v for lane, v in pools.items() if lane[:2] not in (('btc', 'sol'), ('sol', 'btc'))}
+        assert dead and all(v == 0.0 for v in dead.values())
+        assert set(pools) == set(compute_direction_pools({}))  # dead lanes are listed, not dropped
         assert sum(pools.values()) == pytest.approx(MINER_POOL_SHARE)
 
-    def test_volume_is_the_hub_leg_summed_per_pair(self):
+    def test_floor_is_split_among_live_pairs_only(self):
         # BTC pair: 300 SOL (to_amount is the SOL leg of btc→sol); TAO pair:
         # 100 SOL (from_amount is the SOL leg of sol→tao). Spoke-side legs are
-        # deliberately huge to prove they never enter the weighting.
+        # deliberately huge to prove they never enter the weighting. Two live pairs,
+        # both sol family → the family holds everything, floor = (1−α)/2 each.
         pools = compute_direction_pools(
             {
                 ('btc', 'sol'): {'hk_a': (10**15, 200), 'hk_b': (10**15, 100)},
                 ('sol', 'tao'): {'hk_c': (100, 10**15)},
             }
         )
-        floor_pair = (1 - POOL_VOLUME_ALPHA) / N_PAIRS
-        alpha_leg = SOL_FAMILY_SHARE * POOL_VOLUME_ALPHA
-        assert pools[('btc', 'sol', 'sol')] == pytest.approx(MINER_POOL_SHARE * (floor_pair + alpha_leg * 0.75) / 2)
+        floor_pair = (1 - POOL_VOLUME_ALPHA) / 2
+        assert pools[('btc', 'sol', 'sol')] == pytest.approx(
+            MINER_POOL_SHARE * (floor_pair + POOL_VOLUME_ALPHA * 0.75) / 2
+        )
         # Volume tilts the whole sol↔tao PAIR (never split by backing); each
         # direction's tilted pool then halves across its two lanes.
-        tao_sol_direction = MINER_POOL_SHARE * (floor_pair + alpha_leg * 0.25) / 2
+        tao_sol_direction = MINER_POOL_SHARE * (floor_pair + POOL_VOLUME_ALPHA * 0.25) / 2
         assert pools[('tao', 'sol', 'sol')] == pytest.approx(tao_sol_direction / 2)
         assert pools[('tao', 'sol', 'tao')] == pytest.approx(tao_sol_direction / 2)
+        assert pools[('sol', 'eth', 'sol')] == 0.0  # registered, quiet → dead
         assert sum(pools.values()) == pytest.approx(MINER_POOL_SHARE)
 
-    def test_families_split_independently(self):
-        # Volume in each family tilts only its own pairs; the two families' totals
-        # stay at their fixed pair-count shares whatever the volumes are.
+    def test_dust_fill_takes_a_full_floor_when_few_pairs_are_live(self):
+        """The bootstrap bounty: next to one whale pair, a dust fill on a second pair still
+        earns that pair (1−α)/2 of the family — the floor is what makes coverage pay."""
+        pools = compute_direction_pools({('btc', 'sol'): {'hk': (1, 5_000)}, ('sol', 'eth'): {'hk': (50, 1)}})
+        dust_pair = pools[('sol', 'eth', 'sol')] + pools[('eth', 'sol', 'sol')]
+        assert dust_pair == pytest.approx(
+            MINER_POOL_SHARE * ((1 - POOL_VOLUME_ALPHA) / 2 + POOL_VOLUME_ALPHA * 50 / 5_050)
+        )
+        assert dust_pair > MINER_POOL_SHARE * 0.17
+
+    def test_families_share_by_live_pair_count(self):
+        # One live pair in each family: the families split the pool 50/50 however
+        # lopsided the (non-comparable) volumes are, and each live pair takes its
+        # whole family. Registered-but-dead pairs move nothing.
         pools = compute_direction_pools(
             {
                 ('btc', 'sol'): {'hk_a': (1, 10**12)},  # lamports, sol family
@@ -535,11 +539,18 @@ class TestComputeDirectionPools:
         )
         sol_total = sum(v for (f, t, _b), v in pools.items() if 'sol' in (f, t))
         tao_family_total = sum(v for (f, t, _b), v in pools.items() if 'sol' not in (f, t))
-        assert sol_total == pytest.approx(MINER_POOL_SHARE * SOL_FAMILY_SHARE)
-        assert tao_family_total == pytest.approx(MINER_POOL_SHARE * (1 - SOL_FAMILY_SHARE))
-        # The volumed tao pair outweighs its quiet siblings inside its family.
-        assert pools[('tao', 'eth', 'tao')] > pools[('tao', 'btc', 'tao')]
+        assert sol_total == pytest.approx(MINER_POOL_SHARE / 2)
+        assert tao_family_total == pytest.approx(MINER_POOL_SHARE / 2)
+        assert pools[('tao', 'eth', 'tao')] == pytest.approx(MINER_POOL_SHARE / 4)
+        assert pools[('tao', 'btc', 'tao')] == 0.0
         assert sum(pools.values()) == pytest.approx(MINER_POOL_SHARE)
+
+    def test_dead_family_pays_nothing(self):
+        # Only sol-family pairs live → the TAO family's fixed-by-count share is gone; its
+        # lanes are all 0 and the sol family holds the entire pool.
+        pools = compute_direction_pools({('btc', 'sol'): {'hk': (1, 10)}, ('sol', 'eth'): {'hk': (10, 1)}})
+        assert all(v == 0.0 for (f, t, _b), v in pools.items() if 'sol' not in (f, t))
+        assert sum(v for (f, t, _b), v in pools.items() if 'sol' in (f, t)) == pytest.approx(MINER_POOL_SHARE)
 
     def test_pool_conservation_holds_with_hub_hub_lanes(self):
         # The F4 lane split is budget-neutral by construction: however volume lands

--- a/tests/test_scoring_v1.py
+++ b/tests/test_scoring_v1.py
@@ -2877,6 +2877,29 @@ class TestNonEarnerDiagnosis:
         )
         assert reason.startswith('competitive_but_unfilled'), reason
 
+    def test_dead_pair_never_masks_a_live_pairs_reason(self):
+        """A miner quoting a dead pair AND a live pair it lost on reads the live reason;
+        dead_pair is reported only when nothing else explains the zero."""
+        from allways.validator.scoring import DirectionTrace
+        from allways.validator.scoring_trace import diagnose_non_earner
+
+        dead = DirectionTrace(pool=0.0)
+        kwargs = dict(
+            eligible=True,
+            ever_active={'hk'},
+            collaterals={'hk': 500_000_000},
+            swap_bounds={'sol': (100_000_000, 500_000_000)},
+        )
+        reason = diagnose_non_earner(
+            'hk',
+            {('eth', 'sol'): 1.0, ('btc', 'sol'): 281.0},
+            direction_traces={('eth', 'sol'): dead, ('btc', 'sol'): self._trace(280.0)},
+            **kwargs,
+        )
+        assert reason.startswith('outbid'), reason
+        reason = diagnose_non_earner('hk', {('eth', 'sol'): 1.0}, direction_traces={('eth', 'sol'): dead}, **kwargs)
+        assert reason.startswith('dead_pair (eth→sol'), reason
+
 
 class TestNonEarnerLinesUseLiveRates:
     """non_earner_lines must source rates from the round's live on-chain quotes.

--- a/tests/test_validator_storage.py
+++ b/tests/test_validator_storage.py
@@ -61,6 +61,10 @@ class FakeRepo:
         self.conn._maybe_fail()
         return len(rows)
 
+    def store_direction_pools_bulk(self, rows, commit=False):
+        self.conn._maybe_fail()
+        return len(rows)
+
     def delete_crown_in_range(self, from_chain, to_chain, backing, lo, hi, commit=False):
         self.conn._maybe_fail()
 
@@ -185,6 +189,37 @@ def test_halt_flush_clears_live_score_tip(monkeypatch):
     result = storage.flush_halt_window(directions=[('sol', 'btc', 'sol')], window_start=0, window_end=100, max_ts=100)
     assert result.success
     assert calls == [[]]
+
+
+def test_scoring_flush_writes_direction_pools_in_the_same_transaction(monkeypatch):
+    """The round's per-lane pools ride the same all-or-nothing flush as the crown
+    ledger and miner_scores; an absent/empty list writes nothing (older callers)."""
+    conn = FakeConnection()
+    storage = make_storage(monkeypatch, [conn])
+    seen = []
+    storage.repo.store_crown_holders_bulk = lambda rows, commit=False: len(rows)
+    storage.repo.store_miner_scores_bulk = lambda rows, commit=False: len(rows)
+    storage.repo.store_direction_pools_bulk = lambda rows, commit=False: seen.append(rows) or len(rows)
+    lane = ('sol', 'btc', 'sol')
+    rows = [(4_600, 'sol', 'btc', 'sol', 0.5, 12_345, True), (4_600, 'btc', 'sol', 'sol', 0.0, 0, False)]
+    result = storage.flush_scoring_window(
+        crown_rows_by_direction={lane: []},
+        crown_window_bounds_by_direction={lane: (1_000, 4_600)},
+        miner_score_rows=[],
+        crown_holders_max_ts=4_600,
+        direction_pool_rows=rows,
+    )
+    assert result.success and result.stored_counts['direction_pools'] == 2
+    assert seen == [rows]
+    assert conn.commits == 1
+
+    result = storage.flush_scoring_window(
+        crown_rows_by_direction={lane: []},
+        crown_window_bounds_by_direction={lane: (1_000, 4_600)},
+        miner_score_rows=[],
+        crown_holders_max_ts=4_600,
+    )
+    assert result.success and 'direction_pools' not in result.stored_counts
 
 
 def test_scoring_flush_trims_pre_window_tails(monkeypatch):


### PR DESCRIPTION
Builds on #727 (merged to test; this branch is rebased onto it). Direction pools pay **live pairs only**: a pair is live for a round iff it cleared qualified volume in the trailing 24 h pool window. Validator-only, one function.

## What changes in `compute_direction_pools`
- Within a family the equal-split floor `(1−α)` is divided over the family's **live** pairs, not its registered ones. The floor budget is fixed, so it lands on the pairs someone actually filled instead of burning on the registry's dead ones. α stays 0.66.
- Each family's share of the pool is its **live pair count over all live pairs** (was registered count). Still oracle-free — hub-leg volumes are never compared across hubs — and a wave of registered-but-unfilled pairs moves nothing until they fill. This is the emissions objection on #709.
- A dead pair's lanes are present at 0.0; the scorer skips the replay on them and the non-earner trace names it (`dead_pair`).
- A silent network (no qualified fill anywhere in the window) keeps today's equal split over the whole registry, so day one behaves as before.

## Why
The floor at 170+ pairs is a spam problem, not a smallness problem: a miner quoting every pair with wide spreads collected every floor — 34% of the family — for zero service, while unfilled pairs' floors burned. Now keeping a pair funded costs one qualified fill per window (≈0.02 SOL + 1% of a min swap), and the floor scales with activity: 20 live pairs → 1.7% of the family each; 2 live pairs → 17% each. That early concentration is the coverage bounty, and it self-corrects as more pairs come live. At today's ~9 TAO/day miner emission a sole quoter's floor covers the daily fill until roughly 200 live pairs, so the number of funded pairs sizes itself to what the subnet can afford.

## The chicken-and-egg objection, and why we think it resolves
The obvious worry with a zero floor for unfilled pairs: no emission → nobody quotes the pair → a user who wants it finds no rate → no volume → no emission. Nobody can ever be first. This is a hypothesis about miner behaviour, not something we have observed, so treat the rest of this section as our theory of why the loop breaks in our favour.

- **The egg is cheap and any miner can lay it.** A pair goes live the moment one qualified fill clears on it. On an unquoted pair, posting any executable rate *is* holding the crown, so a miner posts a rate and self-fills at min size: ≈0.02 SOL reservation fee + 1% of a min swap + a few minutes of purse time. For that it holds the pair's floor, its α share and its β slice for the next 24 h. Nothing about the loop requires a real user to move first.
- **The floor is a bounty for exactly that.** Because the floor budget is fixed and divided among live pairs, the reward for standing up a pair is *largest* when few pairs are live — two live pairs in a family means 17% of the family each. Expect the first weeks to reward whoever fills the most pairs daily, which is the coverage we want during bootstrap, and it fades on its own as more pairs come live.
- **Quotes come for spread, emission follows the fill.** An aggregator-style miner quotes the long tail anyway because the marginal cost of quoting one more pair from a shared purse is near zero and a user fill pays the spread. The first organic fill on such a pair qualifies (sole quoter = best rate), so real demand bootstraps its own emission without anyone planning it.
- **It sizes itself.** A pair stays funded only while its daily floor covers a daily fill. At today's ~9 TAO/day of miner emission and ~0.015 TAO per fill that break-even is roughly 200 live pairs; past that, pairs stay live on real volume or not at all. The market, not a config list, decides which of 170+ pairs are worth coverage.
- **What we are watching for.** If the daily-fill cadence turns out to be a real burden, the two dials are already constants: raise α to shrink the floor budget, or divide the floor by `max(live, N_min)` so a nearly-empty family burns most of its floor rather than handing it to the first two fillers. We are shipping without either.

## Behaviour to expect
- A miner who spots an unquoted pair posts a rate, self-fills at min size while holding its crown, and holds that pair's floor + α share + β for 24 h. Lapse a day and it drops to zero.
- Whale pairs still dominate within a family through α; dust pairs get a floor, not a share.
- Registered pairs nobody fills (most of the long tail, all of BTC until someone holds inventory) pay nothing and dilute nobody.

## Persisted for the dashboard
Every round now also writes `direction_pools` (entrius/allways-db PR: `feat/direction-pools`): one row per lane, dead lanes at pool 0, with the qualified volume and a live flag — the source for the per-hub / pair / lane emissions view (das + UI PRs to follow). Written in the same transaction as the crown ledger.

## Tests
- Review follow-ups: `direction_pools.live` records the pair's qualified volume, not `pool > 0` (the silent-network fallback pays every lane with no pair live, and the ledger now says so); `diagnose_non_earner` reports `dead_pair` only when no live pair explains the zero, instead of returning on the first dead pair and masking an outbid / collateral reason.

2151 passed. Pool tests rewritten for live semantics: single live pair takes the whole pool, floor split among live pairs only, dust fill takes a full floor next to a whale, families share by live count, dead family pays nothing, conservation, fallback.

Sister docs PR: entrius/allways-docs-ui, same branch.

https://claude.ai/code/session_017ZTCEjbjJwe6Te657adCap

