### PR TITLE
Push miner swap discovery over the program feed instead of polling getProgramAccounts

### DIFF
--- a/allways/constants.py
+++ b/allways/constants.py
@@ -12,6 +12,8 @@ PROGRAM_ID = '6JVBEj5w27J2SVjERmv2c7wXgFee9nSSBKUJevHehyBD'
 # ─── Polling ──────────────────────────────────────────────
 # Bittensor base-neuron heartbeat, not the scoring/forward cadence.
 MINER_POLL_INTERVAL_SECONDS = 12
+# The miner resubscribes its program feed this often, then catches up from chain (one MinerState read idle).
+MINER_FEED_RESUBSCRIBE_SECONDS = 300
 VALIDATOR_POLL_INTERVAL_SECONDS = 12
 # Consecutive polls of zero block progress before we force a substrate reconnect.
 STALE_BLOCK_POLL_THRESHOLD = 30

--- a/allways/miner/swap_poller.py
+++ b/allways/miner/swap_poller.py
@@ -1,36 +1,62 @@
-"""Polls the Solana program for swaps assigned to this miner.
+"""Finds this miner's swaps: pushed by the program feed (SwapInitiated) and followed by point read, with a
+MinerState-gated getProgramAccounts snapshot as the catch-up whenever push can't be trusted. Whether a swap
+was already handled is ``SwapFulfiller``'s send cache — this poller reports raw on-chain state only."""
 
-Solana keys swaps by `swap_key` (== keccak(from_tx_hash)) and exposes them through a single
-`getProgramAccounts` snapshot per poll, partitioned by status locally, so there is no incremental
-cursor and no per-id transient miss to defend against (the old ink! poller scanned `get_swap(id)`
-one id at a time): each poll is an atomic, authoritative view. Whether a swap has already been handled is tracked by ``SwapFulfiller``'s
-persistent send cache — this poller reports raw on-chain state only.
-"""
-
-from typing import List, Set, Tuple
+import threading
+import time
+from typing import Callable, Dict, List, Optional, Set, Tuple
 
 import bittensor as bt
 
 from allways.solana.client import SolanaSwap, _as_pubkey, swap_from_solana
+from allways.utils.logging import log_on_change
 
 # Statuses the miner acts on: ACTIVE needs fulfillment; FULFILLED is awaiting validator confirm but is
 # still reported so the fulfiller retains its send-cache entry until the swap closes on-chain.
 ACTIVE_STATUSES = ('Active', 'Fulfilled')
+# A pushed swap_key that no point read can find yet (a lagging node) is retried this long, then synced.
+ANNOUNCE_GRACE_SECS = 60.0
+# A followed swap must read absent this many passes in a row before it counts as closed.
+VANISH_MISSES = 2
 
 
 class SwapPoller:
-    """Enumerates the program's swaps and returns the ones assigned to this miner."""
+    """Reports this miner's live swaps as (active, fulfilled) each pass."""
 
-    def __init__(self, solana_client, miner_pubkey):
+    def __init__(self, solana_client, miner_pubkey, feed=None, wake: Optional[Callable[[], None]] = None):
         self.client = solana_client
         self.miner_pubkey = _as_pubkey(miner_pubkey)
-        self.known: Set[str] = set()  # swap_key hexes already logged as discovered (cosmetic)
+        self.known: Set[str] = set()  # swap_key hexes of this miner's live swaps, followed by point read
         self.last_poll_ok: bool = True
         self._counters = None  # (successful_swaps, failed_swaps) baseline for naming terminal outcomes
+        self.feed = feed
+        self.wake = wake
+        self._announced: Dict[str, float] = {}  # pushed swap_key hex -> first-seen monotonic time
+        self._announced_lock = threading.Lock()
+        self._misses: Dict[str, int] = {}
+        self._synced_session: Optional[int] = None
+        self._resync = True
+        if feed is not None:
+            feed.on('SwapInitiated', self.on_swap_initiated)
+
+    # ── push ────────────────────────────────────────────────────────────────
+
+    def on_swap_initiated(self, _name: str, event) -> None:
+        """Feed-thread handler: remember our new swap and wake the loop to fulfill it now."""
+        if _as_pubkey(event.miner) != self.miner_pubkey:
+            return
+        key_hex = bytes(event.swap_key).hex()
+        with self._announced_lock:
+            self._announced.setdefault(key_hex, time.monotonic())
+        bt.logging.info(f'Swap {key_hex[:16]}: initiated (pushed)')
+        if self.wake is not None:
+            self.wake()
+
+    # ── poll ────────────────────────────────────────────────────────────────
 
     def poll(self) -> Tuple[List[SolanaSwap], List[SolanaSwap]]:
-        """Snapshot poll. Returns (active, fulfilled) for this miner. On RPC failure returns ([], [])
-        with ``last_poll_ok`` False so the caller skips send-cache cleanup against an empty set."""
+        """Returns (active, fulfilled) for this miner. On RPC failure returns ([], []) with
+        ``last_poll_ok`` False so the caller skips send-cache cleanup against an empty set."""
         try:
             result = self.poll_inner()
             self.last_poll_ok = True
@@ -38,7 +64,96 @@ class SwapPoller:
         except Exception as e:
             bt.logging.error(f'SwapPoller poll error: {type(e).__name__}: {e}')
             self.last_poll_ok = False
+            self._resync = True
             return [], []
+
+    def poll_inner(self) -> Tuple[List[SolanaSwap], List[SolanaSwap]]:
+        if self.needs_sync():
+            return self.sync()
+        return self.follow()
+
+    def needs_sync(self) -> bool:
+        if self.feed is None:
+            return True
+        live = self.feed.connected
+        log_on_change(
+            'swap_poller:feed',
+            live,
+            'Program feed live — following swaps by push'
+            if live
+            else 'Program feed down — syncing from chain every pass until it reconnects',
+        )
+        return not live or self.feed.session != self._synced_session or self._resync
+
+    def sync(self) -> Tuple[List[SolanaSwap], List[SolanaSwap]]:
+        """Authoritative catch-up. `has_active_swap` is set in the same instruction that makes a swap Active,
+        so with it clear and nothing followed here there is nothing to find — skip the snapshot."""
+        session = self.feed.session if self.feed is not None else None
+        try:
+            ms = self.client.get_miner_state(self.miner_pubkey)
+        except Exception as e:
+            bt.logging.debug(f'SwapPoller: MinerState read failed ({e}); taking the snapshot')
+            ms = None
+        if ms is not None and not ms.has_active_swap and not self.known and not self._pending():
+            active, fulfilled = [], []
+        else:
+            rows = self.client.get_swaps()
+            active = self._mine(rows, 'Active')
+            fulfilled = self._mine(rows, 'Fulfilled')
+        live = {s.key_hex for s in active} | {s.key_hex for s in fulfilled}
+        self._settle(live)
+        with self._announced_lock:
+            for k in live:
+                self._announced.pop(k, None)
+        self._misses.clear()
+        self._synced_session = session
+        self._resync = False
+        return active, fulfilled
+
+    def follow(self) -> Tuple[List[SolanaSwap], List[SolanaSwap]]:
+        """Push mode: point-read each followed or pushed swap. No keys → no calls."""
+        now = time.monotonic()
+        pending = self._pending()
+        active: List[SolanaSwap] = []
+        fulfilled: List[SolanaSwap] = []
+        live: Set[str] = set()
+        for key_hex in self.known | set(pending):
+            acct = self.client.get_swap(key_hex)
+            status = type(acct.status).__name__ if acct is not None else None
+            if status in ACTIVE_STATUSES and _as_pubkey(acct.miner) == self.miner_pubkey:
+                swap = self._adopt(swap_from_solana(acct))
+                (active if status == 'Active' else fulfilled).append(swap)
+                live.add(key_hex)
+                self._misses.pop(key_hex, None)
+                with self._announced_lock:
+                    self._announced.pop(key_hex, None)
+            elif key_hex in self.known:
+                self._misses[key_hex] = self._misses.get(key_hex, 0) + 1
+                if self._misses[key_hex] < VANISH_MISSES:
+                    live.add(key_hex)  # one miss can be a lagging node; keep following it
+                else:
+                    self._misses.pop(key_hex, None)
+                    self._resync = True  # confirm the close against the snapshot next pass
+            elif now - pending[key_hex] > ANNOUNCE_GRACE_SECS:
+                with self._announced_lock:
+                    self._announced.pop(key_hex, None)
+                self._resync = True
+        self._settle(live)
+        return active, fulfilled
+
+    # ── helpers ─────────────────────────────────────────────────────────────
+
+    def _pending(self) -> Dict[str, float]:
+        with self._announced_lock:
+            return dict(self._announced)
+
+    def _adopt(self, swap: SolanaSwap) -> SolanaSwap:
+        if swap.key_hex not in self.known:
+            bt.logging.info(
+                f'Discovered swap {swap.key_hex[:16]}: {swap.from_chain} -> {swap.to_chain}, '
+                f'collateral_amount={swap.collateral_amount}, status={swap.status}'
+            )
+        return swap
 
     def _mine(self, rows, status: str) -> List[SolanaSwap]:
         out = []
@@ -47,29 +162,15 @@ class SwapPoller:
                 continue
             if _as_pubkey(acct.miner) != self.miner_pubkey:
                 continue
-            swap = swap_from_solana(acct)
-            if swap.key_hex not in self.known:
-                bt.logging.info(
-                    f'Discovered swap {swap.key_hex[:16]}: {swap.from_chain} -> {swap.to_chain}, '
-                    f'collateral_amount={swap.collateral_amount}, status={swap.status}'
-                )
-                self.known.add(swap.key_hex)
-            out.append(swap)
+            out.append(self._adopt(swap_from_solana(acct)))
         return out
 
-    def poll_inner(self) -> Tuple[List[SolanaSwap], List[SolanaSwap]]:
-        # One snapshot fetch, partitioned locally — both statuses come from the same atomic view
-        # (and half the getProgramAccounts of fetching per status).
-        rows = self.client.get_swaps()
-        active = self._mine(rows, 'Active')
-        fulfilled = self._mine(rows, 'Fulfilled')
-        # Forget keys no longer present so a reused-tx swap re-logs; bounded to the live set.
-        live = {s.key_hex for s in active} | {s.key_hex for s in fulfilled}
+    def _settle(self, live: Set[str]) -> None:
+        """Forget keys no longer live (so a reused-tx swap re-logs) and name how each one ended."""
         gone = self.known - live
         if gone or self._counters is None:
             self._log_terminal(gone)
-        self.known &= live
-        return active, fulfilled
+        self.known = set(live)
 
     def _read_counters(self):
         ms = self.client.get_miner_state(self.miner_pubkey)

--- a/allways/solana/program_feed.py
+++ b/allways/solana/program_feed.py
@@ -1,17 +1,13 @@
-"""Pushed program events over a Solana WebSocket (`logsSubscribe`).
-
-One daemon thread holds a `logsSubscribe(mentions=[program])` session on the RPC's wss twin (a keyed Helius
-HTTP URL derives its keyed wss endpoint), decodes every `Program data:` line through the canonical event
-decoder, and hands (name, event) to the handlers registered per event name. A dropped socket reconnects
-with jittered backoff; a handler exception is logged, never fatal. Consumers that need "did I miss
-something while the socket was down" keep their own poll as the backstop — the feed is latency, not truth.
-"""
+"""Pushed program events over a Solana WebSocket: `logsSubscribe(mentions=[account])` on the RPC's wss twin,
+decoded and dispatched per event name, reconnecting with jittered backoff. The account defaults to the program;
+a miner narrows it to its own pubkey. The feed is latency, not truth — consumers keep a catch-up for gaps."""
 
 import asyncio
 import base64
 import json
 import random
 import threading
+import time
 from collections import defaultdict
 from typing import Any, Callable, Dict, List, Optional
 
@@ -46,20 +42,28 @@ def events_from_logs(logs: List[str]) -> List[tuple]:
 
 
 class ProgramEventFeed:
-    """`logsSubscribe` on one program, dispatched to per-event handlers on the feed thread (keep them short —
-    hand real work to a timer/executor). `connected` tells a consumer whether to trust the push path or
-    fall back to polling."""
+    """Handlers run on the feed thread (keep them short). `connected` is set once the node acks the subscribe;
+    `session` counts acks so a consumer can catch up after each one. ``max_session_secs`` resubscribes on a
+    schedule — pings prove the socket, not that the node still delivers."""
 
-    def __init__(self, ws_url: str, program_id) -> None:
+    def __init__(self, ws_url: str, program_id, mentions=None, max_session_secs: Optional[float] = None) -> None:
         self.ws_url = ws_url
         self.program_id = str(program_id)
+        self.mentions = str(mentions) if mentions is not None else self.program_id
+        self.max_session_secs = max_session_secs
         self._handlers: Dict[str, List[Handler]] = defaultdict(list)
         self._connected = threading.Event()
+        self._session_count = 0
         self._thread: Optional[threading.Thread] = None
 
     @property
     def connected(self) -> bool:
         return self._connected.is_set()
+
+    @property
+    def session(self) -> int:
+        """Acknowledged subscriptions so far; a change means events may have been missed in between."""
+        return self._session_count
 
     def on(self, event_name: str, handler: Handler) -> None:
         self._handlers[event_name].append(handler)
@@ -89,6 +93,18 @@ class ProgramEventFeed:
 
     # ── transport ───────────────────────────────────────────────────────────
 
+    def handle_frame(self, msg: dict) -> None:
+        """One inbound frame: the subscribe ack (id 1) marks the feed live; notifications dispatch."""
+        if msg.get('id') == 1:
+            if 'error' in msg:
+                raise ConnectionError(f'logsSubscribe rejected: {msg["error"]}')
+            self._session_count += 1
+            self._connected.set()
+            log = bt.logging.info if self._session_count == 1 else bt.logging.debug
+            log(f'program feed: logsSubscribe({self.mentions}) @ {_mask(self.ws_url)} (session {self._session_count})')
+        elif msg.get('method') == 'logsNotification':
+            self.handle_notification(msg)
+
     async def _session(self) -> None:
         import websockets
 
@@ -96,28 +112,38 @@ class ProgramEventFeed:
             'jsonrpc': '2.0',
             'id': 1,
             'method': 'logsSubscribe',
-            'params': [{'mentions': [self.program_id]}, {'commitment': 'confirmed'}],
+            'params': [{'mentions': [self.mentions]}, {'commitment': 'confirmed'}],
         }
+        deadline = time.monotonic() + self.max_session_secs if self.max_session_secs else None
         async with websockets.connect(self.ws_url, ping_interval=20, ping_timeout=20, max_size=None) as ws:
             await ws.send(json.dumps(sub))
-            self._connected.set()
-            bt.logging.info(f'program feed: logsSubscribe({self.program_id}) @ {_mask(self.ws_url)}')
-            async for raw in ws:
+            while True:
+                remaining = None if deadline is None else deadline - time.monotonic()
+                if remaining is not None and remaining <= 0:
+                    return  # scheduled resubscribe
+                try:
+                    raw = await asyncio.wait_for(ws.recv(), remaining)
+                except asyncio.TimeoutError:
+                    return
                 try:
                     msg = json.loads(raw)
                 except (ValueError, TypeError):
                     continue
-                if msg.get('method') == 'logsNotification':
-                    self.handle_notification(msg)
+                self.handle_frame(msg)
 
     def _run(self) -> None:
         backoff = RECONNECT_MIN_SECS
+        failures = 0
         while True:
             try:
                 asyncio.run(self._session())
                 backoff = RECONNECT_MIN_SECS
+                failures = 0
             except Exception as e:
-                bt.logging.warning(f'program feed: socket down ({e}); reconnecting in ~{backoff:.0f}s')
+                failures += 1
+                # An endpoint with no WebSocket fails every attempt; say so once, not every 30 s.
+                log = bt.logging.warning if failures == 1 else bt.logging.debug
+                log(f'program feed: socket down ({e}); reconnecting in ~{backoff:.0f}s')
             finally:
                 self._connected.clear()
             threading.Event().wait(backoff * random.uniform(0.8, 1.2))

--- a/neurons/base/miner.py
+++ b/neurons/base/miner.py
@@ -28,6 +28,8 @@ class BaseMinerNeuron(BaseNeuron):
         self.loop = asyncio.get_event_loop()
 
         self.should_exit: bool = False
+        # Set by a pushed event (e.g. our swap turning Active) to cut the inter-poll sleep short.
+        self.wake_event = threading.Event()
         self.is_running: bool = False
         self.thread: Union[threading.Thread, None] = None
 
@@ -63,7 +65,8 @@ class BaseMinerNeuron(BaseNeuron):
                     time.sleep(min(2**consecutive_errors, 30))
 
                 self.step += 1
-                time.sleep(self.config.miner.poll_interval)
+                self.wake_event.wait(self.config.miner.poll_interval)
+                self.wake_event.clear()
 
         except KeyboardInterrupt:
             bt.logging.success('Miner killed by keyboard interrupt.')

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -22,12 +22,18 @@ from bittensor import Keypair as BtKeypair  # noqa: E402
 
 from allways.assets import create_assets  # noqa: E402
 from allways.chains import apply_testnet_network_defaults  # noqa: E402
-from allways.constants import FORWARD_STALL_THRESHOLD_SECONDS, NETUID_FINNEY, NUMERAIRE_CHAIN  # noqa: E402
+from allways.constants import (  # noqa: E402
+    FORWARD_STALL_THRESHOLD_SECONDS,
+    MINER_FEED_RESUBSCRIBE_SECONDS,
+    NETUID_FINNEY,
+    NUMERAIRE_CHAIN,
+)
 from allways.miner.fulfillment import SwapFulfiller  # noqa: E402
 from allways.miner.swap_poller import SwapPoller  # noqa: E402
 from allways.solana import keys  # noqa: E402
 from allways.solana.client import AllwaysSolanaClient  # noqa: E402
-from allways.solana.rpc import assert_cluster_safe, resolve_rpc_url  # noqa: E402
+from allways.solana.program_feed import ProgramEventFeed  # noqa: E402
+from allways.solana.rpc import assert_cluster_safe, resolve_rpc_url, resolve_ws_url  # noqa: E402
 from neurons.base.miner import BaseMinerNeuron  # noqa: E402
 
 
@@ -89,7 +95,18 @@ class Miner(BaseMinerNeuron):
         # Bind the bt hotkey ↔ Solana pubkey so on-chain state (keyed by pubkey) attributes to this UID.
         self.ensure_hotkey_bound()
 
-        self.swap_poller = SwapPoller(self.solana_client, self.solana_pubkey)
+        # Swaps are pushed: the feed carries only txs that mention this miner, and SwapInitiated wakes the loop.
+        # While it is down (or on an endpoint with no WebSocket) the poller syncs from chain every pass instead.
+        self.program_feed = ProgramEventFeed(
+            resolve_ws_url(solana_rpc_url),
+            self.solana_client.program_id,
+            mentions=self.solana_pubkey,
+            max_session_secs=MINER_FEED_RESUBSCRIBE_SECONDS,
+        )
+        self.swap_poller = SwapPoller(
+            self.solana_client, self.solana_pubkey, feed=self.program_feed, wake=self.wake_event.set
+        )
+        self.program_feed.start()
 
         hotkey = self.wallet.hotkey.ss58_address
         sent_cache_path = Path.home() / '.allways' / 'miner' / f'sent_cache_{hotkey[:12]}.json'

--- a/tests/test_program_feed.py
+++ b/tests/test_program_feed.py
@@ -1,6 +1,11 @@
+import asyncio
 import base64
+import json
 import os
+import sys
+import types
 
+import pytest
 from solders.pubkey import Pubkey
 
 from allways.solana.layouts import EVENT_DISCRIMINATORS, EVENT_LAYOUTS
@@ -57,3 +62,56 @@ def test_resolve_ws_url_swaps_scheme_and_keeps_the_key(monkeypatch):
     monkeypatch.setenv('SOLANA_WS_URL', 'wss://override')
     assert resolve_ws_url('https://x') == 'wss://override'
     assert os.environ['SOLANA_WS_URL'] == 'wss://override'
+
+
+def test_mentions_defaults_to_the_program_and_narrows_to_a_miner():
+    assert ProgramEventFeed('ws://x', 'prog').mentions == 'prog'
+    assert ProgramEventFeed('ws://x', 'prog', mentions=MINER).mentions == str(MINER)
+
+
+def test_connected_only_after_the_subscribe_ack_and_session_counts_acks():
+    feed = ProgramEventFeed('ws://x', 'prog')
+    assert not feed.connected and feed.session == 0
+    feed.handle_frame({'jsonrpc': '2.0', 'result': 7, 'id': 1})
+    assert feed.connected and feed.session == 1
+    feed.handle_frame({'jsonrpc': '2.0', 'result': 8, 'id': 1})
+    assert feed.session == 2
+
+
+def test_rejected_subscribe_raises_so_the_session_reconnects():
+    feed = ProgramEventFeed('ws://x', 'prog')
+    with pytest.raises(ConnectionError):
+        feed.handle_frame({'jsonrpc': '2.0', 'error': {'code': -32601}, 'id': 1})
+    assert not feed.connected
+
+
+class FakeSocket:
+    def __init__(self, frames):
+        self.frames = list(frames)
+        self.sent = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def send(self, data):
+        self.sent.append(json.loads(data))
+
+    async def recv(self):
+        if self.frames:
+            return json.dumps(self.frames.pop(0))
+        await asyncio.sleep(3600)  # a quiet socket
+
+
+def test_session_subscribes_to_the_mentioned_account_and_ends_on_schedule(monkeypatch):
+    sock = FakeSocket([{'jsonrpc': '2.0', 'result': 1, 'id': 1}])
+    monkeypatch.setitem(sys.modules, 'websockets', types.SimpleNamespace(connect=lambda *a, **k: sock))
+    feed = ProgramEventFeed('ws://x', 'prog', mentions=MINER, max_session_secs=0.2)
+
+    asyncio.run(feed._session())  # returns on its own once the session is due for a resubscribe
+
+    assert sock.sent[0]['method'] == 'logsSubscribe'
+    assert sock.sent[0]['params'][0] == {'mentions': [str(MINER)]}
+    assert feed.session == 1

--- a/tests/test_swap_poller.py
+++ b/tests/test_swap_poller.py
@@ -1,7 +1,8 @@
-"""B4.1 — SwapPoller against the Solana getProgramAccounts snapshot model.
+"""SwapPoller: the getProgramAccounts snapshot (sync) and the pushed, point-read follow mode.
 
-No cursor, no per-id transient miss: each poll is an atomic view. The poller filters the program's
-swaps to this miner's pubkey and splits them into (active, fulfilled).
+A sync is an atomic view: the poller filters the program's swaps to this miner's pubkey and splits them
+into (active, fulfilled). With a live program feed it follows pushed swaps by point read instead, and
+falls back to syncing whenever the feed can't be trusted.
 """
 
 import types
@@ -9,7 +10,9 @@ from unittest.mock import MagicMock
 
 from solders.keypair import Keypair
 
+from allways.miner import swap_poller
 from allways.miner.swap_poller import ACTIVE_STATUSES, SwapPoller
+from allways.solana.client import swap_key_from_tx_hash
 
 
 def _acct(miner_bytes: bytes, from_tx_hash: str, status_name: str = 'Active'):
@@ -111,8 +114,8 @@ def test_known_set_tracks_live_swaps_only():
     assert poller.known == set()
 
 
-def _miner_state(ok: int, failed: int):
-    return types.SimpleNamespace(successful_swaps=ok, failed_swaps=failed)
+def _miner_state(ok: int, failed: int, active: bool = True):
+    return types.SimpleNamespace(successful_swaps=ok, failed_swaps=failed, has_active_swap=active)
 
 
 def test_terminal_outcome_named_completed(caplog):
@@ -156,3 +159,169 @@ def test_terminal_outcome_read_failure_degrades(caplog):
     poller.poll()  # must not raise; falls back to ambiguous log
 
     assert poller.known == set()
+
+
+# ─── push / follow mode ──────────────────────────────────────────────────────
+
+
+class FakeFeed:
+    """Stands in for ProgramEventFeed: records handlers; a test flips connected/session and pushes events."""
+
+    def __init__(self, connected=True, session=1):
+        self.connected = connected
+        self.session = session
+        self.handlers = {}
+
+    def on(self, name, handler):
+        self.handlers[name] = handler
+
+    def push_initiated(self, miner, from_tx_hash):
+        ev = types.SimpleNamespace(swap_key=swap_key_from_tx_hash(from_tx_hash), miner=miner)
+        self.handlers['SwapInitiated']('SwapInitiated', ev)
+
+
+def _idle_client():
+    client = MagicMock()
+    client.get_miner_state.return_value = _miner_state(0, 0, active=False)
+    client.get_swaps.return_value = []
+    client.get_swap.return_value = None
+    return client
+
+
+def test_sync_skips_the_snapshot_when_nothing_is_in_flight():
+    me = Keypair().pubkey()
+    client = _idle_client()
+    poller = SwapPoller(client, me)  # no feed: syncs every pass, like a miner whose socket is down
+
+    assert poller.poll() == ([], [])
+    assert poller.last_poll_ok is True
+    assert client.get_swaps.call_count == 0  # MinerState said no swap is Active → no getProgramAccounts
+
+
+def test_live_feed_idle_miner_makes_no_calls_after_catch_up():
+    me = Keypair().pubkey()
+    client = _idle_client()
+    poller = SwapPoller(client, me, feed=FakeFeed())
+
+    poller.poll()  # first pass: catch-up for session 1
+    client.reset_mock()
+    for _ in range(5):
+        assert poller.poll() == ([], [])
+    assert client.method_calls == []
+
+
+def test_pushed_swap_wakes_the_loop_and_is_point_read_not_scanned():
+    me = Keypair().pubkey()
+    client = _idle_client()
+    feed = FakeFeed()
+    woke = []
+    poller = SwapPoller(client, me, feed=feed, wake=lambda: woke.append(1))
+    poller.poll()
+
+    feed.push_initiated(me, 'aa')
+    client.get_swap.side_effect = lambda key: _acct(bytes(me), 'aa')
+    active, fulfilled = poller.poll()
+
+    assert woke == [1]
+    assert [s.from_tx_hash for s in active] == ['aa'] and fulfilled == []
+    assert client.get_swaps.call_count == 0
+    assert client.get_swap.call_args.args[0] == swap_key_from_tx_hash('aa').hex()
+
+
+def test_swap_initiated_for_another_miner_is_ignored():
+    me = Keypair().pubkey()
+    client = _idle_client()
+    feed = FakeFeed()
+    woke = []
+    poller = SwapPoller(client, me, feed=feed, wake=lambda: woke.append(1))
+    poller.poll()
+
+    feed.push_initiated(Keypair().pubkey(), 'aa')
+    poller.poll()
+    assert woke == [] and client.get_swap.call_count == 0
+
+
+def test_followed_swap_is_dropped_after_repeated_misses_then_resynced():
+    me = Keypair().pubkey()
+    client = _idle_client()
+    feed = FakeFeed()
+    poller = SwapPoller(client, me, feed=feed)
+    poller.poll()
+    feed.push_initiated(me, 'aa')
+    client.get_swap.side_effect = lambda key: _acct(bytes(me), 'aa', 'Fulfilled')
+    assert [s.from_tx_hash for s in poller.poll()[1]] == ['aa']
+
+    client.get_swap.side_effect = lambda key: None  # closed on-chain (or one lagging node)
+    poller.poll()
+    assert poller.known == {swap_key_from_tx_hash('aa').hex()}  # one miss: still followed
+    poller.poll()
+    assert poller.known == set()  # second miss: closed
+
+    client.get_miner_state.reset_mock()
+    poller.poll()  # the close is confirmed against chain state
+    assert client.get_miner_state.called
+
+
+def test_pushed_key_that_never_appears_forces_a_sync_after_the_grace(monkeypatch):
+    me = Keypair().pubkey()
+    client = _idle_client()
+    feed = FakeFeed()
+    poller = SwapPoller(client, me, feed=feed)
+    poller.poll()
+    clock = [1000.0]
+    monkeypatch.setattr(swap_poller.time, 'monotonic', lambda: clock[0])
+    feed.push_initiated(me, 'aa')
+
+    poller.poll()  # lagging node: not readable yet, keep waiting
+    assert not poller._resync
+    clock[0] += swap_poller.ANNOUNCE_GRACE_SECS + 1
+    poller.poll()
+    assert poller._resync and poller._pending() == {}
+
+
+def test_feed_down_or_new_session_syncs_from_chain():
+    me = Keypair().pubkey()
+    client = _idle_client()
+    feed = FakeFeed()
+    poller = SwapPoller(client, me, feed=feed)
+    poller.poll()
+
+    client.reset_mock()
+    feed.session = 2  # resubscribed: anything in the gap must be caught up
+    poller.poll()
+    assert client.get_miner_state.call_count == 1
+    poller.poll()
+    assert client.get_miner_state.call_count == 1  # caught up; back to push
+
+    feed.connected = False
+    poller.poll()
+    poller.poll()
+    assert client.get_miner_state.call_count == 3  # every pass while down
+
+
+def test_catch_up_finds_a_swap_whose_push_was_missed():
+    me = Keypair().pubkey()
+    client = _idle_client()
+    feed = FakeFeed()
+    poller = SwapPoller(client, me, feed=feed)
+    poller.poll()
+
+    client.get_miner_state.return_value = _miner_state(0, 0, active=True)
+    client.get_swaps.return_value = [('pda', _acct(bytes(me), 'aa'))]
+    feed.session = 2
+    active, _ = poller.poll()
+    assert [s.from_tx_hash for s in active] == ['aa']
+    assert client.get_swaps.call_count == 1
+
+
+def test_point_read_failure_marks_poll_failed_and_resyncs():
+    me = Keypair().pubkey()
+    client = _idle_client()
+    feed = FakeFeed()
+    poller = SwapPoller(client, me, feed=feed)
+    poller.poll()
+    feed.push_initiated(me, 'aa')
+    client.get_swap.side_effect = ConnectionError('rpc down')
+
+    assert poller.poll() == ([], [])
+    assert poller.last_poll_ok is False and poller._resync


### PR DESCRIPTION
## Problem

The miner finds its swaps by scanning every `Swap` account with `getProgramAccounts` on every pass (`swap_poller.py:63`). Measured on the test branch: one gPA every 12.55 s, 6,882 a day, and that scan is the miner's whole idle RPC bill. Helius publishes gPA at 10 credits, which puts an idle miner at ~2M credits a month against the free tier's 1M. At 1 credit per gPA it is ~206k. Either way the miner pays for a scan that almost always comes back empty, and a new swap waits up to 12 s to be noticed.

## Fix

- **Push.** The miner subscribes `logsSubscribe(mentions=[its pubkey])`, so it only receives txs that touch it. `vote_initiate` emits `SwapInitiated{swap_key, miner}` in the same instruction that makes the swap Active. The poller adds that key, wakes the forward loop, and follows the swap by point read (`getAccountInfo`) until it closes. An idle miner with a live feed makes no RPC calls.
- **Catch-up instead of the poll.** It runs on every (re)subscribe, on every pass while the feed is down, and when a followed swap vanishes. It reads `MinerState` and takes the gPA snapshot only when `has_active_swap` is set. That flag is set with the swap turning Active and cleared on confirm, timeout or cancel, so a clear flag with nothing followed means there is nothing to find.
- **Silent-miss bound.** The feed resubscribes every 5 min (`MINER_FEED_RESUBSCRIBE_SECONDS`), and each resubscribe runs the catch-up. Pings prove the socket, not that the node is still delivering.
- **Lagging-node guards.** A followed swap has to read absent twice in a row before it counts as closed, and the close is then confirmed against chain state. A pushed key that no point read can find within 60 s forces a catch-up.
- **Fallback.** If the endpoint has no WebSocket, or the socket is down, the miner syncs every pass. That is one `MinerState` read instead of a gPA. The feed now warns once instead of every 30 s.
- **`ProgramEventFeed` changes.** It gains `mentions` and `max_session_secs`, and it reports `connected` only after the node acks the subscribe. The validator's use is unchanged apart from that ack gating.

## Cost

| Idle miner, per day | Before | After |
| --- | --- | --- |
| gPA | ~6,900 | 0 (only if a swap is in flight at a catch-up) |
| Point reads | 0 | ~500–600 measured (1–2 `MinerState` reads per 5-min resubscribe) |
| WebSocket | 0 | 288 connections, plus bytes for txs that mention the miner |

That is roughly 20–30k credits a month whatever gPA costs, well inside a free keyed tier. While a swap is live, the miner makes one point read per swap per pass, the same cadence as before.

## Test

- `tests/test_swap_poller.py`:
  - the snapshot is skipped when `MinerState` shows nothing in flight
  - a live-feed idle miner makes no calls after catch-up
  - a pushed swap wakes the loop and is point-read, not scanned
  - a `SwapInitiated` for another miner is ignored
  - a followed swap is dropped after two misses and the close is re-checked
  - an unreadable pushed key forces a sync after the grace period
  - a new session or a feed outage syncs from chain
  - catch-up finds a swap whose push was missed
  - a point-read failure resyncs
- `tests/test_program_feed.py`:
  - `mentions` defaults to the program
  - `connected` and `session` follow the subscribe ack
  - a rejected subscribe raises
  - a session subscribes to the mentioned account and ends on schedule
- Live, observe-only, keyless public devnet, 25 min, real feed + poller for both testnet miners (`ER9Jt5…`, `BKHKu16h…`): node acked `logsSubscribe(mentions=[miner])`; 125 passes each, 5 sessions (resubscribe every 5 min as scheduled), **8–10 `getAccountInfo` total and 0 gPA** per miner (the old poller would have made 125 gPA), no errors. No swap touched either miner in the window, so the pushed `SwapInitiated` path is covered by unit tests only.

The full suite has 4 pre-existing, order-dependent failures (`test_assets_optional`, `test_bitcoin_signing`). The same 4 fail on `test` without this change.

