### PR TITLE
Miner setup wizard: alw miner init + alw doctor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,10 +6,12 @@
 NETUID=7                            # 7 mainnet | 19 testnet
 WALLET_NAME=default                 # your btcli names (`btcli w list`)
 HOTKEY_NAME=default
-WALLET_PATH=~/.bittensor/wallets
+WALLET_PATH=~/.bittensor/wallets        # absolute path for docker (compose does not expand ~); alw reads it too
 SUBTENSOR_NETWORK=finney            # finney | test | local | ws://host:9944 (validators: local lite node)
 PORT=8091
 LOG_LEVEL=info
+# Image tag docker compose runs: unset = latest (mainnet); testnet miners set test
+# ALLWAYS_IMAGE_TAG=test
 # Rotating log file data/allways/bittensor.log (survives container rebuilds): size per file, files kept.
 LOG_FILE_MAX_MB=10
 LOG_FILE_BACKUPS=4

--- a/README.md
+++ b/README.md
@@ -86,14 +86,22 @@ alw --help
 
 ## Miner Onboarding
 
-Bond, then activate, then quote — in that order, for either backing. A quote is a promise that
+The fast path is the wizard — it creates or picks the wallet, generates the signing keys, writes
+`.env`, runs a preflight, then walks the on-chain sequence in order and resumes on re-run:
+
+```bash
+alw miner init          # step by step; every prompt has a flag, -y runs it unattended
+alw doctor              # the preflight on its own
+```
+
+The manual sequence it automates: bond, then activate, then quote — in that order, for either backing. A quote is a promise that
 one specific bond answers for, so `set_quote` refuses a purse you are not already serving
 (`MinerNotActive`). Quoting before activation is rejected, not queued.
 
 **SOL-backed** (collateral held on Solana):
 
 ```bash
-alw collateral deposit <SOL>                   # fund the local purse (bind-hotkey needs it — see below)
+alw collateral deposit --amount <SOL>          # fund the local purse (bind-hotkey needs it — see below)
 alw miner bind-hotkey                          # bind your hotkey to your Solana pubkey (once)
 alw miner activate                             # validators vote you active
 alw miner post sol <addr> btc <addr> <rate>    # quote

--- a/allways/cli/main.py
+++ b/allways/cli/main.py
@@ -175,6 +175,11 @@ def _effective_settings(config: dict) -> list:
         ('solana-keypair', resolve_solana_keypair_path(config), keypair_src),
         *(chain_row(c) for c in NAME_SELECTED_CHAINS),
         row('router'),
+        (
+            'vault-address',
+            os.environ.get('ALLWAYS_VAULT_ADDRESS') or config.get('vault-address') or '(not set)',
+            source('ALLWAYS_VAULT_ADDRESS', bool(config.get('vault-address')), '—'),
+        ),
         ('program-id', program_id, program_src),
     ]
 
@@ -228,6 +233,7 @@ CONFIG_SET_HELP = """Set a configuration value.
         solana-keypair      Path to the Solana keypair that signs miner/admin ops (SOLANA_KEYPAIR_PATH env wins)
 {chain_keys}
         router              Validator hotkey (ss58) to route reservations through; "" = self-represent
+        vault-address       TAO bond vault contract (ss58); `env` sets the of-record one (ALLWAYS_VAULT_ADDRESS env wins)
         program-id          Solana program ID (miner/admin commands)[/dim]
 
     [dim]Networks per chain:

--- a/allways/cli/swap_commands/__init__.py
+++ b/allways/cli/swap_commands/__init__.py
@@ -2,6 +2,7 @@ from allways.cli.swap_commands.admin import admin_group
 from allways.cli.swap_commands.bind import bind_hotkey_command
 from allways.cli.swap_commands.collateral import collateral_group
 from allways.cli.swap_commands.miner_commands import miner_group
+from allways.cli.swap_commands.miner_init import doctor_command, init_command
 from allways.cli.swap_commands.numeraire import quotes_command
 from allways.cli.swap_commands.pair import post_pair
 from allways.cli.swap_commands.post_tx import post_tx_command
@@ -12,6 +13,7 @@ from allways.cli.swap_commands.vault import vault_group
 from allways.cli.swap_commands.view import view_group
 
 # Register post + the SOL-numéraire batch quoting under the miner group
+miner_group.add_command(init_command, 'init')
 miner_group.add_command(post_pair, 'post')
 miner_group.add_command(quotes_command, 'quotes')
 # bind-hotkey is role-agnostic (miners and validators); the miner alias is kept for compatibility.
@@ -31,4 +33,6 @@ def register_commands(cli):
     cli.add_command(admin_group, 'admin')
     cli.add_command(vault_group, 'vault')
     cli.add_command(status_command, 'status')
+    cli.add_command(doctor_command, 'doctor')
+    cli.add_command(init_command, 'init')
     cli.add_command(bind_hotkey_command, 'bind-hotkey')

--- a/allways/cli/swap_commands/helpers.py
+++ b/allways/cli/swap_commands/helpers.py
@@ -723,6 +723,12 @@ def get_effective_config() -> dict:
     return config
 
 
+def wallet_path() -> Optional[str]:
+    """Wallet dir the CLI reads: WALLET_PATH (the same var docker compose mounts) or bittensor's default."""
+    raw = os.environ.get('WALLET_PATH')
+    return os.path.expanduser(raw) if raw else None
+
+
 def get_cli_context(
     need_wallet: bool = True,
     need_client: bool = False,
@@ -743,6 +749,7 @@ def get_cli_context(
             wallet = bt.Wallet(
                 name=config.get('wallet', 'default'),
                 hotkey=config.get('hotkey', 'default'),
+                path=wallet_path(),
             )
     # Ensure netuid is resolved for callers
     if 'netuid' not in config:

--- a/allways/cli/swap_commands/miner_init.py
+++ b/allways/cli/swap_commands/miner_init.py
@@ -1,0 +1,862 @@
+"""alw miner init — step-by-step miner onboarding; alw doctor — the preflight on its own.
+
+Every step reads its "done" state from disk or chain (never a local flag), so re-running resumes
+where the operator left off, and every prompt has a flag so the whole thing can run unattended.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import click
+
+from allways.cli import ui
+from allways.cli.help import StyledCommand
+from allways.cli.swap_commands import setup_env as se
+from allways.cli.swap_commands.helpers import (
+    ALLWAYS_DIR,
+    CONFIG_FILE,
+    ENV_BUNDLES,
+    SOLANA_NETWORKS,
+    apply_chain_network_env,
+    console,
+    fail,
+    from_lamports,
+    from_rao,
+    get_effective_config,
+    get_solana_cli_context,
+    load_cli_config,
+    network_key,
+    purse_states,
+    resolve_solana_keypair_path,
+)
+from allways.cli.swap_commands.swap_intake import floors_from_config
+from allways.constants import TAO_HUB_VAULT_ADDRESSES
+from allways.solana.pdas import BACKING_CHAIN_SOL, BACKING_CHAIN_TAO
+
+COMPOSE_FILE = 'docker-compose.miner.yml'
+CONTAINER = 'aw-miner'
+Check = Tuple[Optional[bool], str, str]
+
+
+@dataclass
+class Setup:
+    project_dir: Path
+    yes: bool = False
+    env: str = ''  # testnet | mainnet
+    wallet: str = ''
+    hotkey: str = ''
+    backing: str = ''  # sol | tao | both
+    families: List[str] = field(default_factory=list)
+    solana_keypair: Optional[Path] = None
+    env_values: Dict[str, str] = field(default_factory=dict)
+    addresses: Dict[str, str] = field(default_factory=dict)
+
+    @property
+    def env_path(self) -> Path:
+        return self.project_dir / '.env'
+
+    @property
+    def bundle(self) -> dict:
+        return ENV_BUNDLES[self.env]
+
+    @property
+    def backings(self) -> Tuple[str, ...]:
+        return (BACKING_CHAIN_SOL, BACKING_CHAIN_TAO) if self.backing == 'both' else (self.backing,)
+
+
+def _save_config(updates: dict) -> dict:
+    ALLWAYS_DIR.mkdir(parents=True, exist_ok=True)
+    config = load_cli_config()
+    config.update(updates)
+    CONFIG_FILE.write_text(json.dumps(config, indent=2))
+    return config
+
+
+def _bt_wallet(name: str, hotkey: str):
+    import bittensor as bt
+
+    return bt.Wallet(name=name, hotkey=hotkey, path=str(se.wallets_root()))
+
+
+def _pub_ss58(wallet, which: str) -> Optional[str]:
+    """ss58 off the public key file only — never unlocks anything."""
+    try:
+        return wallet.coldkeypub.ss58_address if which == 'coldkey' else wallet.hotkey.ss58_address
+    except Exception:
+        return None
+
+
+def _prompt(s: Setup, text: str, default=None, **kw):
+    """Interactive prompt, or the default under --yes (a missing default is then an error)."""
+    if s.yes:
+        if default is None or default == '':
+            fail(f'--yes needs a value for "{text}" — pass the matching flag.')
+        return default
+    return click.prompt(text, default=default, **kw)
+
+
+def _typed_confirm(s: Setup, word: str, why: str) -> bool:
+    """Irreversible actions take a typed word, not a y/n — unless --yes was passed explicitly."""
+    if s.yes:
+        return True
+    console.print(f'  [yellow]{why}[/yellow]')
+    return click.prompt(f'  Type "{word}" to continue', default='', show_default=False).strip() == word
+
+
+# ─── Steps 1–6: local configuration ─────────────────────────────────────────
+
+
+def step_network(s: Setup, preset: Optional[str]) -> None:
+    ui.draw_step(
+        console,
+        1,
+        'Choose a network',
+        'testnet = SN19 + Solana devnet, to rehearse with play money. mainnet = SN7, real funds.',
+    )
+    existing = load_cli_config()
+    current = {'19': 'testnet', '7': 'mainnet'}.get(str(existing.get('netuid', '')))
+    s.env = preset or _prompt(s, 'Network', default=current or 'testnet', type=click.Choice(list(ENV_BUNDLES)))
+    bundle = dict(s.bundle)
+    bundle['vault-address'] = TAO_HUB_VAULT_ADDRESSES[bundle['network']]
+    _save_config(bundle)
+    apply_chain_network_env(get_effective_config())
+    s.env_values.update(NETUID=bundle['netuid'], SUBTENSOR_NETWORK=bundle['network'])
+    ui.draw_done(
+        console,
+        f'{s.env}: netuid {bundle["netuid"]} · subtensor {bundle["network"]} · solana {bundle["solana-network"]}',
+    )
+
+
+def _create_wallet_part(name: str, hotkey: str, which: str) -> None:
+    """bittensor-wallet prints the mnemonic and (for a coldkey) asks for a password itself."""
+    wallet = _bt_wallet(name, hotkey)
+    console.print(f'  [bold]Creating {which} — write the mnemonic down; it is shown once.[/bold]')
+    if which == 'coldkey':
+        wallet.create_new_coldkey(n_words=12, use_password=True, overwrite=False)
+    else:
+        wallet.create_new_hotkey(n_words=12, use_password=False, overwrite=False)
+
+
+def step_wallet(s: Setup, wallet: Optional[str], hotkey: Optional[str]) -> None:
+    ui.draw_step(
+        console,
+        2,
+        'Bittensor wallet',
+        'The hotkey is your subnet identity; the coldkey registers it and signs TAO payouts.',
+    )
+    wallets = se.list_wallets()
+    existing = load_cli_config()
+    if wallets:
+        ui.draw_kv(console, ((n, ', '.join(h) or '[dim]no hotkeys[/dim]') for n, h in wallets.items()))
+        console.print('  [dim]Name an existing coldkey, or "new" to create one.[/dim]')
+    default_wallet = existing.get('wallet') if existing.get('wallet') in wallets else next(iter(wallets), 'new')
+    name = wallet or _prompt(s, 'Coldkey', default=default_wallet)
+    if name == 'new':
+        name = _prompt(s, 'New coldkey name', default='miner')
+    if name not in wallets:
+        if s.yes:
+            fail(
+                f'No coldkey named {name!r} under {se.wallets_root()}; creating one needs a mnemonic + password prompt.'
+            )
+        _create_wallet_part(name, 'default', 'coldkey')
+        wallets[name] = []
+
+    hotkeys = wallets.get(name, [])
+    default_hotkey = existing.get('hotkey') if existing.get('hotkey') in hotkeys else (hotkeys[0] if hotkeys else 'new')
+    hk = hotkey or _prompt(s, 'Hotkey', default=default_hotkey)
+    if hk == 'new':
+        hk = _prompt(s, 'New hotkey name', default='default')
+    if hk not in hotkeys:
+        _create_wallet_part(name, hk, 'hotkey')
+
+    s.wallet, s.hotkey = name, hk
+    _save_config({'wallet': name, 'hotkey': hk})
+    s.env_values.update(WALLET_NAME=name, HOTKEY_NAME=hk, WALLET_PATH=str(se.wallets_root()))
+    w = _bt_wallet(name, hk)
+    ui.draw_kv(console, [('coldkey', _pub_ss58(w, 'coldkey') or '?'), ('hotkey', _pub_ss58(w, 'hotkey') or '?')])
+
+
+def step_chains(s: Setup, backing: Optional[str], chains: Optional[str]) -> None:
+    ui.draw_step(
+        console,
+        3,
+        'Backing and chains',
+        'SOL purse: a failed delivery refunds the user instantly in SOL. TAO bond: reimburses in TAO after timeout.',
+        'Then pick every chain family you will quote — each needs one signing key. SOL and TAO are always on.',
+    )
+    s.backing = backing or _prompt(s, 'Backing', default='sol', type=click.Choice(['sol', 'tao', 'both']))
+    families = se.optional_families()
+    env = se.read_env(s.env_path)
+    ui.draw_kv(console, ((f.prefix.lower(), ', '.join(f.assets)) for f in families))
+    default = ','.join(f.prefix.lower() for f in families if env.get(f.key_env))
+    raw = chains if chains is not None else _prompt(s, 'Chains (comma-separated; blank = none)', default=default)
+    while True:
+        try:
+            s.families = se.parse_family_list(raw or '')
+            break
+        except ValueError as e:
+            if s.yes:
+                fail(str(e))
+            console.print(f'  [red]{e}[/red]')
+            raw = click.prompt('Chains', default=default)
+    ui.draw_done(console, f'{s.backing} backing · spokes: {", ".join(f.lower() for f in s.families) or "none"}')
+
+
+def _solana_keypair(s: Setup, flag: Optional[str]) -> None:
+    from allways.solana import keys
+
+    default = s.project_dir / 'data' / 'solana' / 'id.json'
+    current = load_cli_config().get('solana-keypair')
+    raw = flag or _prompt(s, 'Solana keypair path', default=current or str(default))
+    path = Path(raw).expanduser().resolve()
+    created = not path.exists()
+    kp = keys.load_or_create(str(path))
+    if created:
+        os.chmod(path, 0o600)
+    s.solana_keypair = path
+    _save_config({'solana-keypair': str(path)})
+    ui.draw_done(console, f'{"generated" if created else "using"} Solana keypair {path}')
+    if path.parent != default.parent.resolve():
+        ui.draw_warn(console, f'docker mounts ./data/solana as the miner keypair dir — copy this key to {default}')
+    s.addresses['SOL'] = str(kp.pubkey())
+
+
+def _family_key(s: Setup, fam: se.KeyFamily, env: Dict[str, str]) -> None:
+    network = s.bundle.get(network_key(fam.network_chain)) if fam.network_chain else 'mainnet'
+    s.env_values[fam.network_env] = network
+    existing = env.get(fam.key_env)
+    derive = (lambda k: se.btc_address(k, network)) if fam.kind == 'btc' else se.evm_address
+    addr = derive(existing) if existing else None
+    if existing and addr is None:
+        ui.draw_warn(console, f'{fam.key_env} in .env is not a usable key')
+        if not _prompt(s, f'  Replace {fam.key_env} with a fresh key?', default=False, type=bool):
+            return
+        existing = None
+    if not existing:
+        key, addr = se.generate_btc_key(network) if fam.kind == 'btc' else se.generate_evm_key()
+        s.env_values[fam.key_env] = key
+    ui.draw_done(
+        console,
+        f'{fam.prefix} key {"kept from .env" if existing else "generated"} ({network}; {", ".join(fam.assets)})',
+    )
+    s.addresses[fam.prefix] = addr
+
+
+def step_keys(s: Setup, solana_keypair: Optional[str]) -> None:
+    ui.draw_step(
+        console,
+        4,
+        'Signing keys',
+        'Generated keys are written to .env only and never printed. Fund the addresses shown at the end.',
+    )
+    _solana_keypair(s, solana_keypair)
+    coldkey = _pub_ss58(_bt_wallet(s.wallet, s.hotkey), 'coldkey')
+    s.addresses['TAO'] = coldkey or '?'
+    env = se.read_env(s.env_path)
+    by_prefix = {f.prefix: f for f in se.optional_families()}
+    for prefix in s.families:
+        _family_key(s, by_prefix[prefix], env)
+    console.print()
+    ui.draw_kv(console, s.addresses.items())
+    console.print(
+        '  [dim]Each spoke wallet needs the asset it pays out plus gas; the Solana keypair covers fees.[/dim]'
+    )
+
+
+def step_rpc(s: Setup, solana_rpc: Optional[str]) -> None:
+    ui.draw_step(
+        console,
+        5,
+        'Solana RPC',
+        'Public endpoints rate-limit; on mainnet use a keyed provider (Helius, Triton, QuickNode…).',
+    )
+    current = se.read_env(s.env_path).get('SOLANA_RPC_URL') or os.environ.get('SOLANA_RPC_URL')
+    default = current or SOLANA_NETWORKS[s.bundle['solana-network']]
+    url = solana_rpc or _prompt(s, 'Solana RPC URL', default=default)
+    s.env_values['SOLANA_RPC_URL'] = url
+    os.environ['SOLANA_RPC_URL'] = url
+    ui.draw_done(console, f'Solana RPC {url}')
+    console.print(
+        '  [dim]Spoke RPCs ({PREFIX}_RPC_URLS, BTC_ESPLORA_URLS) keep public defaults — edit .env to add keyed ones.[/dim]'
+    )
+
+
+def step_write_env(s: Setup, coldkey_password: Optional[str]) -> None:
+    ui.draw_step(console, 6, 'Write configuration', f'{s.env_path} feeds docker compose, the miner, and alw.')
+    s.env_values.setdefault('PORT', '8091')
+    s.env_values.setdefault('LOG_LEVEL', 'info')
+    if coldkey_password is None and not s.yes:
+        coldkey_password = click.prompt(
+            'Coldkey password for headless starts (blank = prompt at each start)',
+            default='',
+            hide_input=True,
+            show_default=False,
+        )
+    if coldkey_password:
+        s.env_values['MINER_BITTENSOR_COLDKEY_PASSWORD'] = coldkey_password
+    se.write_env(s.env_path, s.env_values, template=s.project_dir / '.env.example')
+    ui.draw_done(console, f'wrote {s.env_path} (mode 600): {", ".join(s.env_values)}')
+    ui.draw_done(console, f'wrote {CONFIG_FILE}')
+
+
+# ─── Step 7: preflight (alw doctor) ─────────────────────────────────────────
+
+
+def _check_docker(project_dir: Path, env: Dict[str, str]) -> List[Check]:
+    rows: List[Check] = []
+    docker = shutil.which('docker')
+    rows.append((bool(docker), 'docker', docker or 'not on PATH — install Docker Engine + compose plugin'))
+    compose = project_dir / COMPOSE_FILE
+    rows.append((compose.is_file(), COMPOSE_FILE, str(compose) if compose.is_file() else f'not in {project_dir}'))
+    env_file = project_dir / '.env'
+    rows.append((env_file.is_file(), '.env', str(env_file) if env_file.is_file() else 'missing — run alw miner init'))
+    missing = [
+        k for k in ('NETUID', 'WALLET_NAME', 'HOTKEY_NAME', 'SUBTENSOR_NETWORK', 'PORT', 'LOG_LEVEL') if not env.get(k)
+    ]
+    rows.append((not missing, 'required vars', 'all set' if not missing else f'missing {", ".join(missing)}'))
+    wp = env.get('WALLET_PATH', '')
+    ok = bool(wp) and Path(wp).expanduser().is_dir() and not wp.startswith('~')
+    rows.append(
+        (
+            ok,
+            'WALLET_PATH',
+            wp if ok else f'{wp or "unset"} — must be an absolute existing dir (compose does not expand ~)',
+        )
+    )
+    rows.append((container_running(), 'miner container', 'running' if container_running() else 'not running'))
+    return rows
+
+
+def _check_keys(env: Dict[str, str], config: dict) -> List[Check]:
+    rows: List[Check] = []
+    path = resolve_solana_keypair_path(config)
+    try:
+        from allways.solana import keys
+
+        rows.append((True, 'solana keypair', f'{keys.load_keypair(path).pubkey()}  {path}'))
+    except Exception as e:
+        rows.append((False, 'solana keypair', f'{path}: {e}'))
+    for fam in se.optional_families():
+        key = env.get(fam.key_env)
+        if not key:
+            rows.append((None, fam.key_env, 'not set (fine unless you quote ' + '/'.join(fam.assets) + ')'))
+            continue
+        net = env.get(fam.network_env) or config.get(network_key(fam.network_chain), '') if fam.network_chain else ''
+        addr = se.btc_address(key, net or 'mainnet') if fam.kind == 'btc' else se.evm_address(key)
+        rows.append((addr is not None, fam.key_env, f'{addr}  ({net})' if addr else 'unusable key'))
+    return rows
+
+
+def _check_wallet(config: dict) -> Tuple[List[Check], Optional[str]]:
+    name, hk = config.get('wallet'), config.get('hotkey')
+    if not name or not hk:
+        return [(False, 'bittensor wallet', 'wallet/hotkey not configured — alw config set wallet/hotkey')], None
+    w = _bt_wallet(name, hk)
+    cold, hot = _pub_ss58(w, 'coldkey'), _pub_ss58(w, 'hotkey')
+    rows: List[Check] = [
+        (cold is not None, 'coldkey', cold or f'{name}: coldkeypub.txt unreadable under {se.wallets_root()}'),
+        (hot is not None, 'hotkey', hot or f'{name}/{hk}: hotkey file unreadable'),
+    ]
+    return rows, hot
+
+
+def _check_chain(config: dict, hotkey_ss58: Optional[str]) -> List[Check]:
+    """Solana program + subtensor state. Every read is best-effort: one dead RPC yields one ✗ row."""
+    import bittensor as bt
+
+    from allways.solana.rpc import assert_cluster_safe, redact_rpc_url
+
+    rows: List[Check] = []
+    netuid = int(config.get('netuid', 7))
+    try:
+        _, client = get_solana_cli_context(need_keypair=False)
+        cfg = client.get_config()
+        assert_cluster_safe(client.rpc, client.program_id, netuid, role='miner')
+        rows.append((cfg is not None, 'solana rpc + program', redact_rpc_url(client.rpc.url)))
+    except Exception as e:
+        return rows + [(False, 'solana rpc + program', str(e))]
+    if cfg is None:
+        return rows
+    floors = floors_from_config(cfg)
+    try:
+        from allways.solana import keys
+
+        pubkey = keys.load_keypair(resolve_solana_keypair_path(config)).pubkey()
+    except Exception:
+        return rows
+    bal = client.rpc.get_account_lamports(pubkey) or 0
+    need = floors[BACKING_CHAIN_SOL]
+    rows.append(
+        (bal > 0, 'SOL balance', f'{from_lamports(bal):.4f} SOL  (min collateral {from_lamports(need):.4f} + fees)')
+    )
+    ms = client.get_miner_state(pubkey)
+    have = client.get_collateral_lamports(pubkey) or 0
+    rows.append(
+        (
+            have >= need,
+            'SOL collateral',
+            f'{from_lamports(have):.4f} / {from_lamports(need):.4f} SOL' + ('' if ms else '  (no miner state yet)'),
+        )
+    )
+    binding = client.get_binding(pubkey)
+    if binding is None:
+        rows.append((False, 'hotkey binding', 'not bound — alw bind-hotkey (AFTER collateral, BEFORE register)'))
+    else:
+        from allways.cli.swap_commands.helpers import hotkey_bytes_to_ss58
+
+        bound = hotkey_bytes_to_ss58(bytes(binding.hotkey))
+        rows.append(
+            (bound == hotkey_ss58, 'hotkey binding', bound + ('' if bound == hotkey_ss58 else '  ≠ configured hotkey!'))
+        )
+    if ms is not None:
+        for st in purse_states(client, pubkey, ms, cfg):
+            rows.append((st.lit, f'{st.backing} purse', 'serving' if st.lit else 'not serving'))
+    if hotkey_ss58:
+        try:
+            sub = bt.Subtensor(network=config.get('network', 'finney'))
+            uid = sub.get_uid_for_hotkey_on_subnet(hotkey_ss58, netuid)
+            rows.append(
+                (uid is not None, f'registered on SN{netuid}', f'uid {uid}' if uid is not None else 'not registered')
+            )
+            if config.get('vault-address'):
+                from allways.vault import BondVaultClient
+
+                vault = BondVaultClient.from_config(sub, config)
+                bond = vault.get_collateral(hotkey_ss58) or 0
+                lock = vault.get_lock_state(hotkey_ss58)
+                locked = bool(lock and lock[0])
+                rows.append(
+                    (
+                        None if bond == 0 else locked,
+                        'TAO bond',
+                        f'{from_rao(bond):.4f} TAO  {"locked" if locked else "unlocked"}  (floor {from_rao(floors[BACKING_CHAIN_TAO]):.4f})',
+                    )
+                )
+        except Exception as e:
+            rows.append((False, 'subtensor', str(e)))
+    return rows
+
+
+def container_running() -> bool:
+    if not shutil.which('docker'):
+        return False
+    try:
+        out = subprocess.run(
+            ['docker', 'ps', '--filter', f'name=^{CONTAINER}$', '--format', '{{.Status}}'],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        return out.stdout.strip().startswith('Up')
+    except Exception:
+        return False
+
+
+def run_doctor(project_dir: Path) -> List[Check]:
+    config = get_effective_config()
+    env = se.read_env(project_dir / '.env')
+    rows: List[Check] = [
+        (
+            bool(config.get('netuid')),
+            'alw config',
+            f'netuid {config.get("netuid", "?")} · {config.get("network", "finney")}',
+        ),
+    ]
+    wallet_rows, hot = _check_wallet(config)
+    rows += wallet_rows
+    rows += _check_keys(env, config)
+    rows += _check_chain(config, hot)
+    rows += _check_docker(project_dir, env)
+    return rows
+
+
+def step_doctor(project_dir: Path, number: int = 7) -> List[Check]:
+    ui.draw_step(console, number, 'Preflight', 'Every check reads live state; re-run any time with `alw doctor`.')
+    with console.status('[cyan]Checking...[/cyan]', spinner='dots'):
+        rows = run_doctor(project_dir)
+    console.print(ui.check_table(rows))
+    return rows
+
+
+# ─── Step 8: go live ─────────────────────────────────────────────────────────
+
+
+def _resume_hint(cmd: str) -> None:
+    console.print(f'\n  [dim]Fix the above, then re-run `alw miner init` (it resumes) or `{cmd}` directly.[/dim]')
+
+
+def _deposit(ctx, s: Setup, client, pubkey, floors) -> bool:
+    from allways.cli.swap_commands.collateral import collateral_deposit
+
+    need = floors[BACKING_CHAIN_SOL]
+    have = client.get_collateral_lamports(pubkey) or 0
+    what = (
+        'SOL collateral'
+        if BACKING_CHAIN_SOL in s.backings
+        else 'identity deposit (TAO-only miners still stake the minimum once)'
+    )
+    ui.draw_step(console, 8, f'Deposit {what}', 'Binding requires a live stake, so this comes first.')
+    if have >= need and client.get_miner_state(pubkey) is not None:
+        ui.draw_done(console, f'{from_lamports(have):.4f} SOL already posted (floor {from_lamports(need):.4f})')
+        return True
+    shortfall = from_lamports(max(need - have, 0))
+    amount = float(_prompt(s, 'Amount to deposit (SOL)', default=f'{shortfall:.4f}' if shortfall else '1.0'))
+    try:
+        ctx.invoke(collateral_deposit, amount=amount, yes=True)
+    except SystemExit:
+        _resume_hint(f'alw collateral deposit --amount {amount}')
+        return False
+    return True
+
+
+def _bind(ctx, s: Setup, client, pubkey, wallet) -> bool:
+    from allways.cli.swap_commands.bind import bind_hotkey_command
+    from allways.cli.swap_commands.helpers import hotkey_bytes_to_ss58
+
+    ui.draw_step(
+        console,
+        9,
+        'Bind hotkey ↔ Solana pubkey',
+        'Permanent in both directions. Bind BEFORE registering so nobody can squat your hotkey.',
+    )
+    hot = wallet.hotkey.ss58_address
+    binding = client.get_binding(pubkey)
+    if binding is not None:
+        bound = hotkey_bytes_to_ss58(bytes(binding.hotkey))
+        if bound == hot:
+            ui.draw_done(console, f'already bound to {hot}')
+            return True
+        fail(
+            f'This Solana keypair is permanently bound to {bound}, not {hot}. Use that hotkey, or start over with a fresh keypair.'
+        )
+    other = client.get_hotkey_binding(bytes(wallet.hotkey.public_key))
+    if other is not None:
+        fail(
+            f'Hotkey {hot} is already bound to Solana pubkey {other.miner}. Point solana-keypair at that key, or use another hotkey.'
+        )
+    if not _typed_confirm(s, 'bind', f'Binding {hot} → {pubkey} cannot be undone.'):
+        console.print('  [yellow]Skipped.[/yellow]')
+        return False
+    try:
+        ctx.invoke(bind_hotkey_command, yes=True)
+    except SystemExit:
+        _resume_hint('alw bind-hotkey')
+        return False
+    return True
+
+
+def _register(s: Setup, subtensor, wallet, netuid: int) -> bool:
+    hot = wallet.hotkey.ss58_address
+    ui.draw_step(
+        console,
+        10,
+        f'Register on subnet {netuid}',
+        'Burns the registration cost from the coldkey. The coldkey password is asked for here.',
+    )
+    uid = subtensor.get_uid_for_hotkey_on_subnet(hot, netuid)
+    if uid is not None:
+        ui.draw_done(console, f'already registered as uid {uid}')
+        return True
+    try:
+        cost = subtensor.get_subnet_burn_cost(netuid)
+        console.print(f'  Registration cost: [bold]{cost}[/bold]')
+    except Exception:
+        pass
+    if not s.yes and not click.confirm('  Register now?', default=True):
+        _resume_hint(f'btcli subnet register --netuid {netuid} --wallet.name {s.wallet} --wallet.hotkey {s.hotkey}')
+        return False
+    resp = subtensor.burned_register(wallet, netuid)
+    ok = bool(getattr(resp, 'success', resp))
+    if not ok:
+        console.print(f'  [red]{getattr(resp, "message", "registration failed")}[/red]')
+        _resume_hint(f'btcli subnet register --netuid {netuid}')
+        return False
+    uid = subtensor.get_uid_for_hotkey_on_subnet(hot, netuid)
+    ui.draw_done(console, f'registered as uid {uid}')
+    return True
+
+
+def _bond(ctx, s: Setup, subtensor, config, wallet, floors) -> bool:
+    from allways.cli.swap_commands.vault import vault_deposit, vault_lock
+    from allways.vault import BondVaultClient
+
+    ui.draw_step(
+        console,
+        11,
+        'Post and lock the TAO bond',
+        'The hotkey signs vault calls. Locking is not self-service to undo: exit is deactivate → settle → unlock.',
+    )
+    hot = wallet.hotkey.ss58_address
+    vault = BondVaultClient.from_config(subtensor, config)
+    have = vault.get_collateral(hot) or 0
+    need = floors[BACKING_CHAIN_TAO]
+    if have < need:
+        amount = float(_prompt(s, 'Bond amount (TAO)', default=f'{from_rao(need - have):.4f}'))
+        try:
+            ctx.invoke(vault_deposit, amount=amount)
+        except SystemExit:
+            _resume_hint(f'alw vault deposit --amount {amount}')
+            return False
+    else:
+        ui.draw_done(console, f'{from_rao(have):.4f} TAO already bonded (floor {from_rao(need):.4f})')
+    lock = vault.get_lock_state(hot)
+    if lock and lock[0]:
+        ui.draw_done(console, 'bond already locked')
+        return True
+    if not _typed_confirm(
+        s, 'lock', 'Locking enters service; validators unlock you only after you deactivate and settle.'
+    ):
+        console.print('  [yellow]Skipped.[/yellow]')
+        return False
+    try:
+        ctx.invoke(vault_lock)
+    except SystemExit:
+        _resume_hint('alw vault lock')
+        return False
+    console.print(
+        '  [dim]Validators mirror the lock to Solana on their cadence — TAO activation may need a minute.[/dim]'
+    )
+    return True
+
+
+def _run_container(s: Setup) -> bool:
+    ui.draw_step(
+        console,
+        12,
+        'Start the miner',
+        'Start BEFORE activating: an active purse that nobody serves gets reserved, times out, and is slashed.',
+    )
+    if container_running():
+        ui.draw_done(console, f'{CONTAINER} is running')
+        return True
+    cmd = ['docker', 'compose', '-f', COMPOSE_FILE, 'up', '-d']
+    console.print(f'  $ {" ".join(cmd)}')
+    if not s.yes and not click.confirm('  Start it now?', default=True):
+        _resume_hint(' '.join(cmd))
+        return False
+    try:
+        subprocess.run(cmd, cwd=s.project_dir, check=True)
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        console.print(f'  [red]{e}[/red]')
+        _resume_hint(' '.join(cmd))
+        return False
+    with console.status('[cyan]Waiting for the container...[/cyan]', spinner='dots'):
+        for _ in range(10):
+            time.sleep(2)
+            if container_running():
+                break
+    if not container_running():
+        console.print(f'  [red]{CONTAINER} is not up — check `docker logs {CONTAINER}`.[/red]')
+        return False
+    ui.draw_done(console, f'{CONTAINER} up · logs: docker logs -f {CONTAINER}')
+    return True
+
+
+def _activate(ctx, s: Setup, client, pubkey) -> bool:
+    from allways.cli.swap_commands.miner_commands import miner_activate
+
+    ui.draw_step(
+        console, 13, 'Activate', 'Tells validators each purse is ready; they verify and vote it live on-chain.'
+    )
+    ms = client.get_miner_state(pubkey)
+    states = {st.backing: st for st in purse_states(client, pubkey, ms, client.get_config())}
+    ok = True
+    for backing in s.backings:
+        if states[backing].lit:
+            ui.draw_done(console, f'{backing} purse already serving')
+            continue
+        try:
+            ctx.invoke(miner_activate, backing=backing)
+        except SystemExit:
+            ok = False
+            _resume_hint(f'alw miner activate --backing {backing}')
+    return ok
+
+
+def go_live(ctx, s: Setup) -> bool:
+    import bittensor as bt
+
+    config, client = get_solana_cli_context()
+    pubkey = client.keypair.pubkey()
+    wallet = _bt_wallet(s.wallet, s.hotkey)
+    netuid = int(config.get('netuid', 7))
+    floors = floors_from_config(client.get_config())
+    subtensor = bt.Subtensor(network=config.get('network', 'finney'))
+
+    if not _deposit(ctx, s, client, pubkey, floors):
+        return False
+    if not _bind(ctx, s, client, pubkey, wallet):
+        return False
+    if not _register(s, subtensor, wallet, netuid):
+        return False
+    if BACKING_CHAIN_TAO in s.backings and not _bond(ctx, s, subtensor, config, wallet, floors):
+        return False
+    if not _run_container(s):
+        return False
+    return _activate(ctx, s, client, pubkey)
+
+
+# ─── Commands ────────────────────────────────────────────────────────────────
+
+# The CLI strips --wallet/--hotkey/--network/--netuid from argv as global overrides before Click runs.
+# Here they mean the same thing as the wizard's own flags, so take them back (and drop them from the
+# effective config, which the wizard rewrites from scratch).
+_NETWORK_ALIASES = {'test': 'testnet', 'finney': 'mainnet', 'testnet': 'testnet', 'mainnet': 'mainnet'}
+
+
+def _take_global_flags(network, wallet, hotkey):
+    from allways.cli.swap_commands import helpers
+
+    ov = helpers._CLI_OVERRIDES
+    raw_network = ov.pop('network', None)
+    ov.pop('netuid', None)
+    if not network and raw_network:
+        network = _NETWORK_ALIASES.get(raw_network)
+        if network is None:
+            fail(f'--network must be testnet or mainnet (got {raw_network!r}).')
+    return network, wallet or ov.pop('wallet', None), hotkey or ov.pop('hotkey', None)
+
+
+@click.command('init', cls=StyledCommand, show_disclaimer=True)
+@click.option('--network', type=click.Choice(list(ENV_BUNDLES)), default=None, help='testnet | mainnet')
+@click.option('--wallet', default=None, help='Coldkey name (created interactively if missing)')
+@click.option('--hotkey', default=None, help='Hotkey name (created if missing)')
+@click.option(
+    '--backing', type=click.Choice(['sol', 'tao', 'both']), default=None, help='Which purse(s) back your quotes'
+)
+@click.option(
+    '--chains', default=None, help='Comma-separated spoke families to key: btc,eth,arb,hype,bnb,avax,base,cro,pol'
+)
+@click.option(
+    '--solana-keypair', default=None, help='Keypair path (default ./data/solana/id.json; generated if missing)'
+)
+@click.option('--solana-rpc', default=None, help='Solana RPC URL')
+@click.option('--coldkey-password', default=None, help='Store for headless starts (MINER_BITTENSOR_COLDKEY_PASSWORD)')
+@click.option(
+    '--project-dir',
+    type=click.Path(file_okay=False, path_type=Path),
+    default='.',
+    help='Checkout holding .env + docker-compose.miner.yml',
+)
+@click.option(
+    '--configure-only', is_flag=True, help='Stop after writing config + preflight; skip the on-chain go-live steps'
+)
+@click.option(
+    '--yes', '-y', is_flag=True, help='Take every default and skip confirmations (including the irreversible ones)'
+)
+@click.pass_context
+def init_command(
+    ctx,
+    network,
+    wallet,
+    hotkey,
+    backing,
+    chains,
+    solana_keypair,
+    solana_rpc,
+    coldkey_password,
+    project_dir,
+    configure_only,
+    yes,
+):
+    """Set up a miner step by step: network, wallet, keys, .env, preflight, then the go-live sequence.
+
+    [dim]Resumable — every step checks disk/chain state and skips what is already done. Each prompt has a flag,
+    so `alw miner init --network testnet --wallet w --hotkey h --backing sol --chains eth -y` runs unattended.[/dim]
+
+    [dim]Examples:
+        $ alw miner init
+        $ alw miner init --configure-only
+        $ alw doctor[/dim]
+    """
+    network, wallet, hotkey = _take_global_flags(network, wallet, hotkey)
+    s = Setup(project_dir=project_dir.resolve(), yes=yes)
+    ui.draw_logo(console, 'Welcome to the Allways miner setup!')
+    console.print('[dim]Order matters on-chain: deposit → bind → register → (bond) → run → activate → quote.[/dim]')
+    if not (s.project_dir / COMPOSE_FILE).is_file():
+        ui.draw_warn(
+            console,
+            f'{COMPOSE_FILE} not found in {s.project_dir} — run this from your allways checkout (or --project-dir).',
+        )
+
+    step_network(s, network)
+    step_wallet(s, wallet, hotkey)
+    step_chains(s, backing, chains)
+    step_keys(s, solana_keypair)
+    step_rpc(s, solana_rpc)
+    step_write_env(s, coldkey_password)
+    rows = step_doctor(s.project_dir)
+
+    if configure_only:
+        _finish(s, live=False)
+        return
+    failed = [c for ok, c, _ in rows if ok is False]
+    if (
+        failed
+        and not yes
+        and not click.confirm(f'\n{len(failed)} check(s) failed. Continue to go-live anyway?', default=False)
+    ):
+        _finish(s, live=False)
+        return
+    if not yes and not click.confirm(
+        '\nContinue to go-live (deposit → bind → register → bond → run → activate)?', default=True
+    ):
+        _finish(s, live=False)
+        return
+    _finish(s, live=go_live(ctx, s))
+
+
+def _finish(s: Setup, live: bool) -> None:
+    rows = [('network', s.env), ('wallet', f'{s.wallet} / {s.hotkey}'), ('backing', s.backing), *s.addresses.items()]
+    width = max(len(k) for k, _ in rows)
+    lines = [f'{k.ljust(width)}  {v}' for k, v in rows]
+    ui.draw_success_box(console, lines, title='Miner live' if live else 'Configured')
+    if live:
+        ui.draw_next_steps(
+            console,
+            [
+                ('alw miner post', 'post your first quote (interactive) — emission starts when you hold the best rate'),
+                ('alw miner status', 'collateral, purses, quotes, active swaps'),
+                (f'docker logs -f {CONTAINER}', 'watch the miner'),
+            ],
+        )
+    else:
+        ui.draw_next_steps(
+            console,
+            [
+                ('alw doctor', 're-run the preflight after funding'),
+                ('alw miner init', 'resume the go-live sequence'),
+            ],
+        )
+    console.print(
+        f'[dim]Back up: {se.wallets_root()}/{s.wallet}, {s.solana_keypair}, and {s.env_path} — they ARE the miner.[/dim]\n'
+    )
+
+
+@click.command('doctor', cls=StyledCommand)
+@click.option(
+    '--project-dir',
+    type=click.Path(file_okay=False, path_type=Path),
+    default='.',
+    help='Checkout holding .env + docker-compose.miner.yml',
+)
+def doctor_command(project_dir):
+    """Preflight a miner setup: config, wallet, keys, RPC, collateral, binding, registration, docker.
+
+    [dim]Examples:
+        $ alw doctor[/dim]
+    """
+    rows = run_doctor(project_dir.resolve())
+    console.print(ui.check_table(rows))
+    bad = sum(1 for ok, _, _ in rows if ok is False)
+    console.print(f'[{"green" if not bad else "red"}]{len(rows) - bad}/{len(rows)} checks passed[/]\n')
+    if bad:
+        raise SystemExit(1)

--- a/allways/cli/swap_commands/miner_init.py
+++ b/allways/cli/swap_commands/miner_init.py
@@ -42,7 +42,12 @@ from allways.constants import TAO_HUB_VAULT_ADDRESSES
 from allways.solana.pdas import BACKING_CHAIN_SOL, BACKING_CHAIN_TAO
 
 COMPOSE_FILE = 'docker-compose.miner.yml'
+IMAGE_TAGS = {'testnet': 'test', 'mainnet': 'latest'}  # entrius/allways:<tag>, read by the compose file
 CONTAINER = 'aw-miner'
+# Validators learn of a new registration on their next metagraph sync (epoch_length 150 blocks ≈ 30 min),
+# so an activation right after registering must be retried across that window.
+ACTIVATE_RETRY_SECS = 180
+ACTIVATE_WAIT_AFTER_REGISTER_MINS = 35
 Check = Tuple[Optional[bool], str, str]
 
 
@@ -58,6 +63,8 @@ class Setup:
     solana_keypair: Optional[Path] = None
     env_values: Dict[str, str] = field(default_factory=dict)
     addresses: Dict[str, str] = field(default_factory=dict)
+    registered_now: bool = False
+    activate_wait_mins: Optional[int] = None  # None = auto: wait only after a fresh registration
 
     @property
     def env_path(self) -> Path:
@@ -128,7 +135,9 @@ def step_network(s: Setup, preset: Optional[str]) -> None:
     bundle['vault-address'] = TAO_HUB_VAULT_ADDRESSES[bundle['network']]
     _save_config(bundle)
     apply_chain_network_env(get_effective_config())
-    s.env_values.update(NETUID=bundle['netuid'], SUBTENSOR_NETWORK=bundle['network'])
+    s.env_values.update(
+        NETUID=bundle['netuid'], SUBTENSOR_NETWORK=bundle['network'], ALLWAYS_IMAGE_TAG=IMAGE_TAGS[s.env]
+    )
     ui.draw_done(
         console,
         f'{s.env}: netuid {bundle["netuid"]} · subtensor {bundle["network"]} · solana {bundle["solana-network"]}',
@@ -553,33 +562,59 @@ def _bind(ctx, s: Setup, client, pubkey, wallet) -> bool:
     return True
 
 
+def _unlock_coldkey(s: Setup, wallet) -> bool:
+    """Cache the coldkey password the way the miner does, so burned_register never prompts under -y."""
+    if not wallet.coldkey_file.is_encrypted():
+        return True
+    password = s.env_values.get('MINER_BITTENSOR_COLDKEY_PASSWORD') or os.environ.get(
+        'MINER_BITTENSOR_COLDKEY_PASSWORD'
+    )
+    if not password and s.yes:
+        console.print(
+            '  [red]Coldkey is encrypted; pass --coldkey-password (or unset -y) so registration can sign.[/red]'
+        )
+        return False
+    if password:
+        wallet.coldkey_file.save_password_to_env(password)
+    try:
+        wallet.unlock_coldkey()
+    except Exception as e:
+        console.print(f'  [red]Could not unlock coldkey: {e}[/red]')
+        return False
+    return True
+
+
 def _register(s: Setup, subtensor, wallet, netuid: int) -> bool:
     hot = wallet.hotkey.ss58_address
     ui.draw_step(
         console,
         10,
         f'Register on subnet {netuid}',
-        'Burns the registration cost from the coldkey. The coldkey password is asked for here.',
+        'Burns the registration cost from the coldkey. An encrypted coldkey asks for its password here.',
     )
     uid = subtensor.get_uid_for_hotkey_on_subnet(hot, netuid)
     if uid is not None:
         ui.draw_done(console, f'already registered as uid {uid}')
         return True
     try:
-        cost = subtensor.get_subnet_burn_cost(netuid)
-        console.print(f'  Registration cost: [bold]{cost}[/bold]')
+        console.print(f'  Registration cost: [bold]{subtensor.recycle(netuid)}[/bold]')
     except Exception:
         pass
+    manual = f'btcli subnet register --netuid {netuid} --wallet.name {s.wallet} --wallet.hotkey {s.hotkey} --network {s.bundle["network"]}'
     if not s.yes and not click.confirm('  Register now?', default=True):
-        _resume_hint(f'btcli subnet register --netuid {netuid} --wallet.name {s.wallet} --wallet.hotkey {s.hotkey}')
+        _resume_hint(manual)
+        return False
+    if not _unlock_coldkey(s, wallet):
+        _resume_hint(manual)
         return False
     resp = subtensor.burned_register(wallet, netuid)
     ok = bool(getattr(resp, 'success', resp))
     if not ok:
         console.print(f'  [red]{getattr(resp, "message", "registration failed")}[/red]')
-        _resume_hint(f'btcli subnet register --netuid {netuid}')
+        _resume_hint(manual)
         return False
     uid = subtensor.get_uid_for_hotkey_on_subnet(hot, netuid)
+    s.registered_now = True
     ui.draw_done(console, f'registered as uid {uid}')
     return True
 
@@ -660,9 +695,34 @@ def _run_container(s: Setup) -> bool:
     return True
 
 
-def _activate(ctx, s: Setup, client, pubkey) -> bool:
+def _activate_with_retry(ctx, s: Setup, backing: str) -> bool:
+    """Broadcast activation; after a fresh registration keep retrying until validators have resynced."""
     from allways.cli.swap_commands.miner_commands import miner_activate
 
+    wait_mins = s.activate_wait_mins
+    if wait_mins is None:
+        wait_mins = ACTIVATE_WAIT_AFTER_REGISTER_MINS if s.registered_now else 0
+    deadline = time.time() + wait_mins * 60
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            ctx.invoke(miner_activate, backing=backing)
+            return True
+        except SystemExit:
+            pass
+        remaining = deadline - time.time()
+        if remaining <= 0:
+            return False
+        pause = min(ACTIVATE_RETRY_SECS, remaining)
+        console.print(
+            f'  [dim]Validators pick up a new registration on their next metagraph sync (up to ~30 min). '
+            f'Retrying in {max(1, round(pause / 60))} min — attempt {attempt}, {round(remaining / 60)} min left.[/dim]'
+        )
+        time.sleep(pause)
+
+
+def _activate(ctx, s: Setup, client, pubkey) -> bool:
     ui.draw_step(
         console, 13, 'Activate', 'Tells validators each purse is ready; they verify and vote it live on-chain.'
     )
@@ -673,9 +733,7 @@ def _activate(ctx, s: Setup, client, pubkey) -> bool:
         if states[backing].lit:
             ui.draw_done(console, f'{backing} purse already serving')
             continue
-        try:
-            ctx.invoke(miner_activate, backing=backing)
-        except SystemExit:
+        if not _activate_with_retry(ctx, s, backing):
             ok = False
             _resume_hint(f'alw miner activate --backing {backing}')
     return ok
@@ -747,6 +805,12 @@ def _take_global_flags(network, wallet, hotkey):
     help='Checkout holding .env + docker-compose.miner.yml',
 )
 @click.option(
+    '--activate-wait',
+    type=int,
+    default=None,
+    help='Minutes to keep retrying activation (default: 35 after a fresh registration, else 0)',
+)
+@click.option(
     '--configure-only', is_flag=True, help='Stop after writing config + preflight; skip the on-chain go-live steps'
 )
 @click.option(
@@ -764,6 +828,7 @@ def init_command(
     solana_rpc,
     coldkey_password,
     project_dir,
+    activate_wait,
     configure_only,
     yes,
 ):
@@ -778,7 +843,7 @@ def init_command(
         $ alw doctor[/dim]
     """
     network, wallet, hotkey = _take_global_flags(network, wallet, hotkey)
-    s = Setup(project_dir=project_dir.resolve(), yes=yes)
+    s = Setup(project_dir=project_dir.resolve(), yes=yes, activate_wait_mins=activate_wait)
     ui.draw_logo(console, 'Welcome to the Allways miner setup!')
     console.print('[dim]Order matters on-chain: deposit → bind → register → (bond) → run → activate → quote.[/dim]')
     if not (s.project_dir / COMPOSE_FILE).is_file():

--- a/allways/cli/swap_commands/setup_env.py
+++ b/allways/cli/swap_commands/setup_env.py
@@ -1,0 +1,197 @@
+"""Pure helpers behind `alw miner init`: key families, key generation, `.env` editing, wallet listing.
+
+No chain access here — everything is unit-testable against a tmp dir.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from allways.chains import SUPPORTED_CHAINS, ChainDefinition
+
+# Families whose key the wizard can generate itself; sol (keypair file) + tao (coldkey) are handled apart.
+GENERATED_KINDS = ('evm', 'btc')
+
+
+@dataclass(frozen=True)
+class KeyFamily:
+    """One signing key + the assets it serves, keyed by the network's env prefix (ETH, ARB, BTC…)."""
+
+    prefix: str
+    kind: str  # 'solana' | 'tao' | 'btc' | 'evm'
+    assets: Tuple[str, ...]
+    network_chain: Optional[ChainDefinition]  # the row that owns {PREFIX}_NETWORK, if any
+
+    @property
+    def key_env(self) -> str:
+        return f'{self.prefix}_PRIVATE_KEY'
+
+    @property
+    def network_env(self) -> str:
+        return f'{self.prefix}_NETWORK'
+
+    @property
+    def label(self) -> str:
+        return f'{self.prefix.lower()}  ({", ".join(self.assets)})'
+
+
+def _kind(chain: ChainDefinition) -> str:
+    if chain.id == 'btc':
+        return 'btc'
+    if chain.id == 'tao':
+        return 'tao'
+    if chain.id == 'sol' or chain.host_chain == 'solana':
+        return 'solana'
+    return 'evm'
+
+
+def key_families() -> List[KeyFamily]:
+    """Registry-derived, in registry order: a new chain shows up here unaided."""
+    by_prefix: Dict[str, List[ChainDefinition]] = {}
+    for chain in SUPPORTED_CHAINS.values():
+        by_prefix.setdefault(chain.env_prefix, []).append(chain)
+    out = []
+    for prefix, chains in by_prefix.items():
+        owner = next((c for c in chains if c.networks), None)
+        out.append(KeyFamily(prefix, _kind(chains[0]), tuple(c.id for c in chains), owner))
+    return out
+
+
+def optional_families() -> List[KeyFamily]:
+    """Families the operator opts into (everything but the always-on Solana keypair + TAO coldkey)."""
+    return [f for f in key_families() if f.kind in GENERATED_KINDS]
+
+
+def parse_family_list(raw: str) -> List[str]:
+    """'btc, eth,ARB' → ['BTC', 'ETH', 'ARB']; raises ValueError naming any unknown prefix."""
+    known = {f.prefix for f in optional_families()}
+    picked = [p.strip().upper() for p in raw.split(',') if p.strip()]
+    unknown = [p for p in picked if p not in known]
+    if unknown:
+        raise ValueError(f'unknown chain(s) {", ".join(unknown)}; choose from {", ".join(sorted(known))}')
+    return list(dict.fromkeys(picked))
+
+
+# ─── Key generation / derivation ─────────────────────────────────────────────
+
+
+def generate_evm_key() -> Tuple[str, str]:
+    """(0x-prefixed 32-byte hex key, checksummed address)."""
+    from eth_account import Account
+
+    acct = Account.create()
+    return '0x' + acct.key.hex().removeprefix('0x'), acct.address
+
+
+def evm_address(hex_key: str) -> Optional[str]:
+    from eth_account import Account
+
+    try:
+        return Account.from_key(hex_key).address
+    except Exception:
+        return None
+
+
+def _embit_network(btc_network: str):
+    from embit.networks import NETWORKS
+
+    from allways.assets.btc import TESTNET_ENCODINGS
+
+    if btc_network in TESTNET_ENCODINGS:
+        return NETWORKS['test']
+    return NETWORKS['regtest'] if btc_network == 'regtest' else NETWORKS['main']
+
+
+def generate_btc_key(btc_network: str) -> Tuple[str, str]:
+    """(WIF for the network, native-segwit address) — the address form the docker miner pays from."""
+    from embit.ec import PrivateKey
+    from embit.script import p2wpkh
+
+    key = PrivateKey(os.urandom(32))
+    net = _embit_network(btc_network)
+    return key.wif(net), p2wpkh(key.get_public_key()).address(net)
+
+
+def btc_address(wif: str, btc_network: str) -> Optional[str]:
+    from embit.ec import PrivateKey
+    from embit.script import p2wpkh
+
+    try:
+        return p2wpkh(PrivateKey.from_wif(wif).get_public_key()).address(_embit_network(btc_network))
+    except Exception:
+        return None
+
+
+# ─── .env editing ────────────────────────────────────────────────────────────
+
+WIZARD_SECTION = '# ─── alw miner init ────────────────────────────────────────'
+
+
+def _quote(value: str) -> str:
+    return f'"{value}"' if (' ' in value or '#' in value) else value
+
+
+def upsert_env(text: str, values: Dict[str, str]) -> str:
+    """Set each KEY=value in a dotenv text, replacing an existing (or commented-out) line in place and
+    keeping its trailing comment; keys not present are appended under the wizard section."""
+    lines = text.splitlines()
+    pending = dict(values)
+    for i, line in enumerate(lines):
+        m = re.match(r'^\s*#?\s*([A-Z][A-Z0-9_]*)=.*?(\s+#.*)?$', line)
+        if not m or m.group(1) not in pending:
+            continue
+        key = m.group(1)
+        lines[i] = f'{key}={_quote(pending.pop(key))}{m.group(2) or ""}'
+    if pending:
+        if lines and lines[-1].strip():
+            lines.append('')
+        lines.append(WIZARD_SECTION)
+        lines.extend(f'{k}={_quote(v)}' for k, v in pending.items())
+    return '\n'.join(lines) + '\n'
+
+
+def read_env(path: Path) -> Dict[str, str]:
+    from dotenv import dotenv_values
+
+    if not path.exists():
+        return {}
+    return {k: v for k, v in dotenv_values(path).items() if v is not None}
+
+
+def write_env(path: Path, values: Dict[str, str], template: Optional[Path] = None) -> None:
+    """Upsert into ``path``; a missing file starts from ``template`` (the repo's .env.example) so the
+    operator keeps every documented knob and comment. Written 0600 — it holds signing keys."""
+    if path.exists():
+        base = path.read_text()
+    elif template and template.exists():
+        base = template.read_text()
+    else:
+        base = ''
+    path.write_text(upsert_env(base, values))
+    os.chmod(path, 0o600)
+
+
+# ─── Bittensor wallet discovery ──────────────────────────────────────────────
+
+
+def wallets_root() -> Path:
+    return Path(os.environ.get('WALLET_PATH') or Path.home() / '.bittensor' / 'wallets').expanduser()
+
+
+def list_wallets(root: Optional[Path] = None) -> Dict[str, List[str]]:
+    """{coldkey name: [hotkey names]} for every wallet dir holding a coldkeypub.txt."""
+    root = root or wallets_root()
+    if not root.is_dir():
+        return {}
+    out: Dict[str, List[str]] = {}
+    for d in sorted(root.iterdir()):
+        if not (d / 'coldkeypub.txt').is_file():
+            continue
+        hk_dir = d / 'hotkeys'
+        files = hk_dir.iterdir() if hk_dir.is_dir() else ()
+        out[d.name] = sorted(p.name for p in files if p.is_file() and not p.name.endswith('pub.txt'))
+    return out

--- a/allways/cli/swap_commands/status.py
+++ b/allways/cli/swap_commands/status.py
@@ -22,6 +22,7 @@ from allways.cli.swap_commands.helpers import (
     resolve_solana_keypair_path,
     safe_read,
     set_json_output,
+    wallet_path,
 )
 from allways.solana.rpc import redact_rpc_url
 
@@ -36,7 +37,7 @@ def _tao_identity(config):
     import bittensor as bt
 
     try:
-        ss58 = bt.Wallet(name=name).coldkeypub.ss58_address
+        ss58 = bt.Wallet(name=name, path=wallet_path()).coldkeypub.ss58_address
     except Exception:
         return None
     try:
@@ -54,7 +55,7 @@ def _configured_hotkey_ss58(config):
     import bittensor as bt
 
     try:
-        return bt.Wallet(name=config['wallet'], hotkey=config['hotkey']).hotkey.ss58_address
+        return bt.Wallet(name=config['wallet'], hotkey=config['hotkey'], path=wallet_path()).hotkey.ss58_address
     except Exception:
         return None
 

--- a/allways/cli/ui.py
+++ b/allways/cli/ui.py
@@ -1,0 +1,91 @@
+"""Shared wizard chrome for `alw`: the startup banner, numbered steps, and result panels.
+
+Pure presentation — no chain or config access — so every wizard-style command renders the same way.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+from rich import box
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+BRAND = 'cyan'
+
+# figlet "larry3d"; rendered once so the CLI carries no figlet dependency.
+BANNER = r"""
+ ______  __       __       __      __  ______   __    __  ____
+/\  _  \/\ \     /\ \     /\ \  __/\ \/\  _  \ /\ \  /\ \/\  _`\
+\ \ \L\ \ \ \    \ \ \    \ \ \/\ \ \ \ \ \L\ \\ `\`\\/'/\ \,\L\_\
+ \ \  __ \ \ \  __\ \ \  __\ \ \ \ \ \ \ \  __ \`\ `\ /'  \/_\__ \
+  \ \ \/\ \ \ \L\ \\ \ \L\ \\ \ \_/ \_\ \ \ \/\ \ `\ \ \    /\ \L\ \
+   \ \_\ \_\ \____/ \ \____/ \ `\___x___/\ \_\ \_\  \ \_\   \ `\____\
+    \/_/\/_/\/___/   \/___/   '\/__//__/  \/_/\/_/   \/_/    \/_____/
+"""
+
+
+def draw_logo(console: Console, tagline: str | None = None) -> None:
+    """Print the ALLWAYS banner in the brand colour, optionally followed by a bold tagline."""
+    console.print(f'[bold {BRAND}]{BANNER}[/bold {BRAND}]', highlight=False, markup=True)
+    if tagline:
+        console.print(f'[bold {BRAND}]{tagline}[/bold {BRAND}]\n')
+
+
+def draw_step(console: Console, number: int, title: str, *notes: str) -> None:
+    """A numbered step header plus dim explanatory lines beneath it."""
+    console.print(f'\n[bold {BRAND}]Step {number}:[/bold {BRAND}] [bold]{title}[/bold]')
+    for note in notes:
+        console.print(f'  [dim]{note}[/dim]')
+
+
+def draw_done(console: Console, message: str) -> None:
+    """A green check line for a step that completed or was already satisfied."""
+    console.print(f'  [green]✓[/green] {message}')
+
+
+def draw_skip(console: Console, message: str) -> None:
+    """A dim dash line for a step the operator chose to skip."""
+    console.print(f'  [dim]– {message}[/dim]')
+
+
+def draw_warn(console: Console, message: str) -> None:
+    console.print(f'  [yellow]![/yellow] {message}')
+
+
+def draw_kv(console: Console, rows: Iterable[tuple[str, str]], key_style: str = f'bold {BRAND}') -> None:
+    """Aligned key/value lines, indented under the current step."""
+    rows = list(rows)
+    if not rows:
+        return
+    width = max(len(k) for k, _ in rows)
+    for key, value in rows:
+        console.print(f'  [{key_style}]{key.ljust(width)}[/{key_style}]  {value}', highlight=False)
+
+
+def draw_panel(console: Console, lines: Sequence[str], title: str, border: str = BRAND) -> None:
+    console.print(Panel('\n'.join(lines), title=f'[bold]{title}[/bold]', border_style=border, box=box.ROUNDED))
+
+
+def draw_success_box(console: Console, lines: Sequence[str], title: str = 'Success') -> None:
+    draw_panel(console, lines, title, border='green')
+
+
+def draw_next_steps(console: Console, rows: Iterable[tuple[str, str]]) -> None:
+    """A 'Next steps' block: command on the left, what it does on the right."""
+    console.print(f'\n[bold {BRAND}]Next steps:[/bold {BRAND}]')
+    draw_kv(console, rows, key_style='bold')
+    console.print()
+
+
+def check_table(rows: Iterable[tuple[bool | None, str, str]]) -> Table:
+    """Preflight table: (ok, check, detail) → ✓ / ✗ / – rows. ``None`` = not applicable."""
+    table = Table(show_header=True, box=box.SIMPLE, header_style='bold')
+    table.add_column('', width=2, justify='center')
+    table.add_column('Check', style='bold', no_wrap=True)
+    table.add_column('Detail', overflow='fold')
+    for ok, check, detail in rows:
+        mark = '[green]✓[/green]' if ok else '[dim]–[/dim]' if ok is None else '[red]✗[/red]'
+        table.add_row(mark, check, detail)
+    return table

--- a/docker-compose.miner.yml
+++ b/docker-compose.miner.yml
@@ -1,6 +1,6 @@
 services:
   miner:
-    image: entrius/allways:latest
+    image: entrius/allways:${ALLWAYS_IMAGE_TAG:-latest}   # testnet miners: ALLWAYS_IMAGE_TAG=test
     container_name: aw-miner
     restart: unless-stopped
     entrypoint: /app/scripts/miner-entrypoint.sh

--- a/tests/test_cli_miner_init.py
+++ b/tests/test_cli_miner_init.py
@@ -1,0 +1,225 @@
+"""`alw miner init` — the pure setup helpers, and the unattended configure-only path end to end
+against a tmp project dir with the chain + wallet layers stubbed out."""
+
+import json
+import os
+import stat
+from types import SimpleNamespace
+
+import pytest
+from click.testing import CliRunner
+
+from allways.cli.swap_commands import helpers, miner_init
+from allways.cli.swap_commands import setup_env as se
+from allways.constants import TAO_HUB_VAULT_ADDRESSES
+
+# ─── key families ────────────────────────────────────────────────────────────
+
+
+def test_key_families_group_assets_by_network_prefix():
+    fams = {f.prefix: f for f in se.key_families()}
+    assert fams['ETH'].kind == 'evm'
+    assert set(fams['ETH'].assets) >= {'eth', 'ethusdc', 'uni', 'qnt', 'paxg'}
+    assert fams['ETH'].network_chain.id == 'eth'
+    assert fams['BTC'].kind == 'btc'
+    assert fams['SOL'].kind == 'solana' and 'solusdc' in fams['SOL'].assets
+    assert fams['TAO'].kind == 'tao'
+    assert fams['BNB'].assets == ('bnb', 'aster')
+
+
+def test_optional_families_exclude_sol_and_tao():
+    prefixes = {f.prefix for f in se.optional_families()}
+    assert 'SOL' not in prefixes and 'TAO' not in prefixes
+    assert {'BTC', 'ETH', 'ARB'} <= prefixes
+
+
+def test_parse_family_list_normalizes_and_rejects_unknown():
+    assert se.parse_family_list(' btc, eth,ARB,eth ') == ['BTC', 'ETH', 'ARB']
+    assert se.parse_family_list('') == []
+    with pytest.raises(ValueError, match='DOGE'):
+        se.parse_family_list('btc,doge')
+
+
+# ─── key generation ──────────────────────────────────────────────────────────
+
+
+def test_evm_key_roundtrips_to_its_address():
+    key, addr = se.generate_evm_key()
+    assert key.startswith('0x') and len(key) == 66
+    assert se.evm_address(key) == addr
+    assert se.evm_address('nope') is None
+
+
+@pytest.mark.parametrize('network,prefix', [('mainnet', 'bc1q'), ('testnet4', 'tb1q'), ('signet', 'tb1q')])
+def test_btc_key_roundtrips_for_network(network, prefix):
+    wif, addr = se.generate_btc_key(network)
+    assert addr.startswith(prefix)
+    assert se.btc_address(wif, network) == addr
+    assert se.btc_address('garbage', network) is None
+
+
+# ─── .env editing ────────────────────────────────────────────────────────────
+
+TEMPLATE = """# header
+NETUID=7                            # 7 mainnet | 19 testnet
+WALLET_NAME=default
+# SOLANA_KEYPAIR_PATH=
+BTC_NETWORK=mainnet                 # mainnet | testnet
+ETH_PRIVATE_KEY=
+"""
+
+
+def test_upsert_env_replaces_in_place_and_keeps_trailing_comment():
+    out = se.upsert_env(TEMPLATE, {'NETUID': '19', 'BTC_NETWORK': 'testnet4', 'ETH_PRIVATE_KEY': '0xabc'})
+    assert 'NETUID=19                            # 7 mainnet | 19 testnet' in out
+    assert 'BTC_NETWORK=testnet4                 # mainnet | testnet' in out
+    assert 'ETH_PRIVATE_KEY=0xabc\n' in out
+    assert out.count('NETUID=') == 1
+    assert se.WIZARD_SECTION not in out
+
+
+def test_upsert_env_uncomments_and_appends_missing_keys():
+    out = se.upsert_env(TEMPLATE, {'SOLANA_KEYPAIR_PATH': '/k.json', 'NEW_KEY': 'v', 'SPACED': 'a b'})
+    assert '\nSOLANA_KEYPAIR_PATH=/k.json\n' in out
+    assert '# SOLANA_KEYPAIR_PATH' not in out
+    assert out.endswith(f'{se.WIZARD_SECTION}\nNEW_KEY=v\nSPACED="a b"\n')
+
+
+def test_write_env_starts_from_template_and_is_private(tmp_path):
+    template = tmp_path / '.env.example'
+    template.write_text(TEMPLATE)
+    env = tmp_path / '.env'
+    se.write_env(env, {'WALLET_NAME': 'w'}, template=template)
+    assert stat.S_IMODE(env.stat().st_mode) == 0o600
+    assert se.read_env(env) == {'NETUID': '7', 'WALLET_NAME': 'w', 'BTC_NETWORK': 'mainnet', 'ETH_PRIVATE_KEY': ''}
+    se.write_env(env, {'NETUID': '19'})  # second write edits, never re-templates
+    assert se.read_env(env)['WALLET_NAME'] == 'w' and se.read_env(env)['NETUID'] == '19'
+
+
+def test_list_wallets_reads_coldkeypub_dirs_and_hotkeys(tmp_path):
+    (tmp_path / 'a' / 'hotkeys').mkdir(parents=True)
+    (tmp_path / 'a' / 'coldkeypub.txt').write_text('{}')
+    (tmp_path / 'a' / 'hotkeys' / 'h2').write_text('{}')
+    (tmp_path / 'a' / 'hotkeys' / 'h1').write_text('{}')
+    (tmp_path / 'a' / 'hotkeys' / 'h1pub.txt').write_text('{}')  # public half, not a hotkey
+    (tmp_path / 'b').mkdir()  # no coldkeypub → not a wallet
+    (tmp_path / 'c' / 'coldkeypub.txt').parent.mkdir()
+    (tmp_path / 'c' / 'coldkeypub.txt').write_text('{}')
+    assert se.list_wallets(tmp_path) == {'a': ['h1', 'h2'], 'c': []}
+    assert se.list_wallets(tmp_path / 'missing') == {}
+
+
+# ─── the wizard, unattended ──────────────────────────────────────────────────
+
+
+@pytest.fixture
+def sandbox(tmp_path, monkeypatch):
+    """Tmp config + wallets + project dir; wallet objects and the preflight are stubbed."""
+    allways_dir = tmp_path / 'allways'
+    config = allways_dir / 'config.json'
+    monkeypatch.setattr(miner_init, 'ALLWAYS_DIR', allways_dir)
+    monkeypatch.setattr(miner_init, 'CONFIG_FILE', config)
+    monkeypatch.setattr(helpers, 'CONFIG_FILE', config)
+    monkeypatch.setattr(helpers, '_CLI_OVERRIDES', {})
+    for var in ('SOLANA_RPC_URL', 'SOLANA_KEYPAIR_PATH', 'WALLET_PATH', 'ETH_NETWORK', 'BTC_NETWORK'):
+        monkeypatch.delenv(var, raising=False)
+
+    wallets = tmp_path / 'wallets'
+    (wallets / 'w' / 'hotkeys').mkdir(parents=True)
+    (wallets / 'w' / 'coldkeypub.txt').write_text('{}')
+    (wallets / 'w' / 'hotkeys' / 'h').write_text('{}')
+    monkeypatch.setattr(se, 'wallets_root', lambda: wallets)
+
+    stub = SimpleNamespace(
+        coldkeypub=SimpleNamespace(ss58_address='5Cold'), hotkey=SimpleNamespace(ss58_address='5Hot')
+    )
+    monkeypatch.setattr(miner_init, '_bt_wallet', lambda name, hotkey: stub)
+    monkeypatch.setattr(miner_init, 'run_doctor', lambda project_dir: [(True, 'stub', 'ok')])
+
+    project = tmp_path / 'proj'
+    project.mkdir()
+    (project / 'docker-compose.miner.yml').write_text('services: {}')
+    (project / '.env.example').write_text(TEMPLATE)
+    return SimpleNamespace(config=config, project=project, wallets=wallets)
+
+
+def _run(sandbox, *extra):
+    args = [
+        '--network', 'testnet', '--wallet', 'w', '--hotkey', 'h', '--backing', 'sol', '--chains', 'eth,btc',
+        '--solana-rpc', 'http://rpc.test', '--project-dir', str(sandbox.project), '--configure-only', '-y', *extra,
+    ]  # fmt: skip
+    return CliRunner().invoke(miner_init.init_command, args)
+
+
+def test_configure_only_writes_config_env_and_keys(sandbox):
+    result = _run(sandbox)
+    assert result.exit_code == 0, result.output
+
+    config = json.loads(sandbox.config.read_text())
+    assert config['netuid'] == '19' and config['network'] == 'test'
+    assert config['vault-address'] == TAO_HUB_VAULT_ADDRESSES['test']
+    assert config['wallet'] == 'w' and config['hotkey'] == 'h'
+    keypair = sandbox.project / 'data' / 'solana' / 'id.json'
+    assert config['solana-keypair'] == str(keypair) and keypair.exists()
+    assert stat.S_IMODE(keypair.stat().st_mode) == 0o600
+
+    env = se.read_env(sandbox.project / '.env')
+    assert env['NETUID'] == '19' and env['SUBTENSOR_NETWORK'] == 'test'
+    assert env['WALLET_NAME'] == 'w' and env['HOTKEY_NAME'] == 'h' and env['WALLET_PATH'] == str(sandbox.wallets)
+    assert env['SOLANA_RPC_URL'] == 'http://rpc.test'
+    assert env['ETH_NETWORK'] == 'sepolia' and env['BTC_NETWORK'] == 'testnet4'
+    assert se.evm_address(env['ETH_PRIVATE_KEY']) is not None
+    assert se.btc_address(env['BTC_PRIVATE_KEY'], 'testnet4') is not None
+    assert env['PORT'] == '8091' and env['LOG_LEVEL'] == 'info'
+    assert 'MINER_BITTENSOR_COLDKEY_PASSWORD' not in env
+    assert stat.S_IMODE((sandbox.project / '.env').stat().st_mode) == 0o600
+
+    # keys are never echoed; addresses and the summary box are
+    assert env['ETH_PRIVATE_KEY'] not in result.output and env['BTC_PRIVATE_KEY'] not in result.output
+    assert se.evm_address(env['ETH_PRIVATE_KEY']) in result.output
+    assert '5Cold' in result.output and 'Configured' in result.output
+
+
+def test_rerun_keeps_existing_keys(sandbox):
+    assert _run(sandbox).exit_code == 0
+    first = se.read_env(sandbox.project / '.env')
+    result = _run(sandbox)
+    assert result.exit_code == 0, result.output
+    second = se.read_env(sandbox.project / '.env')
+    assert second['ETH_PRIVATE_KEY'] == first['ETH_PRIVATE_KEY']
+    assert second['BTC_PRIVATE_KEY'] == first['BTC_PRIVATE_KEY']
+    assert 'kept from .env' in result.output
+
+
+def test_coldkey_password_flag_lands_in_env(sandbox):
+    assert _run(sandbox, '--coldkey-password', 'hunter 2').exit_code == 0
+    assert se.read_env(sandbox.project / '.env')['MINER_BITTENSOR_COLDKEY_PASSWORD'] == 'hunter 2'
+
+
+def test_yes_defaults_to_the_only_wallet_and_refuses_to_create_one(sandbox):
+    result = CliRunner().invoke(
+        miner_init.init_command,
+        ['--network', 'testnet', '--backing', 'sol', '--chains', '', '--project-dir', str(sandbox.project), '-y'],
+    )
+    assert result.exit_code == 0, result.output
+    assert json.loads(sandbox.config.read_text())['wallet'] == 'w'
+
+    result = _run(sandbox, '--wallet', 'ghost')
+    assert result.exit_code != 0
+    assert 'ghost' in result.output and 'mnemonic' in result.output
+
+
+def test_unknown_chain_fails_under_yes(sandbox):
+    result = _run(sandbox, '--chains', 'btc,doge')
+    assert result.exit_code != 0
+    assert 'DOGE' in result.output
+
+
+def test_typed_confirm_requires_the_exact_word(monkeypatch):
+    s = miner_init.Setup(project_dir=os.getcwd())
+    monkeypatch.setattr(miner_init.click, 'prompt', lambda *a, **k: 'nope')
+    assert miner_init._typed_confirm(s, 'bind', 'why') is False
+    monkeypatch.setattr(miner_init.click, 'prompt', lambda *a, **k: ' bind ')
+    assert miner_init._typed_confirm(s, 'bind', 'why') is True
+    s.yes = True
+    assert miner_init._typed_confirm(s, 'bind', 'why') is True

--- a/tests/test_cli_miner_init.py
+++ b/tests/test_cli_miner_init.py
@@ -164,7 +164,7 @@ def test_configure_only_writes_config_env_and_keys(sandbox):
     assert stat.S_IMODE(keypair.stat().st_mode) == 0o600
 
     env = se.read_env(sandbox.project / '.env')
-    assert env['NETUID'] == '19' and env['SUBTENSOR_NETWORK'] == 'test'
+    assert env['NETUID'] == '19' and env['SUBTENSOR_NETWORK'] == 'test' and env['ALLWAYS_IMAGE_TAG'] == 'test'
     assert env['WALLET_NAME'] == 'w' and env['HOTKEY_NAME'] == 'h' and env['WALLET_PATH'] == str(sandbox.wallets)
     assert env['SOLANA_RPC_URL'] == 'http://rpc.test'
     assert env['ETH_NETWORK'] == 'sepolia' and env['BTC_NETWORK'] == 'testnet4'
@@ -223,3 +223,26 @@ def test_typed_confirm_requires_the_exact_word(monkeypatch):
     assert miner_init._typed_confirm(s, 'bind', 'why') is True
     s.yes = True
     assert miner_init._typed_confirm(s, 'bind', 'why') is True
+
+
+def test_activate_retries_across_the_metagraph_sync_window(monkeypatch):
+    """After a fresh registration, activation keeps retrying (bounded) until validators resync."""
+    s = miner_init.Setup(project_dir=os.getcwd(), registered_now=True)
+    calls = []
+
+    class Ctx:
+        def invoke(self, cmd, **kw):
+            calls.append(kw['backing'])
+            if len(calls) < 3:
+                raise SystemExit(1)
+
+    slept = []
+    monkeypatch.setattr(miner_init.time, 'sleep', lambda secs: slept.append(secs))
+    assert miner_init._activate_with_retry(Ctx(), s, 'sol') is True
+    assert calls == ['sol', 'sol', 'sol'] and len(slept) == 2
+
+    # not freshly registered → one attempt only
+    s2 = miner_init.Setup(project_dir=os.getcwd())
+    calls.clear()
+    assert miner_init._activate_with_retry(Ctx(), s2, 'sol') is False
+    assert calls == ['sol']


### PR DESCRIPTION
## What

A step-by-step miner onboarding wizard and a standalone preflight.

- `alw miner init` (alias `alw init`): network → wallet → backing + chains → signing keys → Solana RPC → write `.env` + `alw config` → preflight → go-live (deposit → bind → register → TAO bond → `docker compose up` → activate).
- `alw doctor`: the preflight alone. ✓/✗/– table over config, wallet files, every purse key, RPC + cluster guard, SOL balance/collateral, binding, registration, TAO bond, docker/compose/.env/WALLET_PATH, container state. Exit 1 on any ✗.

## Design

- **Resumable**: every step checks disk or chain state and skips what is done. No local progress flag.
- **Unattended**: every prompt has a flag; `-y` takes defaults. `-y` refuses to create a coldkey (needs the mnemonic/password prompt) but will create a hotkey.
- **Generate, don't ask**: Solana keypair via `load_or_create`, EVM keys via `eth_account`, BTC WIF via embit for the chosen network. Only addresses are printed; keys land in `.env` (0600) which is built from `.env.example` so the comments survive.
- **Irreversible steps** (bind, vault lock) take a typed word.
- Key families are registry-derived by `env_prefix`, so a new chain shows up in the wizard unaided.
- The CLI strips `--wallet/--hotkey/--network/--netuid` as global overrides before Click runs; the wizard reclaims them (and maps `test`/`finney` → `testnet`/`mainnet`).
- Validators only see a fresh registration on their next metagraph sync (`epoch_length` 150 blocks ≈ 30 min), so activation right after the wizard registered you is retried across that window (`--activate-wait`, default 35 min in that case, else 0).

## Also in here

- `alw config` now shows `vault-address`; `alw config set env …` sets it from `TAO_HUB_VAULT_ADDRESSES`. TAO-backed miners previously had no visible way to know it was required.
- The CLI's wallet builders honor `WALLET_PATH` (the same var compose mounts) — previously `alw bind-hotkey` etc. only ever looked in `~/.bittensor/wallets`.
- `docker-compose.miner.yml` takes its image tag from `ALLWAYS_IMAGE_TAG` (default `latest`); the wizard sets `test` on testnet.
- README miner section leads with the wizard; the `alw collateral deposit` example is `--amount` (the command is flag-only).

## Verification

- `tests/test_cli_miner_init.py` (18): key-family grouping, EVM/BTC key roundtrips, `.env` upsert semantics, template + 0600, wallet listing (ignores `*pub.txt`), the unattended `--configure-only` path end to end against a tmp HOME, refusals under `-y`, typed confirms, and the activation retry loop. Full suite green.
- **Live on testnet (SN19 / devnet), unattended, from a sandboxed HOME**: `alw miner init --network testnet --wallet alice --hotkey wiz1 --backing sol --chains eth -y` created hotkey `wiz1`, generated + funded a Solana keypair and an ETH key, wrote `.env`, deposited 0.1 SOL, bound the hotkey, registered as uid 13 (τ0.0005 burn), started `entrius/allways:test` via compose, then retried activation every 3 min until the isaiah validator resynced — `1/1 validators accepted`, `SOL purse activated successfully`. A second run resumed cleanly (every earlier step reported already done). Test miner deactivated and container stopped afterwards.

Sister docs PR: entrius/allways-docs-ui#118.
